### PR TITLE
ci(*): Add pre-commit hooks and linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,85 @@
+run:
+  timeout: 5m
+  go: "1.21"
+  skip-files:
+    - ".*\\.pb\\.go$" # Ignore generated protobuf files
+linters-settings:
+  exhaustive:
+    default-signifies-exhaustive: true
+  forbidigo:
+    forbid:
+      - 'fmt\.Print.*(# Avoid debug logging)?'
+      - 'fmt\.Errorf.*(# Prefer app/errors.Wrap)?'
+  gci: # Auto-format imports
+    sections:
+      - standard                           # Go stdlib
+      - prefix(github.com/omni-network)    # Omni
+      - prefix(github.com/cometbft)        # CometBFT
+      - prefix(github.com/ethereum)        # Go-Ethereum
+      - default                            # All other imports not matched to another section type.
+      - blank                              # Blank imports
+    custom-order: true
+  govet:
+    enable-all: true
+  importas:
+    no-unaliased: true
+    # TODO(corver): Add our own import aliases here
+  misspell:
+    locale: US
+  nolintlint:
+    require-explanation: true
+    require-specific: true
+  revive:
+    enable-all-rules: true
+    severity: warning
+    rules:
+      # Disabled revive rules
+      - name: file-header # Doesn't support auto fix
+        disabled: true
+      # Some configured revive rules
+      - name: unhandled-error
+        arguments:
+         - 'fmt.Printf'
+         - 'fmt.Println'
+      - name: imports-blacklist
+        arguments:
+         - "errors" # Prefer ./lib/errors
+         - "github.com/pkg/errors" # Prefer ./lib/errors
+         - "github.com/gogo/protobuf/proto" # Prefer google.golang.org/protobuf
+  staticcheck:
+    checks:
+     - "all"
+  testpackage:
+    skip-regexp: internal_test\.go # Allow internal tests
+  wrapcheck:
+    ignoreSigs:
+      - github.com/omni-network/omni/
+
+issues:
+  fix: true
+  exclude-rules:
+    - path: '(.+)_test\.go'
+      linters: # Relax linters for tests
+        - gosec
+        - revive
+  exclude:
+    - fieldalignment # Ignore "fieldalignment: struct with XXX pointer bytes could be YYY"
+    - "shadow: declaration of \"err\" shadows declaration" # Relax govet
+
+linters:
+  enable-all: true
+  disable:
+    # Disable some linters
+    - godox # Allow TODOs
+
+    # Disable deprecated/archived linters
+    - deadcode
+    - exhaustivestruct
+    - golint
+    - ifshort
+    - interfacer
+    - maligned
+    - nosnakecase
+    - scopelint
+    - structcheck
+    - varcheck

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,47 @@
+repos:
+  # First run code formatters
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.5.0
+    hooks:
+      - id: trailing-whitespace # trims trailing whitespace
+        exclude: "testdata"
+      - id: end-of-file-fixer # ensures that a file is either empty, or ends with one newline
+        exclude_types: ["proto"]
+        exclude: "testdata"
+      - id: mixed-line-ending # ensures that a file doesn't contain a mix of LF and CRLF
+      - id: no-commit-to-branch # Protect specific branches (default: main/master) from direct checkins
+
+  - repo: https://github.com/dnephin/pre-commit-golang
+    rev: v0.5.1
+    hooks:
+      - id: go-mod-tidy # Run go mod tidy when go.mod changes
+        files: go.mod
+      - id: go-fmt
+        args: [ -w, -s ] # simplify code and write result to (source) file instead of stdout
+
+  # TODO(corver): Add hooks for the following:
+  # - Local minor go version matches go.mod
+  # - Auto-fix file license headers
+
+  # Then run code validators (on the formatted code)
+
+  - repo: https://github.com/golangci/golangci-lint # See .golangci.yml for config
+    rev: v1.55.2
+    hooks:
+      - id: golangci-lint
+        # Lint all go files in the repo, since this aligns with github actions.
+        entry: golangci-lint run --fix
+
+  - repo: local
+    hooks:
+      - id: run-go-tests
+        name: run-go-tests
+        language: script
+        entry: .pre-commit/run_tests.sh
+        types: [ file, go ]
+      - id: run-regexp
+        name: run-regexp
+        language: script
+        entry: .pre-commit/run_regexp.sh
+        types: [ file, go ]
+        exclude: "_test.go"

--- a/.pre-commit/run_regexp.sh
+++ b/.pre-commit/run_regexp.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+FILES=$@
+
+function check() {
+    grep -HnE "$2" $FILES && printf "\n❌ Regexp check failed: %s\n\n" "$1"
+}
+
+check 'Log messages must be capitalised' 'log\.(Error|Warn|Info|Debug)\(ctx, "[[:lower:]]' && exit 1
+check 'Error messages must not be capitalised' 'errors\.(New|Wrap)\((err, )?"[[:upper:]]' && exit 1
+
+true

--- a/.pre-commit/run_tests.sh
+++ b/.pre-commit/run_tests.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+# Runs go test for all touched packages
+MOD=$(go list -m)
+PKGS=$(echo "$@"| xargs -n1 dirname | sort -u | sed -e "s#^#${MOD}/#")
+
+go test -failfast -race -timeout=2m $PKGS


### PR DESCRIPTION
Adds the following:
- [pre-commit:](https://pre-commit.com/) a tool to run a bunch of checks and verifications as part of git pre-commit hooks. #failfast
- [golangci-lint](https://golangci-lint.run/): Mega golang linter. Most linters are enabled by default.

task: https://app.asana.com/0/1206208509925075/1206265166156265