### PR TITLE
ci(*): add makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,14 @@
+help:  ## Display this help message
+	@egrep -h '\s##\s' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m  %-30s\033[0m %s\n", $$1, $$2}'
+###############################################################################
+###                                Utils                                 	###
+###############################################################################
+
+install-pre-commit: ## Installs the pre-commit tool as the git pre-commit hook for this repo.
+	@which pre-commit > /dev/null || echo "pre-commit not installed, see https://pre-commit.com/#install"
+	@pre-commit install --install-hooks
+
+lint: ## Runs linters via pre-commit.
+	@pre-commit run -v --all-files
+
+.PHONY: install-pre-commit lint


### PR DESCRIPTION
Adds a simple `Makefile` to the root that install the linter (`pre-commit`) and does linting. To see available make commands, run `make help`.

task: none