### PR TITLE
ci(github): adds dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+- package-ecosystem: "gomod"
+  directory: "/"
+  schedule:
+    interval: "daily"


### PR DESCRIPTION
Adds dependabot config so out dependencies are automatically updated. 
See https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuring-dependabot-version-updates.

task: none