### PR TITLE
refactor(lib/xtypes): add txhash to xreceipt

### DIFF
--- a/lib/xtypes/types.go
+++ b/lib/xtypes/types.go
@@ -30,6 +30,7 @@ type Receipt struct {
 	GasUsed        uint64   // Gas used during message "call"
 	Success        bool     // Result, true for success, false for revert
 	RelayerAddress [20]byte // Address of relayer that submitted the message
+	TxHash         [32]byte // Hash of the relayer submission transaction
 }
 
 // BlockHeader uniquely identifies a cross chain block.


### PR DESCRIPTION
Adds the `TxHash` field to the `XReceipt`, this ensures the explorer has all the information it requires directly from the `XBlock`.

task: none