### PR TITLE
refactor(lib/xchain): rename xtypes to xchain

### DIFF
--- a/lib/xchain/doc.go
+++ b/lib/xchain/doc.go
@@ -1,0 +1,2 @@
+// Package xchain defines the types and interfaces used by the omni cross-chain protocol.
+package xchain

--- a/lib/xchain/provider.go
+++ b/lib/xchain/provider.go
@@ -1,0 +1,20 @@
+package xchain
+
+import "context"
+
+// ProviderCallback is the callback function signature that will be called with every finalized.
+type ProviderCallback func(context.Context, Block) error
+
+// Provider abstracts connecting to any supported source chain and streaming finalized
+// XBlocks from a specific height. It provides exactly once-delivery guarantees for the callback function.
+// It will exponentially backoff and retry forever while the callback function returns an error.
+type Provider interface {
+	// Subscribe registers a callback function that will be called with every finalized
+	// XBlock (as they become available) on the source chain from the provided height (inclusive).
+	Subscribe(
+		ctx context.Context,
+		chainID uint64,
+		fromHeight uint64,
+		callback ProviderCallback,
+	)
+}

--- a/lib/xchain/types.go
+++ b/lib/xchain/types.go
@@ -1,5 +1,4 @@
-// Package xtypes defines the types used by the omni cross-chain protocol.
-package xtypes
+package xchain
 
 // StreamID uniquely identifies a cross-chain stream.
 // A stream is a logical representation of a cross-chain connection between two chains.


### PR DESCRIPTION
Add the `Provider` interface to the cross chain types package. Also rename the package from `xtypes` to `xchain` since that is more specific and conveys the "cross chain" concept more clearly and explicitly. 

task: none