### PR TITLE
feat(lib/xchain): add timestamp to xblock

### DIFF
--- a/lib/xchain/types.go
+++ b/lib/xchain/types.go
@@ -1,5 +1,7 @@
 package xchain
 
+import "time"
+
 // StreamID uniquely identifies a cross-chain stream.
 // A stream is a logical representation of a cross-chain connection between two chains.
 type StreamID struct {
@@ -42,8 +44,9 @@ type BlockHeader struct {
 // Block is a deterministic representation of the omni cross-chain properties of a source chain EVM block.
 type Block struct {
 	BlockHeader
-	Msgs     []Msg     // All cross-chain messages sent/emittted in the block
-	Receipts []Receipt // Receipts of all submitted cross-chain messages applied in the block
+	Msgs      []Msg     // All cross-chain messages sent/emittted in the block
+	Receipts  []Receipt // Receipts of all submitted cross-chain messages applied in the block
+	Timestamp time.Time // Timestamp of the source chain block
 }
 
 // Attestation by a validator of a cross-chain Block.


### PR DESCRIPTION
Adds a timestamp field to the `XBlock`,  this is mostly for Explorer to populate timestamps, also useful for debugging.

Note this field isn't included in the attestation root, it is a convenience field.

task: none