### PR TITLE
feat(halo/consensus): persist json state to disk

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -89,7 +89,7 @@ issues:
   exclude:
     - add-constant         # Ignore "add-constant: avoid magic numbers like" since it is too strict
     - fieldalignment # Ignore "fieldalignment: struct with XXX pointer bytes could be YYY"
-    - "shadow: declaration of \"err\" shadows declaration" # Relax govet
+    - "shadow: declaration of" # Relax govet
     - "ifElseChain: rewrite if-else to switch statement"   # IfElseChain actually preferred to switches
 linters:
   enable-all: true

--- a/halo/consensus/core.go
+++ b/halo/consensus/core.go
@@ -13,15 +13,16 @@ import (
 // - Maintains the consensus chain state.
 type Core struct {
 	ethCl     engine.Client
-	state     state
+	state     *State
 	attestSvc attest.Service
 }
 
 // NewCore returns a new Core instance.
-func NewCore(ethCl engine.Client, attestSvc attest.Service) *Core {
+func NewCore(ethCl engine.Client, attestSvc attest.Service, state *State) *Core {
 	return &Core{
 		ethCl:     ethCl,
 		attestSvc: attestSvc,
+		state:     state,
 	}
 }
 

--- a/halo/consensus/state.go
+++ b/halo/consensus/state.go
@@ -1,50 +1,86 @@
 package consensus
 
 import (
+	"crypto/sha256"
 	"encoding/json"
+	"os"
+	"path/filepath"
 	"sync"
 
 	"github.com/omni-network/omni/lib/errors"
 	"github.com/omni-network/omni/lib/xchain"
 
 	abci "github.com/cometbft/cometbft/abci/types"
-
-	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/cometbft/cometbft/libs/tempfile"
 )
 
-const pubKeyLen = 33
+const (
+	pubKeyLen         = 33
+	stateFileName     = "halo_state.json"
+	prevStateFileName = "halo_app_state.json"
+)
 
 type validator struct {
 	PubKey [pubKeyLen]byte
 	Power  int64
 }
-type state struct {
-	mu                 sync.Mutex
-	ExecutionStateRoot [32]byte
-	valSetID           uint64
-	validators         []validator
-	pendingAggs        []xchain.AggAttestation
-	approvedAggs       []xchain.AggAttestation
+
+// State is the halo application state.
+type State struct {
+	// Immutable config fields (not persisted to disk)
+	filePath        string
+	prevFilePath    string
+	persistInterval uint64 // Persist state every internal
+
+	// Mutable state fields (persisted to disk)
+	mu            sync.RWMutex
+	initialHeight uint64
+	height        uint64
+	valSetID      uint64
+	validators    []validator
+	pendingAggs   []xchain.AggAttestation
+	approvedAggs  []xchain.AggAttestation
+
+	hash [32]byte // Calculated from above fields
 }
 
-// InitChainState sets consensus validators.
+// LoadOrGenState loads the state from the dir or creates a new state. It will persist to that dir.
+func LoadOrGenState(dir string, persistInterval uint64) (*State, error) {
+	filePath := filepath.Join(dir, stateFileName)
+	prevFilePath := filepath.Join(dir, prevStateFileName)
+
+	stateJSON, err := loadStateJSON(filePath, prevFilePath)
+	if errors.Is(err, os.ErrNotExist) { //nolint:revive // Catch and swallow this error.
+		// No file on disk, use empty state
+	} else if err != nil {
+		return nil, err
+	}
+
+	state := &State{
+		filePath:        filePath,
+		prevFilePath:    prevFilePath,
+		persistInterval: persistInterval,
+	}
+	populateStateFromJSON(state, stateJSON)
+
+	state.hash, err = state.calcHashUnsafe() // No need to lock since just created above.
+	if err != nil {
+		return nil, errors.Wrap(err, "calculate state hash")
+	}
+
+	return state, nil
+}
+
+// InitValidators sets consensus validators.
 // It returns an error if the validators are already set.
 // This implies validators can only be set once and never change.
-func (s *state) InitChainState(req *abci.RequestInitChain) error {
+func (s *State) InitValidators(vals []abci.ValidatorUpdate) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	if s.valSetID > 0 {
-		return errors.New("chain already initialized")
-	}
-
-	if len(req.AppStateBytes) > 0 {
-		return errors.New("app state bytes must be empty")
-	}
-
 	s.valSetID++ // Update from 0 to 1.
 
-	for _, v := range req.Validators {
+	for _, v := range vals {
 		if len(v.PubKey.GetEd25519()) > 0 {
 			return errors.New("ed25519 keys not supported")
 		}
@@ -60,29 +96,17 @@ func (s *state) InitChainState(req *abci.RequestInitChain) error {
 		})
 	}
 
+	var err error
+	s.hash, err = s.calcHashUnsafe()
+	if err != nil {
+		return errors.Wrap(err, "calculate state hash")
+	}
+
 	return nil
 }
 
-// AppHash returns the application hash.
-func (s *state) AppHash() ([]byte, error) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-
-	buf, err := json.Marshal(appHashJSON{
-		ValSetID:     s.valSetID,
-		Validators:   s.validators,
-		PendingAggs:  s.pendingAggs,
-		ApprovedAggs: s.approvedAggs,
-	})
-	if err != nil {
-		return nil, errors.Wrap(err, "failed to marshal app hash json")
-	}
-
-	return crypto.Keccak256(buf), nil
-}
-
 // AddAttestations adds the provided aggregates to the state, moving pending to approved if applicable.
-func (s *state) AddAttestations(aggregates []xchain.AggAttestation) {
+func (s *State) AddAttestations(aggregates []xchain.AggAttestation) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
@@ -111,9 +135,9 @@ func (s *state) AddAttestations(aggregates []xchain.AggAttestation) {
 
 // ApprovedAggregates returns a copy of the approved aggregates.
 // For testing purposes only.
-func (s *state) ApprovedAggregates() []xchain.AggAttestation {
-	s.mu.Lock()
-	defer s.mu.Unlock()
+func (s *State) ApprovedAggregates() []xchain.AggAttestation {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
 
 	// Return a copy of the approved aggregates.
 	aggs := make([]xchain.AggAttestation, len(s.approvedAggs))
@@ -122,11 +146,216 @@ func (s *state) ApprovedAggregates() []xchain.AggAttestation {
 	return aggs
 }
 
-// appHashJSON is the JSON representation of the state used to calculate app hash.
-type appHashJSON struct {
-	ExecutionStateRoot [32]byte                `json:"execution_state_root"`
-	ValSetID           uint64                  `json:"validator_set_id"`
-	Validators         []validator             `json:"validators"`
-	PendingAggs        []xchain.AggAttestation `json:"pending_aggregate_attestations"`
-	ApprovedAggs       []xchain.AggAttestation `json:"approved_aggregate_attestations"`
+// saveUnsafe saves the state to disk. It is unsafe since it assumes the lock is held.
+func (s *State) saveUnsafe() error {
+	bz, err := s.marshalJSONUnsafe()
+	if err != nil {
+		return err
+	}
+
+	// Replace previous file with current, if it exists.
+	if _, err := os.Stat(s.filePath); err == nil {
+		if err := os.Rename(s.filePath, s.prevFilePath); err != nil {
+			return errors.Wrap(err, "replace previous state")
+		}
+	}
+
+	if err := tempfile.WriteFileAtomic(s.filePath, bz, 0o644); err != nil {
+		return errors.Wrap(err, "write state file")
+	}
+
+	return nil
+}
+
+// Hash returns the existing state hash.
+func (s *State) Hash() []byte {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	return s.hash[:]
+}
+
+// Height returns the current height of the state.
+func (s *State) Height() uint64 {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	return s.height
+}
+
+// Export returns the state json, used for state sync snapshots.
+// Additionally, returns the current height and hash.
+func (s *State) Export() ([]byte, uint64, [32]byte, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	bz, err := s.marshalJSONUnsafe()
+	if err != nil {
+		return nil, 0, [32]byte{}, err
+	}
+
+	return bz, s.height, s.hash, nil
+}
+
+// Import imports state JSON bytes (overwriting existing state). It used for InitChain.AppStateBytes and
+// state sync snapshots. It also saves the state once imported.
+func (s *State) Import(height uint64, jsonBytes []byte) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	var stateJSON stateJSON
+	err := json.Unmarshal(jsonBytes, &stateJSON)
+	if err != nil {
+		return errors.Wrap(err, "unmarshal state")
+	} else if stateJSON.Height != height {
+		return errors.New("mismatching height")
+	}
+
+	*s = State{
+		filePath:        s.filePath,
+		prevFilePath:    s.prevFilePath,
+		persistInterval: s.persistInterval,
+	}
+	populateStateFromJSON(s, stateJSON)
+
+	s.hash, err = s.calcHashUnsafe()
+	if err != nil {
+		return errors.Wrap(err, "calculate state hash")
+	}
+
+	return s.saveUnsafe()
+}
+
+// Finalize is called after applying a block, it updates the height and returns the new state hash.
+func (s *State) Finalize() ([32]byte, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.height > 0 {
+		s.height++
+	} else if s.initialHeight > 0 {
+		s.height = s.initialHeight
+	} else {
+		s.height = 1
+	}
+
+	var err error
+	s.hash, err = s.calcHashUnsafe()
+	if err != nil {
+		return [32]byte{}, errors.Wrap(err, "calculate state hash")
+	}
+
+	return s.hash, nil
+}
+
+// Commit commits the current state, returning the current height.
+func (s *State) Commit() (uint64, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.persistInterval > 0 && s.height%s.persistInterval == 0 {
+		err := s.saveUnsafe()
+		if err != nil {
+			return 0, err
+		}
+	}
+
+	return s.height, nil
+}
+
+// Rollback rolls back the state to the previous state file.
+func (s *State) Rollback() error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	stateJSON, err := loadStateJSON(s.prevFilePath, "")
+	if err != nil {
+		return errors.Wrap(err, "read prev state file")
+	}
+
+	*s = State{
+		filePath:        s.filePath,
+		prevFilePath:    s.prevFilePath,
+		persistInterval: s.persistInterval,
+	}
+	populateStateFromJSON(s, stateJSON)
+
+	s.hash, err = s.calcHashUnsafe()
+	if err != nil {
+		return errors.Wrap(err, "calculate state hash")
+	}
+
+	return nil
+}
+
+// marshalJSONUnsafe marshals the state to JSON.
+// Note this is unsafe, it assumes the lock is held.
+func (s *State) marshalJSONUnsafe() ([]byte, error) {
+	stateJSON := &stateJSON{
+		InitialHeight: s.initialHeight,
+		Height:        s.height,
+		ValSetID:      s.valSetID,
+		Validators:    s.validators,
+		PendingAggs:   s.pendingAggs,
+		ApprovedAggs:  s.approvedAggs,
+	}
+
+	bz, err := json.Marshal(stateJSON)
+	if err != nil {
+		return nil, errors.Wrap(err, "marshal state")
+	}
+
+	return bz, nil
+}
+
+// calcHash calculate the hash of the state.
+// It is unsafe since it assumes the lock is held.
+func (s *State) calcHashUnsafe() ([32]byte, error) {
+	// TODO(corver): Improve this, make it more robust.
+	bz, err := s.marshalJSONUnsafe()
+	if err != nil {
+		return [32]byte{}, errors.Wrap(err, "marshal state")
+	}
+
+	return sha256.Sum256(bz), nil
+}
+
+// stateJSON represents the JSON state file.
+type stateJSON struct {
+	InitialHeight uint64                  `json:"initial_height"`
+	Height        uint64                  `json:"height"`
+	ValSetID      uint64                  `json:"val_set_id"`
+	Validators    []validator             `json:"validators"`
+	PendingAggs   []xchain.AggAttestation `json:"pending_aggs"`
+	ApprovedAggs  []xchain.AggAttestation `json:"approved_aggs"`
+}
+
+// loadState loads stateJSON from filePath, trying fallback if filePath does not exist.
+func loadStateJSON(filePath, fallback string) (stateJSON, error) {
+	bz, err := os.ReadFile(filePath)
+	if errors.Is(err, os.ErrNotExist) && fallback != "" {
+		bz, err = os.ReadFile(fallback)
+		if err != nil {
+			return stateJSON{}, errors.Wrap(err, "read both state files")
+		}
+	} else if err != nil {
+		return stateJSON{}, errors.Wrap(err, "read state file")
+	}
+
+	var state stateJSON
+	if err := json.Unmarshal(bz, &state); err != nil {
+		return stateJSON{}, errors.Wrap(err, "unmarshal state file")
+	}
+
+	return state, nil
+}
+
+// populateStateFromJSON populates the state fields from the provided stateJSON.
+func populateStateFromJSON(state *State, stateJSON stateJSON) {
+	state.initialHeight = stateJSON.InitialHeight
+	state.height = stateJSON.Height
+	state.valSetID = stateJSON.ValSetID
+	state.validators = stateJSON.Validators
+	state.pendingAggs = stateJSON.PendingAggs
+	state.approvedAggs = stateJSON.ApprovedAggs
 }

--- a/test/smoke/smoke_test.go
+++ b/test/smoke/smoke_test.go
@@ -55,7 +55,10 @@ func TestSmoke(t *testing.T) {
 		fuzzer:     fuzz.New().NilChance(0),
 	}
 
-	core := consensus.NewCore(ethCl, attSvc)
+	state, err := consensus.LoadOrGenState(t.TempDir(), 1)
+	require.NoError(t, err)
+
+	core := consensus.NewCore(ethCl, attSvc, state)
 
 	conf := rpctest.GetConfig(true)
 	writeFiles(t, conf)


### PR DESCRIPTION
Implements the [persisted JSON state file as used by cometBFT e2e tests](https://github.com/cometbft/cometbft/blob/main/test/e2e/app/state.go). This should be good enough for v0 to get our app state up and running. 

task: none