### PR TITLE
feat(lib/cchain): implement basic cprovider

### DIFF
--- a/halo/consensus/state.go
+++ b/halo/consensus/state.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"slices"
 	"sync"
 
 	"github.com/omni-network/omni/lib/errors"
@@ -139,11 +140,32 @@ func (s *State) ApprovedAggregates() []xchain.AggAttestation {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
-	// Return a copy of the approved aggregates.
-	aggs := make([]xchain.AggAttestation, len(s.approvedAggs))
-	copy(aggs, s.approvedAggs)
+	return slices.Clone(s.approvedAggs)
+}
 
-	return aggs
+// ApprovedFrom returns a sequential range of approved aggregates from the provided chain ID and height.
+// It returns at most max aggregates. Their block heights are sequentially increasing.
+func (s *State) ApprovedFrom(chainID uint64, height uint64, max uint64) []xchain.AggAttestation {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	next := height
+
+	resp := make([]xchain.AggAttestation, 0, max)
+	for _, agg := range s.approvedAggs { // approvedAggs is sorted by block height.
+		if agg.SourceChainID != chainID || agg.BlockHeight != next {
+			continue
+		}
+
+		resp = append(resp, agg)
+		next++
+
+		if uint64(len(resp)) >= max {
+			break
+		}
+	}
+
+	return resp
 }
 
 // saveUnsafe saves the state to disk. It is unsafe since it assumes the lock is held.

--- a/lib/cchain/provider.go
+++ b/lib/cchain/provider.go
@@ -6,9 +6,9 @@ import (
 	"github.com/omni-network/omni/lib/xchain"
 )
 
-// ProviderCallback is the callback function signature that will be called with all approved attestation per
-// source chain block.
-type ProviderCallback func(ctx context.Context, height uint64, approved []xchain.AggAttestation) error
+// ProviderCallback is the callback function signature that will be called with each approved attestation per
+// source chain block in strictly sequential order.
+type ProviderCallback func(ctx context.Context, approved xchain.AggAttestation) error
 
 // Provider abstracts connecting to the omni consensus chain and streaming approved
 // aggregate attestations for each source chain block from a specific height.

--- a/lib/cchain/provider/provider.go
+++ b/lib/cchain/provider/provider.go
@@ -1,0 +1,95 @@
+// Package provider implements the cchain.Provider interface.
+package provider
+
+import (
+	"context"
+	"testing"
+
+	"github.com/omni-network/omni/lib/cchain"
+	"github.com/omni-network/omni/lib/log"
+	"github.com/omni-network/omni/lib/xchain"
+)
+
+var _ cchain.Provider = Provider{}
+
+// FetchFunc abstracts fetching attestation from the consensus chain.
+type FetchFunc func(ctx context.Context, chainID uint64, fromHeight uint64, max uint64,
+) ([]xchain.AggAttestation, error)
+
+// Provider implements cchain.Provider.
+type Provider struct {
+	fetch       FetchFunc
+	batchSize   uint64
+	backoffFunc func(context.Context) (func(), func())
+}
+
+// TODO(corver): Add prod constructor once halo has an API.
+
+// NewProviderForT creates a new provider for testing.
+func NewProviderForT(_ *testing.T, fetch FetchFunc, batchSize uint64,
+	backoffFunc func(context.Context) (func(), func()),
+) Provider {
+	return Provider{
+		fetch:       fetch,
+		batchSize:   batchSize,
+		backoffFunc: backoffFunc,
+	}
+}
+
+// Subscribe implements cchain.Provider.
+func (p Provider) Subscribe(ctx context.Context, chainID uint64, height uint64, callback cchain.ProviderCallback) {
+	// Start a async goroutine to fetch attestations until ctx is canceled.
+	go func() {
+		backoff, reset := p.backoffFunc(ctx) // Note that backoff returns immediately on ctx cancel.
+
+		for ctx.Err() == nil {
+			// Fetch next batch of attestations.
+			atts, err := p.fetch(ctx, chainID, height, p.batchSize)
+			if ctx.Err() != nil {
+				return // Don't backoff or log on ctx cancel, just return.
+			} else if err != nil {
+				log.Warn(ctx, "Failed fetching attestation; will retry", err)
+				backoff()
+
+				continue
+			} else if len(atts) == 0 {
+				// We reached the head of the chain, wait for new blocks.
+				backoff() // Maybe do (consensus-block-period / N)
+
+				continue
+			}
+
+			reset() // Reset fetch backoff
+
+			// Call callback for each attestation
+			for _, att := range atts {
+				// Sanity checks
+				if att.SourceChainID != chainID {
+					log.Error(ctx, "Invalid attestation chain ID [BUG!]", nil)
+					return
+				} else if att.BlockHeight != height {
+					log.Error(ctx, "Invalid attestation height [BUG!]", nil)
+					return
+				}
+
+				// Retry callback on error
+				for ctx.Err() == nil {
+					err := callback(ctx, att)
+					if ctx.Err() != nil {
+						return // Don't backoff or log on ctx cancel, just return.
+					} else if err != nil {
+						log.Warn(ctx, "Failed processing attestation; will retry", err)
+						backoff()
+
+						continue
+					}
+
+					break // Success, stop retrying.
+				}
+
+				reset() // Reset callback backoff
+				height++
+			}
+		}
+	}()
+}

--- a/lib/cchain/provider/provider_test.go
+++ b/lib/cchain/provider/provider_test.go
@@ -1,0 +1,103 @@
+package provider_test
+
+import (
+	"context"
+	"errors"
+	"math/rand"
+	"testing"
+
+	"github.com/omni-network/omni/lib/cchain/provider"
+	"github.com/omni-network/omni/lib/xchain"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestProvider(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	const (
+		errs      = 2
+		batchSize = 5
+		total     = 10
+	)
+
+	chainID := rand.Uint64()
+	fromHeight := rand.Uint64()
+
+	var backoff testBackOff
+	fetcher := &testFetcher{errs: errs}
+
+	p := provider.NewProviderForT(t, fetcher.Fetch, batchSize, backoff.BackOff)
+
+	var actual []xchain.AggAttestation
+	p.Subscribe(ctx, chainID, fromHeight, func(ctx context.Context, approved xchain.AggAttestation) error {
+		actual = append(actual, approved)
+		if len(actual) == total {
+			cancel()
+		}
+
+		return nil
+	})
+
+	<-ctx.Done()
+
+	require.Empty(t, fetcher.errs) // All errors returned
+	require.Equal(t, total, fetcher.fetched)
+	require.Equal(t, errs+1, backoff.backoff) // 2 errors + 1 empty fetch
+	require.Equal(t, total+errs+1, backoff.reset)
+
+	require.Len(t, actual, total)
+	for i, attestation := range actual {
+		require.Equal(t, chainID, attestation.SourceChainID)
+		require.Equal(t, fromHeight+uint64(i), attestation.BlockHeight)
+	}
+}
+
+// testFetcher implements FetchFunc.
+// It first returns errs errors.
+// Then it returns 0,1,2,3,4,5... attestations up to max.
+type testFetcher struct {
+	errs    int
+	count   int
+	fetched int
+}
+
+func (f *testFetcher) Fetch(_ context.Context, chainID uint64, fromHeight uint64, max uint64,
+) ([]xchain.AggAttestation, error) {
+	if f.errs > 0 {
+		f.errs--
+		return nil, errors.New("test error")
+	}
+
+	toReturn := f.count
+	f.count++
+
+	if toReturn > int(max) {
+		toReturn = int(max)
+	}
+
+	var resp []xchain.AggAttestation
+	for i := 0; i < toReturn; i++ {
+		resp = append(resp, xchain.AggAttestation{
+			BlockHeader: xchain.BlockHeader{
+				SourceChainID: chainID,
+				BlockHeight:   fromHeight + uint64(i),
+			},
+		})
+	}
+
+	f.fetched += len(resp)
+
+	return resp, nil
+}
+
+type testBackOff struct {
+	backoff int
+	reset   int
+}
+
+func (b *testBackOff) BackOff(context.Context) (func(), func()) {
+	return func() { b.backoff++ }, func() { b.reset++ }
+}


### PR DESCRIPTION
Implements a basic cprovider implementation. The actual fetching is still abstracted. This allows using the halo consensus core directly in the mean time while we do not have a halo API.

task: none