### PR TITLE
feat(lib/gitinfo): lib to provide git build info

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -102,6 +102,7 @@ linters:
     - goerr113             # We do not religiously follow the Go 1.13 package level error convention
     - godox                # Allow TODOs
     - gomnd                # Too many false positives
+    - ireturn              # Too many false positives
     - tagliatelle          # Too strict
     - varnamelen           # False positives
     - wsl                  # Way to strict and opinionated

--- a/lib/gitinfo/gitinfo.go
+++ b/lib/gitinfo/gitinfo.go
@@ -1,0 +1,27 @@
+package gitinfo
+
+import "runtime/debug"
+
+// Get returns the git commit hash and timestamp from the runtime build info.
+func Get() (hash string, timestamp string) { //nolint:nonamedreturns // Disambiguate identical return types.
+	hash, timestamp = "unknown", "unknown"
+	hashLen := 7
+
+	info, ok := debug.ReadBuildInfo()
+	if !ok {
+		return hash, timestamp
+	}
+
+	for _, s := range info.Settings {
+		if s.Key == "vcs.revision" {
+			if len(s.Value) < hashLen {
+				hashLen = len(s.Value)
+			}
+			hash = s.Value[:hashLen]
+		} else if s.Key == "vcs.time" {
+			timestamp = s.Value
+		}
+	}
+
+	return hash, timestamp
+}


### PR DESCRIPTION
Adds a simple `gitinfo.Get` library that returns the build-time git commit hash and timestamp. This will be logged on startup by all apps.

task: none
