### PR TITLE
ci(golangcilint): block usage of log package

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -56,9 +56,10 @@ linters-settings:
       # Some configured revive rules
       - name: imports-blacklist
         arguments:
-          - "errors" # Prefer ./lib/errors
-          - "github.com/pkg/errors" # Prefer ./lib/errors
-          - "github.com/gogo/protobuf/proto" # Prefer google.golang.org/protobuf
+          - "log"                                # Prefer ./lib/log
+          - "errors"                             # Prefer ./lib/errors
+          - "github.com/pkg/errors"              # Prefer ./lib/errors
+          - "github.com/gogo/protobuf/proto"     # Prefer google.golang.org/protobuf
           - "github.com/stretchr/testify/assert" # Prefer github.com/stretchr/testify/require
       - name: line-length-limit
         arguments:


### PR DESCRIPTION
Blocks the usage of `log` package, prefer `github.com/omni-network/omni/lib/log`.

task: none