### PR TITLE
ci(goreleaser): fix failing action

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -25,14 +25,16 @@ builds:
     goarch: [ amd64, arm64 ]
 
 dockers:
-  # - ids: [halo]
-  #   dockerfile: ./halo/Dockerfile
-  #   image_templates:
-  #     - omniops/halo:latest
+  - ids: [halo]
+    dockerfile: ./halo/Dockerfile
+    image_templates:
+     - omniops/halo:latest
+
   - ids: [explorer-api]
     dockerfile: ./explorer/api/Dockerfile
     image_templates:
       - omniops/explorer/api:latest
+
   - ids: [indexer]
     dockerfile: ./explorer/indexer/Dockerfile
     image_templates:


### PR DESCRIPTION
Fixes goreleaser action failing since halo docker config was disabled.

task: none
