### PR TITLE
refactor(halo/consensus): rename to comet app

### DIFF
--- a/halo/app/app.go
+++ b/halo/app/app.go
@@ -4,7 +4,7 @@ import (
 	"context"
 
 	"github.com/omni-network/omni/halo/attest"
-	"github.com/omni-network/omni/halo/consensus"
+	"github.com/omni-network/omni/halo/comet"
 	"github.com/omni-network/omni/lib/engine"
 	"github.com/omni-network/omni/lib/errors"
 	"github.com/omni-network/omni/lib/xchain"
@@ -61,19 +61,19 @@ func Run(ctx context.Context, cfg Config) error {
 		return errors.Wrap(err, "create attester")
 	}
 
-	appState, err := consensus.LoadOrGenState(cfg.AppStateDir(), cfg.AppStatePersistInterval)
+	appState, err := comet.LoadOrGenState(cfg.AppStateDir(), cfg.AppStatePersistInterval)
 	if err != nil {
 		return errors.Wrap(err, "load or gen app state")
 	}
 
-	snapshotStore, err := consensus.NewSnapshotStore(cfg.SnapshotDir())
+	snapshotStore, err := comet.NewSnapshotStore(cfg.SnapshotDir())
 	if err != nil {
 		return errors.Wrap(err, "create snapshot store")
 	}
 
-	core := consensus.NewCore(ethCl, attSvc, appState, snapshotStore, cfg.SnapshotInterval)
+	app := comet.NewApp(ethCl, attSvc, appState, snapshotStore, cfg.SnapshotInterval)
 
-	cmtNode, err := newCometNode(ctx, &cfg.Comet, core, privVal)
+	cmtNode, err := newCometNode(ctx, &cfg.Comet, app, privVal)
 	if err != nil {
 		return errors.Wrap(err, "create comet node")
 	}

--- a/halo/comet/app.go
+++ b/halo/comet/app.go
@@ -1,4 +1,4 @@
-package consensus
+package comet
 
 import (
 	"sync"
@@ -10,10 +10,10 @@ import (
 	abci "github.com/cometbft/cometbft/abci/types"
 )
 
-// Core of the Halo consensus client with the following responsibilities:
+// App of the CometBFT consensus application with the following responsibilities:
 // - Implements the server side of the ABCI++ interface, see abci.go.
-// - Maintains the consensus chain state.
-type Core struct {
+// - Maintains the consensus app state.
+type App struct {
 	// Immutable fields (configured at construction)
 	ethCl            engine.API
 	state            *State
@@ -29,11 +29,11 @@ type Core struct {
 	}
 }
 
-// NewCore returns a new Core instance.
-func NewCore(ethCl engine.API, attestSvc attest.Service, state *State, snapshots *SnapshotStore,
+// NewApp returns a new App instance.
+func NewApp(ethCl engine.API, attestSvc attest.Service, state *State, snapshots *SnapshotStore,
 	snapshotInterval uint64,
-) *Core {
-	return &Core{
+) *App {
+	return &App{
 		ethCl:            ethCl,
 		attestSvc:        attestSvc,
 		state:            state,
@@ -44,15 +44,15 @@ func NewCore(ethCl engine.API, attestSvc attest.Service, state *State, snapshots
 
 // ApprovedAggregates returns a copy of the latest state's approved aggregates.
 // For testing purposes only.
-func (c *Core) ApprovedAggregates() []xchain.AggAttestation {
+func (c *App) ApprovedAggregates() []xchain.AggAttestation {
 	return c.state.ApprovedAggregates()
 }
 
 // ApprovedFrom returns a sequential range of approved aggregates from the provided chain ID and height.
 // It returns at most max aggregates. Their block heights are sequentially increasing.
 // For testing purposes only.
-func (c *Core) ApprovedFrom(chainID uint64, height uint64, max uint64) []xchain.AggAttestation {
+func (c *App) ApprovedFrom(chainID uint64, height uint64, max uint64) []xchain.AggAttestation {
 	return c.state.ApprovedFrom(chainID, height, max)
 }
 
-var _ abci.Application = (*Core)(nil)
+var _ abci.Application = (*App)(nil)

--- a/halo/comet/helpers.go
+++ b/halo/comet/helpers.go
@@ -1,4 +1,4 @@
-package consensus
+package comet
 
 import (
 	"bytes"

--- a/halo/comet/snapshot.go
+++ b/halo/comet/snapshot.go
@@ -1,4 +1,4 @@
-package consensus
+package comet
 
 import (
 	"encoding/json"

--- a/halo/comet/state.go
+++ b/halo/comet/state.go
@@ -1,4 +1,4 @@
-package consensus
+package comet
 
 import (
 	"crypto/sha256"


### PR DESCRIPTION
Renames Halo's`consensus.Core` package and type to `comet.App` for more explicit naming since this is our comet application.

task: none