### PR TITLE
ci(refactor): no-parallel for golangcilint and gotests

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,6 +34,7 @@ repos:
     rev: v1.55.2
     hooks:
       - id: golangci-lint
+        require_serial: true # Don't run this in parallel
         # Lint all go files in the repo, since this aligns with github actions.
         entry: golangci-lint run --fix
 
@@ -42,6 +43,7 @@ repos:
       - id: run-go-tests
         name: run-go-tests
         language: script
+        require_serial: true # Don't run this in parallel
         entry: .pre-commit/run_go_tests.sh
         types: [ file, go ]
 


### PR DESCRIPTION
`go test` and `golangci-lint` has built-in performance optimisations so no need to split linted files and run these hooks in parallel. This should also hopefully solve some formatting race conditions I've been seeing locally when fixing imports in files.

task: none
