### PR TITLE
feat(halo/cmd): improve init command

### DIFF
--- a/halo/app/config.go
+++ b/halo/app/config.go
@@ -22,15 +22,16 @@ const (
 	attestStateFile = "xattestations_state.json"
 
 	// defaults.
-	defaultHomeDir                 = "."  // Defaults to current directory
-	defaultAppStatePersistInterval = 1    // Persist app state every block. Set to 0 to disable persistence.
-	defaultSnapshotInterval        = 1000 // Roughly once an hour (given 3s blocks)
+
+	DefaultHomeDir                 = "./halo" // Defaults to "halo" in current directory
+	defaultAppStatePersistInterval = 1        // Persist app state every block. Set to 0 to disable persistence.
+	defaultSnapshotInterval        = 1000     // Roughly once an hour (given 3s blocks)
 )
 
 // DefaultHaloConfig returns the default halo config.
 func DefaultHaloConfig() HaloConfig {
 	return HaloConfig{
-		HomeDir:                 defaultHomeDir,
+		HomeDir:                 DefaultHomeDir,
 		EngineJWTFile:           "", // No default
 		AppStatePersistInterval: defaultAppStatePersistInterval,
 		SnapshotInterval:        defaultSnapshotInterval,

--- a/halo/cmd/init_internal_test.go
+++ b/halo/cmd/init_internal_test.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"context"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -16,7 +17,7 @@ import (
 func TestInitFiles(t *testing.T) {
 	t.Parallel()
 	dir := t.TempDir()
-	err := initFiles(context.Background(), dir)
+	err := initFiles(context.Background(), dir, false)
 	require.NoError(t, err)
 
 	files, err := filepath.Glob(dir + "/**/*")
@@ -28,4 +29,19 @@ func TestInitFiles(t *testing.T) {
 	}
 
 	tutil.RequireGoldenBytes(t, []byte(resp))
+}
+
+func TestInitForce(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+
+	// Create a dummy file
+	err := os.WriteFile(filepath.Join(dir, "dummy"), nil, 0o644)
+	require.NoError(t, err)
+
+	err = initFiles(context.Background(), dir, false)
+	require.ErrorContains(t, err, "unexpected file")
+
+	err = initFiles(context.Background(), dir, true)
+	require.NoError(t, err)
 }

--- a/halo/cmd/testdata/TestCLIReference_halo.golden
+++ b/halo/cmd/testdata/TestCLIReference_halo.golden
@@ -6,7 +6,7 @@ Usage:
 Available Commands:
   completion  Generate the autocompletion script for the specified shell
   help        Help about any command
-  init        Initializes halo files and folders
+  init        Initializes required halo files and directories
   run         Runs the halo consensus client
 
 Flags:

--- a/halo/cmd/testdata/TestCLIReference_init.golden
+++ b/halo/cmd/testdata/TestCLIReference_init.golden
@@ -1,8 +1,25 @@
-Initializes halo files and folders
+Initializes required halo files and directories.
+
+Ensures all the following files and directories exist:
+  <home>/                            # Halo home directory
+  ├── config                         # Config directory
+  │   ├── config.toml                # CometBFT configuration
+  │   ├── genesis.json               # Omni chain genesis file
+  │   ├── halo.toml                  # Halo configuration
+  │   ├── node_key.json              # Node P2P identity key
+  │   └── priv_validator_key.json    # CometBFT private validator key (back this up and keep it safe)
+  ├── data                           # Data directory
+  │   ├── priv_validator_state.json  # CometBFT private validator state (slashing protection)
+  │   ├── snapshots                  # Snapshot directory
+  │   └── xattestations_state.json   # Cross chain attestation state (slashing protection)
+
+Existing files are not overwritten.
+The home directory should only contain subdirectories, no files, use --force to ignore this check.
 
 Usage:
   halo init [flags]
 
 Flags:
+      --force         Force initialization even if home directory contains files
   -h, --help          help for init
-      --home string   The application home directory containing config and data
+      --home string   The application home directory containing config and data (default "./halo")

--- a/halo/cmd/testdata/TestCLIReference_run.golden
+++ b/halo/cmd/testdata/TestCLIReference_run.golden
@@ -6,6 +6,6 @@ Usage:
 Flags:
       --engine-jwt-file string        The path to the Engine API JWT file
   -h, --help                          help for run
-      --home string                   The application home directory containing config and data (default ".")
+      --home string                   The application home directory containing config and data (default "./halo")
       --snapshot-interval uint        The interval (in blocks) at which to create snapshots (default 1000)
       --state-persist-interval uint   The interval (in blocks) at which to persist the app state (default 1)

--- a/halo/cmd/testdata/TestRunCmd_defaults.golden
+++ b/halo/cmd/testdata/TestRunCmd_defaults.golden
@@ -1,11 +1,11 @@
 {
- "HomeDir": ".",
+ "HomeDir": "./halo",
  "EngineJWTFile": "",
  "AppStatePersistInterval": 1,
  "SnapshotInterval": 1000,
  "Comet": {
   "Version": "0.38.3",
-  "RootDir": ".",
+  "RootDir": "./halo",
   "ProxyApp": "tcp://127.0.0.1:26658",
   "Moniker": "testmoniker",
   "DBBackend": "goleveldb",
@@ -20,7 +20,7 @@
   "ABCI": "socket",
   "FilterPeers": false,
   "RPC": {
-   "RootDir": ".",
+   "RootDir": "./halo",
    "ListenAddress": "tcp://127.0.0.1:26657",
    "CORSAllowedOrigins": [],
    "CORSAllowedMethods": [
@@ -52,7 +52,7 @@
    "PprofListenAddress": ""
   },
   "P2P": {
-   "RootDir": ".",
+   "RootDir": "./halo",
    "ListenAddress": "tcp://0.0.0.0:26656",
    "ExternalAddress": "",
    "Seeds": "",
@@ -85,7 +85,7 @@
   },
   "Mempool": {
    "Type": "flood",
-   "RootDir": ".",
+   "RootDir": "./halo",
    "Recheck": true,
    "Broadcast": true,
    "WalPath": "",
@@ -113,7 +113,7 @@
    "Version": "v0"
   },
   "Consensus": {
-   "RootDir": ".",
+   "RootDir": "./halo",
    "WalPath": "data/cs.wal/wal",
    "TimeoutPropose": 3000000000,
    "TimeoutProposeDelta": 500000000,


### PR DESCRIPTION
Improves the `halo init` command with:
- Changes default `--home` to `./halo`.
- more informative `--help` output
- sanity check for inadvertent `halo init` in wrong directories, like repo root.

task: none