### PR TITLE
feat(halo/app): run halo simnet

### DIFF
--- a/halo/app/app.go
+++ b/halo/app/app.go
@@ -2,12 +2,17 @@ package app
 
 import (
 	"context"
+	"time"
 
 	"github.com/omni-network/omni/halo/attest"
 	"github.com/omni-network/omni/halo/comet"
 	"github.com/omni-network/omni/lib/engine"
 	"github.com/omni-network/omni/lib/errors"
+	"github.com/omni-network/omni/lib/gitinfo"
+	"github.com/omni-network/omni/lib/log"
+	"github.com/omni-network/omni/lib/netconf"
 	"github.com/omni-network/omni/lib/xchain"
+	"github.com/omni-network/omni/lib/xchain/provider"
 
 	abci "github.com/cometbft/cometbft/abci/types"
 	cmtconfig "github.com/cometbft/cometbft/config"
@@ -25,27 +30,24 @@ type Config struct {
 
 // Run runs the halo client.
 func Run(ctx context.Context, cfg Config) error {
+	log.Info(ctx, "Starting halo consensus client")
+
+	commit, timestamp := gitinfo.Get()
+	log.Info(ctx, "Version info", "git_commit", commit, "git_timestamp", timestamp)
+
 	// Load private validator key and state from disk (this hard exits on any error).
 	privVal := privval.LoadFilePV(cfg.Comet.PrivValidatorKeyFile(), cfg.Comet.PrivValidatorStateFile())
 
-	network, err := cfg.Network()
+	network, err := netconf.Load(cfg.NetworkFile())
 	if err != nil {
 		return errors.Wrap(err, "load network")
+	} else if err := network.Validate(); err != nil {
+		return errors.Wrap(err, "validate network configuration")
 	}
 
-	omniChain, ok := network.OmniChain()
-	if !ok {
-		return errors.New("omni chain not found in network")
-	}
-
-	jwtBytes, err := engine.LoadJWTHexFile(cfg.EngineJWTFile)
+	ethCl, err := newEthCl(ctx, cfg.HaloConfig, network)
 	if err != nil {
-		return errors.Wrap(err, "load engine JWT file")
-	}
-
-	ethCl, err := engine.NewClient(ctx, omniChain.RPCURL, jwtBytes)
-	if err != nil {
-		return errors.Wrap(err, "create engine client")
+		return err
 	}
 
 	attState, err := attest.LoadState(cfg.AttestStateFile())
@@ -53,8 +55,10 @@ func Run(ctx context.Context, cfg Config) error {
 		return errors.Wrap(err, "load attest state")
 	}
 
-	var xprovider xchain.Provider
-	// TODO(corver): Instantiate xprovider
+	xprovider, err := newXProvider(network)
+	if err != nil {
+		return errors.Wrap(err, "create xchain provider")
+	}
 
 	attSvc, err := attest.NewAttester(ctx, attState, privVal.Key.PrivKey, xprovider, network.ChainIDs())
 	if err != nil {
@@ -78,17 +82,57 @@ func Run(ctx context.Context, cfg Config) error {
 		return errors.Wrap(err, "create comet node")
 	}
 
+	log.Info(ctx, "Starting CometBFT", "listeners", cmtNode.Listeners())
+
 	if err := cmtNode.Start(); err != nil {
 		return errors.Wrap(err, "start comet node")
 	}
 
+	if err := maybeSetupSimnetRelayer(ctx, network, app, xprovider); err != nil {
+		return errors.Wrap(err, "setup simnet relayer")
+	}
+
 	<-ctx.Done()
+	log.Info(ctx, "Shutdown detected, stopping...")
 
 	if err := cmtNode.Stop(); err != nil {
 		return errors.Wrap(err, "stop comet node")
 	}
 
 	return nil
+}
+
+// newXProvider returns a new xchain provider.
+func newXProvider(network netconf.Network) (xchain.Provider, error) {
+	if network.Name == netconf.Simnet {
+		return provider.NewMock(time.Millisecond * 750), nil // Slightly faster than our chain.
+	}
+
+	return nil, errors.New("only simnet is supported at this point")
+}
+
+// newEthCl returns a new engine API client.
+func newEthCl(ctx context.Context, cfg HaloConfig, network netconf.Network) (engine.API, error) {
+	if network.Name == netconf.Simnet {
+		return engine.NewMock()
+	}
+
+	jwtBytes, err := engine.LoadJWTHexFile(cfg.EngineJWTFile)
+	if err != nil {
+		return nil, errors.Wrap(err, "load engine JWT file")
+	}
+
+	omniChain, ok := network.OmniChain()
+	if !ok {
+		return nil, errors.New("omni chain not found in network")
+	}
+
+	ethCl, err := engine.NewClient(ctx, omniChain.RPCURL, jwtBytes)
+	if err != nil {
+		return nil, errors.Wrap(err, "create engine client")
+	}
+
+	return ethCl, nil
 }
 
 func newCometNode(ctx context.Context, config *cmtconfig.Config, app abci.Application, privVal cmttypes.PrivValidator,
@@ -103,6 +147,11 @@ func newCometNode(ctx context.Context, config *cmtconfig.Config, app abci.Applic
 		Indexer: "null",
 	}
 
+	cmtLog, err := newCmtLogger(ctx, config.LogLevel)
+	if err != nil {
+		return nil, err
+	}
+
 	cmtNode, err := node.NewNode(config,
 		privVal,
 		nodeKey,
@@ -110,7 +159,7 @@ func newCometNode(ctx context.Context, config *cmtconfig.Config, app abci.Applic
 		node.DefaultGenesisDocProviderFunc(config),
 		cmtconfig.DefaultDBProvider,
 		node.DefaultMetricsProvider(config.Instrumentation),
-		newCmtLogger(ctx),
+		cmtLog,
 	)
 	if err != nil {
 		return nil, errors.Wrap(err, "create node")

--- a/halo/app/cmtlog.go
+++ b/halo/app/cmtlog.go
@@ -2,7 +2,9 @@ package app
 
 import (
 	"context"
+	"strings"
 
+	"github.com/omni-network/omni/lib/errors"
 	"github.com/omni-network/omni/lib/log"
 
 	cmtlog "github.com/cometbft/cometbft/libs/log"
@@ -10,31 +12,64 @@ import (
 
 var _ cmtlog.Logger = (*cmtLogger)(nil)
 
-// cmtLogger implements cmtlog.Logger by using the omni logging pattern.
-type cmtLogger struct {
-	ctx context.Context //nolint:containedctx // This is a wrapper around the omni logger which is context based.
+const (
+	levelError = iota + 1
+	levelInfo
+	levelDebug
+)
+
+// levels maps strings to numbers for easy comparison.
+//
+//nolint:gochecknoglobals // Global is ok here.
+var levels = map[string]int{
+	"error": levelError,
+	"info":  levelInfo,
+	"debug": levelDebug,
 }
 
-func newCmtLogger(ctx context.Context) cmtLogger {
-	return cmtLogger{
-		ctx: ctx,
+// cmtLogger implements cmtlog.Logger by using the omni logging pattern.
+// Comet log level is controlled separately in config.toml, since comet logs are very noisy.
+type cmtLogger struct {
+	ctx   context.Context //nolint:containedctx // This is a wrapper around the omni logger which is context based.
+	level int
+}
+
+func newCmtLogger(ctx context.Context, levelStr string) (cmtLogger, error) {
+	level, ok := levels[strings.ToLower(levelStr)]
+	if !ok {
+		return cmtLogger{}, errors.New("invalid comet log level", "level", levelStr)
 	}
+
+	return cmtLogger{
+		ctx:   ctx,
+		level: level,
+	}, nil
 }
 
 func (c cmtLogger) Debug(msg string, keyvals ...any) {
+	if c.level < levelDebug {
+		return
+	}
 	log.Debug(c.ctx, msg, keyvals...)
 }
 
 func (c cmtLogger) Info(msg string, keyvals ...any) {
+	if c.level < levelInfo {
+		return
+	}
 	log.Info(c.ctx, msg, keyvals...)
 }
 
 func (c cmtLogger) Error(msg string, keyvals ...any) {
+	if c.level < levelError {
+		return
+	}
 	log.Error(c.ctx, msg, nil, keyvals...)
 }
 
 func (c cmtLogger) With(keyvals ...any) cmtlog.Logger { //nolint:ireturn // This signature is required by interface.
 	return cmtLogger{
-		ctx: log.WithCtx(c.ctx, keyvals...),
+		ctx:   log.WithCtx(c.ctx, keyvals...),
+		level: c.level,
 	}
 }

--- a/halo/app/config.go
+++ b/halo/app/config.go
@@ -6,7 +6,6 @@ import (
 	"text/template"
 
 	"github.com/omni-network/omni/lib/errors"
-	"github.com/omni-network/omni/lib/netconf"
 
 	cmtos "github.com/cometbft/cometbft/libs/os"
 
@@ -51,8 +50,8 @@ func (c HaloConfig) ConfigFile() string {
 	return filepath.Join(c.HomeDir, configDir, configFile)
 }
 
-func (c HaloConfig) Network() (netconf.Network, error) {
-	return netconf.Load(filepath.Join(c.HomeDir, configDir, networkFile))
+func (c HaloConfig) NetworkFile() string {
+	return filepath.Join(c.HomeDir, configDir, networkFile)
 }
 
 func (c HaloConfig) DataDir() string {

--- a/halo/app/simnet.go
+++ b/halo/app/simnet.go
@@ -1,0 +1,66 @@
+package app
+
+import (
+	"context"
+
+	"github.com/omni-network/omni/halo/comet"
+	cprovider "github.com/omni-network/omni/lib/cchain/provider"
+	"github.com/omni-network/omni/lib/errors"
+	"github.com/omni-network/omni/lib/expbackoff"
+	"github.com/omni-network/omni/lib/log"
+	"github.com/omni-network/omni/lib/netconf"
+	"github.com/omni-network/omni/lib/xchain"
+	"github.com/omni-network/omni/lib/xchain/provider"
+	relayer "github.com/omni-network/omni/relayer/app"
+)
+
+// maybeSetupSimnetRelayer sets up the simnet relayer if the network is simnet.
+func maybeSetupSimnetRelayer(ctx context.Context, network netconf.Network, app *comet.App, xprovider xchain.Provider,
+) error {
+	if network.Name != netconf.Simnet {
+		return nil // Skip if not simnet.
+	}
+
+	fetchFunc := func(ctx context.Context, chainID uint64, fromHeight uint64, max uint64,
+	) ([]xchain.AggAttestation, error) {
+		return app.ApprovedFrom(chainID, fromHeight, max), nil
+	}
+
+	backoffFunc := func(ctx context.Context) (func(), func()) {
+		return expbackoff.NewWithReset(ctx, expbackoff.WithFastConfig())
+	}
+
+	cprov := cprovider.NewProviderForT(nil, fetchFunc, 99, backoffFunc)
+
+	mockXPriv, ok := xprovider.(*provider.Mock)
+	if !ok {
+		return errors.New("xchain provider is not a mock")
+	}
+
+	relayer.StartRelayer(ctx, cprov, network.ChainIDs(), mockXPriv, relayer.CreateSubmissions, simnetSender{})
+
+	return nil
+}
+
+var _ relayer.Sender = simnetSender{}
+
+// simnetSender implements relayer.Sender for simnet by just logging.
+type simnetSender struct{}
+
+func (simnetSender) SendTransaction(ctx context.Context, submission xchain.Submission) error {
+	var destChainID, offset uint64
+	for _, msg := range submission.Msgs {
+		destChainID = msg.DestChainID
+		offset = msg.StreamOffset
+
+		break
+	}
+
+	log.Info(ctx, "Simnet relayer sending transaction",
+		"dest_chain", destChainID,
+		"msgs", len(submission.Msgs),
+		"first_offset", offset,
+	)
+
+	return nil
+}

--- a/halo/cmd/cmd.go
+++ b/halo/cmd/cmd.go
@@ -32,6 +32,10 @@ func newRunCmd(runFunc func(context.Context, app.Config) error) *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
 
+			if err := logConfig(ctx, cmd.Flags()); err != nil {
+				return err
+			}
+
 			var err error
 			cfg.Comet, err = parseCometConfig(ctx, cfg.HomeDir)
 			if err != nil {
@@ -42,7 +46,7 @@ func newRunCmd(runFunc func(context.Context, app.Config) error) *cobra.Command {
 		},
 	}
 
-	bindHaloFlags(cmd.Flags(), &cfg.HaloConfig)
+	bindRunFlags(cmd.Flags(), &cfg.HaloConfig)
 
 	return cmd
 }

--- a/halo/cmd/cometconfig.go
+++ b/halo/cmd/cometconfig.go
@@ -9,6 +9,7 @@ import (
 	"github.com/omni-network/omni/lib/log"
 
 	cfg "github.com/cometbft/cometbft/config"
+	"github.com/cometbft/cometbft/types"
 
 	"github.com/spf13/viper"
 )
@@ -36,8 +37,18 @@ func defaultCometConfig(homeDir string) cfg.Config {
 
 	conf.RootDir = homeDir
 	conf.SetRoot(conf.RootDir)
+	conf.LogLevel = "error" // Decrease default comet log level, it is super noisy.
 
 	return *conf
+}
+
+// defaultConsensusParams returns the default cometBFT consensus params for omni protocol.
+func defaultConsensusParams() *types.ConsensusParams {
+	resp := types.DefaultConsensusParams()
+	resp.ABCI.VoteExtensionsEnableHeight = 1                             // Enable vote extensions from the start.
+	resp.Validator.PubKeyTypes = []string{types.ABCIPubKeyTypeSecp256k1} // Only k1 keys.
+
+	return resp
 }
 
 // parseCometConfig parses the cometBFT config from disk and verifies it.

--- a/halo/cmd/flags.go
+++ b/halo/cmd/flags.go
@@ -2,15 +2,46 @@
 package cmd
 
 import (
+	"context"
+	"strings"
+
 	"github.com/omni-network/omni/halo/app"
 	libcmd "github.com/omni-network/omni/lib/cmd"
+	"github.com/omni-network/omni/lib/log"
 
 	"github.com/spf13/pflag"
 )
 
-func bindHaloFlags(flags *pflag.FlagSet, cfg *app.HaloConfig) {
+func bindRunFlags(flags *pflag.FlagSet, cfg *app.HaloConfig) {
 	libcmd.BindHomeFlag(flags, &cfg.HomeDir)
 	flags.StringVar(&cfg.EngineJWTFile, "engine-jwt-file", cfg.EngineJWTFile, "The path to the Engine API JWT file")
 	flags.Uint64Var(&cfg.AppStatePersistInterval, "state-persist-interval", cfg.AppStatePersistInterval, "The interval (in blocks) at which to persist the app state")
 	flags.Uint64Var(&cfg.SnapshotInterval, "snapshot-interval", cfg.SnapshotInterval, "The interval (in blocks) at which to create snapshots")
+}
+
+func bindInitFlags(flags *pflag.FlagSet, cfg *initConfig) {
+	libcmd.BindHomeFlag(flags, &cfg.HomeDir)
+	flags.StringVar(&cfg.Network, "network", cfg.Network, "The network to initialize")
+	flags.BoolVar(&cfg.Force, "force", cfg.Force, "Force initialization (overwrite existing files)")
+}
+
+// logConfig logs the config struct kv pairs.
+func logConfig(ctx context.Context, flags *pflag.FlagSet) error {
+	skip := map[string]bool{
+		"help": true,
+	}
+	// Flatten config into key/value pairs for logging.
+	var fields []any
+	flags.VisitAll(func(f *pflag.Flag) {
+		if skip[f.Name] {
+			return
+		}
+		// TODO(corver): Allow dashes for one-to-one mapping with actual flags?
+		fields = append(fields, strings.ReplaceAll(f.Name, "-", "_"))
+		fields = append(fields, f.Value)
+	})
+
+	log.Info(ctx, "Parsed config from flags", fields...)
+
+	return nil
 }

--- a/halo/cmd/init.go
+++ b/halo/cmd/init.go
@@ -2,20 +2,18 @@ package cmd
 
 import (
 	"context"
-	"fmt"
 	"os"
 	"path/filepath"
 
 	"github.com/omni-network/omni/halo/app"
 	"github.com/omni-network/omni/halo/attest"
-	libcmd "github.com/omni-network/omni/lib/cmd"
 	"github.com/omni-network/omni/lib/errors"
 	"github.com/omni-network/omni/lib/log"
+	"github.com/omni-network/omni/lib/netconf"
 
 	cmtconfig "github.com/cometbft/cometbft/config"
 	k1 "github.com/cometbft/cometbft/crypto/secp256k1"
 	cmtos "github.com/cometbft/cometbft/libs/os"
-	cmtrand "github.com/cometbft/cometbft/libs/rand"
 	"github.com/cometbft/cometbft/p2p"
 	"github.com/cometbft/cometbft/privval"
 	"github.com/cometbft/cometbft/types"
@@ -24,12 +22,20 @@ import (
 	"github.com/spf13/cobra"
 )
 
+type initConfig struct {
+	HomeDir string
+	Network string
+	Force   bool
+}
+
 // newInitCmd returns a new cobra command that initializes the files and folders required by halo.
 func newInitCmd() *cobra.Command {
-	var (
-		homeDir = app.DefaultHomeDir
-		force   bool
-	)
+	// Default config flags
+	cfg := initConfig{
+		HomeDir: app.DefaultHomeDir,
+		Network: netconf.Simnet,
+		Force:   false,
+	}
 
 	cmd := &cobra.Command{
 		Use:   "init",
@@ -42,6 +48,7 @@ Ensures all the following files and directories exist:
   │   ├── config.toml                # CometBFT configuration
   │   ├── genesis.json               # Omni chain genesis file
   │   ├── halo.toml                  # Halo configuration
+  │   ├── network.json               # Omni network configuration
   │   ├── node_key.json              # Node P2P identity key
   │   └── priv_validator_key.json    # CometBFT private validator key (back this up and keep it safe)
   ├── data                           # Data directory
@@ -53,26 +60,35 @@ Existing files are not overwritten.
 The home directory should only contain subdirectories, no files, use --force to ignore this check.
 `,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return initFiles(cmd.Context(), homeDir, force)
+			ctx := cmd.Context()
+			if err := logConfig(ctx, cmd.Flags()); err != nil {
+				return err
+			}
+
+			return initFiles(cmd.Context(), cfg)
 		},
 	}
 
-	libcmd.BindHomeFlag(cmd.Flags(), &homeDir)
-	cmd.Flags().BoolVar(&force, "force", false, "Force initialization even if home directory contains files")
+	bindInitFlags(cmd.Flags(), &cfg)
 
 	return cmd
 }
 
 // initFiles initializes the files and folders required by halo.
-// If no other genesis file exists, it will create a devnet genesis file.
+// It ensures a network and genesis file is generated/downloaded for the provided network.
 //
-//nolint:revive // Force bool is ok.
-func initFiles(ctx context.Context, homeDir string, force bool) error {
-	log.Info(ctx, "Initializing files and directories", "home", homeDir, "force", force)
+//nolint:gocognit // This is just many sequential steps.
+func initFiles(ctx context.Context, initCfg initConfig) error {
+	log.Info(ctx, "Initializing halo files and directories")
+	homeDir := initCfg.HomeDir
+
+	if initCfg.Network != netconf.Simnet {
+		return errors.New("only simnet is supported for now")
+	}
 
 	// Quick sanity check if --home contains files (it should only contain dirs).
 	// This prevents accidental initialization in wrong current dir.
-	if !force {
+	if !initCfg.Force {
 		files, _ := os.ReadDir(homeDir) // Ignore error, we'll just assume it's empty.
 		for _, file := range files {
 			if file.IsDir() { // Ignore directories
@@ -158,16 +174,38 @@ func initFiles(ctx context.Context, homeDir string, force bool) error {
 		log.Info(ctx, "Generated node key", "path", nodeKeyFile)
 	}
 
+	//  Setup network file
+	networkFile := cfg.NetworkFile()
+	if cmtos.FileExists(networkFile) {
+		log.Info(ctx, "Found network config", "path", networkFile)
+	} else {
+		// Create a simnet (single binary with mocked clients).
+		network := netconf.Network{
+			Name: initCfg.Network,
+			Chains: []netconf.Chain{
+				{
+					ID:     999,
+					Name:   "omni",
+					IsOmni: true,
+				},
+			},
+		}
+		if err := netconf.Save(network, networkFile); err != nil {
+			return errors.Wrap(err, "save network file")
+		}
+		log.Info(ctx, "Generated simnet network config", "path", networkFile)
+	}
+
 	// Setup genesis file
 	genFile := comet.GenesisFile()
 	if cmtos.FileExists(genFile) {
 		log.Info(ctx, "Found genesis file", "path", genFile)
 	} else {
-		// Create a devnet genesis file with this node as single validator.
+		// Create a simnet genesis file with this node as single validator.
 		genDoc := types.GenesisDoc{
-			ChainID:         fmt.Sprintf("dev-%s", cmtrand.Str(6)),
+			ChainID:         initCfg.Network,
 			GenesisTime:     cmttime.Now(),
-			ConsensusParams: types.DefaultConsensusParams(),
+			ConsensusParams: defaultConsensusParams(),
 		}
 		pubKey, err := pv.GetPubKey()
 		if err != nil {
@@ -184,7 +222,7 @@ func initFiles(ctx context.Context, homeDir string, force bool) error {
 		if err := genDoc.SaveAs(genFile); err != nil {
 			return errors.Wrap(err, "save genesis file")
 		}
-		log.Info(ctx, "Generated devnet genesis file", "path", genFile)
+		log.Info(ctx, "Generated simnet genesis file", "path", genFile)
 	}
 
 	// Attest state

--- a/halo/cmd/init_internal_test.go
+++ b/halo/cmd/init_internal_test.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/omni-network/omni/lib/netconf"
 	"github.com/omni-network/omni/test/tutil"
 
 	"github.com/stretchr/testify/require"
@@ -17,7 +18,11 @@ import (
 func TestInitFiles(t *testing.T) {
 	t.Parallel()
 	dir := t.TempDir()
-	err := initFiles(context.Background(), dir, false)
+	cfg := initConfig{
+		HomeDir: dir,
+		Network: netconf.Simnet,
+	}
+	err := initFiles(context.Background(), cfg)
 	require.NoError(t, err)
 
 	files, err := filepath.Glob(dir + "/**/*")
@@ -39,9 +44,15 @@ func TestInitForce(t *testing.T) {
 	err := os.WriteFile(filepath.Join(dir, "dummy"), nil, 0o644)
 	require.NoError(t, err)
 
-	err = initFiles(context.Background(), dir, false)
+	cfg := initConfig{
+		HomeDir: dir,
+		Network: netconf.Simnet,
+	}
+
+	err = initFiles(context.Background(), cfg)
 	require.ErrorContains(t, err, "unexpected file")
 
-	err = initFiles(context.Background(), dir, true)
+	cfg.Force = true
+	err = initFiles(context.Background(), cfg)
 	require.NoError(t, err)
 }

--- a/halo/cmd/testdata/TestCLIReference_init.golden
+++ b/halo/cmd/testdata/TestCLIReference_init.golden
@@ -6,6 +6,7 @@ Ensures all the following files and directories exist:
   │   ├── config.toml                # CometBFT configuration
   │   ├── genesis.json               # Omni chain genesis file
   │   ├── halo.toml                  # Halo configuration
+  │   ├── network.json               # Omni network configuration
   │   ├── node_key.json              # Node P2P identity key
   │   └── priv_validator_key.json    # CometBFT private validator key (back this up and keep it safe)
   ├── data                           # Data directory
@@ -20,6 +21,7 @@ Usage:
   halo init [flags]
 
 Flags:
-      --force         Force initialization even if home directory contains files
-  -h, --help          help for init
-      --home string   The application home directory containing config and data (default "./halo")
+      --force            Force initialization (overwrite existing files)
+  -h, --help             help for init
+      --home string      The application home directory containing config and data (default "./halo")
+      --network string   The network to initialize (default "simnet")

--- a/halo/cmd/testdata/TestInitFiles.golden
+++ b/halo/cmd/testdata/TestInitFiles.golden
@@ -1,6 +1,7 @@
 /config/config.toml
 /config/genesis.json
 /config/halo.toml
+/config/network.json
 /config/node_key.json
 /config/priv_validator_key.json
 /data/priv_validator_state.json

--- a/halo/cmd/testdata/TestRunCmd_defaults.golden
+++ b/halo/cmd/testdata/TestRunCmd_defaults.golden
@@ -10,7 +10,7 @@
   "Moniker": "testmoniker",
   "DBBackend": "goleveldb",
   "DBPath": "data",
-  "LogLevel": "info",
+  "LogLevel": "error",
   "LogFormat": "plain",
   "Genesis": "config/genesis.json",
   "PrivValidatorKey": "config/priv_validator_key.json",

--- a/halo/cmd/testdata/TestRunCmd_flags.golden
+++ b/halo/cmd/testdata/TestRunCmd_flags.golden
@@ -10,7 +10,7 @@
   "Moniker": "testmoniker",
   "DBBackend": "goleveldb",
   "DBPath": "data",
-  "LogLevel": "info",
+  "LogLevel": "error",
   "LogFormat": "plain",
   "Genesis": "config/genesis.json",
   "PrivValidatorKey": "config/priv_validator_key.json",

--- a/halo/cmd/testdata/TestRunCmd_json_files.golden
+++ b/halo/cmd/testdata/TestRunCmd_json_files.golden
@@ -10,7 +10,7 @@
   "Moniker": "testmoniker",
   "DBBackend": "goleveldb",
   "DBPath": "data",
-  "LogLevel": "info",
+  "LogLevel": "error",
   "LogFormat": "plain",
   "Genesis": "config/genesis.json",
   "PrivValidatorKey": "config/priv_validator_key.json",

--- a/halo/cmd/testdata/TestRunCmd_toml_files.golden
+++ b/halo/cmd/testdata/TestRunCmd_toml_files.golden
@@ -10,7 +10,7 @@
   "Moniker": "config.toml",
   "DBBackend": "goleveldb",
   "DBPath": "data",
-  "LogLevel": "info",
+  "LogLevel": "error",
   "LogFormat": "plain",
   "Genesis": "config/genesis.json",
   "PrivValidatorKey": "config/priv_validator_key.json",

--- a/lib/netconf/netconf.go
+++ b/lib/netconf/netconf.go
@@ -13,8 +13,19 @@ import (
 // It spans an omni chain (both execution and consensus) and a set of
 // supported rollup EVMs.
 type Network struct {
-	Name   string  `json:"name"`   // Name of the network. e.g. "testnet", "staging", "mainnet"
+	Name   string  `json:"name"`   // Name of the network. e.g. "simnet", "testnet", "staging", "mainnet"
 	Chains []Chain `json:"chains"` // Chains that are part of the network
+}
+
+// Validate returns an error if the configuration is invalid.
+func (n Network) Validate() error {
+	if !supported[n.Name] {
+		return errors.New("unsupported network", "name", n.Name)
+	}
+
+	// TODO(corver): Validate chains
+
+	return nil
 }
 
 // ChainIDs returns the all chain IDs in the network.

--- a/lib/netconf/network.go
+++ b/lib/netconf/network.go
@@ -1,0 +1,35 @@
+package netconf
+
+const (
+	// Simnet is a simulated network for very simple testing of individual binaries.
+	// It is a single binary with mocked clients (no networking).
+	Simnet = "simnet" // Single binary with mocked clients (no network)
+
+	// Devnet is the most basic single-machine deployment of the Omni cross chain protocol.
+	// It uses docker compose to setup a network with multi containers.
+	// E.g. 2 geth nodes, 4 halo validators, a relayer, and 2 anvil rollups.
+	Devnet = "devnet"
+
+	// Staging is the Omni team's internal staging network, similar to a internal testnet.
+	// It connects to real public rollup testnets (e.g. Arbitrum testnet).
+	// It is deployed to GCP using terraform.
+	// E.g. 1 Erigon, 1 Geth, 4 halo validators, 2 halo sentries, 1 relayer.
+	Staging = "staging"
+
+	// Testnet is the Omni public testnet.
+	Testnet = "testnet"
+
+	// Mainnet is the Omni public mainnet.
+	Mainnet = "mainnet"
+)
+
+// supported is a map of supported networks.
+//
+//nolint:gochecknoglobals // Global state here is fine.
+var supported = map[string]bool{
+	Simnet:  true,
+	Devnet:  false,
+	Staging: false,
+	Testnet: false,
+	Mainnet: false,
+}


### PR DESCRIPTION
Improves halo in order to run a simple single binary `simnet` from the command line.

Improvements include:
- Decrease comet bft logging to `error` by default since it is very noisy
- Add basic info logs to halo comet app
- Log all flags on startup
- Introduce explicit network types in `netconf` including `simnet` (only network supported at this point)
- Generate `network.json` for simnet in `init`
- Fix default comet consensus params for omni.
- Add convenience `log.Hex7` to log hashes with less noise.

task: none
