### PR TITLE
ci(*): notify slack on ci failures

### DIFF
--- a/.github/workflows/slack.yml
+++ b/.github/workflows/slack.yml
@@ -1,0 +1,21 @@
+name: ci notify
+
+# run after all workflows on main
+on:
+  workflow_run:
+    workflows: ["*"]
+    branches: [main]
+
+jobs:
+  notify:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Notify Slack Action
+        uses: ravsamhq/notify-slack-action@2.3.0
+        if: always()
+        with:
+          status: ${{ job.status }}
+          notify_when: "failure"
+          notification_title: "{workflow} is failing"
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}


### PR DESCRIPTION
Added a slack webhook, and running a notify action after every workflow run on main, and notifying us on those that fail. In the documentation, t's unclear if `"*"` syntax is supported, and if it doesn't work we'll need to add which workflows we want to check.

The current webhook uses the #eng channel. If this becomes too noisy, we can easily move it to #alerts. But resolving failures on `main` should be high pri, so I kept it in #eng for now.

task: none