### PR TITLE
fix(ci): update slack notify workflow

### DIFF
--- a/.github/workflows/slack.yml
+++ b/.github/workflows/slack.yml
@@ -1,6 +1,6 @@
 name: ci notify
 
-# run after all workflows on main
+# run after specified workflows on main
 on:
   workflow_run:
     workflows: ["pre-commit hooks", "go tests", "go releaser", "go lint"]
@@ -12,10 +12,10 @@ jobs:
     steps:
       - name: Notify Slack Action
         uses: ravsamhq/notify-slack-action@2.3.0
-        if: always()
+        if: ${{ github.event.workflow_run.conclusion == 'failure' }}
         with:
-          status: ${{ job.status }}
-          notify_when: "failure"
-          notification_title: "{workflow} is failing"
+          status: "${{github.event.workflow_run.name}} is failing"
+          notification_title: "CI run failed on ${{github.event.workflow_run.head_branch}}"
+          footer: "url: ${{github.event.workflow_run.html_url}}"
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}


### PR DESCRIPTION
Fix:
- Since we previously used `workflows: ["*"]`, it ran recursively on itself
- Don't use `job.status`, since that's only checking the status of this job, which always succeeds. We need to check the status of the workflow run we were running this after

Add:
- metadata to the slack message. we can add more as we see fit

task: none