### PR TITLE
fix(ci): use native slack action

### DIFF
--- a/.github/workflows/slack.yml
+++ b/.github/workflows/slack.yml
@@ -1,21 +1,39 @@
 name: ci notify
 
-# run after specified workflows on main
+# run after all completed workflows on main
 on:
   workflow_run:
-    workflows: ["pre-commit hooks", "go tests", "go releaser", "go lint"]
+    workflows: ["*"]
     branches: [main]
+    types: [completed]
 
 jobs:
   notify:
     runs-on: ubuntu-latest
     steps:
-      - name: Notify Slack Action
-        uses: ravsamhq/notify-slack-action@2.3.0
+      - name: Notify Slack
+        uses: slackapi/slack-github-action@v1.24.0
         if: ${{ github.event.workflow_run.conclusion == 'failure' }}
         with:
-          status: "${{github.event.workflow_run.name}} is failing"
-          notification_title: "CI run failed on ${{github.event.workflow_run.head_branch}}"
-          footer: "url: ${{github.event.workflow_run.html_url}}"
+          payload: |
+            {
+              "blocks": [
+                {
+                  "type": "header",
+                  "text": {
+                    "type": "plain_text",
+                    "text": "CI failed on ${{github.event.workflow_run.head_branch}}"
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "${{ github.event.workflow_run.name }} is failing. See here: ${{github.event.workflow_run.html_url}}"
+                  }
+                }
+              ]
+            }
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK


### PR DESCRIPTION
3rd times the charm?
- It was previously triggering 3 times for each workflow (requested, in progress, completed) - we only need to run this when a workflow is `completed`
- We can go back to using "*", I mistook the ^ runs as recursive
- Use slack's native action, rather than a third party, since we don't need that additional config. And it didn't work nicely with how we're using to follow up on multiple workflows. It's typically used as a step in a job.
- Use slack's [Block Kit](https://api.slack.com/block-kit/building) for building the message. Kind of annoying, but it's fine.

task: none