### PR TITLE
fix(xchain/provider): support restarting simnet

### DIFF
--- a/halo/comet/abci.go
+++ b/halo/comet/abci.go
@@ -5,6 +5,7 @@ import (
 	"math/big"
 
 	"github.com/omni-network/omni/lib/errors"
+	"github.com/omni-network/omni/lib/log"
 
 	abci "github.com/cometbft/cometbft/abci/types"
 
@@ -152,11 +153,15 @@ func (a *App) ProcessProposal(ctx context.Context, req *abci.RequestProcessPropo
 }
 
 // ExtendVote extends a vote with application-injected data (vote extensions).
-func (a *App) ExtendVote(context.Context, *abci.RequestExtendVote) (*abci.ResponseExtendVote, error) {
-	attBytes, err := encode(a.attestSvc.GetAvailable())
+func (a *App) ExtendVote(ctx context.Context, _ *abci.RequestExtendVote) (*abci.ResponseExtendVote, error) {
+	atts := a.attestSvc.GetAvailable()
+
+	attBytes, err := encode(atts)
 	if err != nil {
 		return nil, err
 	}
+
+	log.Info(ctx, "Attesting to rollup blocks", "attestations", len(atts))
 
 	return &abci.ResponseExtendVote{
 		VoteExtension: attBytes,

--- a/lib/log/attrs.go
+++ b/lib/log/attrs.go
@@ -1,0 +1,19 @@
+package log
+
+import (
+	"encoding/hex"
+	"log/slog"
+)
+
+// Hex7 is a convenience function for a hex-encoded log attribute limited to first 7 chars for brevity.
+// Note this is NOT 0x prefixed.
+func Hex7(key string, value []byte) slog.Attr {
+	h := hex.EncodeToString(value)
+
+	const maxLen = 7
+	if len(h) > maxLen {
+		h = h[:maxLen]
+	}
+
+	return slog.String(key, h)
+}

--- a/lib/xchain/provider/mock_internal_test.go
+++ b/lib/xchain/provider/mock_internal_test.go
@@ -15,7 +15,7 @@ func TestMock(t *testing.T) {
 
 	const (
 		chainID    = 123
-		fromHeight = 456
+		fromHeight = 0
 		total      = 5
 	)
 
@@ -38,8 +38,8 @@ func TestMock(t *testing.T) {
 	// Just some very basic sanity checks
 	assertMsgs(t, blocks[0].Msgs, 0, 0)
 	assertMsgs(t, blocks[1].Msgs, 1, 0)
-	assertMsgs(t, blocks[2].Msgs, 0, 1)
-	assertMsgs(t, blocks[3].Msgs, 1, 1)
+	assertMsgs(t, blocks[2].Msgs, 1, 1)
+	assertMsgs(t, blocks[3].Msgs, 2, 1)
 	assertMsgs(t, blocks[4].Msgs, 0, 0)
 
 	assertOffsets(t, blocks)


### PR DESCRIPTION
Refactor xprovider mock to provide consistent offsets even if simnet app is restarted and we start streaming from non-zero height. This allows testing simnet restarts.

Also improve relayer sanity checks.

Also improve logging slightly.

task: none