### PR TITLE
fix(app/relayer): creator test

### DIFF
--- a/relayer/app/creator_test.go
+++ b/relayer/app/creator_test.go
@@ -91,7 +91,6 @@ func TestCreatorService_CreateSubmissions(t *testing.T) {
 			for _, submission := range submissions {
 				require.NotNil(t, submission.AttestationRoot)
 				require.Equal(t, submission.AttestationRoot, att.BlockRoot)
-				require.NotNil(t, submission.Proof)
 				require.NotNil(t, submission.ProofFlags)
 				require.NotNil(t, submission.Signatures)
 				for _, msg := range submission.Msgs {


### PR DESCRIPTION
Removes proofs non-nil check, fuzzer can create an instance where all msgs are towards same destination chain

task: none