### PR TITLE
ci(*): format slack notification

### DIFF
--- a/.github/workflows/slack.yml
+++ b/.github/workflows/slack.yml
@@ -22,7 +22,7 @@ jobs:
                   "type": "section",
                   "text": {
                     "type": "mrkdwn",
-                    "text": "🚨 CI failed on `${{github.event.workflow_run.head_branch}}`. *${{ github.event.workflow_run.name }}* was unsuccessful."
+                    "text": "🚨 CI failed on `${{ github.event.workflow_run.head_branch }}`. *${{ github.event.workflow_run.name }}* was unsuccessful."
                   }
                 },
                 {
@@ -35,7 +35,7 @@ jobs:
                     },
                     {
                       "type": "mrkdwn",
-                      "text": "by: ${{github.event.workflow_run.head_commit.author}} \n url: ${{github.event.workflow_run.html_url}}"
+                      "text": "by: ${{ github.event.workflow_run.head_commit.author }} \n url: ${{ github.event.workflow_run.html_url }}"
                     }
                   ]
                 }


### PR DESCRIPTION
- don't use the header block, it's too bulky
- add footer with commit author and workflow run URL
- tested [here](https://app.slack.com/block-kit-builder/T025RDRS8A0#%7B%22blocks%22:%5B%7B%22type%22:%22section%22,%22text%22:%7B%22type%22:%22mrkdwn%22,%22text%22:%22%F0%9F%9A%A8%20CI%20failed%20on%20%60$%7B%7Bgithub.event.workflow_run.head_branch%7D%7D%60.%20*$%7B%7B%20github.event.workflow_run.name%20%7D%7D*%20was%20unsuccessful.%22%7D%7D,%7B%22type%22:%22context%22,%22elements%22:%5B%7B%22type%22:%22image%22,%22image_url%22:%22https://upload.wikimedia.org/wikipedia/commons/4/43/Minimalist_info_Icon.png%22,%22alt_text%22:%22images%22%7D,%7B%22type%22:%22mrkdwn%22,%22text%22:%22by:%20$%7B%7Bgithub.event.workflow_run.head_commit.author%7D%7D%20%5Cn%20url:%20$%7B%7Bgithub.event.workflow_run.html_url%7D%7D%22%7D%5D%7D%5D%7D)

Preview:
<img width="508" alt="Screenshot 2024-01-22 at 2 28 33 PM" src="https://github.com/omni-network/omni/assets/31632172/090c8416-6702-4241-8dca-58313bd0146b">


task: none
