### PR TITLE
test(e2e): fixes for simple e2e test

### DIFF
--- a/halo/app/cmtlog.go
+++ b/halo/app/cmtlog.go
@@ -64,7 +64,10 @@ func (c cmtLogger) Error(msg string, keyvals ...any) {
 	if c.level < levelError {
 		return
 	}
-	log.Error(c.ctx, msg, nil, keyvals...)
+
+	keyvals, err := splitOutError(keyvals)
+
+	log.Error(c.ctx, msg, err, keyvals...)
 }
 
 func (c cmtLogger) With(keyvals ...any) cmtlog.Logger { //nolint:ireturn // This signature is required by interface.
@@ -72,4 +75,19 @@ func (c cmtLogger) With(keyvals ...any) cmtlog.Logger { //nolint:ireturn // This
 		ctx:   log.WithCtx(c.ctx, keyvals...),
 		level: c.level,
 	}
+}
+
+// splitOutError splits the keyvals into a slice of keyvals without the error and the error.
+func splitOutError(keyvals []any) ([]any, error) {
+	var remaining []any
+	var err error
+	for i := 0; i < len(keyvals); i += 2 {
+		if keyErr, ok := keyvals[i+1].(error); ok {
+			err = keyErr
+		} else {
+			remaining = append(remaining, keyvals[i], keyvals[i+1])
+		}
+	}
+
+	return remaining, err
 }

--- a/lib/engine/fuzz.go
+++ b/lib/engine/fuzz.go
@@ -2,6 +2,7 @@ package engine
 
 import (
 	"math/big"
+	"time"
 
 	"github.com/ethereum/go-ethereum/beacon/engine"
 	"github.com/ethereum/go-ethereum/common"
@@ -12,8 +13,13 @@ import (
 )
 
 // NewFuzzer returns a new fuzzer for valid Engine API types.
-func NewFuzzer() *fuzz.Fuzzer {
-	f := fuzz.New().NilChance(0)
+// If seed is zero, it uses current nano time as the seed.
+func NewFuzzer(seed int64) *fuzz.Fuzzer {
+	if seed == 0 {
+		seed = time.Now().UnixNano()
+	}
+
+	f := fuzz.NewWithSeed(seed).NilChance(0)
 	f.Funcs(
 		func(h *types.Header, c fuzz.Continue) {
 			c.FuzzNoCustom(h)

--- a/lib/engine/fuzz_test.go
+++ b/lib/engine/fuzz_test.go
@@ -12,7 +12,7 @@ import (
 
 func TestFuzzer(t *testing.T) {
 	t.Parallel()
-	f := engineclient.NewFuzzer()
+	f := engineclient.NewFuzzer(0)
 
 	var payload engine.ExecutableData
 	f.Fuzz(&payload)

--- a/lib/log/log_test.go
+++ b/lib/log/log_test.go
@@ -10,6 +10,8 @@ import (
 	"github.com/omni-network/omni/lib/errors"
 	"github.com/omni-network/omni/lib/log"
 	"github.com/omni-network/omni/test/tutil"
+
+	pkgerrors "github.com/pkg/errors"
 )
 
 //go:generate go test . -update -clean
@@ -20,22 +22,30 @@ func TestSimpleLogs(t *testing.T) {
 
 	AssertLogging(t, func(t *testing.T, ctx context.Context) {
 		t.Helper()
-
-		log.Info(ctx, "info message", "with", "args")
-		log.Debug(ctx, "debug this code for me please", "number", 1)
-		log.Warn(ctx, "watch out!", os.ErrExist)
-		log.Error(ctx, "something went wrong", io.EOF, "float", 1.234)
-
-		err := errors.New("first", "1", 1)
-		log.Warn(ctx, "err1", err)
-		err = errors.Wrap(err, "second", "2", 2)
-		log.Error(ctx, "err2", err)
-
-		// Test attributes in context
-		ctx1 := log.WithCtx(ctx, "ctx_key1", "ctx_value1")
-		log.Debug(ctx1, "ctx debug message", "debug_key1", "debug_value1")
-		ctx2 := log.WithCtx(ctx1, "ctx_key2", "ctx_value2")
-		log.Info(ctx2, "ctx info message", "info_key2", "info_value2")
+		{ // Test some basic logging
+			log.Info(ctx, "info message", "with", "args")
+			log.Debug(ctx, "debug this code for me please", "number", 1)
+			log.Warn(ctx, "watch out!", os.ErrExist)
+			log.Error(ctx, "something went wrong", io.EOF, "float", 1.234)
+		}
+		{ // Test errors wrapping and logging
+			err := errors.New("first", "1", 1)
+			log.Warn(ctx, "err1", err)
+			err = errors.Wrap(err, "second", "2", 2)
+			log.Error(ctx, "err2", err)
+		}
+		{ // Test attributes in context
+			ctx1 := log.WithCtx(ctx, "ctx_key1", "ctx_value1")
+			log.Debug(ctx1, "ctx debug message", "debug_key1", "debug_value1")
+			ctx2 := log.WithCtx(ctx1, "ctx_key2", "ctx_value2")
+			log.Info(ctx2, "ctx info message", "info_key2", "info_value2")
+		}
+		{ // Test cometBFT wrapping our errors in pkg errors
+			err := errors.New("new", "new", "new")
+			err = errors.Wrap(err, "omni wrap", "wrap", "wrap")
+			err = pkgerrors.Wrap(err, "pkg wrap")
+			log.Warn(ctx, "Pkg wrapped error", err)
+		}
 	})
 }
 

--- a/lib/log/logger.go
+++ b/lib/log/logger.go
@@ -72,3 +72,10 @@ func LoggersForT(_ *testing.T) map[string]func(...func(*TestOptions)) *slog.Logg
 		"console": newConsoleLogger,
 	}
 }
+
+// WithNoopLogger returns a copy of the context with a noop logger which discards all logs.
+func WithNoopLogger(ctx context.Context) context.Context {
+	return WithLogger(ctx, newConsoleLogger(func(o *TestOptions) {
+		o.Writer = io.Discard
+	}))
+}

--- a/lib/log/testdata/TestSimpleLogs_console.golden
+++ b/lib/log/testdata/TestSimpleLogs_console.golden
@@ -2,7 +2,8 @@
 00-00-00 00:00:00 DEBU debug this code for me please number=1
 00-00-00 00:00:00 WARN watch out! err="file already exists"
 00-00-00 00:00:00 ERRO something went wrong float=1.234 err=EOF
-00-00-00 00:00:00 WARN err1 err=first 1=1 stacktrace="[log_test.go:29 log_test.go:62 testing.go:1595]"
-00-00-00 00:00:00 ERRO err2 err="second: first" 2=2 1=1 stacktrace="[log_test.go:31 log_test.go:62 testing.go:1595]"
+00-00-00 00:00:00 WARN err1 err=first 1=1 stacktrace="[log_test.go:32 log_test.go:72 testing.go:1595]"
+00-00-00 00:00:00 ERRO err2 err="second: first" 2=2 1=1 stacktrace="[log_test.go:34 log_test.go:72 testing.go:1595]"
 00-00-00 00:00:00 DEBU ctx debug message ctx_key1=ctx_value1 debug_key1=debug_value1
 00-00-00 00:00:00 INFO ctx info message ctx_key1=ctx_value1 ctx_key2=ctx_value2 info_key2=info_value2
+00-00-00 00:00:00 WARN Pkg wrapped error err="pkg wrap: omni wrap: new" wrap=wrap new=new stacktrace="[log_test.go:45 log_test.go:72 testing.go:1595]"

--- a/test/e2e/runner/setup.go
+++ b/test/e2e/runner/setup.go
@@ -102,7 +102,9 @@ func Setup(ctx context.Context, testnet *e2e.Testnet, infp infra.Provider) error
 			filepath.Join(nodeDir, PrivvalStateFile),
 		)).Save()
 
-		if err := halocmd.InitFiles(ctx, halocmd.InitConfig{HomeDir: nodeDir, Network: netconf.Simnet}); err != nil {
+		// Initialize the node's data directory (with noop logger since it is noisy).
+		initCfg := halocmd.InitConfig{HomeDir: nodeDir, Network: netconf.Simnet}
+		if err := halocmd.InitFiles(log.WithNoopLogger(ctx), initCfg); err != nil {
 			return errors.Wrap(err, "init files")
 		}
 	}


### PR DESCRIPTION
Improvements and fixes for e2e manifest `simple.yaml` which runs a 4 validator cluster (each running deterministic engine and xprovider mocks). This tests cometBFT networking.

Fixes include:
- Extract cometBFT log errors for proper attributes and stack traces.
- Support unwrapping pkgerror wrapped errors to obtain our structured error.
- Deterministic engine API mock (and fuzzer)
- Improve sanity checks in engine API mock
- silence halo init logs in e2e tests (very noisy)

task: none
