### PR TITLE
chore(halo): add make halo-simnet command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@ help:  ## Display this help message
 ###                                Docker                                 	###
 ###############################################################################
 
+.PHONY: build-docker
 build-docker: ensure-go-releaser ## Builds the docker images.
 	@goreleaser release --snapshot --clean
 
@@ -12,6 +13,7 @@ build-docker: ensure-go-releaser ## Builds the docker images.
 ###                                Contracts                                 ###
 ###############################################################################
 
+.PHONY: contracts-gen
 contract-bindings: ## Generate golang contract bindings.
 	make -C ./contracts bindings
 
@@ -19,6 +21,7 @@ contract-bindings: ## Generate golang contract bindings.
 ###                               Explorer                                 	###
 ###############################################################################
 
+.PHONY: explorer-gen
 explorer-gen: ## Generates code for our explorer
 	make -C ./explorer/db gen
 	make -C ./explorer/api gen
@@ -27,14 +30,25 @@ explorer-gen: ## Generates code for our explorer
 ###                                Utils                                 	###
 ###############################################################################
 
+.PHONY: ensure-go-releaser
 ensure-go-releaser: ## Installs the go-releaser tool.
 	@which goreleaser > /dev/null || echo "go-releaser not installed, see https://goreleaser.com/install/"
 
+.PHONY: install-pre-commit
 install-pre-commit: ## Installs the pre-commit tool as the git pre-commit hook for this repo.
 	@which pre-commit > /dev/null || echo "pre-commit not installed, see https://pre-commit.com/#install"
 	@pre-commit install --install-hooks
 
+.PHONY: lint
 lint: ## Runs linters via pre-commit.
 	@pre-commit run -v --all-files
 
-.PHONY: install-pre-commit lint
+###############################################################################
+###                                Testing                                 	###
+###############################################################################
+
+.PHONY: halo-simnet
+halo-simnet: ## Runs halo in simnet mode.
+	@go install github.com/omni-network/omni/halo
+	@halo init --home=/tmp/halo --network=simnet --clean
+	@halo run --home=/tmp/halo

--- a/halo/cmd/flags.go
+++ b/halo/cmd/flags.go
@@ -23,6 +23,7 @@ func bindInitFlags(flags *pflag.FlagSet, cfg *InitConfig) {
 	libcmd.BindHomeFlag(flags, &cfg.HomeDir)
 	flags.StringVar(&cfg.Network, "network", cfg.Network, "The network to initialize")
 	flags.BoolVar(&cfg.Force, "force", cfg.Force, "Force initialization (overwrite existing files)")
+	flags.BoolVar(&cfg.Clean, "clean", cfg.Clean, "Delete home directory before initialization")
 }
 
 // logConfig logs the config struct kv pairs.

--- a/halo/cmd/init.go
+++ b/halo/cmd/init.go
@@ -27,6 +27,7 @@ type InitConfig struct {
 	HomeDir string
 	Network string
 	Force   bool
+	Clean   bool
 }
 
 // newInitCmd returns a new cobra command that initializes the files and folders required by halo.
@@ -57,7 +58,7 @@ Ensures all the following files and directories exist:
   │   ├── snapshots                  # Snapshot directory
   │   └── xattestations_state.json   # Cross chain attestation state (slashing protection)
 
-Existing files are not overwritten.
+Existing files are not overwritten, unless --clean is specified.
 The home directory should only contain subdirectories, no files, use --force to ignore this check.
 `,
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -98,6 +99,13 @@ func InitFiles(ctx context.Context, initCfg InitConfig) error {
 
 			return errors.New("home directory contains unexpected file(s), use --force to initialize anyway",
 				"home", homeDir, "example_file", file.Name())
+		}
+	}
+
+	if initCfg.Clean {
+		log.Info(ctx, "Deleting home directory, since --clean=true")
+		if err := os.RemoveAll(homeDir); err != nil {
+			return errors.Wrap(err, "remove home dir")
 		}
 	}
 

--- a/halo/cmd/testdata/TestCLIReference_init.golden
+++ b/halo/cmd/testdata/TestCLIReference_init.golden
@@ -14,13 +14,14 @@ Ensures all the following files and directories exist:
   │   ├── snapshots                  # Snapshot directory
   │   └── xattestations_state.json   # Cross chain attestation state (slashing protection)
 
-Existing files are not overwritten.
+Existing files are not overwritten, unless --clean is specified.
 The home directory should only contain subdirectories, no files, use --force to ignore this check.
 
 Usage:
   halo init [flags]
 
 Flags:
+      --clean            Delete home directory before initialization
       --force            Force initialization (overwrite existing files)
   -h, --help             help for init
       --home string      The application home directory containing config and data (default "./halo")


### PR DESCRIPTION
Adds a `make halo-simnet` command for easy running of a simnet locally.

Also add a `--clean` flag to `halo init` to easy delete all existing config and state. 

task: none