### PR TITLE
feat(lib/log): pad console logger messages

### DIFF
--- a/lib/log/logger.go
+++ b/lib/log/logger.go
@@ -32,6 +32,7 @@ func getLogger(ctx context.Context) *slog.Logger {
 // - Colored log levels (if tty supports it)
 // - Timestamps are concise with millisecond precision
 // - Timestamps and structured keys are faint
+// - Messages are right padded to 40 characters
 // This is aimed at local-dev and debugging. Production should use json or logfmt.
 func newConsoleLogger(opts ...func(*TestOptions)) *slog.Logger {
 	o := TestOptions{
@@ -55,6 +56,8 @@ func newConsoleLogger(opts ...func(*TestOptions)) *slog.Logger {
 
 	styles := charm.DefaultStyles()
 	styles.Timestamp = styles.Timestamp.Faint(true)
+	const padWidth = 40
+	styles.Message = styles.Message.Width(padWidth).Inline(true)
 	logger.SetStyles(styles)
 
 	return slog.New(logger)

--- a/lib/log/testdata/TestSimpleLogs_console.golden
+++ b/lib/log/testdata/TestSimpleLogs_console.golden
@@ -1,9 +1,9 @@
-00-00-00 00:00:00 INFO info message with=args
-00-00-00 00:00:00 DEBU debug this code for me please number=1
-00-00-00 00:00:00 WARN watch out! err="file already exists"
-00-00-00 00:00:00 ERRO something went wrong float=1.234 err=EOF
-00-00-00 00:00:00 WARN err1 err=first 1=1 stacktrace="[log_test.go:32 log_test.go:72 testing.go:1595]"
-00-00-00 00:00:00 ERRO err2 err="second: first" 2=2 1=1 stacktrace="[log_test.go:34 log_test.go:72 testing.go:1595]"
-00-00-00 00:00:00 DEBU ctx debug message ctx_key1=ctx_value1 debug_key1=debug_value1
-00-00-00 00:00:00 INFO ctx info message ctx_key1=ctx_value1 ctx_key2=ctx_value2 info_key2=info_value2
-00-00-00 00:00:00 WARN Pkg wrapped error err="pkg wrap: omni wrap: new" wrap=wrap new=new stacktrace="[log_test.go:45 log_test.go:72 testing.go:1595]"
+00-00-00 00:00:00 INFO info message                             with=args
+00-00-00 00:00:00 DEBU debug this code for me please            number=1
+00-00-00 00:00:00 WARN watch out!                               err="file already exists"
+00-00-00 00:00:00 ERRO something went wrong                     float=1.234 err=EOF
+00-00-00 00:00:00 WARN err1                                     err=first 1=1 stacktrace="[log_test.go:32 log_test.go:72 testing.go:1595]"
+00-00-00 00:00:00 ERRO err2                                     err="second: first" 2=2 1=1 stacktrace="[log_test.go:34 log_test.go:72 testing.go:1595]"
+00-00-00 00:00:00 DEBU ctx debug message                        ctx_key1=ctx_value1 debug_key1=debug_value1
+00-00-00 00:00:00 INFO ctx info message                         ctx_key1=ctx_value1 ctx_key2=ctx_value2 info_key2=info_value2
+00-00-00 00:00:00 WARN Pkg wrapped error                        err="pkg wrap: omni wrap: new" wrap=wrap new=new stacktrace="[log_test.go:45 log_test.go:72 testing.go:1595]"


### PR DESCRIPTION
Pads console log messages (to 40chars) to distinguish messages (most important) from attributes (less important) and makes logs easier to scan by humans in general.

task: none