### PR TITLE
test(e2e): start anvil and deploy portal

### DIFF
--- a/test/e2e/runner/contract.go
+++ b/test/e2e/runner/contract.go
@@ -1,0 +1,89 @@
+package main
+
+import (
+	"context"
+	"math/big"
+	"strings"
+
+	"github.com/omni-network/omni/contracts/bindings"
+	"github.com/omni-network/omni/lib/errors"
+	"github.com/omni-network/omni/lib/log"
+	"github.com/omni-network/omni/lib/netconf"
+
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/ethclient"
+)
+
+const (
+	// anvilPrivKeyHex of pre-funded anvil account 0.
+	anvilPrivKeyHex = "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80"
+)
+
+var (
+	// defaultNetworkis the  devnet network configuration.
+	//nolint:gochecknoglobals // This is predefined at this point.
+	defaultNetwork = netconf.Network{
+		Name: netconf.Devnet,
+		Chains: []netconf.Chain{
+			{
+				ID:            100,
+				Name:          "chain_a",
+				RPCURL:        "http://localhost:6545",
+				PortalAddress: "0x5FbDB2315678afecb367f032d93F642f64180aa3",
+			},
+		},
+	}
+)
+
+// defaultServices returns the default additional docker-compose services to start.
+func defaultServices() []string {
+	resp := make([]string, 0, len(defaultNetwork.Chains))
+	for _, chain := range defaultNetwork.Chains {
+		resp = append(resp, chain.Name)
+	}
+
+	return resp
+}
+
+func DeployContracts(ctx context.Context) error {
+	log.Info(ctx, "Deploying portal contracts")
+
+	for _, chain := range defaultNetwork.Chains {
+		ethClient, err := ethclient.Dial(chain.RPCURL)
+		if err != nil {
+			return errors.Wrap(err, "dial chain")
+		}
+
+		txOpts, err := newTxOpts(anvilPrivKeyHex, chain.ID)
+		if err != nil {
+			return err
+		}
+
+		addr, _, _, err := bindings.DeployOmniPortal(txOpts, ethClient)
+		if err != nil {
+			return errors.Wrap(err, "deploy portal")
+		} else if addr.Hex() != chain.PortalAddress {
+			return errors.New("portal address mismatch")
+		}
+	}
+
+	return nil
+}
+
+func newTxOpts(privKeyHex string, chainID uint64) (*bind.TransactOpts, error) {
+	pk, err := crypto.HexToECDSA(strings.TrimPrefix(privKeyHex, "0x"))
+	if err != nil {
+		return nil, errors.Wrap(err, "parse private key")
+	}
+
+	txOpts, err := bind.NewKeyedTransactorWithChainID(
+		pk,
+		big.NewInt(int64(chainID)),
+	)
+	if err != nil {
+		return nil, errors.Wrap(err, "keyed tx ops")
+	}
+
+	return txOpts, nil
+}

--- a/test/e2e/runner/docker/compose.yaml.tmpl
+++ b/test/e2e/runner/docker/compose.yaml.tmpl
@@ -33,3 +33,15 @@ services:
       {{ $.Name }}:
         ipv{{ if $.IPv6 }}6{{ else }}4{{ end}}_address: {{ .InternalIP }}
 {{end}}
+
+  chain_a:
+    labels:
+      e2e: true
+    image: ghcr.io/foundry-rs/foundry:latest
+    entrypoint: ['anvil','--host','0.0.0.0','--chain-id','100']
+    ports:
+      - "6545:8545"
+      - "6546:8546"
+    networks:
+      {{ $.Name }}:
+        ipv4_address: 10.186.73.200

--- a/test/e2e/runner/docker/docker.go
+++ b/test/e2e/runner/docker/docker.go
@@ -2,11 +2,14 @@ package docker
 
 import (
 	"bytes"
+	"context"
 	"os"
 	"path/filepath"
+	"sync"
 	"text/template"
 
 	"github.com/omni-network/omni/lib/errors"
+	"github.com/omni-network/omni/lib/log"
 
 	e2e "github.com/cometbft/cometbft/test/e2e/pkg"
 	"github.com/cometbft/cometbft/test/e2e/pkg/infra"
@@ -20,28 +23,31 @@ import (
 //go:embed compose.yaml.tmpl
 var composeTmpl []byte
 
-var _ infra.Provider = Provider{}
+var _ infra.Provider = &Provider{}
 
 // Provider wraps the cometBFT docker provider, writing a different compose file.
 type Provider struct {
 	*cmtdocker.Provider
+	servicesOnce sync.Once
+	services     []string
 }
 
 // NewProvider returns a new Provider.
-func NewProvider(testnet *e2e.Testnet, data e2e.InfrastructureData) Provider {
-	return Provider{
+func NewProvider(testnet *e2e.Testnet, data e2e.InfrastructureData, services []string) *Provider {
+	return &Provider{
 		Provider: &cmtdocker.Provider{
 			ProviderData: infra.ProviderData{
 				Testnet:            testnet,
 				InfrastructureData: data,
 			},
 		},
+		services: services,
 	}
 }
 
 // Setup generates the docker-compose file and write it to disk, erroring if
 // any of these operations fail. It writes.
-func (p Provider) Setup() error {
+func (p *Provider) Setup() error {
 	tmpl, err := template.New("").Parse(string(composeTmpl))
 	if err != nil {
 		return errors.Wrap(err, "parsing compose template")
@@ -58,4 +64,17 @@ func (p Provider) Setup() error {
 	}
 
 	return nil
+}
+
+func (p *Provider) StartNodes(ctx context.Context, nodes ...*e2e.Node) error {
+	var err error
+	p.servicesOnce.Do(func() {
+		log.Info(ctx, "Starting additional services", "names", p.services)
+		err = cmtdocker.ExecCompose(ctx, p.Testnet.Dir, append([]string{"up", "-d"}, p.services...)...)
+	})
+	if err != nil {
+		return errors.Wrap(err, "start additional services")
+	}
+
+	return p.Provider.StartNodes(ctx, nodes...)
 }

--- a/test/e2e/runner/main.go
+++ b/test/e2e/runner/main.go
@@ -58,7 +58,7 @@ func NewCLI() *CLI {
 			}
 
 			cli.testnet = adaptTestnet(testnet)
-			cli.infp = docker.NewProvider(testnet, ifd)
+			cli.infp = docker.NewProvider(testnet, ifd, defaultServices())
 
 			return nil
 		},
@@ -73,6 +73,10 @@ func NewCLI() *CLI {
 			}
 
 			if err := Start(ctx, cli.testnet, cli.infp); err != nil {
+				return err
+			}
+
+			if err := DeployContracts(ctx); err != nil {
 				return err
 			}
 


### PR DESCRIPTION
Starts a single anvil chain and deploy the portal contract to it as part of all e2e tests. 

Next; configure halo xprovider to query this in e2e tests

task: none