### PR TITLE
test(e2e): build relayer container and add to e2e

### DIFF
--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -35,3 +35,5 @@ jobs:
         run: docker push omniops/explorer-indexer:latest
       - name: Push Halo to Dockerhub
         run: docker push omniops/halo:latest
+      - name: Push Relayer to Dockerhub
+        run: docker push omniops/relayer:latest

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -10,6 +10,13 @@ builds:
     goos: [linux, darwin]
     goarch: [amd64, arm64]
 
+  - id: relayer
+    main: ./relayer
+    binary: relayer
+    env: [CGO_ENABLED=0]
+    goos: [linux, darwin]
+    goarch: [amd64, arm64]
+
   - id: explorer-api
     main: ./explorer/api
     binary: /explorer/api
@@ -29,6 +36,11 @@ dockers:
     dockerfile: ./halo/Dockerfile
     image_templates:
      - omniops/halo:latest
+
+  - ids: [relayer]
+    dockerfile: ./relayer/Dockerfile
+    image_templates:
+     - omniops/relayer:latest
 
   - ids: [explorer-api]
     dockerfile: ./explorer/api/Dockerfile

--- a/halo/cmd/cmd.go
+++ b/halo/cmd/cmd.go
@@ -32,7 +32,7 @@ func newRunCmd(runFunc func(context.Context, app.Config) error) *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
 
-			if err := logConfig(ctx, cmd.Flags()); err != nil {
+			if err := libcmd.LogFlags(ctx, cmd.Flags()); err != nil {
 				return err
 			}
 

--- a/halo/cmd/flags.go
+++ b/halo/cmd/flags.go
@@ -2,12 +2,8 @@
 package cmd
 
 import (
-	"context"
-	"strings"
-
 	"github.com/omni-network/omni/halo/app"
 	libcmd "github.com/omni-network/omni/lib/cmd"
-	"github.com/omni-network/omni/lib/log"
 
 	"github.com/spf13/pflag"
 )
@@ -24,25 +20,4 @@ func bindInitFlags(flags *pflag.FlagSet, cfg *InitConfig) {
 	flags.StringVar(&cfg.Network, "network", cfg.Network, "The network to initialize")
 	flags.BoolVar(&cfg.Force, "force", cfg.Force, "Force initialization (overwrite existing files)")
 	flags.BoolVar(&cfg.Clean, "clean", cfg.Clean, "Delete home directory before initialization")
-}
-
-// logConfig logs the config struct kv pairs.
-func logConfig(ctx context.Context, flags *pflag.FlagSet) error {
-	skip := map[string]bool{
-		"help": true,
-	}
-	// Flatten config into key/value pairs for logging.
-	var fields []any
-	flags.VisitAll(func(f *pflag.Flag) {
-		if skip[f.Name] {
-			return
-		}
-		// TODO(corver): Allow dashes for one-to-one mapping with actual flags?
-		fields = append(fields, strings.ReplaceAll(f.Name, "-", "_"))
-		fields = append(fields, f.Value)
-	})
-
-	log.Info(ctx, "Parsed config from flags", fields...)
-
-	return nil
 }

--- a/halo/cmd/init.go
+++ b/halo/cmd/init.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/omni-network/omni/halo/app"
 	"github.com/omni-network/omni/halo/attest"
+	libcmd "github.com/omni-network/omni/lib/cmd"
 	"github.com/omni-network/omni/lib/errors"
 	"github.com/omni-network/omni/lib/log"
 	"github.com/omni-network/omni/lib/netconf"
@@ -63,7 +64,7 @@ The home directory should only contain subdirectories, no files, use --force to 
 `,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
-			if err := logConfig(ctx, cmd.Flags()); err != nil {
+			if err := libcmd.LogFlags(ctx, cmd.Flags()); err != nil {
 				return err
 			}
 

--- a/lib/cchain/provider/abci.go
+++ b/lib/cchain/provider/abci.go
@@ -49,7 +49,11 @@ func (f ABCIFetcher) ApprovedFrom(ctx context.Context, chainID uint64, fromHeigh
 
 	resp, err := f.abci.ABCIQuery(ctx, halopb.HaloService_ApprovedFrom_FullMethodName, bz)
 	if err != nil {
-		return nil, errors.Wrap(err, "abci query approved-from")
+		return nil, errors.Wrap(err, "abci query approved-from",
+			"chain_id", chainID,
+			"from_height", fromHeight,
+			"len", len(bz),
+		)
 	} else if !resp.Response.IsOK() {
 		return nil, errors.New("abci query approved-from failed",
 			"code", resp.Response.Code,

--- a/lib/cmd/flags.go
+++ b/lib/cmd/flags.go
@@ -1,6 +1,13 @@
 package cmd
 
-import "github.com/spf13/pflag"
+import (
+	"context"
+	"strings"
+
+	"github.com/omni-network/omni/lib/log"
+
+	"github.com/spf13/pflag"
+)
 
 const homeFlag = "home"
 
@@ -9,4 +16,25 @@ const homeFlag = "home"
 // Using this flag will result in the viper config directory to be updated from default "." to "<home>/config".
 func BindHomeFlag(flags *pflag.FlagSet, homeDir *string) {
 	flags.StringVar(homeDir, homeFlag, *homeDir, "The application home directory containing config and data")
+}
+
+// LogFlags logs the configured flags kv pairs.
+func LogFlags(ctx context.Context, flags *pflag.FlagSet) error {
+	skip := map[string]bool{
+		"help": true,
+	}
+	// Flatten config into key/value pairs for logging.
+	var fields []any
+	flags.VisitAll(func(f *pflag.Flag) {
+		if skip[f.Name] {
+			return
+		}
+		// TODO(corver): Allow dashes for one-to-one mapping with actual flags?
+		fields = append(fields, strings.ReplaceAll(f.Name, "-", "_"))
+		fields = append(fields, f.Value)
+	})
+
+	log.Info(ctx, "Parsed config from flags", fields...)
+
+	return nil
 }

--- a/relayer/Dockerfile
+++ b/relayer/Dockerfile
@@ -1,3 +1,12 @@
 FROM scratch
-ENTRYPOINT ["/relayer"]
-COPY relayer /
+
+# Copy relayer binary and rename to /app
+COPY relayer /app
+
+# Mount config directory at /relayer
+VOLUME ["/relayer"]
+
+# Set working directory to /relayer, so it automatically reads relayer.toml from here.
+WORKDIR /relayer
+
+ENTRYPOINT ["/app"]

--- a/relayer/app/config.go
+++ b/relayer/app/config.go
@@ -1,15 +1,49 @@
 package relayer
 
+import (
+	"bytes"
+	"text/template"
+
+	"github.com/omni-network/omni/lib/errors"
+
+	cmtos "github.com/cometbft/cometbft/libs/os"
+
+	_ "embed"
+)
+
 type Config struct {
 	PrivateKey  string
 	HaloURL     string
 	NetworkFile string
 }
 
-func DefaultRelayerConfig() Config {
+func DefaultConfig() Config {
 	return Config{
 		PrivateKey:  "relayer.key",
 		HaloURL:     "localhost:26657",
 		NetworkFile: "network.json",
 	}
+}
+
+//go:embed config.toml.tmpl
+var tomlTemplate []byte
+
+// WriteConfigTOML writes the toml halo config to disk.
+func WriteConfigTOML(cfg Config, path string) error {
+	var buffer bytes.Buffer
+
+	t, err := template.New("").Parse(string(tomlTemplate))
+	if err != nil {
+		return errors.Wrap(err, "parse template")
+	}
+
+	if err := t.Execute(&buffer, cfg); err != nil {
+		panic(err)
+	}
+
+	if err := cmtos.WriteFile(path, buffer.Bytes(), 0o644); err != nil {
+		return errors.Wrap(err, "write config")
+	}
+
+	return nil
 }

--- a/relayer/app/config.toml.tmpl
+++ b/relayer/app/config.toml.tmpl
@@ -1,0 +1,19 @@
+# This is a TOML config file.
+# For more information, see https://github.com/toml-lang/toml
+
+# The version of the Halo binary that created or
+# last modified the config file. Do not modify this.
+version = "unknown"
+
+#######################################################################
+###                         Config Options                          ###
+#######################################################################
+
+# Path to the ethereum private key used to sign submission transactions.
+private-key = "{{ .PrivateKey }}"
+
+# The URL of the halo node to connect to.
+halo-url = "{{ .HaloURL }}"
+
+# The path to the Omni network configuration file.
+network-file = "{{ .NetworkFile }}"

--- a/relayer/cmd/cmd.go
+++ b/relayer/cmd/cmd.go
@@ -2,8 +2,6 @@
 package cmd
 
 import (
-	"context"
-
 	libcmd "github.com/omni-network/omni/lib/cmd"
 	relayer "github.com/omni-network/omni/relayer/app"
 
@@ -12,28 +10,23 @@ import (
 
 // New returns a new root cobra command that handles our command line tool.
 func New() *cobra.Command {
-	return libcmd.NewRootCmd(
+	cmd := libcmd.NewRootCmd(
 		"relayer",
 		"Relayer is a service that relays txs between the omni network and rollups",
-		newRunCmd(relayer.Run),
 	)
-}
 
-// newRunCmd returns a new cobra command that runs the relayer.
-func newRunCmd(runFunc func(context.Context, relayer.Config) error) *cobra.Command {
-	cfg := relayer.DefaultRelayerConfig()
-
-	cmd := &cobra.Command{
-		Use:   "run",
-		Short: "Runs the relayer",
-		RunE: func(cmd *cobra.Command, args []string) error {
-			ctx := cmd.Context()
-
-			return runFunc(ctx, cfg)
-		},
-	}
-
+	cfg := relayer.DefaultConfig()
 	bindRunFlags(cmd.Flags(), &cfg)
+
+	cmd.RunE = func(cmd *cobra.Command, args []string) error {
+		ctx := cmd.Context()
+
+		if err := libcmd.LogFlags(ctx, cmd.Flags()); err != nil {
+			return err
+		}
+
+		return relayer.Run(ctx, cfg)
+	}
 
 	return cmd
 }

--- a/test/e2e/runner/contract.go
+++ b/test/e2e/runner/contract.go
@@ -112,6 +112,7 @@ func newTxOpts(ctx context.Context, privKeyHex string, chainID uint64) (*bind.Tr
 	return txOpts, nil
 }
 
+// SendXMsgs sends one xmsg from every chain to every other chain.
 func SendXMsgs(ctx context.Context, portals map[uint64]Portal) error {
 	log.Info(ctx, "Sending one round of xmsgs between all chains")
 
@@ -130,6 +131,7 @@ func SendXMsgs(ctx context.Context, portals map[uint64]Portal) error {
 	return nil
 }
 
+// xcall sends a ethereum transaction to the portal contract, triggering a xcall.
 func xcall(ctx context.Context, from Portal, destChainID uint64) error {
 	txOpts, err := newTxOpts(ctx, anvilPrivKeyHex, from.Chain.ID)
 	if err != nil {

--- a/test/e2e/runner/docker/compose.yaml.tmpl
+++ b/test/e2e/runner/docker/compose.yaml.tmpl
@@ -95,3 +95,14 @@ services:
     networks:
       {{ $.Name }}:
         ipv4_address: 10.186.73.210
+
+  relayer:
+    labels:
+      e2e: true
+    container_name: relayer
+    image: omniops/relayer:latest
+    volumes:
+      - ./relayer:/relayer
+    networks:
+      {{ $.Name }}:
+        ipv4_address: 10.186.73.220


### PR DESCRIPTION
Builds the relayer docker image (also push it to dockerhub).
Add relayer to e2e test, writing config to disk.

Note; at this point the relayer binary fails with: "failed to get submitted cursors: not implemented"

task: none