### PR TITLE
fix(relayer): use fixed gas limit

### DIFF
--- a/relayer/app/sender.go
+++ b/relayer/app/sender.go
@@ -58,6 +58,10 @@ func newSession(chain netconf.Chain, rpcClient *ethclient.Client,
 		return bindings.OmniPortalSession{}, errors.Wrap(err, "new transactor")
 	}
 
+	// Pick a fixed gas limit to avoid gas estimation issues due to offset errors.
+	const gasLimit = 1_000_000 // TODO(corver): make configurable
+	transactor.GasLimit = gasLimit
+
 	session := bindings.OmniPortalSession{
 		Contract:     contract,
 		TransactOpts: *transactor,

--- a/test/e2e/runner/docker/compose.yaml.tmpl
+++ b/test/e2e/runner/docker/compose.yaml.tmpl
@@ -101,6 +101,7 @@ services:
       e2e: true
     container_name: relayer
     image: omniops/relayer:latest
+    restart: unless-stopped # Restart on crash to mitigate startup race issues
     volumes:
       - ./relayer:/relayer
     networks:

--- a/test/e2e/runner/main.go
+++ b/test/e2e/runner/main.go
@@ -83,20 +83,11 @@ func NewCLI() *CLI {
 				return err
 			}
 
-			if err := SendXMsgs(ctx, portals); err != nil {
-				return err
-			}
-
-			// Relayer crashes if chains not available on start (need to fix this), so start manually here.
-			if err := cmtdocker.ExecCompose(ctx, cli.testnet.Dir, "up", "-d", "relayer"); err != nil {
+			if err := StartSendingXMsgs(ctx, portals); err != nil {
 				return err
 			}
 
 			if err := Wait(ctx, cli.testnet, 5); err != nil { // allow some txs to go through
-				return err
-			}
-
-			if err := SendXMsgs(ctx, portals); err != nil {
 				return err
 			}
 

--- a/test/e2e/runner/setup.go
+++ b/test/e2e/runner/setup.go
@@ -50,6 +50,8 @@ func chainServices(network netconf.Network) []string {
 		resp = append(resp, chain.Name)
 	}
 
+	resp = append(resp, "relayer")
+
 	return resp
 }
 
@@ -373,7 +375,7 @@ func writeRelayerConfig(root string, testnet *e2e.Testnet, network netconf.Netwo
 
 	// Save private key
 	// TODO(corver): Use a different private key (avoid nonce issues)
-	pkBytes := []byte(strings.TrimPrefix(anvilPrivKeyHex, "0x"))
+	pkBytes := []byte(strings.TrimPrefix(privKeyHex1, "0x"))
 	if err := os.WriteFile(filepath.Join(confRoot, privKeyFile), pkBytes, 0o600); err != nil {
 		return errors.Wrap(err, "write private key")
 	}


### PR DESCRIPTION
Fix sporadic "wrong streamOffset" errors when relayer submits multiple transactions in the same block to geth by specifying a fixed gas limit. 

Without a gas limit, the bindings library estimates gas which fails when submitting subsequent transactions in the same block since the contract cursor isn't updated during gas estimation.

Proper solution is calculating our own gas. Which is what relayer has to do in anycase since it must split submissions to avoid “out of gas”.

Also include the following fixes:
- Send many cross chain messages during E2E
- Start relayer along with other "additional services", it will crash loop until it can connect to EVMs.

task: none