### PR TITLE
chore(e2e): use main docker img tag for e2e tests

### DIFF
--- a/test/e2e/runner/docker/compose.yaml.tmpl
+++ b/test/e2e/runner/docker/compose.yaml.tmpl
@@ -102,7 +102,7 @@ services:
     labels:
       e2e: true
     container_name: relayer
-    image: omniops/relayer:latest
+    image: omniops/relayer:main
     restart: unless-stopped # Restart on crash to mitigate startup race issues
     environment:
       - RELAYER_LOG_COLOR=force

--- a/test/e2e/runner/main.go
+++ b/test/e2e/runner/main.go
@@ -231,7 +231,7 @@ func adaptTestnet(testnet *e2e.Testnet) *e2e.Testnet {
 	// Move test dir: path/test/e2e/manifests/single -> path/test/e2e/runs/single
 	testnet.Dir = strings.Replace(testnet.Dir, "manifests", "runs", 1)
 	testnet.VoteExtensionsEnableHeight = 1
-	testnet.UpgradeVersion = "omniops/halo:latest"
+	testnet.UpgradeVersion = "omniops/halo:main"
 	for i := range testnet.Nodes {
 		testnet.Nodes[i] = adaptNode(testnet.Nodes[i])
 	}
@@ -240,7 +240,7 @@ func adaptTestnet(testnet *e2e.Testnet) *e2e.Testnet {
 }
 
 func adaptNode(node *e2e.Node) *e2e.Node {
-	node.Version = "omniops/halo:latest"
+	node.Version = "omniops/halo:main"
 	node.PrivvalKey = k1.GenPrivKey()
 
 	return node


### PR DESCRIPTION
after we push conditional docker image tags, I believe that we should run the e2e tests against the main tag

task: none
