### PR TITLE
fix(ci): update notify workflow

### DIFF
--- a/.github/workflows/ci-notify.yml
+++ b/.github/workflows/ci-notify.yml
@@ -22,7 +22,7 @@ jobs:
                   "type": "section",
                   "text": {
                     "type": "mrkdwn",
-                    "text": "🚨 CI failed on `${{ github.event.workflow_run.head_branch }}`. *${{ github.event.workflow_run.name }}* was unsuccessful."
+                    "text": "🚨 CI failed on `${{ github.event.workflow_run.head_branch }}`."
                   }
                 },
                 {
@@ -35,7 +35,7 @@ jobs:
                     },
                     {
                       "type": "mrkdwn",
-                      "text": "by: ${{ github.event.workflow_run.head_commit.author.username }} \n url: ${{ github.event.workflow_run.html_url }}"
+                      "text": url: ${{ github.event.workflow_run.html_url }}"
                     }
                   ]
                 }


### PR DESCRIPTION
<img width="468" alt="Screenshot 2024-01-30 at 10 13 59 AM" src="https://github.com/omni-network/omni/assets/31632172/707e5c1d-d3d1-4b94-9111-e73419f6472a">

2 issues with the existing message:
- author field is not populated correctly
- since we switched to the "workflows that import jobs" - the workflow run name is "ci main". we don't need the repetitive message.

task: none
