### PR TITLE
fix(relay): make logger code more go-idiomatic

### DIFF
--- a/lib/log/log.go
+++ b/lib/log/log.go
@@ -23,12 +23,12 @@ func WithCtx(ctx context.Context, attrs ...any) context.Context {
 
 // Debug logs the message and attributes at default level.
 func Debug(ctx context.Context, msg string, attrs ...any) {
-	getLogger(ctx).DebugContext(ctx, msg, mergeAttrs(ctx, attrs)...)
+	GetLogger(ctx).DebugContext(ctx, msg, mergeAttrs(ctx, attrs)...)
 }
 
 // Info logs the message and attributes at info level.
 func Info(ctx context.Context, msg string, attrs ...any) {
-	getLogger(ctx).InfoContext(ctx, msg, mergeAttrs(ctx, attrs)...)
+	GetLogger(ctx).InfoContext(ctx, msg, mergeAttrs(ctx, attrs)...)
 }
 
 // Warn logs the message and error and attributes at warning level.
@@ -39,7 +39,7 @@ func Warn(ctx context.Context, msg string, err error, attrs ...any) {
 		attrs = append(attrs, errAttrs(err)...)
 	}
 
-	getLogger(ctx).WarnContext(ctx, msg, mergeAttrs(ctx, attrs)...)
+	GetLogger(ctx).WarnContext(ctx, msg, mergeAttrs(ctx, attrs)...)
 }
 
 // Error logs the message and error and arguments at error level.
@@ -49,7 +49,7 @@ func Error(ctx context.Context, msg string, err error, attrs ...any) {
 		attrs = append(attrs, "err", err)
 		attrs = append(attrs, errAttrs(err)...)
 	}
-	getLogger(ctx).ErrorContext(ctx, msg, mergeAttrs(ctx, attrs)...)
+	GetLogger(ctx).ErrorContext(ctx, msg, mergeAttrs(ctx, attrs)...)
 }
 
 // errFields is similar to z.Err and returns the structured error fields and

--- a/lib/log/logger.go
+++ b/lib/log/logger.go
@@ -41,7 +41,8 @@ func WithLogger(ctx context.Context, logger *slog.Logger) context.Context {
 	return context.WithValue(ctx, loggerKey{}, logger)
 }
 
-func getLogger(ctx context.Context) *slog.Logger {
+// GetLogger returns the logger from the context, or the global logger if not present.
+func GetLogger(ctx context.Context) *slog.Logger {
 	if l := ctx.Value(loggerKey{}); l != nil {
 		return l.(*slog.Logger) //nolint:forcetypeassert,revive // We know the type.
 	}

--- a/relayer/app/ethlog.go
+++ b/relayer/app/ethlog.go
@@ -2,10 +2,13 @@ package relayer
 
 import (
 	"context"
+	"log/slog"
+
+	"github.com/omni-network/omni/lib/log"
 
 	ethlog "github.com/ethereum/go-ethereum/log"
 
-	"golang.org/x/exp/slog"
+	eslog "golang.org/x/exp/slog"
 )
 
 var _ ethlog.Logger = (*ethLogger)(nil)
@@ -14,16 +17,17 @@ type ethLogger struct {
 	log *slog.Logger
 }
 
-func (e ethLogger) With(ctx ...any) ethlog.Logger {
-	return ethLogger{
-		log: e.log.With(ctx...),
+// WrapLogger wraps the logger inside the context and returns a new logger compatible with the
+// Ethereum logger interface.
+func WrapLogger(ctx context.Context) ethlog.Logger {
+	return &ethLogger{
+		log: log.GetLogger(ctx),
 	}
 }
 
-// WrapLogger wraps an instance of [slog.Logger] returns a new logger compatiple with the Ethereum logger interaface.
-func WrapLogger(l *slog.Logger) ethlog.Logger {
-	return &ethLogger{
-		log: l,
+func (e ethLogger) With(ctx ...any) ethlog.Logger {
+	return ethLogger{
+		log: e.log.With(ctx...),
 	}
 }
 
@@ -33,7 +37,7 @@ func (e ethLogger) New(ctx ...any) ethlog.Logger {
 	}
 }
 
-func (e ethLogger) Log(level slog.Level, msg string, ctx ...any) {
+func (e ethLogger) Log(level eslog.Level, msg string, ctx ...any) {
 	e.Write(level, msg, ctx...)
 }
 
@@ -62,19 +66,19 @@ func (e ethLogger) Crit(msg string, ctx ...any) {
 	e.log.Error(msg, ctx...)
 }
 
-func (e ethLogger) Write(level slog.Level, msg string, attrs ...any) {
+func (e ethLogger) Write(level eslog.Level, msg string, attrs ...any) {
 	switch level {
-	case slog.LevelInfo:
+	case eslog.LevelInfo:
 		e.log.Info(msg, attrs...)
-	case slog.LevelWarn:
+	case eslog.LevelWarn:
 		e.log.Warn(msg, attrs...)
-	case slog.LevelError:
+	case eslog.LevelError:
 		e.log.Error(msg, attrs...)
-	case slog.LevelDebug:
+	case eslog.LevelDebug:
 		e.log.Debug(msg, attrs...)
 	}
 }
 
-func (ethLogger) Enabled(context.Context, slog.Level) bool {
+func (ethLogger) Enabled(context.Context, eslog.Level) bool {
 	return true
 }


### PR DESCRIPTION
Stop passing context around as struct fields make the code a little bit more Go-idiomatic.

task: none
