### PR TITLE
test(e2e): support geth p2p cluster

### DIFF
--- a/lib/netconf/network.go
+++ b/lib/netconf/network.go
@@ -29,7 +29,7 @@ const (
 var supported = map[string]bool{
 	Simnet:  true,
 	Devnet:  true,
-	Staging: false,
+	Staging: true,
 	Testnet: false,
 	Mainnet: false,
 }

--- a/test/e2e/app/monitor.go
+++ b/test/e2e/app/monitor.go
@@ -35,7 +35,12 @@ func MonitorCursors(ctx context.Context, portals map[uint64]netman.Portal, netwo
 				continue
 			}
 
-			offset, err := portals[dest.ID].Contract.InXStreamOffset(nil, src.ID)
+			srcOffset, err := portals[src.ID].Contract.OutXStreamOffset(nil, dest.ID)
+			if err != nil {
+				return errors.Wrap(err, "getting inXStreamOffset")
+			}
+
+			destOffset, err := portals[dest.ID].Contract.InXStreamOffset(nil, src.ID)
 			if err != nil {
 				return errors.Wrap(err, "getting inXStreamOffset")
 			}
@@ -43,7 +48,8 @@ func MonitorCursors(ctx context.Context, portals map[uint64]netman.Portal, netwo
 			log.Info(ctx, "Submitted cross chain messages",
 				"src", src.Name,
 				"dest", dest.Name,
-				"count", offset,
+				"total_in", destOffset,
+				"total_out", srcOffset,
 			)
 		}
 	}

--- a/test/e2e/app/run.go
+++ b/test/e2e/app/run.go
@@ -69,7 +69,7 @@ func E2ETest(ctx context.Context, def Definition, cfg E2ETestConfig) error {
 
 	sendCancel() // Stop sending messages
 
-	if err := Wait(ctx, def.Testnet.Testnet, 5); err != nil { // wait for network to settle before tests
+	if err := Wait(ctx, def.Testnet.Testnet, 10); err != nil { // wait for network to settle before tests
 		return err
 	}
 

--- a/test/e2e/app/setup.go
+++ b/test/e2e/app/setup.go
@@ -64,7 +64,7 @@ func Setup(ctx context.Context, testnet types.Testnet, infp infra.Provider, mngr
 		return err
 	}
 
-	if err := writeGethConfig(testnet.Dir); err != nil {
+	if err := writeOmniEVMConfig(testnet); err != nil {
 		return err
 	}
 
@@ -310,8 +310,8 @@ var (
 	gethKeystore []byte
 )
 
-// writeGethConfig writes the geth config to <root>/geth.
-func writeGethConfig(root string) error {
+// writeOmniEVMConfig writes the omni evms (geth) config to <root>/<omni_evm>.
+func writeOmniEVMConfig(testnet types.Testnet) error {
 	var jwtSecret [32]byte
 	_, _ = rand.Read(jwtSecret[:])
 
@@ -322,13 +322,15 @@ func writeGethConfig(root string) error {
 		"geth_password.txt": []byte(""), // Empty password
 	}
 
-	for name, data := range files {
-		path := filepath.Join(root, "omni_evm", name)
-		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
-			return errors.Wrap(err, "mkdir", "path", path)
-		}
-		if err := os.WriteFile(path, data, 0o644); err != nil {
-			return errors.Wrap(err, "write geth config")
+	for _, evm := range testnet.OmniEVMs {
+		for file, data := range files {
+			path := filepath.Join(testnet.Dir, evm.InstanceName, file)
+			if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+				return errors.Wrap(err, "mkdir", "path", path)
+			}
+			if err := os.WriteFile(path, data, 0o644); err != nil {
+				return errors.Wrap(err, "write geth config")
+			}
 		}
 	}
 

--- a/test/e2e/docker/compose.yaml.tmpl
+++ b/test/e2e/docker/compose.yaml.tmpl
@@ -27,11 +27,9 @@ services:
     - {{ .PrometheusProxyPort }}:26660
 {{- end }}
     - 6060
-    environment:
-    - HALO_LOG_COLOR=force
     volumes:
     - ./{{ .Name }}:/halo
-    - ./omni_evm/jwtsecret:/geth/jwtsecret
+    - ./{{ index $.NodeOmniEVMs .Name }}/jwtsecret:/geth/jwtsecret
     networks:
       {{ $.Name }}:
         ipv{{ if $.IPv6 }}6{{ else }}4{{ end}}_address: {{ .InternalIP }}
@@ -88,6 +86,8 @@ services:
       - --password=/geth/geth_password.txt
       - --nodiscover
       - --syncmode=full
+      - --nodekeyhex={{.NodeKeyHex}}
+      - --bootnodes={{.BootNodes}}
     ports:
       - 8551
       - {{ if .ProxyPort }}{{ .ProxyPort }}:{{ end }}8545

--- a/test/e2e/docker/docker_test.go
+++ b/test/e2e/docker/docker_test.go
@@ -12,6 +12,9 @@ import (
 
 	e2e "github.com/cometbft/cometbft/test/e2e/pkg"
 
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/p2p/enode"
+
 	"github.com/stretchr/testify/require"
 )
 
@@ -22,6 +25,10 @@ func TestComposeTemplate(t *testing.T) {
 
 	_, ipNet, err := net.ParseCIDR("10.186.73.0/24")
 	require.NoError(t, err)
+
+	key, err := crypto.HexToECDSA("59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d")
+	require.NoError(t, err)
+	en := enode.NewV4(&key.PublicKey, ipNet.IP, 30303, 30303)
 
 	dir := t.TempDir()
 	testnet := types.Testnet{
@@ -42,6 +49,9 @@ func TestComposeTemplate(t *testing.T) {
 				InstanceName: "omni_evm_0",
 				InternalIP:   ipNet.IP,
 				ProxyPort:    8000,
+				NodeKey:      key,
+				Enode:        en,
+				BootNodes:    []*enode.Node{en},
 			},
 		},
 		AnvilChains: []types.AnvilChain{

--- a/test/e2e/docker/testdata/TestComposeTemplate.golden
+++ b/test/e2e/docker/testdata/TestComposeTemplate.golden
@@ -20,11 +20,9 @@ services:
     - 26656
     - 8584:26657
     - 6060
-    environment:
-    - HALO_LOG_COLOR=force
     volumes:
     - ./node0:/halo
-    - ./omni_evm/jwtsecret:/geth/jwtsecret
+    - ./omni_evm_0/jwtsecret:/geth/jwtsecret
     networks:
       test:
         ipv4_address: 10.186.73.0
@@ -78,6 +76,8 @@ services:
       - --password=/geth/geth_password.txt
       - --nodiscover
       - --syncmode=full
+      - --nodekeyhex=59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d
+      - --bootnodes=enode://ba5734d8f7091719471e7f7ed6b9df170dc70cc661ca05e688601ad984f068b0d67351e5f06073092499336ab0839ef8a521afd334e53807205fa2f08eec74f4@10.186.73.0:30303
     ports:
       - 8551
       - 8000:8545

--- a/test/e2e/manifests/staging.toml
+++ b/test/e2e/manifests/staging.toml
@@ -4,5 +4,3 @@ multi_omni_evms = true
 
 [node.validator01]
 [node.validator02]
-[node.validator03]
-[node.validator04]

--- a/test/e2e/types/testnet.go
+++ b/test/e2e/types/testnet.go
@@ -1,9 +1,12 @@
 package types
 
 import (
+	"crypto/ecdsa"
 	"net"
 
 	e2e "github.com/cometbft/cometbft/test/e2e/pkg"
+
+	"github.com/ethereum/go-ethereum/p2p/enode"
 )
 
 // Testnet wraps e2e.Testnet with additional omni-specific fields.
@@ -32,6 +35,11 @@ type OmniEVM struct {
 	InternalRPC     string   // For JSON-RPC queries from halo/relayer
 	InternalAuthRPC string   // For engine API queries from halo
 	ExternalRPC     string   // For JSON-RPC queries from e2e app.
+
+	// P2P networking
+	NodeKey   *ecdsa.PrivateKey // Private key
+	Enode     *enode.Node       // Public key
+	BootNodes []*enode.Node     // Peer public keys
 }
 
 // AnvilChain represents an anvil chain instance in a omni network.


### PR DESCRIPTION
Add support for multiple omni evm geth nodes. Also ensure they are meshed p2p via bootnodes.

task: none
