### PR TITLE
test(ci): fix omni evm mappings

### DIFF
--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -20,6 +20,15 @@ This creates and runs a testnet named `single` under `test/e2e/runs/single/`.
 
 Please refer to the [cometBFT E2E test framework](https://github.com/cometbft/cometbft/tree/main/test/e2e) for more details.
 
+In order to perform any action on a network (deploy/test/show logs), the following process is followed to create a network `Definition`:
+1. A network is initially declared in a `manifest` file, see [manifests/](./manifests) folder. It defines the desired network topology. See the `e2e/types#Manifest` type for details.
+2. Then the infrastructure provider (only `docker compose` supported at the moment) subsequently generates the `e2e/types#InfrastructureData` from the manifest. This defines the instance IPs and ports of everything we will deploy.
+3. Subsequently, we generate a `Testnet` struct which is basically contains all the configuration/keys/peers/images/files/folders required to deploy a network. See `e2e/types#Testnet` for details.
+4. We then instantiate a `netman.Manager` which is responsible for deploying portals. It takes a `Testnet` struct as input.
+5. Finally, we instantiate new `InfrastructureProvider` which can deploy the network. It takes a `Testnet` struct and `InfrastructureData` as input.
+
+These objects are then wrapped in a `e2e/app#Definition` that can be used to perform any action on a network.
+
 ## Test Stages
 
 The e2e test has the following stages, which can also be executed explicitly by running `e2e -f <manifest> <stage>`:

--- a/test/e2e/app/contract.go
+++ b/test/e2e/app/contract.go
@@ -15,7 +15,7 @@ func StartSendingXMsgs(ctx context.Context, portals map[uint64]netman.Portal) er
 	log.Info(ctx, "Generating cross chain messages async")
 	go func() {
 		for ctx.Err() == nil {
-			err := SendXMsgs(ctx, portals)
+			err := SendXMsgs(ctx, portals, 3)
 			if ctx.Err() != nil {
 				return
 			} else if err != nil {
@@ -30,15 +30,17 @@ func StartSendingXMsgs(ctx context.Context, portals map[uint64]netman.Portal) er
 }
 
 // SendXMsgs sends one xmsg from every chain to every other chain.
-func SendXMsgs(ctx context.Context, portals map[uint64]netman.Portal) error {
+func SendXMsgs(ctx context.Context, portals map[uint64]netman.Portal, count int) error {
 	for _, from := range portals {
 		for _, to := range portals {
 			if from.Chain.ID == to.Chain.ID {
 				continue
 			}
 
-			if err := xcall(ctx, from, to.Chain.ID); err != nil {
-				return err
+			for i := 0; i < count; i++ {
+				if err := xcall(ctx, from, to.Chain.ID); err != nil {
+					return err
+				}
 			}
 		}
 	}

--- a/test/e2e/app/monitor.go
+++ b/test/e2e/app/monitor.go
@@ -8,20 +8,19 @@ import (
 	"github.com/omni-network/omni/lib/log"
 	"github.com/omni-network/omni/lib/netconf"
 	"github.com/omni-network/omni/test/e2e/netman"
-	"github.com/omni-network/omni/test/e2e/types"
 
 	e2e "github.com/cometbft/cometbft/test/e2e/pkg"
 )
 
-func LogMetrics(ctx context.Context, testnet types.Testnet, mngr netman.Manager) error {
-	extNetwork := externalNetwork(testnet, mngr.DeployInfo())
+func LogMetrics(ctx context.Context, def Definition) error {
+	extNetwork := externalNetwork(def.Testnet, def.Netman.DeployInfo())
 
-	// Just pick the first node for now.
-	if err := MonitorCProvider(ctx, testnet.Nodes[0], extNetwork); err != nil {
+	// Pick a random node to monitor.
+	if err := MonitorCProvider(ctx, random(def.Testnet.Nodes), extNetwork); err != nil {
 		return errors.Wrap(err, "monitoring cchain provider")
 	}
 
-	if err := MonitorCursors(ctx, mngr.Portals(), extNetwork); err != nil {
+	if err := MonitorCursors(ctx, def.Netman.Portals(), extNetwork); err != nil {
 		return errors.Wrap(err, "monitoring cursors")
 	}
 

--- a/test/e2e/app/run.go
+++ b/test/e2e/app/run.go
@@ -18,7 +18,7 @@ func Deploy(ctx context.Context, def Definition) error {
 		return err
 	}
 
-	if err := Setup(ctx, def.Testnet, def.Infra, def.Netman); err != nil {
+	if err := Setup(ctx, def); err != nil {
 		return err
 	}
 
@@ -73,11 +73,11 @@ func E2ETest(ctx context.Context, def Definition, cfg E2ETestConfig) error {
 		return err
 	}
 
-	if err := Test(ctx, def.Testnet, def.Infra.GetInfrastructureData(), def.Netman); err != nil {
+	if err := Test(ctx, def); err != nil {
 		return err
 	}
 
-	if err := LogMetrics(ctx, def.Testnet, def.Netman); err != nil {
+	if err := LogMetrics(ctx, def); err != nil {
 		return err
 	}
 

--- a/test/e2e/app/test.go
+++ b/test/e2e/app/test.go
@@ -8,18 +8,15 @@ import (
 	"github.com/omni-network/omni/lib/errors"
 	"github.com/omni-network/omni/lib/log"
 	"github.com/omni-network/omni/lib/netconf"
-	"github.com/omni-network/omni/test/e2e/netman"
-	"github.com/omni-network/omni/test/e2e/types"
 
-	e2e "github.com/cometbft/cometbft/test/e2e/pkg"
 	"github.com/cometbft/cometbft/test/e2e/pkg/exec"
 )
 
 // Test runs test cases under tests/.
-func Test(ctx context.Context, testnet types.Testnet, ifd *e2e.InfrastructureData, mngr netman.Manager) error {
+func Test(ctx context.Context, def Definition) error {
 	log.Info(ctx, "Running tests in ./tests/...")
 
-	extNetwork := externalNetwork(testnet, mngr.DeployInfo())
+	extNetwork := externalNetwork(def.Testnet, def.Netman.DeployInfo())
 
 	networkDir, err := os.MkdirTemp("", "omni-e2e")
 	if err != nil {
@@ -34,7 +31,7 @@ func Test(ctx context.Context, testnet types.Testnet, ifd *e2e.InfrastructureDat
 		return errors.Wrap(err, "setting E2E_MANIFEST")
 	}
 
-	manifestFile, err := filepath.Abs(testnet.File)
+	manifestFile, err := filepath.Abs(def.Testnet.File)
 	if err != nil {
 		return errors.Wrap(err, "absolute manifest path")
 	}
@@ -43,14 +40,15 @@ func Test(ctx context.Context, testnet types.Testnet, ifd *e2e.InfrastructureDat
 		return errors.Wrap(err, "setting E2E_MANIFEST")
 	}
 
-	if p := ifd.Path; p != "" {
+	infd := def.Infra.GetInfrastructureData()
+	if p := infd.Path; p != "" {
 		err = os.Setenv("INFRASTRUCTURE_FILE", p)
 		if err != nil {
 			return errors.Wrap(err, "setting INFRASTRUCTURE_FILE")
 		}
 	}
 
-	if err = os.Setenv("INFRASTRUCTURE_TYPE", ifd.Provider); err != nil {
+	if err = os.Setenv("INFRASTRUCTURE_TYPE", infd.Provider); err != nil {
 		return errors.Wrap(err, "setting INFRASTRUCTURE_TYPE")
 	}
 

--- a/test/e2e/types/testnet.go
+++ b/test/e2e/types/testnet.go
@@ -25,8 +25,7 @@ type EVMChain struct {
 	IsPublic bool
 }
 
-// OmniEVM represetns a omni evm instance in a omni network. Similar to e2e.Node for halo instances.
-// TODO(corver): Extend OmniEVM with bootnode peer addresses for p2p networking.
+// OmniEVM represents a omni evm instance in a omni network. Similar to e2e.Node for halo instances.
 type OmniEVM struct {
 	Chain           EVMChain // For netconf (all instances must have the same chain)
 	InstanceName    string   // For docker container name


### PR DESCRIPTION
Fixes the mappings of halo to omni_evm. Also choose random nodes if possible (not only first)

task: none
