### PR TITLE
test(e2e): add support for vm infra provider

### DIFF
--- a/test/e2e/docker/compose.yaml.tmpl
+++ b/test/e2e/docker/compose.yaml.tmpl
@@ -1,16 +1,13 @@
 version: '2.4'
 networks:
-  {{ .Name }}:
+  {{ .NetworkName }}:
     labels:
       e2e: true
     driver: bridge
-{{- if .IPv6 }}
-    enable_ipv6: true
-{{- end }}
     ipam:
       driver: default
       config:
-      - subnet: {{ .IP }}
+      - subnet: {{ .NetworkCIDR }}
 
 services:
 {{- range .Nodes }}
@@ -31,8 +28,8 @@ services:
     - ./{{ .Name }}:/halo
     - ./{{ index $.NodeOmniEVMs .Name }}/jwtsecret:/geth/jwtsecret
     networks:
-      {{ $.Name }}:
-        ipv{{ if $.IPv6 }}6{{ else }}4{{ end}}_address: {{ .InternalIP }}
+      {{ $.NetworkName }}:
+        ipv4_address: {{ .InternalIP }}
 {{end}}
 
 {{- range .Anvils }}
@@ -46,7 +43,7 @@ services:
     ports:
       - {{ if .ProxyPort }}{{ .ProxyPort }}:{{ end }}8545
     networks:
-      {{ $.Name }}:
+      {{ $.NetworkName }}:
         ipv4_address: {{ .InternalIP }}
 {{end}}
 
@@ -98,10 +95,11 @@ services:
     volumes:
       - ./{{ .Name }}:/geth
     networks:
-      {{ $.Name }}:
+      {{ $.NetworkName }}:
         ipv4_address: {{ .InternalIP }}
 {{end}}
 
+{{ if .Relayer }}
   relayer:
     labels:
       e2e: true
@@ -111,5 +109,6 @@ services:
     volumes:
       - ./relayer:/relayer
     networks:
-      {{ $.Name }}:
+      {{ $.NetworkName }}:
         ipv4_address: 10.186.73.200
+{{end}}

--- a/test/e2e/docker/data.go
+++ b/test/e2e/docker/data.go
@@ -40,18 +40,16 @@ func NewInfraData(manifest types.Manifest) (types.InfrastructureData, error) {
 		return uint32(port)
 	}
 
-	omniEVMS := make(map[string]e2e.InstanceData)
 	for _, name := range manifest.OmniEVMs() {
-		omniEVMS[name] = e2e.InstanceData{
+		infd.Instances[name] = e2e.InstanceData{
 			IPAddress:    nextInternalIP(),
 			ExtIPAddress: localhost,
 			Port:         nextPort(),
 		}
 	}
 
-	anvils := make(map[string]e2e.InstanceData)
 	for _, name := range manifest.AnvilChains {
-		anvils[name] = e2e.InstanceData{
+		infd.Instances[name] = e2e.InstanceData{
 			IPAddress:    nextInternalIP(),
 			ExtIPAddress: localhost,
 			Port:         nextPort(),
@@ -62,7 +60,5 @@ func NewInfraData(manifest types.Manifest) (types.InfrastructureData, error) {
 
 	return types.InfrastructureData{
 		InfrastructureData: infd,
-		OmniEVMs:           omniEVMS,
-		AnvilChains:        anvils,
 	}, nil
 }

--- a/test/e2e/docker/testdata/TestComposeTemplate.golden
+++ b/test/e2e/docker/testdata/TestComposeTemplate.golden
@@ -92,6 +92,7 @@ services:
         ipv4_address: 10.186.73.0
 
 
+
   relayer:
     labels:
       e2e: true
@@ -103,3 +104,4 @@ services:
     networks:
       test:
         ipv4_address: 10.186.73.200
+

--- a/test/e2e/types/infra.go
+++ b/test/e2e/types/infra.go
@@ -5,12 +5,7 @@ import (
 )
 
 // InfrastructureData wraps e2e.InfrastructureData with additional omni-specific fields.
+// TODO(corver): Maybe remove this type if not used.
 type InfrastructureData struct {
 	e2e.InfrastructureData
-
-	// OmniEVMs defines the infrastructure data for the deployed Omni EVMs (keyed by instance name).
-	OmniEVMs map[string]e2e.InstanceData `json:"omni_evms"`
-
-	// AnvilChains defines the instance data per deployed Anvil chains (keyed by chain name).
-	AnvilChains map[string]e2e.InstanceData `json:"anvil_chains"`
 }

--- a/test/e2e/vmcompose/data.go
+++ b/test/e2e/vmcompose/data.go
@@ -1,0 +1,85 @@
+package vmcompose
+
+import (
+	"encoding/json"
+	"net"
+	"os"
+	"regexp"
+
+	"github.com/omni-network/omni/lib/errors"
+	"github.com/omni-network/omni/test/e2e/types"
+
+	e2e "github.com/cometbft/cometbft/test/e2e/pkg"
+)
+
+var evmRegx = regexp.MustCompile("(.*_evm|chain_.*)")
+
+const (
+	evmPort  = 8545
+	haloPort = 26657
+	relayer  = "relayer"
+)
+
+type vmJSON struct {
+	Name string
+	IP   string
+}
+type dataJSON struct {
+	NetworkCIDR  string            `json:"network_cidr"`
+	VMs          []vmJSON          `json:"vms"`
+	ServicesByVM map[string]string `json:"services_by_vm"` // map[service_name]vm_name
+}
+
+// LoadData returns the vmcompose infrastructure data from the given path.
+func LoadData(path string) (types.InfrastructureData, error) {
+	bz, err := os.ReadFile(path)
+	if err != nil {
+		return types.InfrastructureData{}, errors.Wrap(err, "read file")
+	}
+
+	var data dataJSON
+	err = json.Unmarshal(bz, &data)
+	if err != nil {
+		return types.InfrastructureData{}, errors.Wrap(err, "unmarshal json")
+	}
+
+	vmsByName := make(map[string]e2e.InstanceData)
+	for _, vm := range data.VMs {
+		ip := net.ParseIP(vm.IP)
+		vmsByName[vm.Name] = e2e.InstanceData{
+			IPAddress:    ip,
+			ExtIPAddress: ip,
+		}
+	}
+
+	instances := make(map[string]e2e.InstanceData)
+	for serviceName, vmName := range data.ServicesByVM {
+		vm, ok := vmsByName[vmName]
+		if !ok {
+			return types.InfrastructureData{}, errors.New("vm not found", "name", vmName)
+		}
+
+		// Default ports, as VMs don't support overlapping ports.
+		port := haloPort
+		if evmRegx.MatchString(serviceName) {
+			port = evmPort
+		} else if serviceName == relayer {
+			port = 0 // No port for relayer
+		}
+
+		instances[serviceName] = e2e.InstanceData{
+			IPAddress:    vm.IPAddress,
+			ExtIPAddress: vm.IPAddress,
+			Port:         uint32(port),
+		}
+	}
+
+	return types.InfrastructureData{
+		InfrastructureData: e2e.InfrastructureData{
+			Path:      path,
+			Provider:  ProviderName,
+			Instances: instances,
+			Network:   data.NetworkCIDR,
+		},
+	}, nil
+}

--- a/test/e2e/vmcompose/provider.go
+++ b/test/e2e/vmcompose/provider.go
@@ -1,0 +1,112 @@
+package vmcompose
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/omni-network/omni/lib/errors"
+	"github.com/omni-network/omni/test/e2e/docker"
+	"github.com/omni-network/omni/test/e2e/types"
+
+	e2e "github.com/cometbft/cometbft/test/e2e/pkg"
+	"github.com/cometbft/cometbft/test/e2e/pkg/infra"
+)
+
+const ProviderName = "vmcompose"
+
+var _ infra.Provider = (*Provider)(nil)
+
+type Provider struct {
+	Testnet types.Testnet
+	Data    types.InfrastructureData
+}
+
+func NewProvider(testnet types.Testnet, data types.InfrastructureData) *Provider {
+	return &Provider{
+		Testnet: testnet,
+		Data:    data,
+	}
+}
+
+// Setup generates the docker-compose file for each VM IP.
+func (p *Provider) Setup() error {
+	// Group infra services by VM IP
+	for vmIP, services := range groupByVM(p.Data.Instances) {
+		// Get all halo nodes in this VM
+		var nodes []*e2e.Node
+		for _, node := range p.Testnet.Nodes {
+			if services[node.Name] {
+				nodes = append(nodes, node)
+			}
+		}
+
+		// Get all omniEVMs in this VM
+		var omniEVMs []types.OmniEVM
+		for _, omniEVM := range p.Testnet.OmniEVMs {
+			if services[omniEVM.InstanceName] {
+				omniEVMs = append(omniEVMs, omniEVM)
+			}
+		}
+
+		// Get all anvil chains in this VM
+		var anvilChains []types.AnvilChain
+		for _, anvilChain := range p.Testnet.AnvilChains {
+			if services[anvilChain.Chain.Name] {
+				anvilChains = append(anvilChains, anvilChain)
+			}
+		}
+
+		def := docker.ComposeDef{
+			NetworkName: p.Testnet.Name,
+			NetworkCIDR: p.Testnet.IP.String(),
+			Nodes:       nodes,
+			OmniEVMs:    omniEVMs,
+			Anvils:      anvilChains,
+			Relayer:     services["relayer"],
+		}
+		compose, err := docker.GenerateComposeFile(def)
+		if err != nil {
+			return errors.Wrap(err, "generate compose file")
+		}
+
+		filename := strings.ReplaceAll(vmIP, ".", "_") + "_compose.yaml"
+
+		err = os.WriteFile(filepath.Join(p.Testnet.Dir, filename), compose, 0o644)
+		if err != nil {
+			return errors.Wrap(err, "write compose file")
+		}
+	}
+
+	return nil
+}
+
+func (p *Provider) StartNodes(ctx context.Context, node ...*e2e.Node) error {
+	// TODO(corver): Copy all locally generated compose files and folders and config to VMs (see ../docker sync.Once).
+
+	return errors.New("not implemented")
+}
+
+func (p *Provider) StopTestnet(ctx context.Context) error {
+	return errors.New("not implemented")
+}
+
+func (p *Provider) GetInfrastructureData() *e2e.InfrastructureData {
+	return &p.Data.InfrastructureData
+}
+
+func groupByVM(instances map[string]e2e.InstanceData) map[string]map[string]bool {
+	resp := make(map[string]map[string]bool) // map[vm_ip]map[service_name]true
+	for serviceName, instance := range instances {
+		ip := instance.IPAddress.String()
+		m, ok := resp[ip]
+		if !ok {
+			m = make(map[string]bool)
+		}
+		m[serviceName] = true
+		resp[ip] = m
+	}
+
+	return resp
+}

--- a/test/e2e/vmcompose/provider_internal_test.go
+++ b/test/e2e/vmcompose/provider_internal_test.go
@@ -1,0 +1,59 @@
+package vmcompose
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// SetupDataFixtures returns the test fixture filenames of manifest and infrastructure data files.
+// This accesses private types, so it's in the same package as the types.
+func SetupDataFixtures(t *testing.T) (string, string) {
+	t.Helper()
+
+	// Write manifest to disk
+	manifest := `
+network = "devnet"
+anvil_chains = ["chain_a"]
+multi_omni_evms = true
+
+[node.validator01]
+[node.validator02]
+`
+	manifestFile := filepath.Join(t.TempDir(), "manifest.toml")
+	err := os.WriteFile(manifestFile, []byte(manifest), 0o644)
+	require.NoError(t, err)
+
+	const vm1, vm2, vm3 = "vm1", "vm2", "vm3"
+
+	dataJSON := dataJSON{
+		NetworkCIDR: "127.0.0.1/24",
+		VMs: []vmJSON{
+			{Name: vm1, IP: "127.0.0.1"},
+			{Name: vm2, IP: "127.0.0.2"},
+			{Name: vm3, IP: "127.0.0.3"},
+		},
+		ServicesByVM: map[string]string{
+			"validator01":     vm1,
+			"validator01_evm": vm1,
+
+			"validator02":     vm2,
+			"validator02_evm": vm2,
+
+			"chain_a": vm3,
+			"relayer": vm3,
+		},
+	}
+
+	// Write raw data json to disk
+	bz, err := json.Marshal(dataJSON)
+	require.NoError(t, err)
+	dataFile := filepath.Join(t.TempDir(), "data.json")
+	err = os.WriteFile(dataFile, bz, 0o644)
+	require.NoError(t, err)
+
+	return manifestFile, dataFile
+}

--- a/test/e2e/vmcompose/provider_test.go
+++ b/test/e2e/vmcompose/provider_test.go
@@ -1,0 +1,56 @@
+package vmcompose_test
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"testing"
+
+	"github.com/omni-network/omni/test/e2e/app"
+	"github.com/omni-network/omni/test/e2e/vmcompose"
+	"github.com/omni-network/omni/test/tutil"
+
+	"github.com/stretchr/testify/require"
+)
+
+//go:generate go test . -update -clean
+
+func TestSetup(t *testing.T) {
+	t.Parallel()
+	manifestFile, dataFile := vmcompose.SetupDataFixtures(t)
+
+	def, err := app.MakeDefinition(app.DefinitionConfig{
+		ManifestFile:  manifestFile,
+		InfraProvider: vmcompose.ProviderName,
+		InfraDataFile: dataFile,
+	})
+	require.NoError(t, err)
+
+	err = os.MkdirAll(def.Testnet.Dir, 0o755)
+	require.NoError(t, err)
+
+	err = def.Infra.Setup()
+	require.NoError(t, err)
+
+	files, err := filepath.Glob(filepath.Join(def.Testnet.Dir, "*compose.yaml"))
+	require.NoError(t, err)
+
+	for _, file := range files {
+		file := file // Pin
+		t.Run(filepath.Base(file), func(t *testing.T) {
+			t.Parallel()
+			bz, err := os.ReadFile(file)
+			require.NoError(t, err)
+
+			// Replace non-deterministic fields with placeholders
+
+			re1 := regexp.MustCompile(`--nodekeyhex=([0-9a-fA-F]+)`)
+			bz = re1.ReplaceAll(bz, []byte("--nodekeyhex=<nodekeyhex>"))
+
+			re2 := regexp.MustCompile(`enode://([0-9a-fA-F]+)`)
+			bz = re2.ReplaceAll(bz, []byte("enode://<enode_pubkey>"))
+
+			tutil.RequireGoldenBytes(t, bz)
+		})
+	}
+}

--- a/test/e2e/vmcompose/testdata/TestSetup_127_0_0_1_compose.yaml.golden
+++ b/test/e2e/vmcompose/testdata/TestSetup_127_0_0_1_compose.yaml.golden
@@ -1,0 +1,82 @@
+version: '2.4'
+networks:
+  manifest:
+    labels:
+      e2e: true
+    driver: bridge
+    ipam:
+      driver: default
+      config:
+      - subnet: 127.0.0.0/24
+
+services:
+  validator01:
+    labels:
+      e2e: true
+    container_name: validator01
+    image: omniops/halo:main
+    init: true
+    ports:
+    - 26656
+    - 26657:26657
+    - 6060
+    volumes:
+    - ./validator01:/halo
+    - ./validator01_evm/jwtsecret:/geth/jwtsecret
+    networks:
+      manifest:
+        ipv4_address: 127.0.0.1
+
+
+  # Use geth as the omni EVMs.
+  # Initialises geth files and folder from provided genesis file.
+  validator01_evm-init:
+    labels:
+      e2e: true
+    container_name: validator01_evm-init
+    image: "ethereum/client-go:latest"
+    command: --datadir=/geth init /geth/genesis.json
+    volumes:
+      - ./validator01_evm:/geth
+
+  validator01_evm:
+    labels:
+      e2e: true
+    container_name: validator01_evm
+    image: "ethereum/client-go:latest"
+    command:
+      - --http
+      - --http.vhosts=*
+      - --http.api=eth,net,web3
+      - --http.addr=0.0.0.0
+      - --http.corsdomain=*
+      - --ws
+      - --ws.api=eth,net,web3
+      - --ws.addr=0.0.0.0
+      - --ws.origins=*
+      - --authrpc.vhosts=*
+      - --authrpc.addr=0.0.0.0
+      - --authrpc.jwtsecret=/geth/jwtsecret
+      - --datadir=/geth
+      - --allow-insecure-unlock
+      - --unlock=0x123463a4b065722e99115d6c222f267d9cabb524
+      - --password=/geth/geth_password.txt
+      - --nodiscover
+      - --syncmode=full
+      - --nodekeyhex=<nodekeyhex>
+      - --bootnodes=enode://<enode_pubkey>@127.0.0.2:30303
+    ports:
+      - 8551
+      - 8545:8545
+      - 8546
+    depends_on:
+      validator01_evm-init:
+        condition: service_completed_successfully
+    volumes:
+      - ./validator01_evm:/geth
+    networks:
+      manifest:
+        ipv4_address: 127.0.0.1
+
+
+

--- a/test/e2e/vmcompose/testdata/TestSetup_127_0_0_2_compose.yaml.golden
+++ b/test/e2e/vmcompose/testdata/TestSetup_127_0_0_2_compose.yaml.golden
@@ -1,0 +1,82 @@
+version: '2.4'
+networks:
+  manifest:
+    labels:
+      e2e: true
+    driver: bridge
+    ipam:
+      driver: default
+      config:
+      - subnet: 127.0.0.0/24
+
+services:
+  validator02:
+    labels:
+      e2e: true
+    container_name: validator02
+    image: omniops/halo:main
+    init: true
+    ports:
+    - 26656
+    - 26657:26657
+    - 6060
+    volumes:
+    - ./validator02:/halo
+    - ./validator02_evm/jwtsecret:/geth/jwtsecret
+    networks:
+      manifest:
+        ipv4_address: 127.0.0.2
+
+
+  # Use geth as the omni EVMs.
+  # Initialises geth files and folder from provided genesis file.
+  validator02_evm-init:
+    labels:
+      e2e: true
+    container_name: validator02_evm-init
+    image: "ethereum/client-go:latest"
+    command: --datadir=/geth init /geth/genesis.json
+    volumes:
+      - ./validator02_evm:/geth
+
+  validator02_evm:
+    labels:
+      e2e: true
+    container_name: validator02_evm
+    image: "ethereum/client-go:latest"
+    command:
+      - --http
+      - --http.vhosts=*
+      - --http.api=eth,net,web3
+      - --http.addr=0.0.0.0
+      - --http.corsdomain=*
+      - --ws
+      - --ws.api=eth,net,web3
+      - --ws.addr=0.0.0.0
+      - --ws.origins=*
+      - --authrpc.vhosts=*
+      - --authrpc.addr=0.0.0.0
+      - --authrpc.jwtsecret=/geth/jwtsecret
+      - --datadir=/geth
+      - --allow-insecure-unlock
+      - --unlock=0x123463a4b065722e99115d6c222f267d9cabb524
+      - --password=/geth/geth_password.txt
+      - --nodiscover
+      - --syncmode=full
+      - --nodekeyhex=<nodekeyhex>
+      - --bootnodes=enode://<enode_pubkey>@127.0.0.1:30303
+    ports:
+      - 8551
+      - 8545:8545
+      - 8546
+    depends_on:
+      validator02_evm-init:
+        condition: service_completed_successfully
+    volumes:
+      - ./validator02_evm:/geth
+    networks:
+      manifest:
+        ipv4_address: 127.0.0.2
+
+
+

--- a/test/e2e/vmcompose/testdata/TestSetup_127_0_0_3_compose.yaml.golden
+++ b/test/e2e/vmcompose/testdata/TestSetup_127_0_0_3_compose.yaml.golden
@@ -1,0 +1,41 @@
+version: '2.4'
+networks:
+  manifest:
+    labels:
+      e2e: true
+    driver: bridge
+    ipam:
+      driver: default
+      config:
+      - subnet: 127.0.0.0/24
+
+services:
+  # Initialises geth files and folder from provided genesis file.
+  chain_a:
+    labels:
+      e2e: true
+    container_name: chain_a
+    image: ghcr.io/foundry-rs/foundry:latest
+    entrypoint: ['anvil','--host','0.0.0.0','--chain-id','100','--block-time','1', "--silent"]
+    ports:
+      - 8545:8545
+    networks:
+      manifest:
+        ipv4_address: 127.0.0.3
+
+
+  # Use geth as the omni EVMs.
+
+
+  relayer:
+    labels:
+      e2e: true
+    container_name: relayer
+    image: omniops/relayer:main
+    restart: unless-stopped # Restart on crash to mitigate startup race issues
+    volumes:
+      - ./relayer:/relayer
+    networks:
+      manifest:
+        ipv4_address: 10.186.73.200
+


### PR DESCRIPTION
Adds support for `vm (docker) compose` infrastructure provider to e2e app.

The aim is:
 - Define VMs (by IP) that services should be deployed to
 - Generate multiple docker-compose file (one per VM) which contain the services to start on each.
 
 Next steps:
 - Copy the compose and service folders to each VM on `Start`
 - Implement `Start` and `Stop`

task: none