### PR TITLE
test(e2e): make e2e tests robust

### DIFF
--- a/lib/expbackoff/expbackoff.go
+++ b/lib/expbackoff/expbackoff.go
@@ -52,6 +52,14 @@ var FastConfig = Config{
 	MaxDelay:   5 * time.Second,
 }
 
+// WithPeriodicConfig configures the backoff with periodic backoff.
+func WithPeriodicConfig(period time.Duration) func(*Config) {
+	return func(config *Config) {
+		config.BaseDelay = period
+		config.Multiplier = 1
+	}
+}
+
 // WithFastConfig configures the backoff with FastConfig.
 func WithFastConfig() func(*Config) {
 	return func(config *Config) {

--- a/test/e2e/app/contract.go
+++ b/test/e2e/app/contract.go
@@ -5,43 +5,60 @@ import (
 	"time"
 
 	"github.com/omni-network/omni/lib/errors"
+	"github.com/omni-network/omni/lib/expbackoff"
 	"github.com/omni-network/omni/lib/log"
 	"github.com/omni-network/omni/test/e2e/netman"
 
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
+	ethtypes "github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/ethclient"
 )
 
-func StartSendingXMsgs(ctx context.Context, portals map[uint64]netman.Portal) error {
-	log.Info(ctx, "Generating cross chain messages async")
+func StartSendingXMsgs(ctx context.Context, portals map[uint64]netman.Portal, batches ...int) <-chan error {
+	log.Info(ctx, "Generating cross chain messages async", "batches", batches)
+	errChan := make(chan error, 1)
 	go func() {
-		for ctx.Err() == nil {
-			err := SendXMsgs(ctx, portals, 3)
+		for _, count := range batches {
+			err := SendXMsgs(ctx, portals, count)
 			if ctx.Err() != nil {
+				errChan <- ctx.Err()
 				return
 			} else if err != nil {
-				log.Error(ctx, "Failed to send xmsgs, giving up", err)
+				errChan <- errors.Wrap(err, "send xmsgs")
 				return
 			}
-			time.Sleep(time.Millisecond * 1000)
 		}
+		errChan <- nil
 	}()
 
-	return nil
+	return errChan
 }
 
-// SendXMsgs sends one xmsg from every chain to every other chain.
-func SendXMsgs(ctx context.Context, portals map[uint64]netman.Portal, count int) error {
-	for _, from := range portals {
+// SendXMsgs sends <count> xmsgs from every chain to every other chain, then waits for them to be mined.
+func SendXMsgs(ctx context.Context, portals map[uint64]netman.Portal, batch int) error {
+	allTxs := make(map[uint64][]*ethtypes.Transaction)
+	for fromChainID, from := range portals {
 		for _, to := range portals {
 			if from.Chain.ID == to.Chain.ID {
 				continue
 			}
 
-			for i := 0; i < count; i++ {
-				if err := xcall(ctx, from, to.Chain.ID); err != nil {
+			for i := 0; i < batch; i++ {
+				tx, err := xcall(ctx, from, to.Chain.ID)
+				if err != nil {
 					return err
 				}
+				allTxs[fromChainID] = append(allTxs[fromChainID], tx)
+			}
+		}
+	}
+
+	for chainID, txs := range allTxs {
+		portal := portals[chainID]
+		for _, tx := range txs {
+			if err := waitMined(ctx, portal.Client, tx); err != nil {
+				return errors.Wrap(err, "wait mined", "chain_id", chainID)
 			}
 		}
 	}
@@ -50,14 +67,14 @@ func SendXMsgs(ctx context.Context, portals map[uint64]netman.Portal, count int)
 }
 
 // xcall sends a ethereum transaction to the portal contract, triggering a xcall.
-func xcall(ctx context.Context, from netman.Portal, destChainID uint64) error {
+func xcall(ctx context.Context, from netman.Portal, destChainID uint64) (*ethtypes.Transaction, error) {
 	// TODO: use calls to actual contracts
 	var data []byte = nil
 	to := common.Address{}
 
 	fee, err := from.Contract.FeeFor(&bind.CallOpts{}, destChainID, data)
 	if err != nil {
-		return errors.Wrap(err, "feeFor",
+		return nil, errors.Wrap(err, "feeFor",
 			"source_chain", from.Chain.ID,
 			"dest_chain", destChainID,
 		)
@@ -66,13 +83,32 @@ func xcall(ctx context.Context, from netman.Portal, destChainID uint64) error {
 	txOpts := from.TxOpts(ctx)
 	txOpts.Value = fee
 
-	_, err = from.Contract.Xcall(txOpts, destChainID, to, data)
+	tx, err := from.Contract.Xcall(txOpts, destChainID, to, data)
 	if err != nil {
-		return errors.Wrap(err, "xcall",
+		return nil, errors.Wrap(err, "xcall",
 			"source_chain", from.Chain.ID,
 			"dest_chain", destChainID,
 		)
 	}
 
-	return nil
+	return tx, nil
+}
+
+func waitMined(ctx context.Context, ethCl *ethclient.Client, tx *ethtypes.Transaction) error {
+	ctx, cancel := context.WithTimeout(ctx, time.Minute)
+	defer cancel()
+
+	backoff := expbackoff.New(ctx, expbackoff.WithFastConfig())
+	for ctx.Err() == nil {
+		_, pending, err := ethCl.TransactionByHash(ctx, tx.Hash())
+		if err != nil {
+			return errors.Wrap(err, "tx by hash")
+		}
+		if !pending {
+			return nil
+		}
+		backoff()
+	}
+
+	return errors.New("timeout waiting for tx to be mined")
 }

--- a/test/e2e/app/wait.go
+++ b/test/e2e/app/wait.go
@@ -4,7 +4,10 @@ import (
 	"context"
 	"time"
 
+	"github.com/omni-network/omni/lib/errors"
+	"github.com/omni-network/omni/lib/expbackoff"
 	"github.com/omni-network/omni/lib/log"
+	"github.com/omni-network/omni/test/e2e/netman"
 
 	e2e "github.com/cometbft/cometbft/test/e2e/pkg"
 )
@@ -35,4 +38,52 @@ func WaitUntil(ctx context.Context, testnet *e2e.Testnet, height int64) error {
 // More nodes in a network implies we may expect a slower network and may have to wait longer.
 func waitingTime(nodes int, height int64) time.Duration {
 	return time.Duration(20+(int64(nodes)*height)) * time.Second
+}
+
+func WaitAllSubmissions(ctx context.Context, portals map[uint64]netman.Portal, total int) error {
+	log.Info(ctx, "Waiting for submissions on all destination chains")
+	ctx, cancel := context.WithTimeout(ctx, 2*time.Minute)
+	defer cancel()
+
+	for _, dest := range portals {
+		for _, src := range portals {
+			if src.Chain.ID == dest.Chain.ID {
+				continue
+			}
+
+			backoff := expbackoff.New(ctx, expbackoff.WithPeriodicConfig(time.Second))
+			for {
+				if ctx.Err() != nil {
+					return errors.Wrap(ctx.Err(), "timeout waiting for submissions")
+				}
+
+				srcOffset, err := src.Contract.OutXStreamOffset(nil, dest.Chain.ID)
+				if err != nil {
+					return errors.Wrap(err, "getting inXStreamOffset")
+				}
+
+				destOffset, err := dest.Contract.InXStreamOffset(nil, src.Chain.ID)
+				if err != nil {
+					return errors.Wrap(err, "getting inXStreamOffset")
+				}
+
+				if srcOffset != uint64(total) {
+					return errors.New("unexpected source chain offset",
+						"src", src.Chain.Name, "dest", dest.Chain.Name,
+						"src_offset", srcOffset, "expected", total)
+				}
+
+				if destOffset == uint64(total) {
+					break
+				}
+
+				log.Debug(ctx, "Waiting for submissions on destination chain",
+					"src", src.Chain.Name, "dest", dest.Chain.Name,
+					"src_offset", srcOffset, "dest_offset", destOffset)
+				backoff()
+			}
+		}
+	}
+
+	return nil
 }


### PR DESCRIPTION
Refactor e2e tests to wait for all xmsgs to be sent and then for all xmsgs to be submitted on destination before starting tests. This mitigates slow async process.

task: none