### PR TITLE
test(e2e): support prometheus remote write

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,13 +57,13 @@ halo-simnet: ## Runs halo in simnet mode.
 	@halo init --home=/tmp/halo --network=simnet --clean
 	@halo run --home=/tmp/halo
 
-.PHONY: devnet-run
-devnet-run: ## Runs devnet1 (alias for MANIFEST=devnet1 make e2e-run).
+.PHONY: devnet-deploy
+devnet-deploy: ## Deploys devnet1
 	@echo "Creating a docker-compose devnet in ./test/e2e/run/devnet1"
 	@go run github.com/omni-network/omni/test/e2e -f test/e2e/manifests/devnet1.toml deploy
 
-.PHONY: devnet-stop
-devnet-stop: ## Deletes devnet1 containers (alias for MANIFEST=devnet1 make e2e-stop).
+.PHONY: devnet-clean
+devnet-clean: ## Deletes devnet1 containers
 	@echo "Stopping the devnet in ./test/e2e/run/devnet1"
 	@go run github.com/omni-network/omni/test/e2e -f test/e2e/manifests/devnet1.toml clean
 
@@ -79,8 +79,8 @@ e2e-logs: ## Print the docker logs of previously ran e2e manifest (single, simpl
 	@echo "Using MANIFEST=$(MANIFEST)"
 	@go run github.com/omni-network/omni/test/e2e -f test/e2e/manifests/$(MANIFEST).toml logs
 
-.PHONY: e2e-stop
-e2e-stop: ## Deletes all running containers from previously ran e2e.
-	@if [ -z "$(MANIFEST)" ]; then echo "⚠️  Please specify a manifest: MANIFEST=simple make e2e-stop" && exit 1; fi
+.PHONY: e2e-clean
+e2e-clean: ## Deletes all running containers from previously ran e2e.
+	@if [ -z "$(MANIFEST)" ]; then echo "⚠️  Please specify a manifest: MANIFEST=simple make e2e-clean" && exit 1; fi
 	@echo "Using MANIFEST=$(MANIFEST)"
 	@go run github.com/omni-network/omni/test/e2e -f test/e2e/manifests/$(MANIFEST).toml clean

--- a/test/e2e/app/prometheus.go
+++ b/test/e2e/app/prometheus.go
@@ -1,0 +1,113 @@
+package app
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"text/template"
+	"time"
+
+	"github.com/omni-network/omni/lib/errors"
+	"github.com/omni-network/omni/lib/log"
+	"github.com/omni-network/omni/lib/netconf"
+	"github.com/omni-network/omni/test/e2e/types"
+
+	_ "embed"
+)
+
+type PromSecrets struct {
+	URL  string
+	User string
+	Pass string
+}
+
+const promPort = 26660 // Default metrics port for all omni apps (from cometBFT)
+
+//go:embed static/prometheus.yml.tmpl
+var promConfigTmpl []byte
+
+func writePrometheusConfig(ctx context.Context, testnet types.Testnet, secrets PromSecrets) error {
+	bz, err := genPromConfig(ctx, testnet, secrets)
+	if err != nil {
+		return errors.Wrap(err, "generating prometheus config")
+	}
+
+	promFile := filepath.Join(testnet.Dir, "prometheus", "prometheus.yml")
+	if err := os.MkdirAll(filepath.Dir(promFile), 0755); err != nil {
+		return errors.Wrap(err, "creating prometheus dir")
+	}
+
+	if err := os.WriteFile(promFile, bz, 0644); err != nil {
+		return errors.Wrap(err, "writing prometheus config")
+	}
+
+	return nil
+}
+
+func genPromConfig(ctx context.Context, testnet types.Testnet, secrets PromSecrets) ([]byte, error) {
+	var nodeTargets []string
+	for _, node := range testnet.Nodes {
+		// Prometheus is always inside the same docker-compose, so use service names.
+		nodeTargets = append(nodeTargets, fmt.Sprintf("%s:%d", node.Name, promPort))
+	}
+
+	network := testnet.Network
+	if network == netconf.Devnet {
+		network += "-" + time.Now().Format("20060102150405") // Add suffix to distinguish between devnets
+	}
+
+	if secrets.URL == "" {
+		log.Warn(ctx, "Prometheus remote URL not set, metrics not being pushed to Grafana cloud", nil)
+	}
+
+	data := promTmplData{
+		Network:        network,
+		RemoteURL:      secrets.URL,
+		RemoteUsername: secrets.User,
+		RemotePassword: secrets.Pass,
+		ScrapeConfigs: []promScrapConfig{
+			{
+				JobName:     "relayer",
+				MetricsPath: "/metrics",
+				targets:     []string{fmt.Sprintf("relayer:%d", promPort)},
+			}, {
+				JobName:     "halo",
+				MetricsPath: "/metrics",
+				targets:     nodeTargets,
+			},
+		},
+	}
+
+	t, err := template.New("").Parse(string(promConfigTmpl))
+	if err != nil {
+		return nil, errors.Wrap(err, "parsing template")
+	}
+
+	var bz bytes.Buffer
+	if err := t.Execute(&bz, data); err != nil {
+		return nil, errors.Wrap(err, "executing template")
+	}
+
+	return bz.Bytes(), nil
+}
+
+type promTmplData struct {
+	Network        string            // Used a "network" label to all metrics
+	RemoteURL      string            // URL to the Grafana cloud server
+	RemoteUsername string            // Username to the Grafana cloud server
+	RemotePassword string            // Password to the Grafana cloud server
+	ScrapeConfigs  []promScrapConfig // List of scrape configs
+}
+
+type promScrapConfig struct {
+	JobName     string
+	MetricsPath string
+	targets     []string
+}
+
+func (c promScrapConfig) Targets() string {
+	return strings.Join(c.targets, ",")
+}

--- a/test/e2e/app/run.go
+++ b/test/e2e/app/run.go
@@ -8,7 +8,7 @@ import (
 )
 
 // Deploy a new e2e network. It also starts all services in order to deploy private portals.
-func Deploy(ctx context.Context, def Definition) error {
+func Deploy(ctx context.Context, def Definition, promSecrets PromSecrets) error {
 	if err := Cleanup(ctx, def.Testnet.Testnet); err != nil {
 		return err
 	}
@@ -18,7 +18,7 @@ func Deploy(ctx context.Context, def Definition) error {
 		return err
 	}
 
-	if err := Setup(ctx, def); err != nil {
+	if err := Setup(ctx, def, promSecrets); err != nil {
 		return err
 	}
 
@@ -45,7 +45,7 @@ func DefaultE2ETestConfig() E2ETestConfig {
 
 // E2ETest runs a full e2e test.
 func E2ETest(ctx context.Context, def Definition, cfg E2ETestConfig) error {
-	if err := Deploy(ctx, def); err != nil {
+	if err := Deploy(ctx, def, PromSecrets{}); err != nil { // No prometheus in tests for now.
 		return err
 	}
 

--- a/test/e2e/app/setup.go
+++ b/test/e2e/app/setup.go
@@ -46,7 +46,7 @@ const (
 )
 
 // Setup sets up the testnet configuration.
-func Setup(ctx context.Context, def Definition) error {
+func Setup(ctx context.Context, def Definition, promSecrets PromSecrets) error {
 	log.Info(ctx, "Setup testnet", "dir", def.Testnet.Dir)
 
 	if err := os.MkdirAll(def.Testnet.Dir, os.ModePerm); err != nil {
@@ -125,7 +125,7 @@ func Setup(ctx context.Context, def Definition) error {
 	}
 
 	if def.Testnet.Prometheus {
-		if err := def.Testnet.WritePrometheusConfig(); err != nil {
+		if err := writePrometheusConfig(ctx, def.Testnet, promSecrets); err != nil {
 			return errors.Wrap(err, "write prom config")
 		}
 	}

--- a/test/e2e/app/static/prometheus.yml.tmpl
+++ b/test/e2e/app/static/prometheus.yml.tmpl
@@ -1,0 +1,21 @@
+global:
+  scrape_interval: 30s # Set the scrape interval to every 30 seconds.
+  evaluation_interval: 30s # Evaluate rules every 30 seconds.
+
+{{- if .RemoteURL }}
+remote_write:
+  - url: {{ .RemoteURL }}
+    basic_auth:
+      username: {{ .RemoteUsername }}
+      password: {{ .RemotePassword }}
+{{end }}
+
+scrape_configs:
+{{- range .ScrapeConfigs }}
+  - job_name: "{{ .JobName }}"
+    metrics_path: "{{ .MetricsPath }}"
+    static_configs:
+      - targets: [{{ .Targets }}]
+        labels:
+          network: '{{ $.Network }}'
+{{ end }}

--- a/test/e2e/cmd/cmd.go
+++ b/test/e2e/cmd/cmd.go
@@ -42,13 +42,18 @@ func New() *cobra.Command {
 }
 
 func newDeployCmd(def *app.Definition) *cobra.Command {
-	return &cobra.Command{
+	var promSecrets app.PromSecrets
+	cmd := &cobra.Command{
 		Use:   "deploy",
 		Short: "Deploys the e2e network",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return app.Deploy(cmd.Context(), *def)
+			return app.Deploy(cmd.Context(), *def, promSecrets)
 		},
 	}
+
+	bindPromFlags(cmd.Flags(), &promSecrets)
+
+	return cmd
 }
 
 func newLogsCmd(def *app.Definition) *cobra.Command {

--- a/test/e2e/cmd/flags.go
+++ b/test/e2e/cmd/flags.go
@@ -16,3 +16,9 @@ func bindDefFlags(flags *pflag.FlagSet, cfg *app.DefinitionConfig) {
 func bindE2EFlags(flags *pflag.FlagSet, cfg *app.E2ETestConfig) {
 	flags.BoolVar(&cfg.Preserve, "preserve", cfg.Preserve, "preserve infrastructure after test")
 }
+
+func bindPromFlags(flags *pflag.FlagSet, cfg *app.PromSecrets) {
+	flags.StringVar(&cfg.URL, "prom-url", cfg.URL, "prometheus url (only required if prometheus==true)")
+	flags.StringVar(&cfg.User, "prom-user", cfg.User, "prometheus user")
+	flags.StringVar(&cfg.Pass, "prom-password", cfg.Pass, "prometheus password")
+}

--- a/test/e2e/docker/compose.yaml.tmpl
+++ b/test/e2e/docker/compose.yaml.tmpl
@@ -34,35 +34,35 @@ services:
 
 {{- range .Anvils }}
   # Initialises geth files and folder from provided genesis file.
-  {{ .Name }}:
+  {{ .Chain.Name }}:
     labels:
       e2e: true
-    container_name: {{ .Name }}
+    container_name: {{ .Chain.Name }}
     image: ghcr.io/foundry-rs/foundry:latest
-    entrypoint: ['anvil','--host','0.0.0.0','--chain-id','{{ .ChainID }}','--block-time','1', "--silent"]
+    entrypoint: ['anvil','--host','0.0.0.0','--chain-id','{{ .Chain.ID }}','--block-time','1', "--silent"]
     ports:
       - {{ if .ProxyPort }}{{ .ProxyPort }}:{{ end }}8545
     networks:
       {{ $.NetworkName }}:
         ipv4_address: {{ .InternalIP }}
-{{end}}
+{{- end}}
 
   # Use geth as the omni EVMs.
 {{- range .OmniEVMs }}
   # Initialises geth files and folder from provided genesis file.
-  {{ .Name }}-init:
+  {{ .InstanceName }}-init:
     labels:
       e2e: true
-    container_name: {{ .Name }}-init
+    container_name: {{ .InstanceName }}-init
     image: "ethereum/client-go:latest"
     command: --datadir=/geth init /geth/genesis.json
     volumes:
-      - ./{{ .Name }}:/geth
+      - ./{{ .InstanceName }}:/geth
 
-  {{ .Name }}:
+  {{ .InstanceName }}:
     labels:
       e2e: true
-    container_name: {{ .Name }}
+    container_name: {{ .InstanceName }}
     image: "ethereum/client-go:latest"
     command:
       - --http
@@ -84,22 +84,22 @@ services:
       - --nodiscover
       - --syncmode=full
       - --nodekeyhex={{.NodeKeyHex}}
-      - --bootnodes={{.BootNodes}}
+      - --bootnodes={{.BootNodesStr}}
     ports:
       - 8551
       - {{ if .ProxyPort }}{{ .ProxyPort }}:{{ end }}8545
       - 8546
     depends_on:
-      {{ .Name }}-init:
+      {{ .InstanceName }}-init:
         condition: service_completed_successfully
     volumes:
-      - ./{{ .Name }}:/geth
+      - ./{{ .InstanceName }}:/geth
     networks:
       {{ $.NetworkName }}:
         ipv4_address: {{ .InternalIP }}
 {{end}}
 
-{{ if .Relayer }}
+{{- if .Relayer }}
   relayer:
     labels:
       e2e: true
@@ -112,3 +112,17 @@ services:
       {{ $.NetworkName }}:
         ipv4_address: 10.186.73.200
 {{end}}
+
+{{- if .Prometheus }}
+  prometheus:
+    labels:
+      e2e: true
+    container_name: prometheus
+    image: prom/prometheus:latest
+    restart: unless-stopped
+    volumes:
+      - ./prometheus/prometheus.yml:/etc/prometheus/prometheus.yml
+    networks:
+      {{ $.NetworkName }}:
+        ipv4_address: 10.186.73.201
+{{ end }}

--- a/test/e2e/docker/docker.go
+++ b/test/e2e/docker/docker.go
@@ -3,10 +3,8 @@ package docker
 import (
 	"bytes"
 	"context"
-	"encoding/hex"
 	"os"
 	"path/filepath"
-	"strings"
 	"sync"
 	"text/template"
 
@@ -17,8 +15,6 @@ import (
 	e2e "github.com/cometbft/cometbft/test/e2e/pkg"
 	"github.com/cometbft/cometbft/test/e2e/pkg/infra"
 	cmtdocker "github.com/cometbft/cometbft/test/e2e/pkg/infra/docker"
-
-	"github.com/ethereum/go-ethereum/crypto"
 
 	_ "embed"
 )
@@ -60,6 +56,7 @@ func (p *Provider) Setup() error {
 		OmniEVMs:    p.testnet.OmniEVMs,
 		Anvils:      p.testnet.AnvilChains,
 		Relayer:     true,
+		Prometheus:  p.testnet.Prometheus,
 	}
 
 	bz, err := GenerateComposeFile(def)
@@ -97,10 +94,25 @@ type ComposeDef struct {
 	NetworkName string
 	NetworkCIDR string
 
-	Nodes    []*e2e.Node
-	OmniEVMs []types.OmniEVM
-	Anvils   []types.AnvilChain
-	Relayer  bool
+	Nodes      []*e2e.Node
+	OmniEVMs   []types.OmniEVM
+	Anvils     []types.AnvilChain
+	Relayer    bool
+	Prometheus bool
+}
+
+// NodeOmniEVMs returns a map of node name to OmniEVM instance name; map[node_name]omni_evm.
+func (c ComposeDef) NodeOmniEVMs() map[string]string {
+	resp := make(map[string]string)
+	for i, node := range c.Nodes {
+		evm := c.OmniEVMs[0].InstanceName
+		if len(c.OmniEVMs) == len(c.Nodes) {
+			evm = c.OmniEVMs[i].InstanceName
+		}
+		resp[node.Name] = evm
+	}
+
+	return resp
 }
 
 func GenerateComposeFile(def ComposeDef) ([]byte, error) {
@@ -110,81 +122,12 @@ func GenerateComposeFile(def ComposeDef) ([]byte, error) {
 	}
 
 	var buf bytes.Buffer
-	err = tmpl.Execute(&buf, makeTemplateData(def))
+	err = tmpl.Execute(&buf, def)
 	if err != nil {
 		return nil, errors.Wrap(err, "execute template")
 	}
 
 	return buf.Bytes(), nil
-}
-
-type data struct {
-	NetworkName  string
-	NetworkCIDR  string
-	Nodes        []*e2e.Node
-	NodeOmniEVMs map[string]string // Maps node name to Omni EVM instance name.
-	Anvils       []chain
-	OmniEVMs     []chain
-	Relayer      bool
-}
-
-type chain struct {
-	Name       string
-	ChainID    uint64
-	InternalIP string
-	ProxyPort  uint32
-
-	// Only for Geth OmniEVM
-	NodeKeyHex string // --nodekey: P2P node key file
-	BootNodes  string // --bootnodes: Comma separated enode URLs for P2P discovery bootstrap
-}
-
-func makeTemplateData(def ComposeDef) data {
-	var omniEVMs []chain
-	for _, omniEVM := range def.OmniEVMs {
-		var bootnodes []string
-		for _, b := range omniEVM.BootNodes {
-			bootnodes = append(bootnodes, b.String())
-		}
-
-		omniEVMs = append(omniEVMs, chain{
-			Name:       omniEVM.InstanceName,
-			ChainID:    omniEVM.Chain.ID,
-			ProxyPort:  omniEVM.ProxyPort,
-			InternalIP: omniEVM.InternalIP.String(),
-			NodeKeyHex: hex.EncodeToString(crypto.FromECDSA(omniEVM.NodeKey)),
-			BootNodes:  strings.Join(bootnodes, ","),
-		})
-	}
-
-	nodeEVMs := make(map[string]string)
-	for i, node := range def.Nodes {
-		evm := omniEVMs[0].Name
-		if len(omniEVMs) == len(def.Nodes) {
-			evm = omniEVMs[i].Name
-		}
-		nodeEVMs[node.Name] = evm
-	}
-
-	var anvils []chain
-	for _, anvil := range def.Anvils {
-		anvils = append(anvils, chain{
-			Name:       anvil.Chain.Name,
-			ChainID:    anvil.Chain.ID,
-			ProxyPort:  anvil.ProxyPort,
-			InternalIP: anvil.InternalIP.String(),
-		})
-	}
-
-	return data{
-		NetworkName:  def.NetworkName,
-		NetworkCIDR:  def.NetworkCIDR,
-		Nodes:        def.Nodes,
-		Anvils:       anvils,
-		OmniEVMs:     omniEVMs,
-		NodeOmniEVMs: nodeEVMs,
-		Relayer:      def.Relayer,
-	}
 }
 
 // additionalServices returns additional (to halo) docker-compose services to start.
@@ -195,6 +138,10 @@ func additionalServices(testnet types.Testnet) []string {
 	}
 	for _, anvil := range testnet.AnvilChains {
 		resp = append(resp, anvil.Chain.Name)
+	}
+
+	if testnet.Prometheus {
+		resp = append(resp, "prometheus")
 	}
 
 	resp = append(resp, "relayer")

--- a/test/e2e/docker/docker_test.go
+++ b/test/e2e/docker/docker_test.go
@@ -33,9 +33,10 @@ func TestComposeTemplate(t *testing.T) {
 	dir := t.TempDir()
 	testnet := types.Testnet{
 		Testnet: &e2e.Testnet{
-			Name: "test",
-			IP:   ipNet,
-			Dir:  dir,
+			Name:       "test",
+			IP:         ipNet,
+			Dir:        dir,
+			Prometheus: true,
 			Nodes: []*e2e.Node{{
 				Name:       "node0",
 				Version:    "v0.0.0",

--- a/test/e2e/docker/testdata/TestComposeTemplate.golden
+++ b/test/e2e/docker/testdata/TestComposeTemplate.golden
@@ -40,7 +40,6 @@ services:
       test:
         ipv4_address: 10.186.73.0
 
-
   # Use geth as the omni EVMs.
   # Initialises geth files and folder from provided genesis file.
   omni_evm_0-init:
@@ -91,8 +90,6 @@ services:
       test:
         ipv4_address: 10.186.73.0
 
-
-
   relayer:
     labels:
       e2e: true
@@ -104,4 +101,16 @@ services:
     networks:
       test:
         ipv4_address: 10.186.73.200
+
+  prometheus:
+    labels:
+      e2e: true
+    container_name: prometheus
+    image: prom/prometheus:latest
+    restart: unless-stopped
+    volumes:
+      - ./prometheus/prometheus.yml:/etc/prometheus/prometheus.yml
+    networks:
+      test:
+        ipv4_address: 10.186.73.201
 

--- a/test/e2e/manifests/staging.toml
+++ b/test/e2e/manifests/staging.toml
@@ -1,6 +1,7 @@
 network = "staging"
 public_chains = ["arb_goerli"]
 multi_omni_evms = true
+prometheus = true
 
 [node.validator01]
 [node.validator02]

--- a/test/e2e/types/testnet.go
+++ b/test/e2e/types/testnet.go
@@ -2,10 +2,13 @@ package types
 
 import (
 	"crypto/ecdsa"
+	"encoding/hex"
 	"net"
+	"strings"
 
 	e2e "github.com/cometbft/cometbft/test/e2e/pkg"
 
+	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/p2p/enode"
 )
 
@@ -39,6 +42,19 @@ type OmniEVM struct {
 	NodeKey   *ecdsa.PrivateKey // Private key
 	Enode     *enode.Node       // Public key
 	BootNodes []*enode.Node     // Peer public keys
+}
+
+func (o OmniEVM) NodeKeyHex() string {
+	return hex.EncodeToString(crypto.FromECDSA(o.NodeKey))
+}
+
+func (o OmniEVM) BootNodesStr() string {
+	var resp []string
+	for _, b := range o.BootNodes {
+		resp = append(resp, b.String())
+	}
+
+	return strings.Join(resp, ",")
 }
 
 // AnvilChain represents an anvil chain instance in a omni network.

--- a/test/e2e/vmcompose/provider.go
+++ b/test/e2e/vmcompose/provider.go
@@ -65,6 +65,7 @@ func (p *Provider) Setup() error {
 			OmniEVMs:    omniEVMs,
 			Anvils:      anvilChains,
 			Relayer:     services["relayer"],
+			Prometheus:  p.Testnet.Prometheus,
 		}
 		compose, err := docker.GenerateComposeFile(def)
 		if err != nil {

--- a/test/e2e/vmcompose/testdata/TestSetup_127_0_0_1_compose.yaml.golden
+++ b/test/e2e/vmcompose/testdata/TestSetup_127_0_0_1_compose.yaml.golden
@@ -78,5 +78,3 @@ services:
       manifest:
         ipv4_address: 127.0.0.1
 
-
-

--- a/test/e2e/vmcompose/testdata/TestSetup_127_0_0_2_compose.yaml.golden
+++ b/test/e2e/vmcompose/testdata/TestSetup_127_0_0_2_compose.yaml.golden
@@ -78,5 +78,3 @@ services:
       manifest:
         ipv4_address: 127.0.0.2
 
-
-

--- a/test/e2e/vmcompose/testdata/TestSetup_127_0_0_3_compose.yaml.golden
+++ b/test/e2e/vmcompose/testdata/TestSetup_127_0_0_3_compose.yaml.golden
@@ -23,10 +23,7 @@ services:
       manifest:
         ipv4_address: 127.0.0.3
 
-
   # Use geth as the omni EVMs.
-
-
   relayer:
     labels:
       e2e: true


### PR DESCRIPTION
Add support for prometheus in docker compose. It scraps all containers and pushes metrics to our grafana cloud instance if configured.

task: none