### PR TITLE
test(e2e): fix flag typo

### DIFF
--- a/test/e2e/cmd/flags.go
+++ b/test/e2e/cmd/flags.go
@@ -10,7 +10,7 @@ import (
 func bindDefFlags(flags *pflag.FlagSet, cfg *app.DefinitionConfig) {
 	flags.StringVarP(&cfg.ManifestFile, "manifest-file", "f", cfg.ManifestFile, "path to manifest file")
 	flags.StringVar(&cfg.InfraProvider, "infra", cfg.InfraProvider, "infrastructure provider: docker, vmcompose")
-	flags.StringVar(&cfg.InfraProvider, "infra-file", cfg.InfraDataFile, "infrastructure data file (not required for docker provider)")
+	flags.StringVar(&cfg.InfraDataFile, "infra-file", cfg.InfraDataFile, "infrastructure data file (not required for docker provider)")
 	flags.StringVar(&cfg.DeployKeyFile, "deploy-key", cfg.DeployKeyFile, "path to deploy private key file")
 	flags.StringVar(&cfg.RelayerKeyFile, "relayer-key", cfg.RelayerKeyFile, "path to relayer private key file")
 }


### PR DESCRIPTION
Fix type causing e2e tests to fail.

task: none