### PR TITLE
chore(*): remove loop var workarounds

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -101,6 +101,14 @@ issues:
     - fieldalignment # Ignore "fieldalignment: struct with XXX pointer bytes could be YYY"
     - "shadow: declaration of" # Relax govet
     - "ifElseChain: rewrite if-else to switch statement"   # IfElseChain actually preferred to switches
+
+    # Loop variable issues have been fixed in Go 1.22, so can be ignored
+    - "G601: Implicit memory aliasing in for loop"
+    - "loopclosure: loop variable"
+    - "Range statement for test"
+    - "range-val-address: suspicious assignment of"
+    - "exporting a pointer for the loop variable snapshot"
+
 linters:
   enable-all: true
   disable:

--- a/halo/cmd/cmd_internal_test.go
+++ b/halo/cmd/cmd_internal_test.go
@@ -46,8 +46,6 @@ func TestRunCmd(t *testing.T) { //nolint:paralleltest,tparallel // RunCmd modifi
 	}
 
 	for _, test := range tests {
-		test := test      // Pin
-		args := test.Args // Pin
 		t.Run(test.Name, func(t *testing.T) {
 			t.Parallel()
 
@@ -58,7 +56,7 @@ func TestRunCmd(t *testing.T) { //nolint:paralleltest,tparallel // RunCmd modifi
 			})
 
 			rootCmd := libcmd.NewRootCmd("halo", "", cmd)
-			rootCmd.SetArgs(args)
+			rootCmd.SetArgs(test.Args)
 			require.NoError(t, rootCmd.Execute())
 		})
 	}
@@ -77,7 +75,6 @@ func TestCLIReference(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test := test // Pin
 		t.Run(test.Command, func(t *testing.T) {
 			t.Parallel()
 

--- a/halo/comet/abci.go
+++ b/halo/comet/abci.go
@@ -282,7 +282,6 @@ func (a *App) Commit(context.Context, *abci.RequestCommit) (*abci.ResponseCommit
 func (a *App) ListSnapshots(context.Context, *abci.RequestListSnapshots) (*abci.ResponseListSnapshots, error) {
 	var resp abci.ResponseListSnapshots
 	for _, snapshot := range a.snapshots.List() {
-		snapshot := snapshot // Pin.
 		resp.Snapshots = append(resp.Snapshots, &snapshot)
 	}
 

--- a/lib/log/log_internal_test.go
+++ b/lib/log/log_internal_test.go
@@ -20,7 +20,6 @@ func LoggersForT() map[string]func(io.Writer) *slog.Logger {
 
 	resp := make(map[string]func(w io.Writer) *slog.Logger)
 	for name, fn := range loggerFuncs {
-		fn := fn // Pin
 		resp[name] = func(w io.Writer) *slog.Logger {
 			return fn(testOpts(w))
 		}

--- a/lib/log/log_test.go
+++ b/lib/log/log_test.go
@@ -57,7 +57,6 @@ func AssertLogging(t *testing.T, testFunc func(*testing.T, context.Context)) {
 	loggers := log.LoggersForT()
 
 	for name, initFunc := range loggers {
-		initFunc := initFunc // Pin
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			var buf bytes.Buffer

--- a/lib/log/testdata/TestSimpleLogs_console.golden
+++ b/lib/log/testdata/TestSimpleLogs_console.golden
@@ -2,8 +2,8 @@
 00-00-00 00:00:00 DEBU debug this code for me please            number=1
 00-00-00 00:00:00 WARN watch out!                               err="file already exists"
 00-00-00 00:00:00 ERRO something went wrong                     float=1.234 err=EOF
-00-00-00 00:00:00 WARN err1                                     err=first 1=1 stacktrace="[log_test.go:32 log_test.go:69 testing.go:1689]"
-00-00-00 00:00:00 ERRO err2                                     err="second: first" 2=2 1=1 stacktrace="[log_test.go:34 log_test.go:69 testing.go:1689]"
+00-00-00 00:00:00 WARN err1                                     err=first 1=1 stacktrace=<stacktrace>
+00-00-00 00:00:00 ERRO err2                                     err="second: first" 2=2 1=1 stacktrace=<stacktrace>
 00-00-00 00:00:00 DEBU ctx debug message                        ctx_key1=ctx_value1 debug_key1=debug_value1
 00-00-00 00:00:00 INFO ctx info message                         ctx_key1=ctx_value1 ctx_key2=ctx_value2 info_key2=info_value2
-00-00-00 00:00:00 WARN Pkg wrapped error                        err="pkg wrap: omni wrap: new" wrap=wrap new=new stacktrace="[log_test.go:45 log_test.go:69 testing.go:1689]"
+00-00-00 00:00:00 WARN Pkg wrapped error                        err="pkg wrap: omni wrap: new" wrap=wrap new=new stacktrace=<stacktrace>

--- a/relayer/app/creator_test.go
+++ b/relayer/app/creator_test.go
@@ -89,7 +89,6 @@ func TestCreatorService_CreateSubmissions(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			submissions, err := relayer.CreateSubmissions(tt.streamUpdate)

--- a/relayer/app/relayer_test.go
+++ b/relayer/app/relayer_test.go
@@ -184,7 +184,6 @@ func Test_FromHeights(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			got := relayer.FromHeights(tt.args.cursors, tt.args.chains)

--- a/relayer/app/types.go
+++ b/relayer/app/types.go
@@ -25,7 +25,6 @@ type Sender interface {
 func SubmissionToBinding(sub xchain.Submission) bindings.XTypesSubmission {
 	sigs := make([]bindings.XTypesSigTuple, 0, len(sub.Signatures))
 	for _, sig := range sub.Signatures {
-		sig := sig // Pin since we are taking the address of the local variables
 		sigs = append(sigs, bindings.XTypesSigTuple{
 			ValidatorPubKey: sig.ValidatorAddress[:],
 			Signature:       sig.Signature[:],

--- a/relayer/txmgr/price_bump_test.go
+++ b/relayer/txmgr/price_bump_test.go
@@ -96,8 +96,6 @@ func TestUpdateFees(t *testing.T) {
 		},
 	}
 	for i, test := range tests {
-		i := i
-		test := test
 		t.Run(strconv.Itoa(i), func(t *testing.T) {
 			t.Parallel()
 			test.run(t)

--- a/relayer/txmgr/queue_test.go
+++ b/relayer/txmgr/queue_test.go
@@ -165,7 +165,6 @@ func TestQueue_Send(t *testing.T) {
 		},
 	}
 	for _, test := range testCases {
-		test := test
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/relayer/txmgr/txmgr_test.go
+++ b/relayer/txmgr/txmgr_test.go
@@ -964,7 +964,6 @@ func TestIncreaseGasPrice(t *testing.T) {
 		},
 	}
 	for _, test := range tests {
-		test := test
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
 			test.run(t)
@@ -1072,8 +1071,6 @@ func TestErrStringMatch(t *testing.T) {
 	}
 
 	for i, test := range tests {
-		i := i
-		test := test
 		t.Run(strconv.Itoa(i), func(t *testing.T) {
 			t.Parallel()
 			require.Equal(t, test.match, txmgr.ErrStringMatch(test.err, test.target))

--- a/test/e2e/tests/e2e_test.go
+++ b/test/e2e/tests/e2e_test.go
@@ -93,7 +93,6 @@ func test(t *testing.T, testNode func(*testing.T, e2e.Node, []Portal), testPorta
 	}
 
 	for _, portal := range portals {
-		portal := portal // Pin
 		t.Run(portal.Chain.Name, func(t *testing.T) {
 			t.Parallel()
 			testPortal(t, portal, portals)

--- a/test/e2e/vmcompose/provider_test.go
+++ b/test/e2e/vmcompose/provider_test.go
@@ -36,7 +36,6 @@ func TestSetup(t *testing.T) {
 	require.NoError(t, err)
 
 	for _, file := range files {
-		file := file // Pin
 		t.Run(filepath.Base(file), func(t *testing.T) {
 			t.Parallel()
 			bz, err := os.ReadFile(file)

--- a/test/smoke/smoke_test.go
+++ b/test/smoke/smoke_test.go
@@ -77,7 +77,6 @@ func TestSmoke(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			testSmoke(t, tt.ethClFunc(t))


### PR DESCRIPTION
Removes all loop variable workaround since this isn't required in go1.22 anymore.

Also fix logging tests by removing stack traces to make it deterministic.

task: none