### PR TITLE
chore(*): add some important metrics

### DIFF
--- a/halo/app/app.go
+++ b/halo/app/app.go
@@ -57,12 +57,13 @@ func Run(ctx context.Context, cfg Config) error {
 		return errors.Wrap(err, "create xchain provider")
 	}
 
-	attSvc, err := attest.LoadAttester(ctx, privVal.Key.PrivKey, cfg.AttestStateFile(), xprovider, network.ChainIDs())
+	attSvc, err := attest.LoadAttester(ctx, privVal.Key.PrivKey, cfg.AttestStateFile(), xprovider,
+		network.ChainNamesByIDs())
 	if err != nil {
 		return errors.Wrap(err, "create attester")
 	}
 
-	appState, err := comet.LoadOrGenState(cfg.AppStateDir(), cfg.AppStatePersistInterval)
+	appState, err := comet.LoadOrGenState(cfg.AppStateDir(), cfg.AppStatePersistInterval, network.ChainNamesByIDs())
 	if err != nil {
 		return errors.Wrap(err, "load or gen app state")
 	}

--- a/halo/attest/attester_test.go
+++ b/halo/attest/attester_test.go
@@ -37,7 +37,7 @@ func TestAttester(t *testing.T) {
 	reloadAttester := func(t *testing.T, from1, from2 uint64) *attest.Attester {
 		t.Helper()
 		p := make(stubProvider)
-		a, err := attest.LoadAttester(ctx, pk, path, p, []uint64{chain1, chain2, chain3})
+		a, err := attest.LoadAttester(ctx, pk, path, p, map[uint64]string{chain1: "", chain2: "", chain3: ""})
 		require.NoError(t, err)
 
 		require.EqualValues(t, from1, p[chain1])

--- a/halo/attest/metrics.go
+++ b/halo/attest/metrics.go
@@ -1,0 +1,45 @@
+package attest
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+//nolint:gochecknoglobals // Promauto metrics are global.
+var (
+	createLag = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: "halo",
+		Subsystem: "attester",
+		Name:      "create_lag_seconds",
+		Help: "Latest lag between attestation creation and xblock timestamp (in seconds) per source chain. " +
+			"Alert if too high.",
+	}, []string{"chain"})
+
+	createHeight = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: "halo",
+		Subsystem: "attester",
+		Name:      "create_height",
+		Help:      "Latest created attestation height per source chain. Alert if not growing.",
+	}, []string{"chain"})
+
+	commitHeight = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: "halo",
+		Subsystem: "attester",
+		Name:      "commit_height",
+		Help:      "Latest committed attestation height per source chain. Alert if not growing.",
+	}, []string{"chain"})
+
+	availableCount = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: "halo",
+		Subsystem: "attester",
+		Name:      "available_attestations",
+		Help:      "Current number of available attestations per source chain. Alert if growing.",
+	}, []string{"chain"})
+
+	proposedCount = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: "halo",
+		Subsystem: "attester",
+		Name:      "proposed_attestations",
+		Help:      "Current number of proposed attestations per source chain. Alert if growing.",
+	}, []string{"chain"})
+)

--- a/halo/comet/abci.go
+++ b/halo/comet/abci.go
@@ -197,7 +197,7 @@ func (a *App) ExtendVote(ctx context.Context, _ *abci.RequestExtendVote) (*abci.
 func (*App) VerifyVoteExtension(context.Context, *abci.RequestVerifyVoteExtension) (
 	*abci.ResponseVerifyVoteExtension, error,
 ) {
-	// TODO(corver): Figure out what to verify.
+	// TODO(corver): Figure out what to verify. E.g. too far away from latest approved block.
 	return &abci.ResponseVerifyVoteExtension{
 		Status: abci.ResponseVerifyVoteExtension_ACCEPT,
 	}, nil

--- a/halo/comet/metrics.go
+++ b/halo/comet/metrics.go
@@ -1,0 +1,24 @@
+package comet
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+//nolint:gochecknoglobals // Promauto metrics are global.
+var (
+	pendingHeight = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: "halo",
+		Subsystem: "consensus",
+		Name:      "pending_aggregate_height",
+		Help: "Latest pending aggregate attestation height per source chain. Alert if not growing. " +
+			"Or if out-growing approved height.",
+	}, []string{"chain"})
+
+	approvedHeight = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: "halo",
+		Subsystem: "consensus",
+		Name:      "approved_aggregate_height",
+		Help:      "Latest approved aggregate attestation height per source chain. Alert if not growing.",
+	}, []string{"chain"})
+)

--- a/lib/cchain/provider/abci_test.go
+++ b/lib/cchain/provider/abci_test.go
@@ -24,7 +24,7 @@ func TestQueryApprovedFrom(t *testing.T) {
 	f := fuzz.New().NilChance(0).NumElements(2, 8)
 	tutil.PrepRPCTestConfig(t) // Write genesis and priv validator files to temp dir.
 
-	state, err := comet.LoadOrGenState(t.TempDir(), 0)
+	state, err := comet.LoadOrGenState(t.TempDir(), 0, map[uint64]string{})
 	require.NoError(t, err)
 
 	ethCl, err := engine.NewMock()

--- a/lib/cchain/provider/metrics.go
+++ b/lib/cchain/provider/metrics.go
@@ -1,0 +1,23 @@
+package provider
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+//nolint:gochecknoglobals // Promauto metrics are global.
+var (
+	callbackErrTotal = promauto.NewCounter(prometheus.CounterOpts{
+		Namespace: "lib",
+		Subsystem: "cprovider",
+		Name:      "callback_error_total",
+		Help:      "Total number of callback errors per source chain. Alert if growing.",
+	})
+
+	streamHeight = promauto.NewGauge(prometheus.GaugeOpts{
+		Namespace: "lib",
+		Subsystem: "cprovider",
+		Name:      "stream_height",
+		Help:      "Latest streamed xblock height per source chain. Alert if not growing.",
+	})
+)

--- a/lib/cchain/provider/provider.go
+++ b/lib/cchain/provider/provider.go
@@ -82,10 +82,12 @@ func (p Provider) Subscribe(ctx context.Context, chainID uint64, height uint64, 
 						return // Don't backoff or log on ctx cancel, just return.
 					} else if err != nil {
 						log.Warn(ctx, "Failed processing attestation; will retry", err)
+						callbackErrTotal.Inc()
 						backoff()
 
 						continue
 					}
+					streamHeight.Set(float64(height)) // Update stream height metric
 
 					break // Success, stop retrying.
 				}

--- a/lib/log/config.go
+++ b/lib/log/config.go
@@ -20,6 +20,14 @@ const (
 )
 
 //nolint:gochecknoglobals // Static mapping.
+var (
+	levelDebug = strings.ToLower(slog.LevelDebug.String())
+	levelInfo  = strings.ToLower(slog.LevelInfo.String())
+	levelWarn  = strings.ToLower(slog.LevelWarn.String())
+	levelError = strings.ToLower(slog.LevelError.String())
+)
+
+//nolint:gochecknoglobals // Static mapping.
 var loggerFuncs = map[string]func(...func(*options)) *slog.Logger{
 	FormatConsole: newConsoleLogger,
 	FormatJSON:    newJSONLogger,
@@ -35,7 +43,7 @@ var colors = map[string]termenv.Profile{
 // DefaultConfig returns a default config.
 func DefaultConfig() Config {
 	return Config{
-		Level:  strings.ToLower(slog.LevelInfo.String()),
+		Level:  levelInfo,
 		Color:  ColorAuto,
 		Format: FormatConsole,
 	}

--- a/lib/log/log.go
+++ b/lib/log/log.go
@@ -23,33 +23,37 @@ func WithCtx(ctx context.Context, attrs ...any) context.Context {
 
 // Debug logs the message and attributes at default level.
 func Debug(ctx context.Context, msg string, attrs ...any) {
-	GetLogger(ctx).DebugContext(ctx, msg, mergeAttrs(ctx, attrs)...)
+	logTotal.WithLabelValues(levelDebug).Inc()
+	getLogger(ctx).DebugContext(ctx, msg, mergeAttrs(ctx, attrs)...)
 }
 
 // Info logs the message and attributes at info level.
 func Info(ctx context.Context, msg string, attrs ...any) {
-	GetLogger(ctx).InfoContext(ctx, msg, mergeAttrs(ctx, attrs)...)
+	logTotal.WithLabelValues(levelInfo).Inc()
+	getLogger(ctx).InfoContext(ctx, msg, mergeAttrs(ctx, attrs)...)
 }
 
 // Warn logs the message and error and attributes at warning level.
 // If err is nil, it will not be logged.
 func Warn(ctx context.Context, msg string, err error, attrs ...any) {
+	logTotal.WithLabelValues(levelWarn).Inc()
 	if err != nil {
 		attrs = append(attrs, "err", err)
 		attrs = append(attrs, errAttrs(err)...)
 	}
 
-	GetLogger(ctx).WarnContext(ctx, msg, mergeAttrs(ctx, attrs)...)
+	getLogger(ctx).WarnContext(ctx, msg, mergeAttrs(ctx, attrs)...)
 }
 
 // Error logs the message and error and arguments at error level.
 // If err is nil, it will not be logged.
 func Error(ctx context.Context, msg string, err error, attrs ...any) {
+	logTotal.WithLabelValues(levelError).Inc()
 	if err != nil {
 		attrs = append(attrs, "err", err)
 		attrs = append(attrs, errAttrs(err)...)
 	}
-	GetLogger(ctx).ErrorContext(ctx, msg, mergeAttrs(ctx, attrs)...)
+	getLogger(ctx).ErrorContext(ctx, msg, mergeAttrs(ctx, attrs)...)
 }
 
 // errFields is similar to z.Err and returns the structured error fields and

--- a/lib/log/logger.go
+++ b/lib/log/logger.go
@@ -43,8 +43,8 @@ func WithLogger(ctx context.Context, logger *slog.Logger) context.Context {
 	return context.WithValue(ctx, loggerKey{}, logger)
 }
 
-// GetLogger returns the logger from the context, or the global logger if not present.
-func GetLogger(ctx context.Context) *slog.Logger {
+// getLogger returns the logger from the context, or the global logger if not present.
+func getLogger(ctx context.Context) *slog.Logger {
 	if l := ctx.Value(loggerKey{}); l != nil {
 		return l.(*slog.Logger) //nolint:forcetypeassert,revive // We know the type.
 	}

--- a/lib/log/metrics.go
+++ b/lib/log/metrics.go
@@ -1,0 +1,16 @@
+package log
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+//nolint:gochecknoglobals // Promauto metrics are global.
+var (
+	logTotal = promauto.NewCounterVec(prometheus.CounterOpts{
+		Namespace: "lib",
+		Subsystem: "log",
+		Name:      "total",
+		Help:      "Total number of log messages per level.",
+	}, []string{"level"})
+)

--- a/lib/netconf/netconf.go
+++ b/lib/netconf/netconf.go
@@ -39,6 +39,17 @@ func (n Network) ChainIDs() []uint64 {
 	return resp
 }
 
+// ChainNamesByIDs returns the all chain IDs and names in the network.
+// This is a convenience method.
+func (n Network) ChainNamesByIDs() map[uint64]string {
+	resp := make(map[uint64]string)
+	for _, chain := range n.Chains {
+		resp[chain.ID] = chain.Name
+	}
+
+	return resp
+}
+
 // OmniChain returns the Omni execution chain config or false if it does not exist.
 func (n Network) OmniChain() (Chain, bool) {
 	for _, chain := range n.Chains {

--- a/lib/xchain/provider/metrics.go
+++ b/lib/xchain/provider/metrics.go
@@ -1,0 +1,23 @@
+package provider
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+//nolint:gochecknoglobals // Promauto metrics are global.
+var (
+	callbackErrTotal = promauto.NewCounterVec(prometheus.CounterOpts{
+		Namespace: "lib",
+		Subsystem: "xprovider",
+		Name:      "callback_error_total",
+		Help:      "Total number of callback errors per source chain. Alert if growing.",
+	}, []string{"chain"})
+
+	streamHeight = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: "lib",
+		Subsystem: "xprovider",
+		Name:      "stream_height",
+		Help:      "Latest streamed xblock height per source chain. Alert if not growing.",
+	}, []string{"chain"})
+)

--- a/lib/xchain/provider/provider.go
+++ b/lib/xchain/provider/provider.go
@@ -61,7 +61,7 @@ func (p *Provider) Subscribe(
 	log.Info(ctx, "Subscribing to provider", "from_height", fromHeight)
 
 	// run the XBlock stream for this chain
-	p.streamBlocks(ctx, chainID, fromHeight, callback)
+	p.streamBlocks(ctx, chain.Name, chainID, fromHeight, callback)
 
 	return nil
 }

--- a/test/smoke/smoke_test.go
+++ b/test/smoke/smoke_test.go
@@ -93,6 +93,7 @@ func testSmoke(t *testing.T, ethCl engine.API) {
 		srcChainBlockPeriod = 1 * time.Millisecond * 100
 		srcChainID          = 1
 	)
+	chainMap := map[uint64]string{srcChainID: ""}
 
 	// Write genesis and priv validator files to temp dir.
 	conf := tutil.PrepRPCTestConfig(t)
@@ -109,11 +110,11 @@ func testSmoke(t *testing.T, ethCl engine.API) {
 	path := filepath.Join(t.TempDir(), "state.json")
 	err = attest.GenEmptyStateFile(path)
 	require.NoError(t, err)
-	attSvc, err := attest.LoadAttester(ctx, privVal.Key.PrivKey, path, xprov, []uint64{srcChainID})
+	attSvc, err := attest.LoadAttester(ctx, privVal.Key.PrivKey, path, xprov, chainMap)
 	require.NoError(t, err)
 
 	// Create application state
-	state, err := comet.LoadOrGenState(t.TempDir(), 1)
+	state, err := comet.LoadOrGenState(t.TempDir(), 1, chainMap)
 	require.NoError(t, err)
 
 	// Create snapshot store.


### PR DESCRIPTION
Adds prometheus metrics to some important packages:
- `halo/attester`: Track what we are attesting to and what has been committed to chain
- `halo/state`: Track pending and approved aggregates on-chain.
- `lib/log`: Track logs by level
- `xprovider`: Track streaming water-levels and errors.

task: none