### PR TITLE
test(e2e): switch staging to goerli

### DIFF
--- a/test/e2e/app/contract.go
+++ b/test/e2e/app/contract.go
@@ -2,30 +2,28 @@ package app
 
 import (
 	"context"
-	"time"
+	"math/big"
 
 	"github.com/omni-network/omni/lib/errors"
-	"github.com/omni-network/omni/lib/expbackoff"
 	"github.com/omni-network/omni/lib/log"
 	"github.com/omni-network/omni/test/e2e/netman"
 
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
 	ethtypes "github.com/ethereum/go-ethereum/core/types"
-	"github.com/ethereum/go-ethereum/ethclient"
 )
 
 func StartSendingXMsgs(ctx context.Context, portals map[uint64]netman.Portal, batches ...int) <-chan error {
 	log.Info(ctx, "Generating cross chain messages async", "batches", batches)
 	errChan := make(chan error, 1)
 	go func() {
-		for _, count := range batches {
+		for i, count := range batches {
 			err := SendXMsgs(ctx, portals, count)
 			if ctx.Err() != nil {
 				errChan <- ctx.Err()
 				return
 			} else if err != nil {
-				errChan <- errors.Wrap(err, "send xmsgs")
+				errChan <- errors.Wrap(err, "send xmsgs", "batch", i)
 				return
 			}
 		}
@@ -39,17 +37,23 @@ func StartSendingXMsgs(ctx context.Context, portals map[uint64]netman.Portal, ba
 func SendXMsgs(ctx context.Context, portals map[uint64]netman.Portal, batch int) error {
 	allTxs := make(map[uint64][]*ethtypes.Transaction)
 	for fromChainID, from := range portals {
+		nonce, err := from.Client.PendingNonceAt(ctx, from.TxOptsFrom())
+		if err != nil {
+			return errors.Wrap(err, "pending nonce", "chain", from.Chain.Name)
+		}
+
 		for _, to := range portals {
 			if from.Chain.ID == to.Chain.ID {
 				continue
 			}
 
 			for i := 0; i < batch; i++ {
-				tx, err := xcall(ctx, from, to.Chain.ID)
+				tx, err := xcall(ctx, from, to.Chain.ID, nonce)
 				if err != nil {
-					return err
+					return errors.Wrap(err, "batch_offset", i)
 				}
 				allTxs[fromChainID] = append(allTxs[fromChainID], tx)
+				nonce++
 			}
 		}
 	}
@@ -57,7 +61,7 @@ func SendXMsgs(ctx context.Context, portals map[uint64]netman.Portal, batch int)
 	for chainID, txs := range allTxs {
 		portal := portals[chainID]
 		for i, tx := range txs {
-			if err := waitMined(ctx, portal.Client, tx); err != nil {
+			if _, err := bind.WaitMined(ctx, portal.Client, tx); err != nil {
 				return errors.Wrap(err, "wait mined", "chain", portal.Chain.Name, "tx_index", i)
 			}
 		}
@@ -67,48 +71,29 @@ func SendXMsgs(ctx context.Context, portals map[uint64]netman.Portal, batch int)
 }
 
 // xcall sends a ethereum transaction to the portal contract, triggering a xcall.
-func xcall(ctx context.Context, from netman.Portal, destChainID uint64) (*ethtypes.Transaction, error) {
+func xcall(ctx context.Context, from netman.Portal, destChainID uint64, nonce uint64) (*ethtypes.Transaction, error) {
 	// TODO: use calls to actual contracts
-	var data []byte = nil
+	var data []byte
 	to := common.Address{}
 
 	fee, err := from.Contract.FeeFor(&bind.CallOpts{}, destChainID, data)
 	if err != nil {
 		return nil, errors.Wrap(err, "feeFor",
-			"source_chain", from.Chain.ID,
+			"source_chain", from.Chain.Name,
 			"dest_chain", destChainID,
 		)
 	}
 
-	txOpts := from.TxOpts(ctx)
-	txOpts.Value = fee
+	txOpts := from.TxOpts(ctx, fee)
+	txOpts.Nonce = big.NewInt(int64(nonce))
 
 	tx, err := from.Contract.Xcall(txOpts, destChainID, to, data)
 	if err != nil {
 		return nil, errors.Wrap(err, "xcall",
-			"source_chain", from.Chain.ID,
+			"source_chain", from.Chain.Name,
 			"dest_chain", destChainID,
 		)
 	}
 
 	return tx, nil
-}
-
-func waitMined(ctx context.Context, ethCl *ethclient.Client, tx *ethtypes.Transaction) error {
-	ctx, cancel := context.WithTimeout(ctx, time.Minute)
-	defer cancel()
-
-	backoff := expbackoff.New(ctx, expbackoff.WithFastConfig())
-	for ctx.Err() == nil {
-		_, pending, err := ethCl.TransactionByHash(ctx, tx.Hash())
-		if err != nil {
-			return errors.Wrap(err, "tx by hash")
-		}
-		if !pending {
-			return nil
-		}
-		backoff()
-	}
-
-	return errors.New("timeout waiting for tx to be mined")
 }

--- a/test/e2e/cmd/flags.go
+++ b/test/e2e/cmd/flags.go
@@ -13,6 +13,7 @@ func bindDefFlags(flags *pflag.FlagSet, cfg *app.DefinitionConfig) {
 	flags.StringVar(&cfg.InfraDataFile, "infra-file", cfg.InfraDataFile, "infrastructure data file (not required for docker provider)")
 	flags.StringVar(&cfg.DeployKeyFile, "deploy-key", cfg.DeployKeyFile, "path to deploy private key file")
 	flags.StringVar(&cfg.RelayerKeyFile, "relayer-key", cfg.RelayerKeyFile, "path to relayer private key file")
+	flags.StringToStringVar(&cfg.RPCOverrides, "rpc-overrides", cfg.RPCOverrides, "chain rpc overrides: '<chain1>=<url1>'")
 }
 
 func bindE2EFlags(flags *pflag.FlagSet, cfg *app.E2ETestConfig) {

--- a/test/e2e/manifests/staging.toml
+++ b/test/e2e/manifests/staging.toml
@@ -1,5 +1,5 @@
 network = "staging"
-public_chains = ["arb_goerli"]
+public_chains = ["goerli"]
 multi_omni_evms = true
 prometheus = true
 

--- a/test/e2e/netman/manager.go
+++ b/test/e2e/netman/manager.go
@@ -148,11 +148,17 @@ type Portal struct {
 }
 
 // TxOpts returns transaction options using the deploy key.
-func (p Portal) TxOpts(ctx context.Context) *bind.TransactOpts {
+func (p Portal) TxOpts(ctx context.Context, value *big.Int) *bind.TransactOpts {
 	clone := *p.txOpts
 	clone.Context = ctx
+	clone.Value = value
 
 	return &clone
+}
+
+// TxOptsFrom returns the from address of the deploy key.
+func (p Portal) TxOptsFrom() common.Address {
+	return p.txOpts.From
 }
 
 var _ Manager = (*manager)(nil)

--- a/test/e2e/types/chain.go
+++ b/test/e2e/types/chain.go
@@ -14,6 +14,12 @@ var (
 		ID:       421613,
 		IsPublic: true,
 	}
+
+	chainGoerli = EVMChain{
+		Name:     "goerli",
+		ID:       5,
+		IsPublic: true,
+	}
 )
 
 const anvilChainIDFactor = 100
@@ -36,6 +42,8 @@ func PublicChainByName(name string) (EVMChain, error) {
 	switch name {
 	case chainArbGoerli.Name:
 		return chainArbGoerli, nil
+	case chainGoerli.Name:
+		return chainGoerli, nil
 	default:
 		return EVMChain{}, errors.New("unknown chain name")
 	}
@@ -46,6 +54,8 @@ func PublicRPCByName(name string) string {
 	switch name {
 	case chainArbGoerli.Name:
 		return "https://arbitrum-goerli.publicnode.com"
+	case chainGoerli.Name:
+		return "https://rpc.ankr.com/eth_goerli"
 	default:
 		return ""
 	}


### PR DESCRIPTION
Switches staging form `arb_goerli` to `goerli`. 

Had to do explicit nonces when submitting a ton of in-flight txs since goerli blocks are slow

task: none