### PR TITLE
fix(explorer/indexer): preventing rollbacks on success

### DIFF
--- a/explorer/indexer/app/db.go
+++ b/explorer/indexer/app/db.go
@@ -11,14 +11,20 @@ import (
 
 func newCallback(client *ent.Client) xchain.ProviderCallback {
 	return func(ctx context.Context, block xchain.Block) error {
+		var err error
 		tx, err := client.BeginTx(ctx, nil)
 		if err != nil {
 			return errors.Wrap(err, "begin transaction")
 		}
 		defer func() {
-			if err := tx.Rollback(); err != nil {
+			if err == nil {
+				return
+			}
+			err = tx.Rollback()
+			if err != nil {
 				log.Error(ctx, "Rollback failed", err)
 			}
+			log.Info(ctx, "Rolledback transaction")
 		}()
 
 		insertedBlock, err := insertBlock(ctx, tx, block)


### PR DESCRIPTION
Stopping rollbacks attempts from happening after we commit
```
indexer-1  | 24-02-07 14:39:50.949 INFO Inserted xblock                          chain_id=1 chain_name=omni_evm height=54 msgs=0 receipts=0
indexer-1  | 24-02-07 14:39:50.949 ERRO Rollback failed                          chain_id=1 chain_name=omni_evm height=54 err="sql: transaction has already been committed or rolled back"
```

task: none
