### PR TITLE
chore(relayer): monitor stream offsets and acounts

### DIFF
--- a/halo/attest/attester_test.go
+++ b/halo/attest/attester_test.go
@@ -195,3 +195,7 @@ func (stubProvider) GetBlock(context.Context, uint64, uint64) (xchain.Block, boo
 func (stubProvider) GetSubmittedCursor(context.Context, uint64, uint64) (xchain.StreamCursor, bool, error) {
 	panic("unexpected")
 }
+
+func (stubProvider) GetEmittedCursor(context.Context, uint64, uint64) (xchain.StreamCursor, bool, error) {
+	panic("unexpected")
+}

--- a/lib/xchain/provider.go
+++ b/lib/xchain/provider.go
@@ -16,7 +16,11 @@ type Provider interface {
 	// or an error.
 	GetBlock(ctx context.Context, chainID uint64, height uint64) (Block, bool, error)
 
-	// GetSubmittedCursor returns the submitted cursor for the provided chain and source chain,
-	// or false if not available, or an error.
-	GetSubmittedCursor(ctx context.Context, chainID uint64, sourceChainID uint64) (StreamCursor, bool, error)
+	// GetSubmittedCursor returns the submitted cursor for the source chain on the destination chain,
+	// or false if not available, or an error. Calls the destination chain portal InXStreamOffset method.
+	GetSubmittedCursor(ctx context.Context, destDhainID uint64, sourceChainID uint64) (StreamCursor, bool, error)
+
+	// GetEmittedCursor returns the emitted cursor for the destination chain on the source chain,
+	// or false if not available, or an error. Calls the source chain portal OutXStreamOffset method.
+	GetEmittedCursor(ctx context.Context, srcChainID uint64, destChainID uint64) (StreamCursor, bool, error)
 }

--- a/lib/xchain/provider/mock.go
+++ b/lib/xchain/provider/mock.go
@@ -88,6 +88,14 @@ func (*Mock) GetSubmittedCursor(_ context.Context, destChain uint64, srcChain ui
 	}}, true, nil
 }
 
+func (*Mock) GetEmittedCursor(_ context.Context, srcChainID uint64, destChainID uint64,
+) (xchain.StreamCursor, bool, error) {
+	return xchain.StreamCursor{StreamID: xchain.StreamID{
+		SourceChainID: srcChainID,
+		DestChainID:   destChainID,
+	}}, true, nil
+}
+
 func (m *Mock) addBlock(block xchain.Block) {
 	m.mu.Lock()
 	defer m.mu.Unlock()

--- a/relayer/app/metrics.go
+++ b/relayer/app/metrics.go
@@ -41,4 +41,32 @@ var (
 		Name:      "msg_total",
 		Help:      "The total number of messages submitted to a destination chain from a specific source chain",
 	}, []string{"src_chain", "dst_chain"})
+
+	emitCursor = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: "relayer",
+		Subsystem: "monitor",
+		Name:      "emit_cursor",
+		Help:      "The latest emitted cursor on a source chain for a specific destination chain",
+	}, []string{"src_chain", "dst_chain"})
+
+	submitCursor = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: "relayer",
+		Subsystem: "monitor",
+		Name:      "submit_cursor",
+		Help:      "The latest submitted cursor on a destination chain for a specific source chain",
+	}, []string{"src_chain", "dst_chain"})
+
+	accountBalance = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: "relayer",
+		Subsystem: "monitor",
+		Name:      "account_balance_ether",
+		Help:      "The balance of the relayer account on a specific chain in ether",
+	}, []string{"chain"})
+
+	accountNonce = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: "relayer",
+		Subsystem: "monitor",
+		Name:      "account_nonce",
+		Help:      "The nonce of the relayer account on a specific chain",
+	}, []string{"chain"})
 )

--- a/relayer/app/monitor.go
+++ b/relayer/app/monitor.go
@@ -1,0 +1,122 @@
+package relayer
+
+import (
+	"context"
+	"time"
+
+	"github.com/omni-network/omni/lib/errors"
+	"github.com/omni-network/omni/lib/log"
+	"github.com/omni-network/omni/lib/netconf"
+	"github.com/omni-network/omni/lib/xchain"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/ethclient"
+	"github.com/ethereum/go-ethereum/params"
+)
+
+// startMonitoring starts the monitoring goroutines.
+func startMonitoring(ctx context.Context, network netconf.Network, xprovider xchain.Provider,
+	addr common.Address, rpcClients map[uint64]*ethclient.Client) {
+	for _, srcChain := range network.Chains {
+		go monitorAccountForever(ctx, addr, srcChain.Name, rpcClients[srcChain.ID])
+
+		for _, dstChain := range network.Chains {
+			if srcChain.ID == dstChain.ID {
+				continue
+			}
+
+			go monitorOffsetsForever(ctx, srcChain.ID, dstChain.ID, srcChain.Name, dstChain.Name, xprovider)
+		}
+	}
+}
+
+// monitorAccountsForever blocks and periodically monitors the relayer accounts
+// for the given chain.
+func monitorAccountForever(ctx context.Context, addr common.Address, chainName string, client *ethclient.Client) {
+	timer := time.NewTimer(time.Second * 30)
+	defer timer.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-timer.C:
+			err := monitorAccountOnce(ctx, addr, chainName, client)
+			if ctx.Err() != nil {
+				return
+			} else if err != nil {
+				log.Error(ctx, "Monitoring account failed (will retry)", err,
+					"chain", chainName)
+
+				continue
+			}
+		}
+	}
+}
+
+// monitorAccountOnce monitors the relayer account for the given chain.
+func monitorAccountOnce(ctx context.Context, addr common.Address, chainName string, client *ethclient.Client) error {
+	balance, err := client.BalanceAt(ctx, addr, nil)
+	if err != nil {
+		return errors.Wrap(err, "balance at")
+	}
+
+	nonce, err := client.NonceAt(ctx, addr, nil)
+	if err != nil {
+		return errors.Wrap(err, "nonce at")
+	}
+
+	bf, _ := balance.Float64()
+	bf /= params.Ether
+	accountBalance.WithLabelValues(chainName).Set(bf)
+	accountNonce.WithLabelValues(chainName).Set(float64(nonce))
+
+	return nil
+}
+
+// monitorOffsetsForever blocks and periodically monitors the emitted and submitted
+// offsets for a given source and destination chain.
+func monitorOffsetsForever(ctx context.Context, src, dst uint64, srcChain, dstChain string,
+	xprovider xchain.Provider) {
+	timer := time.NewTimer(time.Second * 30)
+	defer timer.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-timer.C:
+			err := monitorOffsetsOnce(ctx, src, dst, srcChain, dstChain, xprovider)
+			if ctx.Err() != nil {
+				return
+			} else if err != nil {
+				log.Error(ctx, "Monitoring stream offsets failed (will retry)", err,
+					"src_chain", srcChain, "dst_chain", dstChain)
+
+				continue
+			}
+		}
+	}
+}
+
+// monitorOffsetsOnce monitors the emitted and submitted offsets for a given source and
+// destination chain.
+func monitorOffsetsOnce(ctx context.Context, src, dst uint64, srcChain, dstChain string,
+	xprovider xchain.Provider) error {
+	emitted, ok, err := xprovider.GetEmittedCursor(ctx, src, dst)
+	if err != nil {
+		return err
+	} else if !ok {
+		return nil
+	}
+
+	submitted, _, err := xprovider.GetSubmittedCursor(ctx, dst, src)
+	if err != nil {
+		return err
+	}
+
+	emitCursor.WithLabelValues(srcChain, dstChain).Set(float64(emitted.Offset))
+	submitCursor.WithLabelValues(srcChain, dstChain).Set(float64(submitted.Offset))
+
+	return nil
+}

--- a/relayer/app/relayer_test.go
+++ b/relayer/app/relayer_test.go
@@ -51,8 +51,11 @@ func Test_StartRelayer(t *testing.T) {
 				},
 			}, true, nil
 		},
-		GetSubmittedCursorFn: func(_ context.Context, chainID uint64, sourceChain uint64) (xchain.StreamCursor, bool, error) {
-			return cursors[chainID], true, nil
+		GetSubmittedCursorFn: func(_ context.Context, srcChainID uint64, _ uint64) (xchain.StreamCursor, bool, error) {
+			return cursors[srcChainID], true, nil
+		},
+		GetEmittedCursorFn: func(_ context.Context, _ uint64, destChainID uint64) (xchain.StreamCursor, bool, error) {
+			return cursors[destChainID], true, nil
 		},
 	}
 
@@ -202,8 +205,9 @@ var (
 )
 
 type mockXChainClient struct {
-	GetBlockFn           func(ctx context.Context, chainID uint64, height uint64) (xchain.Block, bool, error)
-	GetSubmittedCursorFn func(ctx context.Context, chainID uint64, sourceChain uint64) (xchain.StreamCursor, bool, error)
+	GetBlockFn           func(context.Context, uint64, uint64) (xchain.Block, bool, error)
+	GetSubmittedCursorFn func(context.Context, uint64, uint64) (xchain.StreamCursor, bool, error)
+	GetEmittedCursorFn   func(context.Context, uint64, uint64) (xchain.StreamCursor, bool, error)
 }
 
 func (m *mockXChainClient) Subscribe(context.Context, uint64, uint64, xchain.ProviderCallback) error {
@@ -217,6 +221,11 @@ func (m *mockXChainClient) GetBlock(ctx context.Context, chainID uint64, height 
 func (m *mockXChainClient) GetSubmittedCursor(ctx context.Context, chainID uint64, sourceChain uint64,
 ) (xchain.StreamCursor, bool, error) {
 	return m.GetSubmittedCursorFn(ctx, chainID, sourceChain)
+}
+
+func (m *mockXChainClient) GetEmittedCursor(ctx context.Context, srcChainID uint64, destChainID uint64,
+) (xchain.StreamCursor, bool, error) {
+	return m.GetEmittedCursorFn(ctx, srcChainID, destChainID)
 }
 
 type mockSender struct {


### PR DESCRIPTION
Add simple monitoring of emitted and submitted cursors for all streams. Also monitor relayer account balance and nonces.

task: none