### PR TITLE
fix(relayer): filter only worker streams

### DIFF
--- a/relayer/app/opsender.go
+++ b/relayer/app/opsender.go
@@ -61,7 +61,8 @@ func (o OpSender) SendTransaction(ctx context.Context, submission xchain.Submiss
 	if o.txMgr == nil {
 		return errors.New("tx mgr not found", "dest_chain_id", submission.DestChainID)
 	} else if submission.DestChainID != o.chain.ID {
-		return errors.New("unexpected destination chain [BUG]")
+		return errors.New("unexpected destination chain [BUG]",
+			"got", submission.DestChainID, "expect", o.chain.ID)
 	}
 
 	// Get some info for logging

--- a/relayer/app/relayer.go
+++ b/relayer/app/relayer.go
@@ -27,7 +27,7 @@ func StartRelayer(
 	}
 
 	// callback processes each approved attestation/xblock.
-	callback := newCallback(xClient, initialOffsets, creator, sender)
+	callback := newCallback(xClient, initialOffsets, creator, sender, 0)
 
 	// Subscribe to attestations for each chain.
 	for chainID, fromHeight := range FromHeights(cursors, network.Chains) {

--- a/test/e2e/app/test.go
+++ b/test/e2e/app/test.go
@@ -56,15 +56,13 @@ func Test(ctx context.Context, def Definition, verbose bool) error {
 		return errors.Wrap(err, "setting INFRASTRUCTURE_TYPE")
 	}
 
-	v := ""
+	args := []string{"go", "test", "-timeout", "15s", "-count", "1"}
 	if verbose {
-		v = "-v"
+		args = append(args, "-v")
 	}
+	args = append(args, "github.com/omni-network/omni/test/e2e/tests")
 
-	err = exec.CommandVerbose(ctx, "go", "test", v,
-		"-timeout", "15s",
-		"-count", "1",
-		"github.com/omni-network/omni/test/e2e/tests")
+	err = exec.CommandVerbose(ctx, args...)
 	if err != nil {
 		return errors.Wrap(err, "go tests failed")
 	}

--- a/test/e2e/tests/e2e_test.go
+++ b/test/e2e/tests/e2e_test.go
@@ -141,7 +141,7 @@ func loadEnv(t *testing.T) (types.Testnet, netconf.Network) {
 	ifdFile := os.Getenv(EnvInfraFile)
 	if ifdType != docker.ProviderName && ifdFile == "" {
 		require.Fail(t, EnvInfraFile+" not set while INFRASTRUCTURE_TYPE="+ifdType)
-	} else if !filepath.IsAbs(ifdFile) {
+	} else if ifdType != docker.ProviderName && !filepath.IsAbs(ifdFile) {
 		require.Fail(t, EnvInfraFile+" must be an absolute path", "got", ifdFile)
 	}
 


### PR DESCRIPTION
Relayer workers should only submit streams to their own destination chains.

task: none