### PR TITLE
feat(e2e): add --image-tag to e2e cmd

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,6 +1,6 @@
 run:
   timeout: 5m
-  go: "1.21"
+  go: "1.22"
   skip-files:
     - ".*\\.pb\\.go$" # Ignore generated protobuf files
   skip-dirs:

--- a/test/e2e/cmd/flags.go
+++ b/test/e2e/cmd/flags.go
@@ -13,6 +13,7 @@ func bindDefFlags(flags *pflag.FlagSet, cfg *app.DefinitionConfig) {
 	flags.StringVar(&cfg.InfraDataFile, "infra-file", cfg.InfraDataFile, "infrastructure data file (not required for docker provider)")
 	flags.StringVar(&cfg.DeployKeyFile, "deploy-key", cfg.DeployKeyFile, "path to deploy private key file")
 	flags.StringVar(&cfg.RelayerKeyFile, "relayer-key", cfg.RelayerKeyFile, "path to relayer private key file")
+	flags.StringVar(&cfg.ImgTag, "image-tag", cfg.ImgTag, "the tag of the docker images to be deployed")
 	flags.StringToStringVar(&cfg.RPCOverrides, "rpc-overrides", cfg.RPCOverrides, "Pubilc chain rpc overrides: '<chain1>=<url1>'")
 }
 

--- a/test/e2e/docker/docker.go
+++ b/test/e2e/docker/docker.go
@@ -36,6 +36,7 @@ type Provider struct {
 	*cmtdocker.Provider
 	servicesOnce sync.Once
 	testnet      types.Testnet
+	relayerTag   string
 }
 
 func (p *Provider) Clean(ctx context.Context) error {
@@ -52,7 +53,7 @@ func (p *Provider) Clean(ctx context.Context) error {
 }
 
 // NewProvider returns a new Provider.
-func NewProvider(testnet types.Testnet, infd types.InfrastructureData) *Provider {
+func NewProvider(testnet types.Testnet, infd types.InfrastructureData, tag string) *Provider {
 	return &Provider{
 		Provider: &cmtdocker.Provider{
 			ProviderData: infra.ProviderData{
@@ -60,7 +61,8 @@ func NewProvider(testnet types.Testnet, infd types.InfrastructureData) *Provider
 				InfrastructureData: infd.InfrastructureData,
 			},
 		},
-		testnet: testnet,
+		testnet:    testnet,
+		relayerTag: tag,
 	}
 }
 
@@ -77,6 +79,7 @@ func (p *Provider) Setup() error {
 		Anvils:      p.testnet.AnvilChains,
 		Relayer:     true,
 		Prometheus:  p.testnet.Prometheus,
+		RelayerTag:  p.relayerTag,
 	}
 
 	bz, err := GenerateComposeFile(def)
@@ -127,6 +130,7 @@ type ComposeDef struct {
 	Anvils     []types.AnvilChain
 	Relayer    bool
 	Prometheus bool
+	RelayerTag string
 }
 
 // NodeOmniEVMs returns a map of node name to OmniEVM instance name; map[node_name]omni_evm.

--- a/test/e2e/docker/docker_test.go
+++ b/test/e2e/docker/docker_test.go
@@ -23,54 +23,61 @@ import (
 func TestComposeTemplate(t *testing.T) {
 	t.Parallel()
 
-	_, ipNet, err := net.ParseCIDR("10.186.73.0/24")
-	require.NoError(t, err)
+	tags := []string{"main", "7d1ae53"}
 
-	key, err := crypto.HexToECDSA("59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d")
-	require.NoError(t, err)
-	en := enode.NewV4(&key.PublicKey, ipNet.IP, 30303, 30303)
+	for _, tag := range tags {
+		t.Run("image_tag_"+tag, func(t *testing.T) {
+			t.Parallel()
+			_, ipNet, err := net.ParseCIDR("10.186.73.0/24")
+			require.NoError(t, err)
 
-	dir := t.TempDir()
-	testnet := types.Testnet{
-		Testnet: &e2e.Testnet{
-			Name:       "test",
-			IP:         ipNet,
-			Dir:        dir,
-			Prometheus: true,
-			Nodes: []*e2e.Node{{
-				Name:       "node0",
-				Version:    "v0.0.0",
-				InternalIP: ipNet.IP,
-				ProxyPort:  8584,
-			}},
-		},
-		OmniEVMs: []types.OmniEVM{
-			{
-				Chain:        types.ChainOmniEVM,
-				InstanceName: "omni_evm_0",
-				InternalIP:   ipNet.IP,
-				ProxyPort:    8000,
-				NodeKey:      key,
-				Enode:        en,
-				BootNodes:    []*enode.Node{en},
-			},
-		},
-		AnvilChains: []types.AnvilChain{
-			{
-				Chain:      types.EVMChain{Name: "chain_a", ID: 99},
-				InternalIP: ipNet.IP,
-				ProxyPort:  9000,
-			},
-		},
+			key, err := crypto.HexToECDSA("59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d")
+			require.NoError(t, err)
+			en := enode.NewV4(&key.PublicKey, ipNet.IP, 30303, 30303)
+
+			dir := t.TempDir()
+			testnet := types.Testnet{
+				Testnet: &e2e.Testnet{
+					Name:       "test",
+					IP:         ipNet,
+					Dir:        dir,
+					Prometheus: true,
+					Nodes: []*e2e.Node{{
+						Name:       "node0",
+						Version:    "omniops/halo:" + tag,
+						InternalIP: ipNet.IP,
+						ProxyPort:  8584,
+					}},
+				},
+				OmniEVMs: []types.OmniEVM{
+					{
+						Chain:        types.ChainOmniEVM,
+						InstanceName: "omni_evm_0",
+						InternalIP:   ipNet.IP,
+						ProxyPort:    8000,
+						NodeKey:      key,
+						Enode:        en,
+						BootNodes:    []*enode.Node{en},
+					},
+				},
+				AnvilChains: []types.AnvilChain{
+					{
+						Chain:      types.EVMChain{Name: "chain_a", ID: 99},
+						InternalIP: ipNet.IP,
+						ProxyPort:  9000,
+					},
+				},
+			}
+
+			p := docker.NewProvider(testnet, types.InfrastructureData{}, tag)
+			require.NoError(t, err)
+
+			require.NoError(t, p.Setup())
+
+			bz, err := os.ReadFile(filepath.Join(dir, "docker-compose.yml"))
+			require.NoError(t, err)
+
+			tutil.RequireGoldenBytes(t, bz)
+		})
 	}
-
-	p := docker.NewProvider(testnet, types.InfrastructureData{})
-	require.NoError(t, err)
-
-	require.NoError(t, p.Setup())
-
-	bz, err := os.ReadFile(filepath.Join(dir, "docker-compose.yml"))
-	require.NoError(t, err)
-
-	tutil.RequireGoldenBytes(t, bz)
 }

--- a/test/e2e/docker/testdata/TestComposeTemplate_image_tag_7d1ae53.golden
+++ b/test/e2e/docker/testdata/TestComposeTemplate_image_tag_7d1ae53.golden
@@ -1,75 +1,65 @@
 version: '2.4'
 networks:
-  {{ .NetworkName }}:
+  test:
     labels:
       e2e: true
     driver: bridge
-    {{- if .Network }}
     ipam:
       driver: default
       config:
-      - subnet: {{ .NetworkCIDR }}
-    {{- end }}
+      - subnet: 10.186.73.0/24
 
 services:
-{{- range .Nodes }}
-  {{ .Name }}:
+  node0:
     labels:
       e2e: true
-    container_name: {{ .Name }}
-    image: {{ .Version }}
+    container_name: node0
+    image: omniops/halo:7d1ae53
     init: true
     ports:
-    - {{ if $.BindAll }}26656:{{end}}26656
-    - {{ if .ProxyPort }}{{ .ProxyPort }}:{{ end }}26657
-{{- if .PrometheusProxyPort }}
-    - {{ .PrometheusProxyPort }}:26660
-{{- end }}
+    - 26656
+    - 8584:26657
     - 6060
     volumes:
-    - ./{{ .Name }}:/halo
-    - ./{{ index $.NodeOmniEVMs .Name }}/jwtsecret:/geth/jwtsecret
+    - ./node0:/halo
+    - ./omni_evm_0/jwtsecret:/geth/jwtsecret
     depends_on:
-      {{ index $.NodeOmniEVMs .Name }}:
+      omni_evm_0:
         condition: service_healthy
     networks:
-      {{ $.NetworkName }}:
-        {{ if $.Network }}ipv4_address: {{ .InternalIP }}{{ end }}
-{{end}}
+      test:
+        ipv4_address: 10.186.73.0
 
-{{- range .Anvils }}
   # Initialises geth files and folder from provided genesis file.
-  {{ .Chain.Name }}:
+  chain_a:
     labels:
       e2e: true
-    container_name: {{ .Chain.Name }}
+    container_name: chain_a
     image: ghcr.io/foundry-rs/foundry:latest
-    entrypoint: ['anvil','--host','0.0.0.0','--chain-id','{{ .Chain.ID }}','--block-time','1', "--silent"]
+    entrypoint: ['anvil','--host','0.0.0.0','--chain-id','99','--block-time','1', "--silent"]
     ports:
-      - {{ if .ProxyPort }}{{ .ProxyPort }}:{{ end }}8545
+      - 9000:8545
     networks:
-      {{ $.NetworkName }}:
-        {{ if $.Network }}ipv4_address: {{ .InternalIP }}{{ end }}
-{{- end}}
+      test:
+        ipv4_address: 10.186.73.0
 
   # Use geth as the omni EVMs.
-{{- range .OmniEVMs }}
   # Initialises geth files and folder from provided genesis file.
-  {{ .InstanceName }}-init:
+  omni_evm_0-init:
     labels:
       e2e: true
-    container_name: {{ .InstanceName }}-init
+    container_name: omni_evm_0-init
     image: "ethereum/client-go:latest"
     command: --datadir=/geth init /geth/genesis.json
     volumes:
-      - ./{{ .InstanceName }}:/geth
+      - ./omni_evm_0:/geth
     networks:
-      {{ $.NetworkName }}:
+      test:
 
-  {{ .InstanceName }}:
+  omni_evm_0:
     labels:
       e2e: true
-    container_name: {{ .InstanceName }}
+    container_name: omni_evm_0
     image: "ethereum/client-go:latest"
     command:
       - --http
@@ -90,42 +80,38 @@ services:
       - --password=/geth/geth_password.txt
       - --nodiscover
       - --syncmode=full
-      - --nodekeyhex={{.NodeKeyHex}}
-      - --bootnodes={{.BootNodesStr}}
+      - --nodekeyhex=59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d
+      - --bootnodes=enode://ba5734d8f7091719471e7f7ed6b9df170dc70cc661ca05e688601ad984f068b0d67351e5f06073092499336ab0839ef8a521afd334e53807205fa2f08eec74f4@10.186.73.0:30303
     ports:
-      - {{ if $.BindAll }}8551:{{end}}8551
-      - {{ if .ProxyPort }}{{ .ProxyPort }}:{{ end }}8545
-      - {{ if $.BindAll }}30303:{{end}}30303
+      - 8551
+      - 8000:8545
+      - 30303
       - 8546
     depends_on:
-      {{ .InstanceName }}-init:
+      omni_evm_0-init:
         condition: service_completed_successfully
     healthcheck:
       test: "nc -z localhost 8545"
       interval: 1s
       retries: 30
     volumes:
-      - ./{{ .InstanceName }}:/geth
+      - ./omni_evm_0:/geth
     networks:
-      {{ $.NetworkName }}:
-        {{ if $.Network }}ipv4_address: {{ .InternalIP }}{{ end }}
-{{end}}
+      test:
+        ipv4_address: 10.186.73.0
 
-{{- if .Relayer }}
   relayer:
     labels:
       e2e: true
     container_name: relayer
-    image: omniops/relayer:{{or .RelayerTag "main"}}
+    image: omniops/relayer:7d1ae53
     restart: unless-stopped # Restart on crash to mitigate startup race issues
     volumes:
       - ./relayer:/relayer
     networks:
-      {{ $.NetworkName }}:
-        {{ if $.Network }}ipv4_address: 10.186.73.200{{ end }}
-{{end}}
+      test:
+        ipv4_address: 10.186.73.200
 
-{{- if .Prometheus }}
   prometheus:
     labels:
       e2e: true
@@ -135,6 +121,6 @@ services:
     volumes:
       - ./prometheus/prometheus.yml:/etc/prometheus/prometheus.yml
     networks:
-      {{ $.NetworkName }}:
-        {{ if $.Network }}ipv4_address: 10.186.73.201{{ end }}
-{{ end }}
+      test:
+        ipv4_address: 10.186.73.201
+

--- a/test/e2e/docker/testdata/TestComposeTemplate_image_tag_main.golden
+++ b/test/e2e/docker/testdata/TestComposeTemplate_image_tag_main.golden
@@ -14,7 +14,7 @@ services:
     labels:
       e2e: true
     container_name: node0
-    image: v0.0.0
+    image: omniops/halo:main
     init: true
     ports:
     - 26656

--- a/test/e2e/tests/e2e_test.go
+++ b/test/e2e/tests/e2e_test.go
@@ -164,7 +164,7 @@ func loadEnv(t *testing.T) (types.Testnet, netconf.Network) {
 	}
 	require.NoError(t, err)
 
-	testnet, err := app.TestnetFromManifest(m, manifestFile, ifd, nil)
+	testnet, err := app.TestnetFromManifest(m, manifestFile, ifd, nil, "main")
 	require.NoError(t, err)
 	testnetCache[manifestFile] = testnet
 

--- a/test/e2e/vmcompose/provider.go
+++ b/test/e2e/vmcompose/provider.go
@@ -22,15 +22,17 @@ const ProviderName = "vmcompose"
 var _ types.InfraProvider = (*Provider)(nil)
 
 type Provider struct {
-	Testnet types.Testnet
-	Data    types.InfrastructureData
-	once    sync.Once
+	Testnet    types.Testnet
+	Data       types.InfrastructureData
+	once       sync.Once
+	relayerTag string
 }
 
-func NewProvider(testnet types.Testnet, data types.InfrastructureData) *Provider {
+func NewProvider(testnet types.Testnet, data types.InfrastructureData, tag string) *Provider {
 	return &Provider{
-		Testnet: testnet,
-		Data:    data,
+		Testnet:    testnet,
+		Data:       data,
+		relayerTag: tag,
 	}
 }
 
@@ -72,6 +74,7 @@ func (p *Provider) Setup() error {
 			Anvils:      anvilChains,
 			Relayer:     services["relayer"],
 			Prometheus:  p.Testnet.Prometheus,
+			RelayerTag:  p.relayerTag,
 		}
 		compose, err := docker.GenerateComposeFile(def)
 		if err != nil {

--- a/test/e2e/vmcompose/provider_test.go
+++ b/test/e2e/vmcompose/provider_test.go
@@ -23,6 +23,7 @@ func TestSetup(t *testing.T) {
 		ManifestFile:  manifestFile,
 		InfraProvider: vmcompose.ProviderName,
 		InfraDataFile: dataFile,
+		ImgTag:        "7d1ae53",
 	})
 	require.NoError(t, err)
 

--- a/test/e2e/vmcompose/testdata/TestSetup_127_0_0_1_compose.yaml.golden
+++ b/test/e2e/vmcompose/testdata/TestSetup_127_0_0_1_compose.yaml.golden
@@ -10,7 +10,7 @@ services:
     labels:
       e2e: true
     container_name: validator01
-    image: omniops/halo:main
+    image: omniops/halo:7d1ae53
     init: true
     ports:
     - 26656:26656

--- a/test/e2e/vmcompose/testdata/TestSetup_127_0_0_2_compose.yaml.golden
+++ b/test/e2e/vmcompose/testdata/TestSetup_127_0_0_2_compose.yaml.golden
@@ -10,7 +10,7 @@ services:
     labels:
       e2e: true
     container_name: validator02
-    image: omniops/halo:main
+    image: omniops/halo:7d1ae53
     init: true
     ports:
     - 26656:26656

--- a/test/e2e/vmcompose/testdata/TestSetup_127_0_0_3_compose.yaml.golden
+++ b/test/e2e/vmcompose/testdata/TestSetup_127_0_0_3_compose.yaml.golden
@@ -24,7 +24,7 @@ services:
     labels:
       e2e: true
     container_name: relayer
-    image: omniops/relayer:main
+    image: omniops/relayer:7d1ae53
     restart: unless-stopped # Restart on crash to mitigate startup race issues
     volumes:
       - ./relayer:/relayer


### PR DESCRIPTION
This PR adds `--image-tag` to the e2e runner binary so that the generated docker compose files can pin docker images by tag.

task: https://app.asana.com/0/1206208509925075/1206590491637443/f