### PR TITLE
fix(netman): improve txn sending and logs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,5 @@ dist
 
 # MacOS specific file
 .DS_Store
+
+.env

--- a/test/e2e/netman/helpers.go
+++ b/test/e2e/netman/helpers.go
@@ -19,7 +19,7 @@ import (
 	"github.com/ethereum/go-ethereum/params"
 )
 
-func deployContract(ctx context.Context, chainID uint64, client *ethclient.Client, privKey *ecdsa.PrivateKey,
+func deployOmniContracts(ctx context.Context, chainID uint64, client *ethclient.Client, privKey *ecdsa.PrivateKey,
 	valSetID uint64, validators []bindings.Validator,
 ) (common.Address, *bindings.OmniPortal, *bind.TransactOpts, error) {
 	txOpts, err := newTxOpts(ctx, privKey, chainID)

--- a/test/e2e/netman/manager.go
+++ b/test/e2e/netman/manager.go
@@ -186,10 +186,10 @@ func (m *manager) DeployPublicPortals(ctx context.Context, valSetID uint64, vali
 		if !portal.Chain.IsPublic {
 			continue // Only log public chain balances.
 		}
-		if err := logBalance(ctx, portal.Client, m.publicDeployKey, "deploy_key"); err != nil {
+		if err := logBalance(ctx, portal.Client, portal.Chain.Name, m.publicDeployKey, "deploy_key"); err != nil {
 			return err
 		}
-		if err := logBalance(ctx, portal.Client, m.relayerKey, "relayer_key"); err != nil {
+		if err := logBalance(ctx, portal.Client, portal.Chain.Name, m.relayerKey, "relayer_key"); err != nil {
 			return err
 		}
 	}
@@ -202,6 +202,8 @@ func (m *manager) DeployPublicPortals(ctx context.Context, valSetID uint64, vali
 		if !portal.Chain.IsPublic {
 			continue // Only public chains are deployed here.
 		}
+
+		log.Info(ctx, "Deploying to", "chain", portal.Chain.Name)
 
 		height, err := portal.Client.BlockNumber(ctx)
 		if err != nil {

--- a/test/e2e/netman/manager.go
+++ b/test/e2e/netman/manager.go
@@ -208,9 +208,11 @@ func (m *manager) DeployPublicPortals(ctx context.Context, valSetID uint64, vali
 			return errors.Wrap(err, "get block number")
 		}
 
-		addr, contract, txops, err := deployContract(ctx, chainID, portal.Client, m.publicDeployKey, valSetID, validators)
+		addr, contract, txops, err := deployOmniContracts(
+			ctx, chainID, portal.Client, m.publicDeployKey, valSetID, validators,
+		)
 		if err != nil {
-			return errors.Wrap(err, "deploy public portal contract")
+			return errors.Wrap(err, "deploy public omni contracts")
 		}
 
 		portal.DeployInfo = DeployInfo{
@@ -237,9 +239,9 @@ func (m *manager) DeployPrivatePortals(ctx context.Context, valSetID uint64, val
 			continue // Public chains are already deployed.
 		}
 
-		addr, contract, txops, err := deployContract(ctx, chainID, portal.Client, privateDeployKey, valSetID, validators)
+		addr, contract, txops, err := deployOmniContracts(ctx, chainID, portal.Client, privateDeployKey, valSetID, validators)
 		if err != nil {
-			return errors.Wrap(err, "deploy private portal contract")
+			return errors.Wrap(err, "deploy private omni contracts")
 		} else if addr != portal.DeployInfo.PortalAddress {
 			return errors.New("deployed address does not match existing address",
 				"expected", portal.DeployInfo.PortalAddress.Hex(),


### PR DESCRIPTION
Goerli was rejecting deployments for underpriced replacement transactions. Fixed how we wait for transactions to be mined. Also improved some logging

task: none