### PR TITLE
feat(e2e): support upgrading vmcompose networks

### DIFF
--- a/test/e2e/cmd/cmd.go
+++ b/test/e2e/cmd/cmd.go
@@ -58,6 +58,7 @@ func New() *cobra.Command {
 		newLogsCmd(&def),
 		newCleanCmd(&def),
 		newTestCmd(&def),
+		newUpgradeCmd(&def),
 	)
 
 	return cmd
@@ -107,6 +108,16 @@ func newTestCmd(def *app.Definition) *cobra.Command {
 		Short: "Runs go tests against the a previously preserved network",
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			return app.Test(cmd.Context(), *def, true)
+		},
+	}
+}
+
+func newUpgradeCmd(def *app.Definition) *cobra.Command {
+	return &cobra.Command{
+		Use:   "upgrade",
+		Short: "Upgrades docker containers of a previously preserved network",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return def.Infra.Upgrade(cmd.Context())
 		},
 	}
 }

--- a/test/e2e/docker/docker.go
+++ b/test/e2e/docker/docker.go
@@ -95,6 +95,10 @@ func (p *Provider) Setup() error {
 	return nil
 }
 
+func (*Provider) Upgrade(_ context.Context) error {
+	return errors.New("upgrade not supported for docker provider")
+}
+
 func (p *Provider) StartNodes(ctx context.Context, nodes ...*e2e.Node) error {
 	var err error
 	p.servicesOnce.Do(func() {

--- a/test/e2e/types/infra.go
+++ b/test/e2e/types/infra.go
@@ -10,6 +10,8 @@ import (
 type InfraProvider interface {
 	infra.Provider
 
+	Upgrade(ctx context.Context) error
+
 	// Clean deletes all containers, networks, and data on disk.
 	Clean(ctx context.Context) error
 }


### PR DESCRIPTION
Adds support to e2e app to "upgrade" existing `vmcompose` networks. It copies the new docker-compose files and then runs `docker-compose up`

task: none