### PR TITLE
fix(ci): disable docs deploy ci

### DIFF
--- a/.github/workflows/ci-docs.yml
+++ b/.github/workflows/ci-docs.yml
@@ -3,11 +3,13 @@ env:
   VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
   VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
 on:
-  push:
-    branches:
-      - main
-    paths:
-      - 'docs/site/**'
+  workflow_dispatch:
+  # TODO(dennis): uncomment upon docusaurus site launch
+  # push:
+  #   branches:
+  #     - main
+  #   paths:
+  #     - 'docs/site/**'
 jobs:
   deploy:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This PR disables the docs `deploy` workflow (now only to be triggered manually)

task: none
