### PR TITLE
chore(lib/gitinfo): add git info metrics to all apps

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -86,6 +86,9 @@ linters-settings:
 issues:
   fix: true
   exclude-rules:
+    - path: 'metrics.go'
+      linters:
+        - gochecknoglobals # Promauto metrics are global variables
     - path: '(.*)(test|scripts)(.*)'
       linters:        # Relax linters for both tests/scripts (non-production code)
         - gosec       # Security not an issue here

--- a/explorer/graphql/app/app.go
+++ b/explorer/graphql/app/app.go
@@ -20,8 +20,7 @@ func Run(ctx context.Context, cfg Config) error {
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
-	commit, timestamp := gitinfo.Get()
-	log.Info(ctx, "Version info", "git_commit", commit, "git_timestamp", timestamp)
+	gitinfo.Instrument(ctx)
 
 	// create ent client
 	entCl, err := db.NewPostgressClient(cfg.DBUrl)

--- a/explorer/indexer/app/app.go
+++ b/explorer/indexer/app/app.go
@@ -17,8 +17,7 @@ import (
 func Run(ctx context.Context, cfg Config) error {
 	log.Info(ctx, "Starting Explorer Indexer")
 
-	commit, timestamp := gitinfo.Get()
-	log.Info(ctx, "Version info", "git_commit", commit, "git_timestamp", timestamp)
+	gitinfo.Instrument(ctx)
 
 	network, err := netconf.Load(cfg.NetworkFile)
 	if err != nil {

--- a/halo/app/app.go
+++ b/halo/app/app.go
@@ -34,8 +34,7 @@ type Config struct {
 func Run(ctx context.Context, cfg Config) error {
 	log.Info(ctx, "Starting halo consensus client")
 
-	commit, timestamp := gitinfo.Get()
-	log.Info(ctx, "Version info", "git_commit", commit, "git_timestamp", timestamp)
+	gitinfo.Instrument(ctx)
 
 	// Load private validator key and state from disk (this hard exits on any error).
 	privVal := privval.LoadFilePV(cfg.Comet.PrivValidatorKeyFile(), cfg.Comet.PrivValidatorStateFile())

--- a/halo/attest/metrics.go
+++ b/halo/attest/metrics.go
@@ -5,7 +5,6 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promauto"
 )
 
-//nolint:gochecknoglobals // Promauto metrics are global.
 var (
 	createLag = promauto.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: "halo",

--- a/halo/comet/metrics.go
+++ b/halo/comet/metrics.go
@@ -5,7 +5,6 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promauto"
 )
 
-//nolint:gochecknoglobals // Promauto metrics are global.
 var (
 	pendingHeight = promauto.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: "halo",

--- a/halo2/app/start.go
+++ b/halo2/app/start.go
@@ -56,8 +56,7 @@ func Run(ctx context.Context, cfg halo1.Config) error {
 func Start(ctx context.Context, cfg halo1.Config) (func(context.Context) error, error) {
 	log.Info(ctx, "Starting halo consensus client")
 
-	commit, timestamp := gitinfo.Get()
-	log.Info(ctx, "Version info", "git_commit", commit, "git_timestamp", timestamp)
+	gitinfo.Instrument(ctx)
 
 	// Load private validator key and state from disk (this hard exits on any error).
 	privVal := privval.LoadFilePV(cfg.Comet.PrivValidatorKeyFile(), cfg.Comet.PrivValidatorStateFile())

--- a/halo2/attest/attester/metrics.go
+++ b/halo2/attest/attester/metrics.go
@@ -5,7 +5,6 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promauto"
 )
 
-//nolint:gochecknoglobals // Promauto metrics are global.
 var (
 	createLag = promauto.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: "halo2",

--- a/lib/cchain/provider/metrics.go
+++ b/lib/cchain/provider/metrics.go
@@ -5,7 +5,6 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promauto"
 )
 
-//nolint:gochecknoglobals // Promauto metrics are global.
 var (
 	callbackErrTotal = promauto.NewCounter(prometheus.CounterOpts{
 		Namespace: "lib",

--- a/lib/gitinfo/gitinfo.go
+++ b/lib/gitinfo/gitinfo.go
@@ -1,6 +1,11 @@
 package gitinfo
 
-import "runtime/debug"
+import (
+	"context"
+	"runtime/debug"
+
+	"github.com/omni-network/omni/lib/log"
+)
 
 // Get returns the git commit hash and timestamp from the runtime build info.
 func Get() (hash string, timestamp string) { //nolint:nonamedreturns // Disambiguate identical return types.
@@ -24,4 +29,15 @@ func Get() (hash string, timestamp string) { //nolint:nonamedreturns // Disambig
 	}
 
 	return hash, timestamp
+}
+
+// Instrument logs the git commit hash and timestamp from the runtime build info.
+// It also sets the commit and timestamp metrics.
+func Instrument(ctx context.Context) {
+	commit, timestamp := Get()
+
+	log.Info(ctx, "Version info", "git_commit", commit, "git_timestamp", timestamp)
+
+	commitGauge.WithLabelValues(commit).Set(1)
+	timestampGauge.WithLabelValues(timestamp).Set(1)
 }

--- a/lib/gitinfo/metrics.go
+++ b/lib/gitinfo/metrics.go
@@ -1,0 +1,19 @@
+package gitinfo
+
+import "github.com/prometheus/client_golang/prometheus"
+
+var (
+	commitGauge = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: "lib",
+		Subsystem: "git",
+		Name:      "commit",
+		Help:      "Constant gauge with label 'commit' set to the current git commit hash.",
+	}, []string{"commit"})
+
+	timestampGauge = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: "lib",
+		Subsystem: "git",
+		Name:      "timestamp",
+		Help:      "Constant gauge with label 'timestamp' set to the current git commit timestamp.",
+	}, []string{"timestamp"})
+)

--- a/lib/log/metrics.go
+++ b/lib/log/metrics.go
@@ -5,7 +5,6 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promauto"
 )
 
-//nolint:gochecknoglobals // Promauto metrics are global.
 var (
 	logTotal = promauto.NewCounterVec(prometheus.CounterOpts{
 		Namespace: "lib",

--- a/lib/xchain/provider/metrics.go
+++ b/lib/xchain/provider/metrics.go
@@ -5,7 +5,6 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promauto"
 )
 
-//nolint:gochecknoglobals // Promauto metrics are global.
 var (
 	callbackErrTotal = promauto.NewCounterVec(prometheus.CounterOpts{
 		Namespace: "lib",

--- a/relayer/app/app.go
+++ b/relayer/app/app.go
@@ -21,8 +21,7 @@ import (
 func Run(ctx context.Context, cfg Config) error {
 	log.Info(ctx, "Starting relayer")
 
-	commit, timestamp := gitinfo.Get()
-	log.Info(ctx, "Version info", "git_commit", commit, "git_timestamp", timestamp)
+	gitinfo.Instrument(ctx)
 
 	network, err := netconf.Load(cfg.NetworkFile)
 	if err != nil {

--- a/relayer/app/metrics.go
+++ b/relayer/app/metrics.go
@@ -5,7 +5,6 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promauto"
 )
 
-//nolint:gochecknoglobals // Promauto metrics are global by nature
 var (
 	bufferLen = promauto.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: "relayer",

--- a/relayer/txmgr/metrics.go
+++ b/relayer/txmgr/metrics.go
@@ -5,7 +5,6 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promauto"
 )
 
-//nolint:gochecknoglobals // Promauto metrics are global by nature
 var (
 	resendTotal = promauto.NewCounterVec(prometheus.CounterOpts{
 		Namespace: "relayer",


### PR DESCRIPTION
Adds `lib_git_commit` and `lib_git_timestamp` "constant gauge metrics" with labels to set to those values. This makes it easy to visualise what commit is running and how old that commit is (since git commits are not directly human parsable).

task: none