### PR TITLE
fix(halo2): fixes to get halo e2e working

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -76,6 +76,10 @@
       "path": "detect_secrets.filters.allowlist.is_line_allowlisted"
     },
     {
+      "path": "detect_secrets.filters.common.is_baseline_file",
+      "filename": ".secrets.baseline"
+    },
+    {
       "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
       "min_level": 2
     },
@@ -502,21 +506,21 @@
         "filename": "test/e2e/app/setup.go",
         "hashed_secret": "7be029054a936fcb1827abd24388a53136be7b64",
         "is_verified": false,
-        "line_number": 106
+        "line_number": 116
       },
       {
         "type": "Secret Keyword",
         "filename": "test/e2e/app/setup.go",
         "hashed_secret": "55abc9109d5ea8a77be16bf3c76b4b199b524b12",
         "is_verified": false,
-        "line_number": 344
+        "line_number": 354
       },
       {
         "type": "Secret Keyword",
         "filename": "test/e2e/app/setup.go",
         "hashed_secret": "da57af224108e98e24d1e2a86221121990fa6478",
         "is_verified": false,
-        "line_number": 369
+        "line_number": 379
       }
     ],
     "test/e2e/app/static/geth_genesis.json": [
@@ -768,5 +772,5 @@
       }
     ]
   },
-  "generated_at": "2024-02-17T13:45:33Z"
+  "generated_at": "2024-02-19T12:47:38Z"
 }

--- a/halo/app/config.go
+++ b/halo/app/config.go
@@ -30,7 +30,7 @@ const (
 	defaultMinRetainBlocks         = 0        // Retain all blocks
 
 	defaultPruningOption = pruningtypes.PruningOptionNothing // Prune nothing
-	defaultDBBackend     = db.GoLevelDBBackend
+	defaultDBBackend     = db.MemDBBackend
 )
 
 // DefaultHaloConfig returns the default halo config.

--- a/halo/cmd/cmd.go
+++ b/halo/cmd/cmd.go
@@ -17,9 +17,9 @@ func New() *cobra.Command {
 	return libcmd.NewRootCmd(
 		"halo",
 		"Halo is a consensus client implementation for the Omni Protocol",
-		newRunCmd("run", halo1.Run),
+		newRunCmd("run1", halo1.Run),
 		newInitCmd(),
-		newRunCmd("run2", halo2.Run),
+		newRunCmd("run", halo2.Run),
 	)
 }
 

--- a/halo/cmd/cmd_internal_test.go
+++ b/halo/cmd/cmd_internal_test.go
@@ -121,7 +121,7 @@ func TestTomlConfig(t *testing.T) {
 	// TODO(corver): Add support for halo2 flags to config
 	expect.MinRetainBlocks = 0
 	expect.PruningOption = "nothing"
-	expect.BackendType = "goleveldb"
+	expect.BackendType = "memdb"
 
 	// Ensure the <home>/config directory exists.
 	require.NoError(t, os.Mkdir(filepath.Join(dir, "config"), 0o755))

--- a/halo/cmd/testdata/TestCLIReference_halo.golden
+++ b/halo/cmd/testdata/TestCLIReference_halo.golden
@@ -8,7 +8,7 @@ Available Commands:
   help        Help about any command
   init        Initializes required halo files and directories
   run         Runs the halo consensus client
-  run2        Runs the halo consensus client
+  run1        Runs the halo consensus client
 
 Flags:
   -h, --help   help for halo

--- a/halo/cmd/testdata/TestRunCmd_defaults.golden
+++ b/halo/cmd/testdata/TestRunCmd_defaults.golden
@@ -3,7 +3,7 @@
  "EngineJWTFile": "",
  "AppStatePersistInterval": 1,
  "SnapshotInterval": 1000,
- "BackendType": "goleveldb",
+ "BackendType": "memdb",
  "MinRetainBlocks": 0,
  "PruningOption": "nothing",
  "Comet": {

--- a/halo/cmd/testdata/TestRunCmd_flags.golden
+++ b/halo/cmd/testdata/TestRunCmd_flags.golden
@@ -3,7 +3,7 @@
  "EngineJWTFile": "bar",
  "AppStatePersistInterval": 1,
  "SnapshotInterval": 1000,
- "BackendType": "goleveldb",
+ "BackendType": "memdb",
  "MinRetainBlocks": 0,
  "PruningOption": "nothing",
  "Comet": {

--- a/halo/cmd/testdata/TestRunCmd_json_files.golden
+++ b/halo/cmd/testdata/TestRunCmd_json_files.golden
@@ -3,7 +3,7 @@
  "EngineJWTFile": "jwt.json",
  "AppStatePersistInterval": 12,
  "SnapshotInterval": 123,
- "BackendType": "goleveldb",
+ "BackendType": "memdb",
  "MinRetainBlocks": 0,
  "PruningOption": "nothing",
  "Comet": {

--- a/halo/cmd/testdata/TestRunCmd_toml_files.golden
+++ b/halo/cmd/testdata/TestRunCmd_toml_files.golden
@@ -3,7 +3,7 @@
  "EngineJWTFile": "jwt.toml",
  "AppStatePersistInterval": 99,
  "SnapshotInterval": 999,
- "BackendType": "goleveldb",
+ "BackendType": "memdb",
  "MinRetainBlocks": 0,
  "PruningOption": "nothing",
  "Comet": {

--- a/halo2/app/app.go
+++ b/halo2/app/app.go
@@ -4,7 +4,7 @@ import (
 	"github.com/omni-network/omni/halo2/attest/attester"
 	attestkeeper "github.com/omni-network/omni/halo2/attest/keeper"
 	atypes "github.com/omni-network/omni/halo2/attest/types"
-	engevmkeeper "github.com/omni-network/omni/halo2/evmengine/keeper"
+	evmenginekeeper "github.com/omni-network/omni/halo2/evmengine/keeper"
 	evmenginetypes "github.com/omni-network/omni/halo2/evmengine/types"
 	"github.com/omni-network/omni/lib/engine"
 	"github.com/omni-network/omni/lib/errors"
@@ -25,17 +25,15 @@ import (
 	distrkeeper "github.com/cosmos/cosmos-sdk/x/distribution/keeper"
 	stakingkeeper "github.com/cosmos/cosmos-sdk/x/staking/keeper"
 
-	// Blank imports for side-effects.
-	_ "cosmossdk.io/api/cosmos/tx/config/v1"
-	_ "github.com/cosmos/cosmos-sdk/x/auth"
-	_ "github.com/cosmos/cosmos-sdk/x/auth/tx/config"
-	_ "github.com/cosmos/cosmos-sdk/x/bank"
-	_ "github.com/cosmos/cosmos-sdk/x/consensus"
-	_ "github.com/cosmos/cosmos-sdk/x/distribution"
-	_ "github.com/cosmos/cosmos-sdk/x/genutil"
-	_ "github.com/cosmos/cosmos-sdk/x/mint"
-	_ "github.com/cosmos/cosmos-sdk/x/staking"
-	_ "github.com/omni-network/omni/halo2/evmengine/module"
+	_ "cosmossdk.io/api/cosmos/tx/config/v1"          // import for side-effects
+	_ "github.com/cosmos/cosmos-sdk/x/auth"           // import for side-effects
+	_ "github.com/cosmos/cosmos-sdk/x/auth/tx/config" // import for side-effects
+	_ "github.com/cosmos/cosmos-sdk/x/bank"           // import for side-effects
+	_ "github.com/cosmos/cosmos-sdk/x/consensus"      // import for side-effects
+	_ "github.com/cosmos/cosmos-sdk/x/distribution"   // import for side-effects
+	_ "github.com/cosmos/cosmos-sdk/x/genutil"        // import for side-effects
+	_ "github.com/cosmos/cosmos-sdk/x/mint"           // import for side-effects
+	_ "github.com/cosmos/cosmos-sdk/x/staking"        // import for side-effects
 )
 
 const Name = "halo"
@@ -56,7 +54,7 @@ type App struct {
 	StakingKeeper         *stakingkeeper.Keeper
 	DistrKeeper           distrkeeper.Keeper
 	ConsensusParamsKeeper consensuskeeper.Keeper
-	EngEVMKeeper          engevmkeeper.Keeper
+	EngEVMKeeper          evmenginekeeper.Keeper
 	AttestKeeper          attestkeeper.Keeper
 }
 

--- a/halo2/app/app_config.go
+++ b/halo2/app/app_config.go
@@ -30,8 +30,10 @@ import (
 // Bech32HRP is the human-readable-part of the Bech32 address format.
 const Bech32HRP = "omni"
 
-// InitSDKConfig initializes the Cosmos SDK configuration.
-func InitSDKConfig() {
+// init initializes the Cosmos SDK configuration.
+//
+//nolint:gochecknoinits // Cosmos-style
+func init() {
 	// Set prefixes
 	accountPubKeyPrefix := Bech32HRP + "pub"
 	validatorAddressPrefix := Bech32HRP + "valoper"

--- a/halo2/app/logging.go
+++ b/halo2/app/logging.go
@@ -1,0 +1,95 @@
+//nolint:wrapcheck,lll,revive // The abci.Application is our application, so we don't need to wrap it. Long lines are fine here.
+package app
+
+import (
+	"context"
+
+	"github.com/omni-network/omni/lib/log"
+
+	abci "github.com/cometbft/cometbft/abci/types"
+)
+
+type loggingABCIApp struct {
+	abci.Application
+}
+
+func (l loggingABCIApp) Info(ctx context.Context, info *abci.RequestInfo) (*abci.ResponseInfo, error) {
+	log.Debug(ctx, "👾 ABCI call: Info")
+	return l.Application.Info(ctx, info)
+}
+
+func (l loggingABCIApp) Query(ctx context.Context, query *abci.RequestQuery) (*abci.ResponseQuery, error) {
+	log.Debug(ctx, "👾 ABCI call: Query")
+	return l.Application.Query(ctx, query)
+}
+
+func (l loggingABCIApp) CheckTx(ctx context.Context, tx *abci.RequestCheckTx) (*abci.ResponseCheckTx, error) {
+	log.Debug(ctx, "👾 ABCI call: CheckTx")
+	return l.Application.CheckTx(ctx, tx)
+}
+
+func (l loggingABCIApp) InitChain(ctx context.Context, chain *abci.RequestInitChain) (*abci.ResponseInitChain, error) {
+	log.Debug(ctx, "👾 ABCI call: InitChain")
+	return l.Application.InitChain(ctx, chain)
+}
+
+func (l loggingABCIApp) PrepareProposal(ctx context.Context, proposal *abci.RequestPrepareProposal) (*abci.ResponsePrepareProposal, error) {
+	log.Debug(ctx, "👾 ABCI call: PrepareProposal")
+	return l.Application.PrepareProposal(ctx, proposal)
+}
+
+func (l loggingABCIApp) ProcessProposal(ctx context.Context, proposal *abci.RequestProcessProposal) (*abci.ResponseProcessProposal, error) {
+	log.Debug(ctx, "👾 ABCI call: ProcessProposal")
+	return l.Application.ProcessProposal(ctx, proposal)
+}
+
+func (l loggingABCIApp) FinalizeBlock(ctx context.Context, block *abci.RequestFinalizeBlock) (*abci.ResponseFinalizeBlock, error) {
+	log.Debug(ctx, "👾 ABCI call: FinalizeBlock")
+	resp, err := l.Application.FinalizeBlock(ctx, block)
+
+	for i, res := range resp.TxResults {
+		if res.Code == 0 {
+			continue
+		}
+		log.Error(ctx, "Unexpected failed transaction", nil,
+			"info", res.Info, "code", res.Code, "log", res.Log,
+			"code_space", res.Codespace, "index", i, "height", block.Height)
+	}
+
+	return resp, err
+}
+
+func (l loggingABCIApp) ExtendVote(ctx context.Context, vote *abci.RequestExtendVote) (*abci.ResponseExtendVote, error) {
+	log.Debug(ctx, "👾 ABCI call: ExtendVote")
+	return l.Application.ExtendVote(ctx, vote)
+}
+
+func (l loggingABCIApp) VerifyVoteExtension(ctx context.Context, extension *abci.RequestVerifyVoteExtension) (*abci.ResponseVerifyVoteExtension, error) {
+	log.Debug(ctx, "👾 ABCI call: VerifyVoteExtension")
+	return l.Application.VerifyVoteExtension(ctx, extension)
+}
+
+func (l loggingABCIApp) Commit(ctx context.Context, commit *abci.RequestCommit) (*abci.ResponseCommit, error) {
+	log.Debug(ctx, "👾 ABCI call: Commit")
+	return l.Application.Commit(ctx, commit)
+}
+
+func (l loggingABCIApp) ListSnapshots(ctx context.Context, listSnapshots *abci.RequestListSnapshots) (*abci.ResponseListSnapshots, error) {
+	log.Debug(ctx, "👾 ABCI call: ListSnapshots")
+	return l.Application.ListSnapshots(ctx, listSnapshots)
+}
+
+func (l loggingABCIApp) OfferSnapshot(ctx context.Context, snapshot *abci.RequestOfferSnapshot) (*abci.ResponseOfferSnapshot, error) {
+	log.Debug(ctx, "👾 ABCI call: OfferSnapshot")
+	return l.Application.OfferSnapshot(ctx, snapshot)
+}
+
+func (l loggingABCIApp) LoadSnapshotChunk(ctx context.Context, chunk *abci.RequestLoadSnapshotChunk) (*abci.ResponseLoadSnapshotChunk, error) {
+	log.Debug(ctx, "👾 ABCI call: LoadSnapshotChunk")
+	return l.Application.LoadSnapshotChunk(ctx, chunk)
+}
+
+func (l loggingABCIApp) ApplySnapshotChunk(ctx context.Context, chunk *abci.RequestApplySnapshotChunk) (*abci.ResponseApplySnapshotChunk, error) {
+	log.Debug(ctx, "👾 ABCI call: ApplySnapshotChunk")
+	return l.Application.ApplySnapshotChunk(ctx, chunk)
+}

--- a/halo2/app/start.go
+++ b/halo2/app/start.go
@@ -170,7 +170,7 @@ func newCometNode(ctx context.Context, cfg *cmtcfg.Config, app *App, privVal cmt
 	cmtNode, err := node.NewNode(cfg,
 		privVal,
 		nodeKey,
-		proxy.NewLocalClientCreator(server.NewCometABCIWrapper(app)),
+		proxy.NewLocalClientCreator(loggingABCIApp{server.NewCometABCIWrapper(app)}),
 		node.DefaultGenesisDocProviderFunc(cfg),
 		cmtcfg.DefaultDBProvider,
 		node.DefaultMetricsProvider(cfg.Instrumentation),

--- a/halo2/attest/keeper/keeper.go
+++ b/halo2/attest/keeper/keeper.go
@@ -128,7 +128,10 @@ func (k Keeper) addOne(ctx context.Context, agg *types.AggAttestation) error {
 			ValidatorAddress: sig.ValidatorAddress,
 			AggId:            aggID,
 		})
-		if err != nil {
+		if errors.Is(err, ormerrors.UniqueKeyViolation) {
+			// TODO(corver): We should prevent this from happening earlier.
+			log.Warn(ctx, "Ignoring duplicate attestation", nil, "agg_id", aggID, "validator", sig.ValidatorAddress)
+		} else if err != nil {
 			return errors.Wrap(err, "insert signature")
 		}
 	}

--- a/halo2/attest/keeper/msg_server.go
+++ b/halo2/attest/keeper/msg_server.go
@@ -26,10 +26,8 @@ func (s msgServer) AddAggAttestations(ctx context.Context, msg *types.MsgAggAtte
 
 	// Update the attester state with the local headers.
 	localHeaders := headersByAddress(msg.Aggregates, s.attester.LocalAddress())
-	if sdkCtx.ExecMode() == sdk.ExecModeFinalize {
-		if err := s.attester.SetCommitted(localHeaders); err != nil {
-			return nil, errors.Wrap(err, "set committed")
-		}
+	if err := s.attester.SetCommitted(localHeaders); err != nil {
+		return nil, errors.Wrap(err, "set committed")
 	}
 
 	err := s.Keeper.Add(ctx, msg)

--- a/halo2/attest/types/tx.go
+++ b/halo2/attest/types/tx.go
@@ -50,3 +50,23 @@ func (a *Attestation) Verify() error {
 
 	return nil
 }
+
+func (h *BlockHeader) Verify() error {
+	if h == nil {
+		return errors.New("nil block header")
+	}
+
+	if len(h.Hash) != len(common.Hash{}) {
+		return errors.New("invalid block header hash length")
+	}
+
+	return nil
+}
+
+func (h *BlockHeader) ToXChain() xchain.BlockHeader {
+	return xchain.BlockHeader{
+		SourceChainID: h.ChainId,
+		BlockHeight:   h.Height,
+		BlockHash:     common.BytesToHash(h.Hash),
+	}
+}

--- a/halo2/genutil/genutil.go
+++ b/halo2/genutil/genutil.go
@@ -5,7 +5,6 @@ import (
 	"os"
 	"time"
 
-	"github.com/omni-network/omni/halo2/app"
 	attesttypes "github.com/omni-network/omni/halo2/attest/types"
 	etypes "github.com/omni-network/omni/halo2/evmengine/types"
 	"github.com/omni-network/omni/lib/errors"
@@ -33,7 +32,6 @@ import (
 )
 
 func MakeGenesis(chainID string, genesisTime time.Time, valPubkeys ...crypto.PubKey) (*gtypes.AppGenesis, error) {
-	app.InitSDKConfig() // Make sure this is called before anything else
 	cdc := getCodec()
 	txConfig := authtx.NewTxConfig(cdc, nil)
 

--- a/halo2/genutil/genutil_test.go
+++ b/halo2/genutil/genutil_test.go
@@ -8,6 +8,8 @@ import (
 	"github.com/omni-network/omni/test/tutil"
 
 	k1 "github.com/cometbft/cometbft/crypto/secp256k1"
+
+	_ "github.com/omni-network/omni/halo2/app" // To init SDK config.
 )
 
 //go:generate go test . -golden -clean

--- a/lib/cchain/provider/abci2.go
+++ b/lib/cchain/provider/abci2.go
@@ -10,7 +10,7 @@ import (
 
 	rpcclient "github.com/cometbft/cometbft/rpc/client"
 
-	grpc1 "github.com/cosmos/gogoproto/grpc"
+	gogogrpc "github.com/cosmos/gogoproto/grpc"
 	"github.com/cosmos/gogoproto/proto"
 	"google.golang.org/grpc"
 )
@@ -52,7 +52,7 @@ func newABCIFetchFunc(cl atypes.QueryClient) func(ctx context.Context, chainID u
 // rpcAdaptor adapts the cometBFT query client to the gRPC client interface.
 // Note it only supports the Invoke method, not the NewStream method.
 type rpcAdaptor struct {
-	grpc1.ClientConn
+	gogogrpc.ClientConn
 	abci rpcclient.ABCIClient
 }
 
@@ -71,11 +71,11 @@ func (a rpcAdaptor) Invoke(ctx context.Context, method string, req, resp any, _ 
 		return errors.Wrap(err, "marshal approved-from request")
 	}
 
-	r, err := a.abci.ABCIQuery(ctx, method, bz)
+	r, err := a.abci.ABCIQueryWithOptions(ctx, method, bz, rpcclient.ABCIQueryOptions{})
 	if err != nil {
 		return errors.Wrap(err, "abci query")
 	} else if !r.Response.IsOK() {
-		return errors.New("abci query failed", "code", r.Response.Code)
+		return errors.New("abci query failed", "code", r.Response.Code, "info", r.Response.Info, "log", r.Response.Log)
 	}
 
 	err = proto.Unmarshal(r.Response.Value, resppb)

--- a/relayer/app/app.go
+++ b/relayer/app/app.go
@@ -44,7 +44,7 @@ func Run(ctx context.Context, cfg Config) error {
 		return err
 	}
 
-	cprov := cprovider.NewABCIProvider(tmClient, network.ChainNamesByIDs())
+	cprov := cprovider.NewABCIProvider2(tmClient, network.ChainNamesByIDs())
 	xprov := xprovider.New(network, rpcClientPerChain)
 
 	for _, destChain := range network.Chains {


### PR DESCRIPTION
Fixes to halo2 to get e2e working:
- Use MemDB by default (something is from with golevelDB, queries always fail)
- Move SDK init, since it is always required.
- Add logging of ABCI methods
- Fix attester issues (race and protos can't be map keys, tests were pointing to old impl)
- Improve visibility of failed txs.
- Implement post InitChain gas meter issue workaround

task: none