### PR TITLE
fix(e2e/tests): use halo2 cprovider

### DIFF
--- a/halo2/app/logging.go
+++ b/halo2/app/logging.go
@@ -19,8 +19,7 @@ func (l loggingABCIApp) Info(ctx context.Context, info *abci.RequestInfo) (*abci
 }
 
 func (l loggingABCIApp) Query(ctx context.Context, query *abci.RequestQuery) (*abci.ResponseQuery, error) {
-	log.Debug(ctx, "👾 ABCI call: Query")
-	return l.Application.Query(ctx, query)
+	return l.Application.Query(ctx, query) // No log here since this can be very noisy
 }
 
 func (l loggingABCIApp) CheckTx(ctx context.Context, tx *abci.RequestCheckTx) (*abci.ResponseCheckTx, error) {

--- a/test/e2e/tests/attestations_test.go
+++ b/test/e2e/tests/attestations_test.go
@@ -21,7 +21,7 @@ func TestApprovedAttestations(t *testing.T) {
 		t.Helper()
 		client, err := node.Client()
 		require.NoError(t, err)
-		cprov := provider.NewABCIProvider(client, nil)
+		cprov := provider.NewABCIProvider2(client, nil)
 
 		ctx := context.Background()
 		for _, portal := range portals {


### PR DESCRIPTION
Fixes e2e tests to use halo2 cprovider. Also reduce query debug logs.

task: none