### PR TITLE
fix(lib/cchain): fix cprovider metrics and logs

### DIFF
--- a/lib/cchain/provider/metrics.go
+++ b/lib/cchain/provider/metrics.go
@@ -6,17 +6,17 @@ import (
 )
 
 var (
-	callbackErrTotal = promauto.NewCounter(prometheus.CounterOpts{
+	callbackErrTotal = promauto.NewCounterVec(prometheus.CounterOpts{
 		Namespace: "lib",
 		Subsystem: "cprovider",
 		Name:      "callback_error_total",
 		Help:      "Total number of callback errors per source chain. Alert if growing.",
-	})
+	}, []string{"chain"})
 
-	streamHeight = promauto.NewGauge(prometheus.GaugeOpts{
+	streamHeight = promauto.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: "lib",
 		Subsystem: "cprovider",
 		Name:      "stream_height",
 		Help:      "Latest streamed xblock height per source chain. Alert if not growing.",
-	})
+	}, []string{"chain"})
 )


### PR DESCRIPTION
cprovider metrics must be "per chain". Also reduce log label duplication.

task: none