### PR TITLE
chore(ci): add repo to notify action

### DIFF
--- a/.github/workflows/ci-notify.yml
+++ b/.github/workflows/ci-notify.yml
@@ -22,7 +22,7 @@ jobs:
                   "type": "section",
                   "text": {
                     "type": "mrkdwn",
-                    "text": "🚨 CI failed on `${{github.event.workflow_run.head_repository}}:${{ github.event.workflow_run.head_branch }}`."
+                    "text": "🚨 CI failed on `${{ github.event.workflow_run.head_repository }}:${{ github.event.workflow_run.head_branch }}`."
                   }
                 },
                 {

--- a/.github/workflows/ci-notify.yml
+++ b/.github/workflows/ci-notify.yml
@@ -4,7 +4,7 @@ name: ci notify
 on:
   workflow_run:
     workflows: ["*"]
-    branches: [tt/notify]
+    branches: [main]
     types: [completed]
 
 jobs:

--- a/.github/workflows/ci-notify.yml
+++ b/.github/workflows/ci-notify.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - name: Notify Slack
         uses: slackapi/slack-github-action@v1.24.0
-        # if: ${{ github.event.workflow_run.conclusion == 'failure' }}
+        if: ${{ github.event.workflow_run.conclusion == 'failure' }}
         with:
           payload: |
             {

--- a/.github/workflows/ci-notify.yml
+++ b/.github/workflows/ci-notify.yml
@@ -4,7 +4,7 @@ name: ci notify
 on:
   workflow_run:
     workflows: ["*"]
-    branches: [main]
+    branches: [tt/notify]
     types: [completed]
 
 jobs:
@@ -13,7 +13,7 @@ jobs:
     steps:
       - name: Notify Slack
         uses: slackapi/slack-github-action@v1.24.0
-        if: ${{ github.event.workflow_run.conclusion == 'failure' }}
+        # if: ${{ github.event.workflow_run.conclusion == 'failure' }}
         with:
           payload: |
             {
@@ -22,7 +22,7 @@ jobs:
                   "type": "section",
                   "text": {
                     "type": "mrkdwn",
-                    "text": "🚨 CI failed on `${{ github.event.workflow_run.head_branch }}`."
+                    "text": "🚨 CI failed on `${{github.event.workflow_run.head_repository}}:${{ github.event.workflow_run.head_branch }}`."
                   }
                 },
                 {


### PR DESCRIPTION
Since we now have notifications for 2 repos, we need to specify which one CI failed on.

task: none
