### PR TITLE
fix(ci): evm logs

### DIFF
--- a/.github/workflows/ci-notify.yml
+++ b/.github/workflows/ci-notify.yml
@@ -22,7 +22,7 @@ jobs:
                   "type": "section",
                   "text": {
                     "type": "mrkdwn",
-                    "text": "🚨 CI failed on `${{ github.event.workflow_run.head_repository }}:${{ github.event.workflow_run.head_branch }}`."
+                    "text": "🚨 CI failed on `${{ github.event.repository.name }}:${{ github.event.workflow_run.head_branch }}`."
                   }
                 },
                 {

--- a/test/e2e/docker/compose.yaml.tmpl
+++ b/test/e2e/docker/compose.yaml.tmpl
@@ -44,7 +44,7 @@ services:
       e2e: true
     container_name: {{ .Chain.Name }}
     image: ghcr.io/foundry-rs/foundry:latest
-    entrypoint: ['anvil','--host','0.0.0.0','--chain-id','{{ .Chain.ID }}','--block-time','1', {{ if .LoadState }}'--load-state','/anvil/state.json'{{ end }}]
+    entrypoint: ['anvil','--host','0.0.0.0','--chain-id','{{ .Chain.ID }}','--block-time','1', '--silent', {{ if .LoadState }}'--load-state','/anvil/state.json'{{ end }}]
     ports:
       - {{ if .ProxyPort }}{{ .ProxyPort }}:{{ end }}8545
     networks:

--- a/test/e2e/docker/testdata/TestComposeTemplate_image_tag_7d1ae53.golden
+++ b/test/e2e/docker/testdata/TestComposeTemplate_image_tag_7d1ae53.golden
@@ -36,7 +36,7 @@ services:
       e2e: true
     container_name: mock_rollup
     image: ghcr.io/foundry-rs/foundry:latest
-    entrypoint: ['anvil','--host','0.0.0.0','--chain-id','99','--block-time','1', ]
+    entrypoint: ['anvil','--host','0.0.0.0','--chain-id','99','--block-time','1', '--silent', ]
     ports:
       - 9000:8545
     networks:
@@ -49,7 +49,7 @@ services:
       e2e: true
     container_name: mock_l1
     image: ghcr.io/foundry-rs/foundry:latest
-    entrypoint: ['anvil','--host','0.0.0.0','--chain-id','1','--block-time','1', '--load-state','/anvil/state.json']
+    entrypoint: ['anvil','--host','0.0.0.0','--chain-id','1','--block-time','1', '--silent', '--load-state','/anvil/state.json']
     ports:
       - 9000:8545
     networks:

--- a/test/e2e/docker/testdata/TestComposeTemplate_image_tag_main.golden
+++ b/test/e2e/docker/testdata/TestComposeTemplate_image_tag_main.golden
@@ -36,7 +36,7 @@ services:
       e2e: true
     container_name: mock_rollup
     image: ghcr.io/foundry-rs/foundry:latest
-    entrypoint: ['anvil','--host','0.0.0.0','--chain-id','99','--block-time','1', ]
+    entrypoint: ['anvil','--host','0.0.0.0','--chain-id','99','--block-time','1', '--silent', ]
     ports:
       - 9000:8545
     networks:
@@ -49,7 +49,7 @@ services:
       e2e: true
     container_name: mock_l1
     image: ghcr.io/foundry-rs/foundry:latest
-    entrypoint: ['anvil','--host','0.0.0.0','--chain-id','1','--block-time','1', '--load-state','/anvil/state.json']
+    entrypoint: ['anvil','--host','0.0.0.0','--chain-id','1','--block-time','1', '--silent', '--load-state','/anvil/state.json']
     ports:
       - 9000:8545
     networks:

--- a/test/e2e/vmcompose/testdata/TestSetup_127_0_0_3_compose.yaml.golden
+++ b/test/e2e/vmcompose/testdata/TestSetup_127_0_0_3_compose.yaml.golden
@@ -12,7 +12,7 @@ services:
       e2e: true
     container_name: chain_a
     image: ghcr.io/foundry-rs/foundry:latest
-    entrypoint: ['anvil','--host','0.0.0.0','--chain-id','100','--block-time','1', ]
+    entrypoint: ['anvil','--host','0.0.0.0','--chain-id','100','--block-time','1', '--silent', ]
     ports:
       - 8545:8545
     networks:


### PR DESCRIPTION
- I had removed `--silent` because it was useful for debugging locally, but it makes the github workflow unsearchable
- fix repository name in CI (was showing as `Object.main`)

task: none