### PR TITLE
chore(e2e): improve staging logs and metrics

### DIFF
--- a/lib/log/config.go
+++ b/lib/log/config.go
@@ -13,6 +13,7 @@ import (
 const (
 	FormatConsole = "console"
 	FormatJSON    = "json"
+	FormatLogfmt  = "logfmt"
 
 	ColorForce   = "force"
 	ColorDisable = "disable"
@@ -31,6 +32,7 @@ var (
 var loggerFuncs = map[string]func(...func(*options)) *slog.Logger{
 	FormatConsole: newConsoleLogger,
 	FormatJSON:    newJSONLogger,
+	FormatLogfmt:  newLogfmtLogger,
 }
 
 //nolint:gochecknoglobals // Static mapping.

--- a/lib/log/log.go
+++ b/lib/log/log.go
@@ -38,7 +38,7 @@ func Info(ctx context.Context, msg string, attrs ...any) {
 func Warn(ctx context.Context, msg string, err error, attrs ...any) {
 	logTotal.WithLabelValues(levelWarn).Inc()
 	if err != nil {
-		attrs = append(attrs, "err", err)
+		attrs = append(attrs, slog.String("err", err.Error()))
 		attrs = append(attrs, errAttrs(err)...)
 	}
 
@@ -50,7 +50,7 @@ func Warn(ctx context.Context, msg string, err error, attrs ...any) {
 func Error(ctx context.Context, msg string, err error, attrs ...any) {
 	logTotal.WithLabelValues(levelError).Inc()
 	if err != nil {
-		attrs = append(attrs, "err", err)
+		attrs = append(attrs, slog.String("err", err.Error()))
 		attrs = append(attrs, errAttrs(err)...)
 	}
 	getLogger(ctx).ErrorContext(ctx, msg, mergeAttrs(ctx, attrs)...)

--- a/lib/log/testdata/TestSimpleLogs_logfmt.golden
+++ b/lib/log/testdata/TestSimpleLogs_logfmt.golden
@@ -1,0 +1,9 @@
+time="00-00-00 00:00:00" level=INFO source=<source> msg="info message" with=args
+time="00-00-00 00:00:00" level=DEBUG source=<source> msg="debug this code for me please" number=1
+time="00-00-00 00:00:00" level=WARN source=<source> msg="watch out!" err="file already exists"
+time="00-00-00 00:00:00" level=ERROR source=<source> msg="something went wrong" float=1.234 err=EOF
+time="00-00-00 00:00:00" level=WARN source=<source> msg=err1 err=first 1=1 source=<stacktrace>
+time="00-00-00 00:00:00" level=ERROR source=<source> msg=err2 err="second: first" 2=2 1=1 source=<stacktrace>
+time="00-00-00 00:00:00" level=DEBUG source=<source> msg="ctx debug message" ctx_key1=ctx_value1 debug_key1=debug_value1
+time="00-00-00 00:00:00" level=INFO source=<source> msg="ctx info message" ctx_key1=ctx_value1 ctx_key2=ctx_value2 info_key2=info_value2
+time="00-00-00 00:00:00" level=WARN source=<source> msg="Pkg wrapped error" err="pkg wrap: omni wrap: new" wrap=wrap new=new source=<stacktrace>

--- a/test/e2e/app/static/prometheus.yml.tmpl
+++ b/test/e2e/app/static/prometheus.yml.tmpl
@@ -9,10 +9,10 @@ remote_write:
       username: {{ .RemoteUsername }}
       password: {{ .RemotePassword }}
     write_relabel_configs:
-      # Trim port from instance label
-      - source_labels: [__address__]
+      # Add 'container' label using 'instance without port'
+      - source_labels: [instance]
         regex: '(.+):(\d+)'
-        target_label: instance
+        target_label: container
         replacement: '${1}'
 {{end }}
 

--- a/test/e2e/docker/compose.yaml.tmpl
+++ b/test/e2e/docker/compose.yaml.tmpl
@@ -26,6 +26,8 @@ services:
     - {{ .PrometheusProxyPort }}:26660
 {{- end }}
     - 6060
+    environment:
+    - HALO_LOG_FORMAT={{ $.OmniLogFormat }}
     volumes:
     - ./{{ .Name }}:/halo
     - ./{{ index $.NodeOmniEVMs .Name }}/jwtsecret:/geth/jwtsecret
@@ -122,6 +124,8 @@ services:
     container_name: relayer
     image: omniops/relayer:{{or .RelayerTag "main"}}
     restart: unless-stopped # Restart on crash to mitigate startup race issues
+    environment:
+    - RELAYER_LOG_FORMAT={{ $.OmniLogFormat }}
     volumes:
       - ./relayer:/relayer
     networks:

--- a/test/e2e/docker/docker.go
+++ b/test/e2e/docker/docker.go
@@ -70,16 +70,17 @@ func NewProvider(testnet types.Testnet, infd types.InfrastructureData, haloTag s
 // any of these operations fail. It writes.
 func (p *Provider) Setup() error {
 	def := ComposeDef{
-		Network:     true,
-		NetworkName: p.testnet.Name,
-		NetworkCIDR: p.testnet.IP.String(),
-		BindAll:     false,
-		Nodes:       p.testnet.Nodes,
-		OmniEVMs:    p.testnet.OmniEVMs,
-		Anvils:      p.testnet.AnvilChains,
-		Relayer:     true,
-		Prometheus:  p.testnet.Prometheus,
-		RelayerTag:  p.relayerTag,
+		Network:       true,
+		NetworkName:   p.testnet.Name,
+		NetworkCIDR:   p.testnet.IP.String(),
+		BindAll:       false,
+		Nodes:         p.testnet.Nodes,
+		OmniEVMs:      p.testnet.OmniEVMs,
+		Anvils:        p.testnet.AnvilChains,
+		Relayer:       true,
+		Prometheus:    p.testnet.Prometheus,
+		RelayerTag:    p.relayerTag,
+		OmniLogFormat: log.FormatConsole, // Local docker compose always use console log format.
 	}
 
 	bz, err := GenerateComposeFile(def)
@@ -140,12 +141,13 @@ type ComposeDef struct {
 	NetworkCIDR string
 	BindAll     bool
 
-	Nodes      []*e2e.Node
-	OmniEVMs   []types.OmniEVM
-	Anvils     []types.AnvilChain
-	Relayer    bool
-	Prometheus bool
-	RelayerTag string
+	Nodes         []*e2e.Node
+	OmniEVMs      []types.OmniEVM
+	Anvils        []types.AnvilChain
+	Relayer       bool
+	Prometheus    bool
+	RelayerTag    string
+	OmniLogFormat string
 }
 
 // NodeOmniEVMs returns a map of node name to OmniEVM instance name; map[node_name]omni_evm.

--- a/test/e2e/docker/docker_test.go
+++ b/test/e2e/docker/docker_test.go
@@ -18,7 +18,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-//go:generate go test . -clean -update
+//go:generate go test . -golden -clean
 
 func TestComposeTemplate(t *testing.T) {
 	t.Parallel()

--- a/test/e2e/docker/testdata/TestComposeTemplate_image_tag_7d1ae53.golden
+++ b/test/e2e/docker/testdata/TestComposeTemplate_image_tag_7d1ae53.golden
@@ -20,6 +20,8 @@ services:
     - 26656
     - 8584:26657
     - 6060
+    environment:
+    - HALO_LOG_FORMAT=console
     volumes:
     - ./node0:/halo
     - ./omni_evm_0/jwtsecret:/geth/jwtsecret
@@ -123,6 +125,8 @@ services:
     container_name: relayer
     image: omniops/relayer:7d1ae53
     restart: unless-stopped # Restart on crash to mitigate startup race issues
+    environment:
+    - RELAYER_LOG_FORMAT=console
     volumes:
       - ./relayer:/relayer
     networks:

--- a/test/e2e/docker/testdata/TestComposeTemplate_image_tag_main.golden
+++ b/test/e2e/docker/testdata/TestComposeTemplate_image_tag_main.golden
@@ -20,6 +20,8 @@ services:
     - 26656
     - 8584:26657
     - 6060
+    environment:
+    - HALO_LOG_FORMAT=console
     volumes:
     - ./node0:/halo
     - ./omni_evm_0/jwtsecret:/geth/jwtsecret
@@ -123,6 +125,8 @@ services:
     container_name: relayer
     image: omniops/relayer:main
     restart: unless-stopped # Restart on crash to mitigate startup race issues
+    environment:
+    - RELAYER_LOG_FORMAT=console
     volumes:
       - ./relayer:/relayer
     networks:

--- a/test/e2e/vmcompose/provider.go
+++ b/test/e2e/vmcompose/provider.go
@@ -65,16 +65,17 @@ func (p *Provider) Setup() error {
 		}
 
 		def := docker.ComposeDef{
-			Network:     false,
-			BindAll:     true,
-			NetworkName: p.Testnet.Name,
-			NetworkCIDR: p.Testnet.IP.String(),
-			Nodes:       nodes,
-			OmniEVMs:    omniEVMs,
-			Anvils:      anvilChains,
-			Relayer:     services["relayer"],
-			Prometheus:  p.Testnet.Prometheus,
-			RelayerTag:  p.relayerTag,
+			Network:       false,
+			BindAll:       true,
+			NetworkName:   p.Testnet.Name,
+			NetworkCIDR:   p.Testnet.IP.String(),
+			Nodes:         nodes,
+			OmniEVMs:      omniEVMs,
+			Anvils:        anvilChains,
+			Relayer:       services["relayer"],
+			Prometheus:    p.Testnet.Prometheus,
+			RelayerTag:    p.relayerTag,
+			OmniLogFormat: log.FormatLogfmt, // VM compose always use logfmt log format.
 		}
 		compose, err := docker.GenerateComposeFile(def)
 		if err != nil {

--- a/test/e2e/vmcompose/testdata/TestSetup_127_0_0_1_compose.yaml.golden
+++ b/test/e2e/vmcompose/testdata/TestSetup_127_0_0_1_compose.yaml.golden
@@ -16,6 +16,8 @@ services:
     - 26656:26656
     - 26657:26657
     - 6060
+    environment:
+    - HALO_LOG_FORMAT=logfmt
     volumes:
     - ./validator01:/halo
     - ./validator01_evm/jwtsecret:/geth/jwtsecret

--- a/test/e2e/vmcompose/testdata/TestSetup_127_0_0_2_compose.yaml.golden
+++ b/test/e2e/vmcompose/testdata/TestSetup_127_0_0_2_compose.yaml.golden
@@ -16,6 +16,8 @@ services:
     - 26656:26656
     - 26657:26657
     - 6060
+    environment:
+    - HALO_LOG_FORMAT=logfmt
     volumes:
     - ./validator02:/halo
     - ./validator02_evm/jwtsecret:/geth/jwtsecret

--- a/test/e2e/vmcompose/testdata/TestSetup_127_0_0_3_compose.yaml.golden
+++ b/test/e2e/vmcompose/testdata/TestSetup_127_0_0_3_compose.yaml.golden
@@ -27,6 +27,8 @@ services:
     container_name: relayer
     image: omniops/relayer:7d1ae53
     restart: unless-stopped # Restart on crash to mitigate startup race issues
+    environment:
+    - RELAYER_LOG_FORMAT=logfmt
     volumes:
       - ./relayer:/relayer
     networks:


### PR DESCRIPTION
Improves staging metrics and logs:
 - Adds support for `logfmt` log format.
 - Use that in `vmcompose` deployments
 - Add a `container` metric label (to match cadvistor log `container` label)

task: none