### PR TITLE
fix(readability): stop requiring hard line length limit

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -59,6 +59,8 @@ linters-settings:
         disabled: true
       - name: argument-limit # False positives, address in code reviews
         disabled: true
+      - name: line-length-limit # Requires us to cause indentation confusion: https://google.github.io/styleguide/go/decisions#indentation-confusion
+        disabled: true
       # Some configured revive rules
       - name: imports-blacklist
         arguments:
@@ -68,9 +70,6 @@ linters-settings:
           - "github.com/gogo/protobuf/proto"     # Prefer google.golang.org/protobuf
           - "github.com/stretchr/testify/assert" # Prefer github.com/stretchr/testify/require
           - "golang.org/x/exp/slices"            # Prefer slices
-      - name: line-length-limit
-        arguments:
-          - 120
       - name: unhandled-error
         arguments:
          - 'fmt.Printf'
@@ -132,6 +131,7 @@ linters:
     - tagliatelle          # Too strict
     - varnamelen           # False positives
     - wsl                  # Way to strict and opinionated
+    - lll                  # Disable rigid line length limit
 
     # Disable deprecated/archived linters (alphabetical order)
     - deadcode

--- a/halo/app/logging.go
+++ b/halo/app/logging.go
@@ -1,4 +1,4 @@
-//nolint:wrapcheck,lll,revive // The abci.Application is our application, so we don't need to wrap it. Long lines are fine here.
+//nolint:wrapcheck // The abci.Application is our application, so we don't need to wrap it. Long lines are fine here.
 package app
 
 import (

--- a/halo/cmd/flags.go
+++ b/halo/cmd/flags.go
@@ -1,4 +1,3 @@
-//nolint:lll,revive // Flags are long but don't wrap since it makes the code harder to read.
 package cmd
 
 import (

--- a/lib/log/config.go
+++ b/lib/log/config.go
@@ -114,8 +114,6 @@ func (c Config) make() (*slog.Logger, error) {
 }
 
 // BindFlags binds the standard flags to provide logging config at runtime.
-//
-//nolint:lll,revive // Long lines are actually more readable here.
 func BindFlags(flags *pflag.FlagSet, cfg *Config) {
 	flags.StringVar(&cfg.Level, "log-level", cfg.Level, "Log level; debug, info, warn, error")
 	flags.StringVar(&cfg.Color, "log-color", cfg.Color, "Log color (only applicable to console format); auto, force, disable")

--- a/relayer/cmd/flags.go
+++ b/relayer/cmd/flags.go
@@ -6,7 +6,6 @@ import (
 	"github.com/spf13/pflag"
 )
 
-//nolint:lll,revive // Flags read easier when written as a single line.
 func bindRunFlags(flags *pflag.FlagSet, cfg *relayer.Config) {
 	flags.StringVar(&cfg.PrivateKey, "private-key", cfg.PrivateKey, "The path to the private key e.g path/private.key")
 	flags.StringVar(&cfg.HaloURL, "halo-url", cfg.HaloURL, "The URL of the halo node e.g localhost:26657")


### PR DESCRIPTION
This PR removes the hard line length limit for Go code.

task: none