### PR TITLE
test(e2e): upload failed containers logs

### DIFF
--- a/.github/workflows/e2etest.yml
+++ b/.github/workflows/e2etest.yml
@@ -13,7 +13,12 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: 'stable'
-      - run: |
-          go install github.com/omni-network/omni/test/e2e
-          cd test/e2e
-          ./run-multiple.sh manifests/devnet1.toml manifests/simple.toml
+      - name: Run e2e tests
+        run: make e2e-ci
+      - name: Upload failed logs
+        uses: actions/upload-artifact@v4
+        if: failure()
+        with:
+          name: failed-logs
+          path: test/e2e/failed-logs.txt
+          retention-days: 3

--- a/Makefile
+++ b/Makefile
@@ -88,6 +88,11 @@ devnet-clean: ## Deletes devnet1 containers
 	@echo "Stopping the devnet in ./test/e2e/run/devnet1"
 	@go run github.com/omni-network/omni/test/e2e -f test/e2e/manifests/devnet1.toml clean
 
+.PHONY: e2e-ci
+e2e-ci: ## Runs all e2e CI tests
+	@go install github.com/omni-network/omni/test/e2e
+	@cd test/e2e && ./run-multiple.sh manifests/devnet1.toml manifests/simple.toml
+
 .PHONY: e2e-run
 e2e-run: ## Run specific e2e manifest (MANIFEST=single, MANIFEST=simple, etc). Note container remain running after the test.
 	@if [ -z "$(MANIFEST)" ]; then echo "⚠️ Please specify a manifest: MANIFEST=simple make e2e-run" && exit 1; fi

--- a/halo/attest/keeper/keeper.go
+++ b/halo/attest/keeper/keeper.go
@@ -131,8 +131,8 @@ func (k Keeper) addOne(ctx context.Context, agg *types.AggAttestation) error {
 		if errors.Is(err, ormerrors.UniqueKeyViolation) {
 			// TODO(corver): We should prevent this from happening earlier.
 			log.Warn(ctx, "Ignoring duplicate attestation", nil,
-				"agg_id", aggID, "",
-				"chain", agg.BlockHeader.ChainId,
+				"agg_id", aggID,
+				"chain_id", agg.BlockHeader.ChainId,
 				"height", agg.BlockHeader.Height,
 				log.Hex7("validator", sig.ValidatorAddress),
 			)

--- a/test/e2e/.gitignore
+++ b/test/e2e/.gitignore
@@ -1,1 +1,2 @@
 runs
+failed-logs*

--- a/test/e2e/run-multiple.sh
+++ b/test/e2e/run-multiple.sh
@@ -15,35 +15,31 @@ if [[ $# == 0 ]]; then
 	exit 1
 fi
 
-FAILED=()
+echo "🌊==> Running e2e tests:" "$@"
 
 for MANIFEST in "$@"; do
 	START=$SECONDS
-	echo "==> Running testnet: $MANIFEST"
+	echo "🌊==> Running manifest: $MANIFEST"
 
 	if ! e2e -f "$MANIFEST"; then
-		echo "==> Testnet $MANIFEST failed, dumping manifest..."
+		echo "🌊==> ❌ Testnet $MANIFEST failed, dumping manifest..."
 		cat "$MANIFEST"
 
-		echo "==> Dumping container logs for $MANIFEST..."
-		e2e -f "$MANIFEST" logs
+		echo "🌊==> Dumping failed container logs to failed-logs.txt..."
+		e2e -f "$MANIFEST" logs > failed-logs.txt
 
-		echo "==> Cleaning up failed testnet $MANIFEST..."
+		echo "🌊==> Displaying failed container error and warn logs..."
+		grep -iE "(panic|erro|warn)" failed-logs.txt || echo "No errors or warns found"
+
+		echo "🌊==> Cleaning up failed manifest $MANIFEST..."
 		e2e -f "$MANIFEST" clean
 
-		FAILED+=("$MANIFEST")
+    echo "🌊==> ❌ Manifest $MANIFEST failed..."
+		exit 1
 	fi
 
-	echo "==> Completed testnet $MANIFEST in $(( SECONDS - START ))s"
+	echo "🌊==> ✅ Completed manifest $MANIFEST in $(( SECONDS - START ))s"
 	echo ""
 done
 
-if [[ ${#FAILED[@]} -ne 0 ]]; then
-	echo "${#FAILED[@]} testnets failed:"
-	for MANIFEST in "${FAILED[@]}"; do
-		echo "- $MANIFEST"
-	done
-	exit 1
-else
-	echo "All testnets successful"
-fi
+echo "🌊==> 🎉 All manifests successful "


### PR DESCRIPTION
Make debugging CI e2e easier. Currently the github UI is overloaded with container logs.

Uploads failed e2e test container logs as github artefact. Only spew warn|error logs.

task: none