### PR TITLE
fix(halo/attest): fix bug in attestation aggregation

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -179,15 +179,6 @@
         "line_number": 13
       }
     ],
-    "halo/attest/attester.go": [
-      {
-        "type": "Secret Keyword",
-        "filename": "halo/attest/attester.go",
-        "hashed_secret": "9dd83331ff39a93b5b457a8b6b8835f7086a7d6c",
-        "is_verified": false,
-        "line_number": 66
-      }
-    ],
     "halo/attest/attester/attester.go": [
       {
         "type": "Secret Keyword",
@@ -195,6 +186,36 @@
         "hashed_secret": "9dd83331ff39a93b5b457a8b6b8835f7086a7d6c",
         "is_verified": false,
         "line_number": 67
+      }
+    ],
+    "halo/attest/keeper/cpayload_internal_test.go": [
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "halo/attest/keeper/cpayload_internal_test.go",
+        "hashed_secret": "60d1d8055722f0e0d370c7efcbb49c962f805973",
+        "is_verified": false,
+        "line_number": 26
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "halo/attest/keeper/cpayload_internal_test.go",
+        "hashed_secret": "21e500e27f0d26e2cca693b5e2a410ba76d60104",
+        "is_verified": false,
+        "line_number": 27
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "halo/attest/keeper/cpayload_internal_test.go",
+        "hashed_secret": "145dbb5eb956b5a55e2bb9eaec5f3c8cb59ff9d2",
+        "is_verified": false,
+        "line_number": 74
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "halo/attest/keeper/cpayload_internal_test.go",
+        "hashed_secret": "6d2afc8f536c3d5d443d0ba9e8a514e1183020f8",
+        "is_verified": false,
+        "line_number": 74
       }
     ],
     "halo/genutil/testdata/TestMakeGenesis.golden": [
@@ -523,201 +544,201 @@
         "line_number": 400
       }
     ],
-    "test/e2e/app/static/geth_genesis.json": [
+    "test/e2e/app/static/geth-genesis.json": [
       {
         "type": "Hex High Entropy String",
-        "filename": "test/e2e/app/static/geth_genesis.json",
+        "filename": "test/e2e/app/static/geth-genesis.json",
         "hashed_secret": "cd78c461e40612bf67425e745c3c03df6071d98c",
         "is_verified": false,
         "line_number": 30
       },
       {
         "type": "Hex High Entropy String",
-        "filename": "test/e2e/app/static/geth_genesis.json",
+        "filename": "test/e2e/app/static/geth-genesis.json",
         "hashed_secret": "08b650e252263f24012a9f28567c240a20c2f946",
         "is_verified": false,
         "line_number": 33
       },
       {
         "type": "Hex High Entropy String",
-        "filename": "test/e2e/app/static/geth_genesis.json",
+        "filename": "test/e2e/app/static/geth-genesis.json",
         "hashed_secret": "bba31aa004481de49b494ec166f33686c717bc26",
         "is_verified": false,
         "line_number": 36
       },
       {
         "type": "Hex High Entropy String",
-        "filename": "test/e2e/app/static/geth_genesis.json",
+        "filename": "test/e2e/app/static/geth-genesis.json",
         "hashed_secret": "9f56f300e43de46808232a68c4c6a19a2f328af2",
         "is_verified": false,
         "line_number": 39
       },
       {
         "type": "Hex High Entropy String",
-        "filename": "test/e2e/app/static/geth_genesis.json",
+        "filename": "test/e2e/app/static/geth-genesis.json",
         "hashed_secret": "28ef15964c4850182b1fef49fc55950919db756f",
         "is_verified": false,
         "line_number": 42
       },
       {
         "type": "Hex High Entropy String",
-        "filename": "test/e2e/app/static/geth_genesis.json",
+        "filename": "test/e2e/app/static/geth-genesis.json",
         "hashed_secret": "e1073e6a9452b059f602ed8b4f51b95d46d9f32a",
         "is_verified": false,
         "line_number": 45
       },
       {
         "type": "Hex High Entropy String",
-        "filename": "test/e2e/app/static/geth_genesis.json",
+        "filename": "test/e2e/app/static/geth-genesis.json",
         "hashed_secret": "3f0335f2af6f7b386ef0d32f094fbe826e7e3fa7",
         "is_verified": false,
         "line_number": 48
       },
       {
         "type": "Hex High Entropy String",
-        "filename": "test/e2e/app/static/geth_genesis.json",
+        "filename": "test/e2e/app/static/geth-genesis.json",
         "hashed_secret": "9b94e8002a9b2d7fdacb7e2a1089917666ffb610",
         "is_verified": false,
         "line_number": 55
       },
       {
         "type": "Hex High Entropy String",
-        "filename": "test/e2e/app/static/geth_genesis.json",
+        "filename": "test/e2e/app/static/geth-genesis.json",
         "hashed_secret": "e4b52036f9cceab6d083695c6d32a7e35f70f6da",
         "is_verified": false,
         "line_number": 59
       },
       {
         "type": "Hex High Entropy String",
-        "filename": "test/e2e/app/static/geth_genesis.json",
+        "filename": "test/e2e/app/static/geth-genesis.json",
         "hashed_secret": "c52cffacab1f07ba79bbc61c32ff164fff8f9f8b",
         "is_verified": false,
         "line_number": 62
       },
       {
         "type": "Hex High Entropy String",
-        "filename": "test/e2e/app/static/geth_genesis.json",
+        "filename": "test/e2e/app/static/geth-genesis.json",
         "hashed_secret": "342ab97d18b95275dca6990557809c808e24215e",
         "is_verified": false,
         "line_number": 65
       },
       {
         "type": "Hex High Entropy String",
-        "filename": "test/e2e/app/static/geth_genesis.json",
+        "filename": "test/e2e/app/static/geth-genesis.json",
         "hashed_secret": "283b90b0c23d0b75574a60efe793ecd553f1abec",
         "is_verified": false,
         "line_number": 68
       },
       {
         "type": "Hex High Entropy String",
-        "filename": "test/e2e/app/static/geth_genesis.json",
+        "filename": "test/e2e/app/static/geth-genesis.json",
         "hashed_secret": "0b88203fde5908bb7273ca44a7f685f977bde2ca",
         "is_verified": false,
         "line_number": 71
       },
       {
         "type": "Hex High Entropy String",
-        "filename": "test/e2e/app/static/geth_genesis.json",
+        "filename": "test/e2e/app/static/geth-genesis.json",
         "hashed_secret": "9d06254807267e518daa2dc5629b8e298d391966",
         "is_verified": false,
         "line_number": 74
       },
       {
         "type": "Hex High Entropy String",
-        "filename": "test/e2e/app/static/geth_genesis.json",
+        "filename": "test/e2e/app/static/geth-genesis.json",
         "hashed_secret": "a79365b8364bf8a43643be2ac6dc1ecbc56f6d6a",
         "is_verified": false,
         "line_number": 77
       },
       {
         "type": "Hex High Entropy String",
-        "filename": "test/e2e/app/static/geth_genesis.json",
+        "filename": "test/e2e/app/static/geth-genesis.json",
         "hashed_secret": "aac432f7e35804ebe62d41d9f42657ce89479caf",
         "is_verified": false,
         "line_number": 80
       },
       {
         "type": "Hex High Entropy String",
-        "filename": "test/e2e/app/static/geth_genesis.json",
+        "filename": "test/e2e/app/static/geth-genesis.json",
         "hashed_secret": "86ff1e5c4ab61636bd8f4f08b43f83b0472bd4c4",
         "is_verified": false,
         "line_number": 83
       },
       {
         "type": "Hex High Entropy String",
-        "filename": "test/e2e/app/static/geth_genesis.json",
+        "filename": "test/e2e/app/static/geth-genesis.json",
         "hashed_secret": "4c2fe2a849f2e7c1336d847b44e0a06d32344f74",
         "is_verified": false,
         "line_number": 86
       },
       {
         "type": "Hex High Entropy String",
-        "filename": "test/e2e/app/static/geth_genesis.json",
+        "filename": "test/e2e/app/static/geth-genesis.json",
         "hashed_secret": "53d33a624299bcdea3ff1e41519ef942b91036f6",
         "is_verified": false,
         "line_number": 89
       },
       {
         "type": "Hex High Entropy String",
-        "filename": "test/e2e/app/static/geth_genesis.json",
+        "filename": "test/e2e/app/static/geth-genesis.json",
         "hashed_secret": "fd0a0c6ee2612924dd0e5fe169bbd0e0c05c4dfa",
         "is_verified": false,
         "line_number": 92
       },
       {
         "type": "Hex High Entropy String",
-        "filename": "test/e2e/app/static/geth_genesis.json",
+        "filename": "test/e2e/app/static/geth-genesis.json",
         "hashed_secret": "eebcd20719dca59afcceb43f2b9353636726883d",
         "is_verified": false,
         "line_number": 95
       },
       {
         "type": "Hex High Entropy String",
-        "filename": "test/e2e/app/static/geth_genesis.json",
+        "filename": "test/e2e/app/static/geth-genesis.json",
         "hashed_secret": "ac3758d662cbdd3b3067756b1979a60d0e654a19",
         "is_verified": false,
         "line_number": 98
       },
       {
         "type": "Hex High Entropy String",
-        "filename": "test/e2e/app/static/geth_genesis.json",
+        "filename": "test/e2e/app/static/geth-genesis.json",
         "hashed_secret": "d2851d513bfa70cf7655cfc4ce9d68944d7a07a2",
         "is_verified": false,
         "line_number": 101
       }
     ],
-    "test/e2e/app/static/geth_keystore.json": [
+    "test/e2e/app/static/geth-keystore.json": [
       {
         "type": "Hex High Entropy String",
-        "filename": "test/e2e/app/static/geth_keystore.json",
+        "filename": "test/e2e/app/static/geth-keystore.json",
         "hashed_secret": "0c067d3944d8dd16687a1fdc416d92b0d78a523c",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
-        "filename": "test/e2e/app/static/geth_keystore.json",
+        "filename": "test/e2e/app/static/geth-keystore.json",
         "hashed_secret": "a6ba42fe5667d5fdfa788c219dd88a99031566a3",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
-        "filename": "test/e2e/app/static/geth_keystore.json",
+        "filename": "test/e2e/app/static/geth-keystore.json",
         "hashed_secret": "ba1aecf13c1fc45aa1867beb65afbebcf594026d",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
-        "filename": "test/e2e/app/static/geth_keystore.json",
+        "filename": "test/e2e/app/static/geth-keystore.json",
         "hashed_secret": "cd78c461e40612bf67425e745c3c03df6071d98c",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
-        "filename": "test/e2e/app/static/geth_keystore.json",
+        "filename": "test/e2e/app/static/geth-keystore.json",
         "hashed_secret": "f0a9052734814c9b196f44eb9feda62efdf931c5",
         "is_verified": false,
         "line_number": 1
@@ -748,29 +769,29 @@
         "line_number": 30
       }
     ],
-    "test/tutil/testdata/priv_validator_key.json": [
+    "test/tutil/testdata/priv-validator-key.json": [
       {
         "type": "Hex High Entropy String",
-        "filename": "test/tutil/testdata/priv_validator_key.json",
+        "filename": "test/tutil/testdata/priv-validator-key.json",
         "hashed_secret": "e22b9130ca36904f81d6c4781e06afa9ceb2c093",
         "is_verified": false,
         "line_number": 2
       },
       {
         "type": "Base64 High Entropy String",
-        "filename": "test/tutil/testdata/priv_validator_key.json",
+        "filename": "test/tutil/testdata/priv-validator-key.json",
         "hashed_secret": "a25a547f82b0821fe2a149195674547583ffd9c0",
         "is_verified": false,
         "line_number": 5
       },
       {
         "type": "Base64 High Entropy String",
-        "filename": "test/tutil/testdata/priv_validator_key.json",
+        "filename": "test/tutil/testdata/priv-validator-key.json",
         "hashed_secret": "1f7e4e9473c8c12828910d0dfaca31b116f0bfe7",
         "is_verified": false,
         "line_number": 9
       }
     ]
   },
-  "generated_at": "2024-02-20T13:11:49Z"
+  "generated_at": "2024-02-21T08:51:56Z"
 }

--- a/halo/app/prouter.go
+++ b/halo/app/prouter.go
@@ -18,7 +18,7 @@ import (
 func makeProcessProposalHandler(app *App) sdk.ProcessProposalHandler {
 	router := baseapp.NewMsgServiceRouter()
 	router.SetInterfaceRegistry(app.interfaceRegistry)
-	app.EngEVMKeeper.RegisterProposalService(router) // EVMEngine called NewPayload on proposals to veridy it.
+	app.EVMEngKeeper.RegisterProposalService(router) // EVMEngine calls NewPayload on proposals to verify it.
 	app.AttestKeeper.RegisterProposalService(router) // Attester marks attestations as proposed.
 
 	return func(ctx sdk.Context, req *abci.RequestProcessProposal) (*abci.ResponseProcessProposal, error) {

--- a/halo/attest/keeper/cpayload_internal_test.go
+++ b/halo/attest/keeper/cpayload_internal_test.go
@@ -1,0 +1,121 @@
+//nolint:lll // Fixtures are long
+package keeper
+
+import (
+	"encoding/hex"
+	"encoding/json"
+	"testing"
+
+	abci "github.com/cometbft/cometbft/abci/types"
+
+	"github.com/ethereum/go-ethereum/common"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestAggsFromCommit(t *testing.T) {
+	t.Parallel()
+	// Got this fixture from SmokeTest
+	infoBZ := `{
+ "votes": [
+  {
+   "validator": {
+    "address": "9F1DAr20DN7s2Unon0tEhoJ4y4g=",
+    "power": 1
+   },
+   "vote_extension": "CqMBCiQIZBog0rqOcAcpgzhCA8Q41OlL85nL2Iu8r7grYcyW7RJUFwcaIFGTVQ3f8tbEriwwmG9HJdOPKHqeBQrJh9ua3yzb9Df2IlkKFAi8VUZA8x6RD3lySRgD5XkDbyzvEkGHWQRdq9nGd3XdmIck/05A9hkO0RMmgNj6ZMhF6xo8Gxp4UIk1FXtzPNZVDli9AQQ+r93MDICwGxD5HSiOCOquHAqlAQomCGQQARogQHzl1W2CSVfuLTqhGUIZPeC3qQxRrIznC2Ji0aCZqJwaIP8Wbdtod8kSL64GCrUjMBXUKMM4bAo64SN5zWkYaRoAIlkKFAi8VUZA8x6RD3lySRgD5XkDbyzvEkEvCViDA6RySf++/FTdJji4BHbCGYBMy4tW3jHTISK4bzcTj1pdPhXV3dwYJEMvEGMNM4GknKt+hv0iAqukfcT+HAqlAQomCGQQAhogA1RZ6/NKI15QmttssekL4xSy3gK5cSN8szF2i/KlC9kaIOHqJFneqCBjk3OcViyznClMZAbvW8ZS+ba/aFWCPGHRIlkKFAi8VUZA8x6RD3lySRgD5XkDbyzvEkFt1CcLv1cEJzjDygwzG7IiIz4Hn9sje79NseTXsIAVKSTDhqZ0NgEuQtSrB+kiRRAokGTJjr9QLofoytQiKQhIGwqkAQolCMgBGiCwJSTK828xweFAqmnNiw0/X4TjBlMU8JWJEqhsvtZTmhogbERXYGwwxn+Xi2pBY6ZczEq4XiXU9uWC2YXP3IkJ5nciWQoUCLxVRkDzHpEPeXJJGAPleQNvLO8SQUihKIbcmi/U8xK2jg2wyBFO8e+Rpd68F72DloEinILnCbYCBztjKnAPTN3uK+vtScBuOsH9J3gCHhHjN3bByi4bCqYBCicIyAEQARogIAciHdGNZrD6+por50mnBiZmhrIZPS/U+iQ0TpE20ngaICVzvaiwZkYgVzFtIztEf1rFyKnBC5DWwkApz0+ejn6SIlkKFAi8VUZA8x6RD3lySRgD5XkDbyzvEkEEMRBGQSNuE4YjjiTUxNmxXsbdl3i7CZnZJEMqF8GUSHw4TEMlmbuNAln4VLdUWtWe0NDvHPkxujsBue3MRhSQGwqmAQonCMgBEAIaIHp+Wjt3aFpMbisvDhMtTtL1+TfHQSJzGlGKaS4zJ54MGiA4M8gDiN6AGA7bmvPprQNAygF8d+rb7YeQIVpTavDluSJZChQIvFVGQPMekQ95ckkYA+V5A28s7xJBAx4PZs6S0+bVtzpOjZvceWYkh+BRRsaWzgRDb+x7CERMqFVNMdykMi8XmdMXI1xT2fORXxwGJ/fUmGzzFWKHiRsKpAEKJQjnBxogKQWBzPA3HPOzmoWWrIQnMXFLe+PZkEpeJpk6RPGr1uMaIM3uAUOa60YSf+9+lP5TT1rbot+RfP56FCVsJz3hqsqAIlkKFAi8VUZA8x6RD3lySRgD5XkDbyzvEkFSxTl7ciUkrSqnTp0xv+XUg/Nekg8BI0O70Oqcl4w0tCrctbsC1Faa7qnoIxP5Yv2nsFG+qxYXd71R8HIgkg3EGwqmAQonCOcHEAEaIPlpSSXggS6O+ncrrj5soAW2+x8+LXEd2RCNpEGrPRj7GiCPgOk48KYb1AmErANc1e9vILo7yZCeou54F0SuDYJVyyJZChQIvFVGQPMekQ95ckkYA+V5A28s7xJBut/5AgmPCSltlHc3qxdE57yeDXbgYKxD+dkOqn/67LdBgupwCYSiIY8j7LpAGh4+qteWRSmr3CYrqkMGutEvJBsKpgEKJwjnBxACGiAHVIKtQDWVeeo70HPzzSmSpoPFe4wl1g0QoMHRBdR8thogT7eE92qEdeVi/0XzYa/x0p5IKvifCCCRJme/g4y/QZgiWQoUCLxVRkDzHpEPeXJJGAPleQNvLO8SQdEUO6ViHg8is3yhBkMnqa2jCHyGSFxtW8tNu4ZypQ+yC/7nGtAZtyJMyNeRBtko6d1Y1INqByXmHKYoAspHVggc",
+   "extension_signature": "yb/xqE8JHvlXEqcIaC+tZ3CpTIp4EoKMBR8t13dT/IRknZnYGK+sda+92TXzF8Fjk7RlHkfmz2AMg0PAvQ7h5A==",
+   "block_id_flag": 2
+  }
+ ]
+}
+`
+	info := new(abci.ExtendedCommitInfo)
+	err := json.Unmarshal([]byte(infoBZ), info)
+	require.NoError(t, err)
+
+	aggAtts, ok, err := aggregatesFromLastCommit(*info)
+	require.NoError(t, err)
+	require.True(t, ok)
+
+	type block struct {
+		ChainID uint64
+		Height  uint64
+	}
+	expected := map[block]bool{
+		{ChainID: 100, Height: 0}: true,
+		{ChainID: 100, Height: 1}: true,
+		{ChainID: 100, Height: 2}: true,
+		{ChainID: 200, Height: 0}: true,
+		{ChainID: 200, Height: 1}: true,
+		{ChainID: 200, Height: 2}: true,
+		{ChainID: 999, Height: 0}: true,
+		{ChainID: 999, Height: 1}: true,
+		{ChainID: 999, Height: 2}: true,
+	}
+
+	require.Equal(t, len(expected), len(aggAtts.Aggregates))
+	for _, agg := range aggAtts.Aggregates {
+		require.Len(t, agg.Signatures, 1)
+		b := block{
+			ChainID: agg.BlockHeader.ChainId,
+			Height:  agg.BlockHeader.Height,
+		}
+		require.True(t, expected[b], b)
+		delete(expected, b)
+	}
+
+	require.Empty(t, expected)
+}
+
+func TestAggsFromCommit2(t *testing.T) {
+	t.Parallel()
+	// Got this fixture from E2E tests
+	infoBZ := `{"votes":[{"validator":{"address":"Bcn9WsCUB1EubaiqVurLh7ifqbY=","power":1},"vote_extension":"CqMBCiQIZBogsTcVJDfUyPG/Dzuu3XsWL2kVv6wHkdDzWyXPJ2mMNw4aIBNA9/tj0wdGVXWvPGlt/MLDkXmMPS50QaGH3rgQ4H1sIlkKFO2yA3/yeXTfzKwj6LwjD3wcE/s3EkEUnQ30V6RZOZJFw+mMtghMSlJc02Mfm4lMvY+ANr+zpTWY8tsFLsuaDUcqOWI7UdmFYcAPpV7yJDSKipTYI0OzGwqlAQomCGQQARog4uH2PMGSDrCWB9tFGfyLB95SqySmiO6+eRNXiXo6q/caIGfx8OUZo6qNZYY/1mOTeuLZ1Ot5SBrlUV6tK+qm7G7xIlkKFO2yA3/yeXTfzKwj6LwjD3wcE/s3EkFiI83AX2VDrfmWbPDnj6x5HlJ4dRyVomA+jNN/6AguazuAOecuSeNtEJF37CrCxrQWjB6x4KsoCKqjUMA/SuW1GwqlAQomCGQQAhogPbp+8+T2pz9cVn0AQRmPI/Dy3AYPxqdhO2aIyfmZ2l4aIAzWR6TNa17EKU8paffN9cOUcPB9f9aXjrVAbr+h48iTIlkKFO2yA3/yeXTfzKwj6LwjD3wcE/s3EkHUSsJczfd3MMc3WMiVhvkGwdjUqXPt91glIlbQz9M2aChG3IaKMLoEvNafUMW6JOY/J2LOQadvLTfW/O1h/mmDGwqlAQomCGQQAxogX3rTp9xU/80Rt8eS0xRVJW3SdB9nxGkUjNDKok0Wi2EaII0FTCQc9mX7l64CJGbCIssp6t6PZrZNe6NyraKzWEtGIlkKFO2yA3/yeXTfzKwj6LwjD3wcE/s3EkEnc6c38Wf4dkpSKXjHlxBqnG5jcWWniFwcU+HSBkjLoRfyCEMwlNju+icgjB0EeRi++bAdq+6TZNWmjgvFFf8yHAqlAQomCGQQBBogwkUS1uxPP2W3ZaQ6bM1tLypEwAPfICnmJuTJg2wCyncaIDYodsSeU39ZO/emc3IMv254x4I+2Soz6EA/8BkYiWcMIlkKFO2yA3/yeXTfzKwj6LwjD3wcE/s3EkHBV2laIXC3fhUhtNK87XDNy6ACEWqH9zyu4VfReiuft1C9jNd33w4C6jbwqYqlIUUoKHjFEt6kejvlURSmoKTnGwqlAQomCGQQBRog0GdUvltue682mhxepKfjUZMTaF7FxqMY9Y95IWU8uTwaIILbqHcB0ky6ea0ovuFdpb4dskS/cL8Ih8k8lxo+tpnSIlkKFO2yA3/yeXTfzKwj6LwjD3wcE/s3EkFXddra6nWV7XLSPKLwqkZxWDaYY9hrdIvnc2cjhXXQUUJyZYXPX41qFxNdnj+h7MS9LmgNkfk+r2i8CF6SiHQwHAqkAQolCMgBGiCxNxUkN9TI8b8PO67dexYvaRW/rAeR0PNbJc8naYw3DhogHqYcLcEPrh6pDzocJAB+bZj90XXBBwbool66VTeoaCMiWQoU7bIDf/J5dN/MrCPovCMPfBwT+zcSQTHX2q+l0pZMTdpEwdCD+yM7KZZPMZR3rRkSYsJuHE//OgX2aukjhDuDcTT7y4P2SUwBMSjgaICclLTa9BY7Z5UbCqYBCicIyAEQARog4uH2PMGSDrCWB9tFGfyLB95SqySmiO6+eRNXiXo6q/caIH+cekLIAsJYEwPNPiIi3Z8aFB1q8+9v1NgkTGdjla5iIlkKFO2yA3/yeXTfzKwj6LwjD3wcE/s3EkHLtSC5LQcrAeRzmTWUEssdvv/O9JhSyxxHK4302wliSROcCVfcAfcVuFXG/VWPplLsmQ+/UHqHFHwjIK9yMrMjGwqmAQonCMgBEAIaID26fvPk9qc/XFZ9AEEZjyPw8twGD8anYTtmiMn5mdpeGiDYeMZJvXInrO/9vXRfEXHRnFDB/v4o6hd1hkh41qETsCJZChTtsgN/8nl038ysI+i8Iw98HBP7NxJBBwO/0AUrK5SNyTyVTHERrkjGNXxAJ0sauwdrE8razqpCD+IB21VwGe3mUHfm5jGxODUN/Ta2XskC1jywJKqB/BsKpgEKJwjIARADGiBfetOn3FT/zRG3x5LTFFUlbdJ0H2fEaRSM0MqiTRaLYRogLIpPX9REOczZfBIKhb0CBuagyibuDSzsGS92RVrftaUiWQoU7bIDf/J5dN/MrCPovCMPfBwT+zcSQburRFAmIJy9SEl8sCErT6snNrLUhWggGLJwPvfrsOjvCd1g7LrpYnCGH0fPPCNvQChYbn0NlyAP1TUKhmrZzTQbCqYBCicIyAEQBBogwkUS1uxPP2W3ZaQ6bM1tLypEwAPfICnmJuTJg2wCyncaIDFsgz4K6sAfglsYtvsotsYKMOXoWUmGsEo6Rcxt/CUCIlkKFO2yA3/yeXTfzKwj6LwjD3wcE/s3EkGe8s/g3Knade6F0r0xyNp7A7KSuGEFi82cG2MBHBG/JR77os154LbugdqrFxb2PKmNw1sQdqQ4rG4gimUzil4SHAqmAQonCMgBEAUaINBnVL5bbnuvNpocXqSn41GTE2hexcajGPWPeSFlPLk8GiDQde/DO28H4z51w5LN3gLv/cTaIp5hY80LvHCQwl8uZSJZChTtsgN/8nl038ysI+i8Iw98HBP7NxJBlMILm1rmhrTh/wPJGo06vZ58Y6JDjp6BEkt0R87i6D9AwM+IkADkSMspqiw7GsKLC3vksEv6Z7x05XOwt08+Rxs=","extension_signature":"1spgeubk7rihfX1HxeYb0A8yF6FrnEpAM6h/YBHdZdhelEZ3B2zqacgCIM0zhN8GUMeI0mNf0lU+7MJbNmHciQ==","block_id_flag":2},{"validator":{"address":"12SOKLu1Z+ewBXLrClwbDH2S8zY=","power":1},"vote_extension":"CqMBCiQIZBogsTcVJDfUyPG/Dzuu3XsWL2kVv6wHkdDzWyXPJ2mMNw4aIBNA9/tj0wdGVXWvPGlt/MLDkXmMPS50QaGH3rgQ4H1sIlkKFDdFf49ta2frulKCQXoUp11VojgwEkE0pyyI95OeV+jI9GA7B2W7kqc+eU00pbXL0jrp6h1EkXzb5PoQOZ2xPCC/g1WROWrNutfHuubqjhBDoslpnnjYHAqlAQomCGQQARog4uH2PMGSDrCWB9tFGfyLB95SqySmiO6+eRNXiXo6q/caIGfx8OUZo6qNZYY/1mOTeuLZ1Ot5SBrlUV6tK+qm7G7xIlkKFDdFf49ta2frulKCQXoUp11VojgwEkF0NkbXbNGuHOJDa6tZxCkEcHJZWn8PWQ4i4vGm8+YKp0XZ5LDhQezgS9miuD7TeOlTJ23RuxY8/OdYwtwK4fZSGwqlAQomCGQQAhogPbp+8+T2pz9cVn0AQRmPI/Dy3AYPxqdhO2aIyfmZ2l4aIAzWR6TNa17EKU8paffN9cOUcPB9f9aXjrVAbr+h48iTIlkKFDdFf49ta2frulKCQXoUp11VojgwEkHiZTYABmfekcKKUZDK4bztNLuGxaE+Cj0mr51me8y0bhVIyy/DmbDgU8Owj373rv4ATyNOQ4HdBIMRjZDRHmbWHAqlAQomCGQQAxogX3rTp9xU/80Rt8eS0xRVJW3SdB9nxGkUjNDKok0Wi2EaII0FTCQc9mX7l64CJGbCIssp6t6PZrZNe6NyraKzWEtGIlkKFDdFf49ta2frulKCQXoUp11VojgwEkEYrI/yRvIKnlLeev/Yd9IfsFzYPxnlMG+KI89Bcap/Riq85xczjuaGblZhiNpsEWsZ7mXld5jHgbUxvPohctwrHAqlAQomCGQQBBogwkUS1uxPP2W3ZaQ6bM1tLypEwAPfICnmJuTJg2wCyncaIDYodsSeU39ZO/emc3IMv254x4I+2Soz6EA/8BkYiWcMIlkKFDdFf49ta2frulKCQXoUp11VojgwEkHSsy5BCDLqw3VFJvYW/Ohqvy7STM5sKLCxe0TUNdDcLCDpDkidxEcfMlKzeOoKwDxzh6UYph67IP7bCa16actyHAqkAQolCMgBGiCxNxUkN9TI8b8PO67dexYvaRW/rAeR0PNbJc8naYw3DhogHqYcLcEPrh6pDzocJAB+bZj90XXBBwbool66VTeoaCMiWQoUN0V/j21rZ+u6UoJBehSnXVWiODASQVdNboE7o0OU68+TEL0IFRPqNX0yoT6Y9U8lzV4tC30BQ/aF8mLEPPS9bJobiH1EH3weQ1W0QJy0+cHJjf4ivNgcCqYBCicIyAEQARog4uH2PMGSDrCWB9tFGfyLB95SqySmiO6+eRNXiXo6q/caIH+cekLIAsJYEwPNPiIi3Z8aFB1q8+9v1NgkTGdjla5iIlkKFDdFf49ta2frulKCQXoUp11VojgwEkGV7a3EODuB1/iyqp0G5GbJWJo9zpVvmpA8d+LgAygu/2PRZcaJZgkUNKMhJZMD9zd2rTC/AQVdWqR+HPSijeTVHAqmAQonCMgBEAIaID26fvPk9qc/XFZ9AEEZjyPw8twGD8anYTtmiMn5mdpeGiDYeMZJvXInrO/9vXRfEXHRnFDB/v4o6hd1hkh41qETsCJZChQ3RX+PbWtn67pSgkF6FKddVaI4MBJBWb5Tfmp0ohQ71VCma0NnA67p89fqW+umSnMd692YeGtuwc3k0eLwMhsY4QSccrF4FCTbTiWkG5+kjp++7P7nFRwKpgEKJwjIARADGiBfetOn3FT/zRG3x5LTFFUlbdJ0H2fEaRSM0MqiTRaLYRogLIpPX9REOczZfBIKhb0CBuagyibuDSzsGS92RVrftaUiWQoUN0V/j21rZ+u6UoJBehSnXVWiODASQUaW75i0LuzWpS0pd0SHKCt4dMyrbDwtB/BZJ6QwxTNlYVMgKFoD/Q2NefAbGUdR0Dl65gU7u0nyJTE1EKcjumkbCqYBCicIyAEQBBogwkUS1uxPP2W3ZaQ6bM1tLypEwAPfICnmJuTJg2wCyncaIDFsgz4K6sAfglsYtvsotsYKMOXoWUmGsEo6Rcxt/CUCIlkKFDdFf49ta2frulKCQXoUp11VojgwEkH/lOMd3xS6R64eoLMZPJhmJe2KDMljNJb1dqa/qWQMvjfn23ePZ1OdEsntETzVXhVHRlbBMQpYzp/z8DccUae7HAqmAQonCMgBEAUaINBnVL5bbnuvNpocXqSn41GTE2hexcajGPWPeSFlPLk8GiDQde/DO28H4z51w5LN3gLv/cTaIp5hY80LvHCQwl8uZSJZChQ3RX+PbWtn67pSgkF6FKddVaI4MBJBoIplcf56aqL917iAZ/ZYbuhV6tQdhZHWUFftoA4fmq54rfGqhuR/K8InxU5f2ZpYdJzfukLBCTY0AbPy4QD7rhs=","extension_signature":"y6f+Qzug2mc6rivalsAKQxMZKMEkMMsnAi5bSoQe8Q47ChKcUm7uyvCLq19JvIMojbdZO5yfymj93onBjGwCEg==","block_id_flag":2}]}`
+
+	info := new(abci.ExtendedCommitInfo)
+	err := json.Unmarshal([]byte(infoBZ), info)
+	require.NoError(t, err)
+
+	val1, err := hex.DecodeString("edb2037ff27974dfccac23e8bc230f7c1c13fb37")
+	require.NoError(t, err)
+	val2, err := hex.DecodeString("37457f8f6d6b67ebba5282417a14a75d55a23830")
+	require.NoError(t, err)
+
+	aggAtts, ok, err := aggregatesFromLastCommit(*info)
+	require.NoError(t, err)
+	require.True(t, ok)
+
+	type att struct {
+		ChainID uint64
+		Height  uint64
+		Val     common.Address
+	}
+
+	// Fixture contains attestations from both vals for chain 100+200 for blocks 0-5.
+	expected := make(map[att]bool)
+	makeExpected := func(val []byte) {
+		for _, chainID := range []uint64{100, 200} {
+			for _, height := range []uint64{0, 1, 2, 3, 4, 5} {
+				expected[att{ChainID: chainID, Height: height, Val: common.BytesToAddress(val)}] = true
+			}
+		}
+	}
+	makeExpected(val1)
+	makeExpected(val2)
+	delete(expected, att{ChainID: 100, Height: 5, Val: common.BytesToAddress(val2)}) // Except val2 for this block.
+
+	for _, agg := range aggAtts.Aggregates {
+		for _, sig := range agg.Signatures {
+			a := att{
+				Val:     common.BytesToAddress(sig.ValidatorAddress),
+				ChainID: agg.BlockHeader.ChainId,
+				Height:  agg.BlockHeader.Height,
+			}
+			require.True(t, expected[a], a)
+			delete(expected, a)
+		}
+	}
+
+	require.Empty(t, expected)
+}

--- a/halo/attest/keeper/proposal_server.go
+++ b/halo/attest/keeper/proposal_server.go
@@ -2,9 +2,13 @@ package keeper
 
 import (
 	"context"
+	"fmt"
+	"log/slog"
+	"strconv"
 
 	"github.com/omni-network/omni/halo/attest/types"
 	"github.com/omni-network/omni/lib/errors"
+	"github.com/omni-network/omni/lib/log"
 )
 
 type proposalServer struct {
@@ -13,12 +17,34 @@ type proposalServer struct {
 }
 
 // AddAggAttestations handles aggregate attestations proposed in a block.
-func (s proposalServer) AddAggAttestations(_ context.Context, msg *types.MsgAggAttestations,
+func (s proposalServer) AddAggAttestations(ctx context.Context, msg *types.MsgAggAttestations,
 ) (*types.AddAggAttestationsResponse, error) {
 	localHeaders := headersByAddress(msg.Aggregates, s.attester.LocalAddress())
 	if err := s.attester.SetProposed(localHeaders); err != nil {
 		return nil, errors.Wrap(err, "set committed")
 	}
+
+	if len(msg.Aggregates) == 0 {
+		return &types.AddAggAttestationsResponse{}, nil
+	}
+
+	// Make nice logs
+	heights := make(map[uint64][]uint64)
+	for _, header := range localHeaders {
+		heights[header.ChainId] = append(heights[header.ChainId], header.Height)
+	}
+	attrs := []any{
+		slog.Int("attestations", len(localHeaders)),
+		log.Hex7("validator", s.attester.LocalAddress().Bytes()),
+	}
+	for cid, hs := range heights {
+		attrs = append(attrs, slog.String(
+			strconv.FormatUint(cid, 10),
+			fmt.Sprint(hs),
+		))
+	}
+
+	log.Debug(ctx, "Marked local attestations as proposed", attrs...)
 
 	return &types.AddAggAttestationsResponse{}, nil
 }

--- a/halo/evmengine/keeper/abci.go
+++ b/halo/evmengine/keeper/abci.go
@@ -22,7 +22,7 @@ import (
 
 // PrepareProposal returns a proposal for the next block.
 // Note returning an error results in a panic cometbft and CONSENSUS_FAILURE log.
-func (k Keeper) PrepareProposal(ctx sdk.Context, req *abci.RequestPrepareProposal) (
+func (k *Keeper) PrepareProposal(ctx sdk.Context, req *abci.RequestPrepareProposal) (
 	*abci.ResponsePrepareProposal, error,
 ) {
 	defer func() {

--- a/halo/evmengine/keeper/keeper.go
+++ b/halo/evmengine/keeper/keeper.go
@@ -28,25 +28,28 @@ func NewKeeper(
 	logger log.Logger,
 	ethCl engine.API,
 	txConfig client.TxConfig,
-	providers []types.CPayloadProvider,
-) Keeper {
-	return Keeper{
+) *Keeper {
+	return &Keeper{
 		cdc:          cdc,
 		storeService: storeService,
 		logger:       logger,
 		ethCl:        ethCl,
 		txConfig:     txConfig,
-		providers:    providers,
 	}
 }
 
+// TODO(corver): Figure out how to use depinject for this.
+func (k *Keeper) AddProvider(p types.CPayloadProvider) {
+	k.providers = append(k.providers, p)
+}
+
 // Logger returns a module-specific logger.
-func (k Keeper) Logger() log.Logger {
+func (k *Keeper) Logger() log.Logger {
 	return k.logger.With("module", fmt.Sprintf("x/%s", types.ModuleName))
 }
 
 // RegisterProposalService registers the proposal service on the provided router.
 // This implements abci.ProcessProposal verification of new proposals.
-func (k Keeper) RegisterProposalService(server grpc1.Server) {
+func (k *Keeper) RegisterProposalService(server grpc1.Server) {
 	types.RegisterMsgServiceServer(server, NewProposalServer(k))
 }

--- a/halo/evmengine/keeper/msg_server.go
+++ b/halo/evmengine/keeper/msg_server.go
@@ -14,7 +14,7 @@ import (
 )
 
 type msgServer struct {
-	Keeper
+	*Keeper
 	types.UnimplementedMsgServiceServer
 }
 
@@ -71,7 +71,7 @@ func newPayload(ctx context.Context, ethCl engineapi.API, msg *types.MsgExecutio
 
 // NewMsgServerImpl returns an implementation of the MsgServer interface
 // for the provided Keeper.
-func NewMsgServerImpl(keeper Keeper) types.MsgServiceServer {
+func NewMsgServerImpl(keeper *Keeper) types.MsgServiceServer {
 	return &msgServer{Keeper: keeper}
 }
 

--- a/halo/evmengine/keeper/proposal_server.go
+++ b/halo/evmengine/keeper/proposal_server.go
@@ -7,7 +7,7 @@ import (
 )
 
 type proposalServer struct {
-	Keeper
+	*Keeper
 	types.UnimplementedMsgServiceServer
 }
 
@@ -24,7 +24,7 @@ func (s proposalServer) ExecutionPayload(ctx context.Context, msg *types.MsgExec
 
 // NewProposalServer returns an implementation of the MsgServer interface
 // for the provided Keeper.
-func NewProposalServer(keeper Keeper) types.MsgServiceServer {
+func NewProposalServer(keeper *Keeper) types.MsgServiceServer {
 	return &proposalServer{Keeper: keeper}
 }
 

--- a/halo/evmengine/module/module.go
+++ b/halo/evmengine/module/module.go
@@ -60,12 +60,12 @@ func (AppModuleBasic) RegisterGRPCGatewayRoutes(client.Context, *runtime.ServeMu
 type AppModule struct {
 	AppModuleBasic
 
-	keeper keeper.Keeper
+	keeper *keeper.Keeper
 }
 
 func NewAppModule(
 	cdc codec.Codec,
-	keeper keeper.Keeper,
+	keeper *keeper.Keeper,
 ) AppModule {
 	return AppModule{
 		AppModuleBasic: NewAppModuleBasic(cdc),
@@ -108,15 +108,14 @@ type ModuleInputs struct {
 	Logger       log.Logger
 	TXConfig     client.TxConfig
 	EthClient    engine.API
-	Providers    []types.CPayloadProvider
 }
 
 //nolint:revive // Cosmos-style
 type ModuleOutputs struct {
 	depinject.Out
 
-	EVMEngineKeeper keeper.Keeper
-	Module          appmodule.AppModule
+	EngEVMKeeper *keeper.Keeper
+	Module       appmodule.AppModule
 }
 
 func ProvideModule(in ModuleInputs) ModuleOutputs {
@@ -126,12 +125,11 @@ func ProvideModule(in ModuleInputs) ModuleOutputs {
 		in.Logger,
 		in.EthClient,
 		in.TXConfig,
-		in.Providers,
 	)
 	m := NewAppModule(
 		in.Cdc,
 		k,
 	)
 
-	return ModuleOutputs{EVMEngineKeeper: k, Module: m}
+	return ModuleOutputs{EngEVMKeeper: k, Module: m}
 }

--- a/relayer/app/monitor.go
+++ b/relayer/app/monitor.go
@@ -107,7 +107,6 @@ func monitorOffsetsForever(ctx context.Context, src, dst uint64, srcChain, dstCh
 func monitorOffsetsOnce(ctx context.Context, src, dst uint64, srcChain, dstChain string,
 	xprovider xchain.Provider) error {
 	emitted, ok, err := xprovider.GetEmittedCursor(ctx, src, dst)
-	log.Debug(ctx, "Emitted cursor", "src", src, "dst", dst, "emitted", emitted.Offset, "ok", ok)
 	if err != nil {
 		return err
 	} else if !ok {
@@ -119,7 +118,6 @@ func monitorOffsetsOnce(ctx context.Context, src, dst uint64, srcChain, dstChain
 		return err
 	}
 
-	log.Debug(ctx, "Submitted cursor", "src", src, "dst", dst, "submitted", submitted.Offset)
 	emitCursor.WithLabelValues(srcChain, dstChain).Set(float64(emitted.Offset))
 	submitCursor.WithLabelValues(srcChain, dstChain).Set(float64(submitted.Offset))
 

--- a/relayer/app/worker.go
+++ b/relayer/app/worker.go
@@ -2,7 +2,6 @@ package relayer
 
 import (
 	"context"
-	"time"
 
 	"github.com/omni-network/omni/lib/cchain"
 	"github.com/omni-network/omni/lib/errors"
@@ -42,7 +41,7 @@ func NewWorker(destChain netconf.Chain, network netconf.Network, cProvider cchai
 
 func (w *Worker) Run(ctx context.Context) {
 	ctx = log.WithCtx(ctx, "dst_chain", w.destChain.Name)
-	backoff := expbackoff.New(ctx, expbackoff.WithPeriodicConfig(time.Second)) // TODO(corver): Improve backoff.
+	backoff := expbackoff.NewWithAutoReset(ctx)
 	for ctx.Err() == nil {
 		err := w.runOnce(ctx)
 		if ctx.Err() != nil {

--- a/test/e2e/netman/avs/xdapp.go
+++ b/test/e2e/netman/avs/xdapp.go
@@ -91,7 +91,7 @@ func (m *XDapp) Deploy(ctx context.Context) error {
 	m.contractAddr = addr
 	m.height = height
 
-	log.Info(ctx, "Deployed AVS contract", "address", addr.Hex(), "chain", m.chain.Name)
+	log.Debug(ctx, "Deployed AVS contract", "address", addr.Hex(), "chain", m.chain.Name)
 
 	return nil
 }

--- a/test/e2e/netman/pingpong/pingpong.go
+++ b/test/e2e/netman/pingpong/pingpong.go
@@ -100,7 +100,7 @@ func (a *XDapp) StartAllEdges(ctx context.Context, count uint64) error {
 		from := a.contracts[edge.From]
 		to := a.contracts[edge.To]
 
-		log.Info(ctx, "Starting ping pong contract",
+		log.Debug(ctx, "Starting ping pong contract",
 			"from", from.Chain.Name,
 			"to", to.Chain.Name,
 			"count", count,


### PR DESCRIPTION
Fixes a bug in `aggregateAtts`. We assumed `BlockHashes` are unique across chains, which is probably the case in the wild but definitely not the case for anvil chains in e2e. Use `BlockHeader` for uniqueness instead.

Also use the cosmos sdk `baseapp.ValidateVoteExtensions`. This requires moving the attestation CProvider to attest keeper proper. And makes evmkeeper depend on attest keeper so had to change deps.

Also improve relayer worker reset backoff and logs.
Also improve e2e test logs.

task: none