### PR TITLE
fix(halo/evmengine): allow proper blocks to be built

### DIFF
--- a/test/e2e/app/run.go
+++ b/test/e2e/app/run.go
@@ -111,7 +111,7 @@ func E2ETest(ctx context.Context, def Definition, cfg E2ETestConfig, depCfg Depl
 		return errors.Wrap(err, "start all edges")
 	}
 
-	msgBatches := []int{4, 3, 2, 1} // Send 10 msgs from each chain to each other chain
+	msgBatches := []int{3, 2, 1} // Send 6 msgs from each chain to each other chain
 	msgsErr := StartSendingXMsgs(ctx, def.Netman.Portals(), msgBatches...)
 
 	if err := Wait(ctx, def.Testnet.Testnet, 5); err != nil { // allow some txs to go through

--- a/test/e2e/docker/compose.yaml.tmpl
+++ b/test/e2e/docker/compose.yaml.tmpl
@@ -104,6 +104,7 @@ services:
       - --syncmode=full
       - --nodekeyhex={{.NodeKeyHex}}
       - --bootnodes={{.BootNodesStr}}
+      - --miner.recommit=500ms
     ports:
       - {{ if $.BindAll }}8551:{{end}}8551
       - {{ if .ProxyPort }}{{ .ProxyPort }}:{{ end }}8545


### PR DESCRIPTION
Fixes issue where it takes a long time for omni_evm txs to be minded (up to 35min). The issue that we need to wait for geth to mine proper blocks. If we query to early, it returns empty blocks. Configure geth to build faster `--miner.recommit` and wait for that.

task: none
