### PR TITLE
refactor(e2e): ues txmgr as bindings txopts and backends

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -714,16 +714,18 @@
       {
         "type": "Secret Keyword",
         "filename": "test/e2e/netman/manager.go",
-        "hashed_secret": "0738417b55905d283958aad3214022b2cf393911",
-        "is_verified": false,
-        "line_number": 24
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "test/e2e/netman/manager.go",
         "hashed_secret": "8ee08c52583f6381c175cdbcee94daf54e45e08d",
         "is_verified": false,
-        "line_number": 27
+        "line_number": 25
+      }
+    ],
+    "test/e2e/send/sender.go": [
+      {
+        "type": "Secret Keyword",
+        "filename": "test/e2e/send/sender.go",
+        "hashed_secret": "0738417b55905d283958aad3214022b2cf393911",
+        "is_verified": false,
+        "line_number": 25
       }
     ],
     "test/tutil/testdata/genesis.json": [
@@ -759,5 +761,5 @@
       }
     ]
   },
-  "generated_at": "2024-02-22T06:59:36Z"
+  "generated_at": "2024-02-23T13:20:25Z"
 }

--- a/lib/errors/errors.go
+++ b/lib/errors/errors.go
@@ -19,6 +19,10 @@ func New(msg string, attrs ...any) error {
 // Wrap returns a new error wrapping the provided with additional
 // structured fields.
 func Wrap(err error, msg string, attrs ...any) error {
+	if err == nil {
+		panic("wrap nil error")
+	}
+
 	var inner structured
 	if As(err, &inner) {
 		attrs = append(attrs, inner.attrs...) // Append inner attributes

--- a/lib/txmgr/txmgr_internal_test.go
+++ b/lib/txmgr/txmgr_internal_test.go
@@ -1100,7 +1100,7 @@ func TestNonceReset(t *testing.T) {
 
 	ctx := context.Background()
 	for i := 0; i < 8; i++ {
-		_, err := h.mgr.Send(ctx, TxCandidate{
+		_, _, err := h.mgr.Send(ctx, TxCandidate{
 			To: &common.Address{},
 		})
 		// expect every 3rd tx to fail
@@ -1224,7 +1224,7 @@ func TestClose(t *testing.T) {
 	}()
 	// demonstrate that a tx is sent, even when it must retry repeatedly
 	ctx := context.Background()
-	_, err := h.mgr.Send(ctx, TxCandidate{
+	_, _, err := h.mgr.Send(ctx, TxCandidate{
 		To: &common.Address{},
 	})
 	require.NoError(t, err)
@@ -1239,10 +1239,10 @@ func TestClose(t *testing.T) {
 		h.mgr.Close()
 	}()
 	// demonstrate that a tx will cancel if it is in progress when the manager is closed
-	_, err = h.mgr.Send(ctx, TxCandidate{
+	_, _, err = h.mgr.Send(ctx, TxCandidate{
 		To: &common.Address{},
 	})
-	require.ErrorIs(t, ErrClosed, err)
+	require.ErrorIs(t, err, ErrClosed)
 	// confirm that the tx was canceled before it retried to completion
 	require.Less(t, called, retries)
 	require.True(t, h.mgr.closed.Load())
@@ -1251,7 +1251,7 @@ func TestClose(t *testing.T) {
 	// demonstrate that new calls to Send will also fail when the manager is closed
 	// there should be no need to capture the sending signal here because the manager is already closed
 	// and will return immediately
-	_, err = h.mgr.Send(ctx, TxCandidate{
+	_, _, err = h.mgr.Send(ctx, TxCandidate{
 		To: &common.Address{},
 	})
 	require.ErrorIs(t, ErrClosed, err)
@@ -1297,7 +1297,7 @@ func TestCloseWaitingForConfirmation(t *testing.T) {
 	}()
 
 	ctx := context.Background()
-	_, err := h.mgr.Send(ctx, TxCandidate{
+	_, _, err := h.mgr.Send(ctx, TxCandidate{
 		To: &common.Address{},
 	})
 	require.True(t, h.mgr.closed.Load())

--- a/relayer/app/app.go
+++ b/relayer/app/app.go
@@ -48,7 +48,7 @@ func Run(ctx context.Context, cfg Config) error {
 
 	for _, destChain := range network.Chains {
 		sendProvider := func() (SendFunc, error) {
-			sender, err := NewOpSender(ctx, destChain, rpcClientPerChain[destChain.ID], *privateKey,
+			sender, err := NewOpSender(destChain, rpcClientPerChain[destChain.ID], *privateKey,
 				network.ChainNamesByIDs())
 			if err != nil {
 				return nil, err

--- a/relayer/app/opsender.go
+++ b/relayer/app/opsender.go
@@ -28,11 +28,11 @@ type OpSender struct {
 }
 
 // NewOpSender creates a new sender that uses txmgr to send transactions to the destination chain.
-func NewOpSender(ctx context.Context, chain netconf.Chain, rpcClient *ethclient.Client,
+func NewOpSender(chain netconf.Chain, rpcClient *ethclient.Client,
 	privateKey ecdsa.PrivateKey, chainNames map[uint64]string) (OpSender, error) {
 	// we want to query receipts every 1/3 of the block time
-	cfg, err := txmgr.NewConfig(ctx, txmgr.NewCLIConfig(
-		chain.RPCURL,
+	cfg, err := txmgr.NewConfig(txmgr.NewCLIConfig(
+		chain.ID,
 		chain.BlockPeriod/3,
 		txmgr.DefaultSenderFlagValues,
 	),
@@ -101,13 +101,14 @@ func (o OpSender) SendTransaction(ctx context.Context, submission xchain.Submiss
 		Value:    big.NewInt(0),
 	}
 
-	rec, err := o.txMgr.Send(ctx, candidate)
+	tx, rec, err := o.txMgr.Send(ctx, candidate)
 	if err != nil {
 		return errors.Wrap(err, "failed to send tx")
 	}
 
 	log.Info(ctx, "Sent submission transaction",
 		"status", rec.Status,
+		"nonce", tx.Nonce(),
 		"gas_used", rec.GasUsed,
 		"tx_hash", rec.TxHash)
 

--- a/test/e2e/app/avs.go
+++ b/test/e2e/app/avs.go
@@ -46,8 +46,7 @@ func deployAVS(ctx context.Context, def Definition, cfg DeployConfig, deployInfo
 		portal.DeployInfo.PortalAddress,
 		chain,
 		omniChainID,
-		portal.Client,
-		portal.TxOpts(ctx, nil),
+		def.Sender,
 	)
 
 	if err := xdapp.Deploy(ctx); err != nil {

--- a/test/e2e/app/run.go
+++ b/test/e2e/app/run.go
@@ -31,7 +31,7 @@ func DeployWithPingPong(ctx context.Context, def Definition, cfg DeployConfig, p
 		return deployInfo, nil
 	}
 
-	pp, err := pingpong.Deploy(ctx, def.Netman.Portals())
+	pp, err := pingpong.Deploy(ctx, def.Netman, def.Sender)
 	if err != nil {
 		return nil, errors.Wrap(err, "deploy pingpong")
 	} else if err := pp.StartAllEdges(ctx, pingPongN); err != nil {
@@ -104,7 +104,7 @@ func E2ETest(ctx context.Context, def Definition, cfg E2ETestConfig, depCfg Depl
 
 	// Deploy and start ping pong
 	const pingpongN = 4
-	pp, err := pingpong.Deploy(ctx, def.Netman.Portals())
+	pp, err := pingpong.Deploy(ctx, def.Netman, def.Sender)
 	if err != nil {
 		return errors.Wrap(err, "deploy pingpong")
 	} else if err := pp.StartAllEdges(ctx, pingpongN); err != nil {
@@ -112,7 +112,7 @@ func E2ETest(ctx context.Context, def Definition, cfg E2ETestConfig, depCfg Depl
 	}
 
 	msgBatches := []int{3, 2, 1} // Send 6 msgs from each chain to each other chain
-	msgsErr := StartSendingXMsgs(ctx, def.Netman.Portals(), msgBatches...)
+	msgsErr := StartSendingXMsgs(ctx, def.Netman, def.Sender, msgBatches...)
 
 	if err := Wait(ctx, def.Testnet.Testnet, 5); err != nil { // allow some txs to go through
 		return err

--- a/test/e2e/netman/avs/xdapp.go
+++ b/test/e2e/netman/avs/xdapp.go
@@ -2,18 +2,17 @@ package avs
 
 import (
 	"context"
-	"math/big"
 
 	"github.com/omni-network/omni/contracts/bindings"
 	"github.com/omni-network/omni/lib/errors"
 	"github.com/omni-network/omni/lib/log"
 	"github.com/omni-network/omni/test/e2e/netman"
+	"github.com/omni-network/omni/test/e2e/send"
 	"github.com/omni-network/omni/test/e2e/types"
 
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
 	ethtypes "github.com/ethereum/go-ethereum/core/types"
-	"github.com/ethereum/go-ethereum/ethclient"
 )
 
 type XDapp struct {
@@ -23,8 +22,7 @@ type XDapp struct {
 	portalAddr  common.Address
 	chain       types.EVMChain
 	omniChainID uint64
-	ethCl       *ethclient.Client
-	txOpts      *bind.TransactOpts // TODO(corver): Replace this with a txmgr.
+	sender      send.Sender
 
 	// Mutable state
 	contract     *bindings.OmniAVS
@@ -33,93 +31,83 @@ type XDapp struct {
 }
 
 func New(cfg AVSConfig, eigen EigenDeployments, portalAddr common.Address,
-	chain types.EVMChain, omniChainID uint64, ethCl *ethclient.Client, txOpts *bind.TransactOpts) *XDapp {
+	chain types.EVMChain, omniChainID uint64, sender send.Sender) *XDapp {
 	return &XDapp{
 		cfg:         cfg,
 		eigen:       eigen,
 		portalAddr:  portalAddr,
 		chain:       chain,
 		omniChainID: omniChainID,
-		ethCl:       ethCl,
-		txOpts:      txOpts,
+		sender:      sender,
 	}
 }
 
-func (m *XDapp) Deploy(ctx context.Context) error {
-	if m.contract != nil {
+func (d *XDapp) Deploy(ctx context.Context) error {
+	if d.contract != nil {
 		return errors.New("avs already deployed")
 	}
 
-	log.Info(ctx, "Deploying AVS contracts", "chain", m.chain.Name)
+	log.Info(ctx, "Deploying AVS contracts", "chain", d.chain.Name)
 
-	if m.ethCl == nil {
-		return errors.New("avs client not set")
+	txOpts, backend, err := d.sender.BindOpts(ctx, d.chain.ID)
+	if err != nil {
+		return err
 	}
 
-	height, err := m.ethCl.BlockNumber(ctx)
+	height, err := backend.BlockNumber(ctx)
 	if err != nil {
 		return errors.Wrap(err, "get block number")
 	}
 
 	// TODO: use same proxy admin for portal & avs on same chain
-	proxyAdmin, err := netman.DeployProxyAdmin(ctx, m.txOpts, m.ethCl)
+	proxyAdmin, err := netman.DeployProxyAdmin(ctx, txOpts, backend)
 	if err != nil {
 		return errors.Wrap(err, "deploy proxy admin")
 	}
 
-	stratParms := make([]bindings.IOmniAVSStrategyParams, len(m.cfg.StrategyParams))
-	for i, sp := range m.cfg.StrategyParams {
-		stratParms[i] = bindings.IOmniAVSStrategyParams{
-			Strategy:   sp.Strategy,
-			Multiplier: sp.Multiplier,
-		}
-	}
-
-	addr, err := deployOmniAVS(ctx, m.ethCl, m.txOpts, proxyAdmin, m.txOpts.From,
-		m.portalAddr, m.omniChainID, m.eigen.DelegationManager, m.eigen.AVSDirectory,
-		m.cfg.MinimumOperatorStake, m.cfg.MaximumOperatorCount, stratParms)
+	addr, err := d.deployOmniAVS(ctx, backend, txOpts, proxyAdmin, txOpts.From)
 	if err != nil {
 		return errors.Wrap(err, "deploy avs")
 	}
 
-	contract, err := bindings.NewOmniAVS(addr, m.ethCl)
+	contract, err := bindings.NewOmniAVS(addr, backend)
 	if err != nil {
 		return errors.Wrap(err, "instantiate avs")
 	}
 
-	m.contract = contract
-	m.contractAddr = addr
-	m.height = height
+	d.contract = contract
+	d.contractAddr = addr
+	d.height = height
 
-	log.Debug(ctx, "Deployed AVS contract", "address", addr.Hex(), "chain", m.chain.Name)
+	log.Debug(ctx, "Deployed AVS contract", "address", addr.Hex(), "chain", d.chain.Name)
 
 	return nil
 }
 
 // ExportDeployInfo sets the contract addresses in the given DeployInfos.
-func (m *XDapp) ExportDeployInfo(i types.DeployInfos) {
-	i.Set(m.chain.ID, types.ContractOmniAVS, m.contractAddr, m.height)
+func (d *XDapp) ExportDeployInfo(i types.DeployInfos) {
+	i.Set(d.chain.ID, types.ContractOmniAVS, d.contractAddr, d.height)
 
 	const elHeight uint64 = 0 // TODO(corver): Maybe figure this out?
-	i.Set(m.chain.ID, types.ContractELAVSDirectory, m.eigen.AVSDirectory, elHeight)
-	i.Set(m.chain.ID, types.ContractELDelegationManager, m.eigen.DelegationManager, elHeight)
-	i.Set(m.chain.ID, types.ContractELStrategyManager, m.eigen.StrategyManager, elHeight)
-	i.Set(m.chain.ID, types.ContractELPodManager, m.eigen.EigenPodManager, elHeight)
+	i.Set(d.chain.ID, types.ContractELAVSDirectory, d.eigen.AVSDirectory, elHeight)
+	i.Set(d.chain.ID, types.ContractELDelegationManager, d.eigen.DelegationManager, elHeight)
+	i.Set(d.chain.ID, types.ContractELStrategyManager, d.eigen.StrategyManager, elHeight)
+	i.Set(d.chain.ID, types.ContractELPodManager, d.eigen.EigenPodManager, elHeight)
 }
 
-func deployOmniAVS(ctx context.Context, client *ethclient.Client, txOpts *bind.TransactOpts,
-	proxyAdmin common.Address, owner common.Address, portal common.Address, omniChainID uint64,
-	delegationManager common.Address, avsDirectory common.Address, minOperatorStake *big.Int,
-	maxOperators uint32, strategyParams []bindings.IOmniAVSStrategyParams,
+func (d *XDapp) deployOmniAVS(ctx context.Context, client send.Backend, txOpts *bind.TransactOpts,
+	proxyAdmin common.Address, owner common.Address,
 ) (common.Address, error) {
-	impl, tx, _, err := bindings.DeployOmniAVS(txOpts, client, delegationManager, avsDirectory)
+	impl, tx, _, err := bindings.DeployOmniAVS(txOpts, client, d.eigen.DelegationManager, d.eigen.AVSDirectory)
 	if err != nil {
 		return common.Address{}, errors.Wrap(err, "deploy avs impl")
 	}
 
 	receipt, err := bind.WaitMined(ctx, client, tx)
-	if err != nil || receipt.Status != ethtypes.ReceiptStatusSuccessful {
+	if err != nil {
 		return common.Address{}, errors.Wrap(err, "wait mined avs impl")
+	} else if receipt.Status != ethtypes.ReceiptStatusSuccessful {
+		return common.Address{}, errors.New("deploy avs impl failed")
 	}
 
 	abi, err := bindings.OmniAVSMetaData.GetAbi()
@@ -127,8 +115,16 @@ func deployOmniAVS(ctx context.Context, client *ethclient.Client, txOpts *bind.T
 		return common.Address{}, errors.Wrap(err, "get avs abi")
 	}
 
-	enc, err := abi.Pack("initialize", owner, portal, omniChainID,
-		minOperatorStake, maxOperators, []common.Address{} /* allowlist */, strategyParams)
+	stratParms := make([]bindings.IOmniAVSStrategyParams, len(d.cfg.StrategyParams))
+	for i, sp := range d.cfg.StrategyParams {
+		stratParms[i] = bindings.IOmniAVSStrategyParams{
+			Strategy:   sp.Strategy,
+			Multiplier: sp.Multiplier,
+		}
+	}
+
+	enc, err := abi.Pack("initialize", owner, d.portalAddr, d.omniChainID,
+		d.cfg.MinimumOperatorStake, d.cfg.MaximumOperatorCount, []common.Address{} /* allowlist */, stratParms)
 	if err != nil {
 		return common.Address{}, errors.Wrap(err, "encode avs initializer")
 	}
@@ -139,8 +135,10 @@ func deployOmniAVS(ctx context.Context, client *ethclient.Client, txOpts *bind.T
 	}
 
 	receipt, err = bind.WaitMined(ctx, client, tx)
-	if err != nil || receipt.Status != ethtypes.ReceiptStatusSuccessful {
+	if err != nil {
 		return common.Address{}, errors.Wrap(err, "wait mined avs proxy")
+	} else if receipt.Status != ethtypes.ReceiptStatusSuccessful {
+		return common.Address{}, errors.New("deploy avs proxy failed")
 	}
 
 	return proxy, nil

--- a/test/e2e/netman/helpers.go
+++ b/test/e2e/netman/helpers.go
@@ -10,77 +10,76 @@ import (
 	"github.com/omni-network/omni/contracts/bindings"
 	"github.com/omni-network/omni/lib/errors"
 	"github.com/omni-network/omni/lib/log"
+	"github.com/omni-network/omni/test/e2e/send"
 
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
-	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/ethereum/go-ethereum/params"
 )
 
-func deployOmniContracts(ctx context.Context, chainID uint64, client *ethclient.Client, privKey *ecdsa.PrivateKey,
+func deployOmniContracts(ctx context.Context, txOpts *bind.TransactOpts, ethCl send.Backend,
 	valSetID uint64, validators []bindings.Validator,
-) (common.Address, *bindings.OmniPortal, *bind.TransactOpts, error) {
-	txOpts, err := newTxOpts(ctx, privKey, chainID)
-	if err != nil {
-		return common.Address{}, nil, nil, err
-	}
-
+) (common.Address, *bindings.OmniPortal, error) {
 	// TODO: make these configurable
 	owner := txOpts.From
 	fee := new(big.Int).SetUint64(params.GWei)
 
-	proxyAdmin, err := DeployProxyAdmin(ctx, txOpts, client)
+	proxyAdmin, err := DeployProxyAdmin(ctx, txOpts, ethCl)
 	if err != nil {
-		return common.Address{}, nil, nil, err
+		return common.Address{}, nil, errors.Wrap(err, "deploy proxy admin")
 	}
 
-	feeOracle, err := deployFeeOracleV1(ctx, txOpts, client, proxyAdmin, owner, fee)
+	feeOracle, err := deployFeeOracleV1(ctx, txOpts, ethCl, proxyAdmin, owner, fee)
 	if err != nil {
-		return common.Address{}, nil, nil, err
+		return common.Address{}, nil, errors.Wrap(err, "deploy fee oracle")
 	}
 
-	portal, err := deployPortal(ctx, txOpts, client, proxyAdmin, owner, feeOracle, valSetID, validators)
+	portal, err := deployPortal(ctx, txOpts, ethCl, proxyAdmin, owner, feeOracle, valSetID, validators)
 	if err != nil {
-		return common.Address{}, nil, nil, err
+		return common.Address{}, nil, errors.Wrap(err, "deploy portal")
 	}
 
-	contract, err := bindings.NewOmniPortal(portal, client)
+	contract, err := bindings.NewOmniPortal(portal, ethCl)
 	if err != nil {
-		return common.Address{}, nil, nil, err
+		return common.Address{}, nil, errors.Wrap(err, "new portal")
 	}
 
-	return portal, contract, txOpts, nil
+	return portal, contract, nil
 }
 
-func DeployProxyAdmin(ctx context.Context, txOpts *bind.TransactOpts, client *ethclient.Client) (
+func DeployProxyAdmin(ctx context.Context, txOpts *bind.TransactOpts, ethCl send.Backend) (
 	common.Address, error,
 ) {
-	proxyAdmin, tx, _, err := bindings.DeployProxyAdmin(txOpts, client)
+	proxyAdmin, tx, _, err := bindings.DeployProxyAdmin(txOpts, ethCl)
 	if err != nil {
 		return common.Address{}, errors.Wrap(err, "deploy proxy admin")
 	}
 
-	receipt, err := bind.WaitMined(ctx, client, tx)
-	if err != nil || receipt.Status != types.ReceiptStatusSuccessful {
+	receipt, err := bind.WaitMined(ctx, ethCl, tx)
+	if err != nil {
 		return common.Address{}, errors.Wrap(err, "wait mined proxy admin")
+	} else if receipt.Status != types.ReceiptStatusSuccessful {
+		return common.Address{}, errors.New("deploy proxy failed")
 	}
 
 	return proxyAdmin, nil
 }
 
-func deployFeeOracleV1(ctx context.Context, txOpts *bind.TransactOpts, client *ethclient.Client,
+func deployFeeOracleV1(ctx context.Context, txOpts *bind.TransactOpts, ethCl send.Backend,
 	proxyAdmin common.Address, owner common.Address, fee *big.Int,
 ) (common.Address, error) {
-	impl, tx, _, err := bindings.DeployFeeOracleV1(txOpts, client)
+	impl, tx, _, err := bindings.DeployFeeOracleV1(txOpts, ethCl)
 	if err != nil {
 		return common.Address{}, errors.Wrap(err, "deploy fee oracle impl")
 	}
 
-	receipt, err := bind.WaitMined(ctx, client, tx)
-	if err != nil || receipt.Status != types.ReceiptStatusSuccessful {
+	receipt, err := bind.WaitMined(ctx, ethCl, tx)
+	if err != nil {
 		return common.Address{}, errors.Wrap(err, "wait mined fee oracle impl")
+	} else if receipt.Status != types.ReceiptStatusSuccessful {
+		return common.Address{}, errors.New("deploy fee oracle imple failed")
 	}
 
 	abi, err := bindings.FeeOracleV1MetaData.GetAbi()
@@ -93,31 +92,35 @@ func deployFeeOracleV1(ctx context.Context, txOpts *bind.TransactOpts, client *e
 		return common.Address{}, errors.Wrap(err, "encode fee oracle initializer")
 	}
 
-	proxy, tx, _, err := bindings.DeployTransparentUpgradeableProxy(txOpts, client, impl, proxyAdmin, enc)
+	proxy, tx, _, err := bindings.DeployTransparentUpgradeableProxy(txOpts, ethCl, impl, proxyAdmin, enc)
 	if err != nil {
 		return common.Address{}, errors.Wrap(err, "deploy fee oracle proxy")
 	}
 
-	receipt, err = bind.WaitMined(ctx, client, tx)
-	if err != nil || receipt.Status != types.ReceiptStatusSuccessful {
-		return common.Address{}, errors.Wrap(err, "wait mined fee oracle proxy")
+	receipt, err = bind.WaitMined(ctx, ethCl, tx)
+	if err != nil {
+		return common.Address{}, errors.Wrap(err, "wait mined transparent proxy")
+	} else if receipt.Status != types.ReceiptStatusSuccessful {
+		return common.Address{}, errors.New("deploy fee transparent proxy failed")
 	}
 
 	return proxy, nil
 }
 
-func deployPortal(ctx context.Context, txOpts *bind.TransactOpts, client *ethclient.Client,
+func deployPortal(ctx context.Context, txOpts *bind.TransactOpts, ethCl send.Backend,
 	proxyAdmin common.Address, owner common.Address, feeOracle common.Address, valSetID uint64,
 	validators []bindings.Validator,
 ) (common.Address, error) {
-	impl, tx, _, err := bindings.DeployOmniPortal(txOpts, client)
+	impl, tx, _, err := bindings.DeployOmniPortal(txOpts, ethCl)
 	if err != nil {
 		return common.Address{}, errors.Wrap(err, "deploy portal impl")
 	}
 
-	receipt, err := bind.WaitMined(ctx, client, tx)
-	if err != nil || receipt.Status != types.ReceiptStatusSuccessful {
-		return common.Address{}, errors.Wrap(err, "wait mined portal proxy")
+	receipt, err := bind.WaitMined(ctx, ethCl, tx)
+	if err != nil {
+		return common.Address{}, errors.Wrap(err, "wait mined portal")
+	} else if receipt.Status != types.ReceiptStatusSuccessful {
+		return common.Address{}, errors.New("deploy portal failed")
 	}
 
 	abi, err := bindings.OmniPortalMetaData.GetAbi()
@@ -130,35 +133,24 @@ func deployPortal(ctx context.Context, txOpts *bind.TransactOpts, client *ethcli
 		return common.Address{}, errors.Wrap(err, "encode portal initializer")
 	}
 
-	proxy, tx, _, err := bindings.DeployTransparentUpgradeableProxy(txOpts, client, impl, proxyAdmin, enc)
+	proxy, tx, _, err := bindings.DeployTransparentUpgradeableProxy(txOpts, ethCl, impl, proxyAdmin, enc)
 	if err != nil {
 		return common.Address{}, errors.Wrap(err, "deploy portal proxy")
 	}
 
-	receipt, err = bind.WaitMined(ctx, client, tx)
-	if err != nil || receipt.Status != types.ReceiptStatusSuccessful {
-		return common.Address{}, errors.Wrap(err, "wait mined portal proxy")
+	receipt, err = bind.WaitMined(ctx, ethCl, tx)
+	if err != nil {
+		return common.Address{}, errors.Wrap(err, "wait mined upgradable proxy")
+	} else if receipt.Status != types.ReceiptStatusSuccessful {
+		return common.Address{}, errors.New("deploy upgradable proxy failed")
 	}
 
 	return proxy, nil
 }
 
-func newTxOpts(ctx context.Context, privKey *ecdsa.PrivateKey, chainID uint64) (*bind.TransactOpts, error) {
-	txOpts, err := bind.NewKeyedTransactorWithChainID(privKey, big.NewInt(int64(chainID)))
-	if err != nil {
-		return nil, errors.Wrap(err, "keyed tx ops")
-	}
-
-	txOpts.Context = ctx
-
-	return txOpts, nil
-}
-
-func logBalance(ctx context.Context, client *ethclient.Client, chain string, privkey *ecdsa.PrivateKey, name string,
+func logBalance(ctx context.Context, backend send.Backend, chain string, addr common.Address, name string,
 ) error {
-	addr := crypto.PubkeyToAddress(privkey.PublicKey)
-
-	b, err := client.BalanceAt(ctx, addr, nil)
+	b, err := backend.BalanceAt(ctx, addr, nil)
 	if err != nil {
 		return errors.Wrap(err, "get balance")
 	}

--- a/test/e2e/netman/pingpong/pingpong.go
+++ b/test/e2e/netman/pingpong/pingpong.go
@@ -4,16 +4,15 @@ import (
 	"context"
 	"math/big"
 
-	examples "github.com/omni-network/omni/contracts/bindings/examples"
+	"github.com/omni-network/omni/contracts/bindings/examples"
 	"github.com/omni-network/omni/lib/errors"
 	"github.com/omni-network/omni/lib/log"
 	"github.com/omni-network/omni/test/e2e/netman"
+	"github.com/omni-network/omni/test/e2e/send"
 	"github.com/omni-network/omni/test/e2e/types"
 
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
-	etypes "github.com/ethereum/go-ethereum/core/types"
-	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/ethereum/go-ethereum/params"
 )
 
@@ -21,74 +20,76 @@ import (
 // The XDapp is graph of ping pong pairs that connects all chains to all chains.
 // So given a network of N chains (vertexes), there will be N! pairs (edges).
 type XDapp struct {
-	contracts map[uint64]Contract
+	contracts map[uint64]contract
 	edges     []Edge
+	sender    send.Sender
 }
 
-func Deploy(ctx context.Context, portals map[uint64]netman.Portal) (XDapp, error) {
+func Deploy(ctx context.Context, netman netman.Manager, sender send.Sender) (XDapp, error) {
 	log.Info(ctx, "Deploying ping pong contracts")
 
-	contracts := make(map[uint64]Contract)
-	miner := make(miner)
-	for chainID := range portals {
-		portal := portals[chainID]
+	contracts := make(map[uint64]contract)
+	for chainID, portal := range netman.Portals() {
 		portalAddr := portal.DeployInfo.PortalAddress
 
-		height, err := portal.Client.BlockNumber(ctx)
+		txOpts, backend, err := sender.BindOpts(ctx, chainID)
+		if err != nil {
+			return XDapp{}, errors.Wrap(err, "deploy opts")
+		}
+
+		height, err := backend.BlockNumber(ctx)
 		if err != nil {
 			return XDapp{}, errors.Wrap(err, "block number")
 		}
 
-		txOpts := portal.TxOpts(ctx, nil)
-		addr, tx, pingPong, err := examples.DeployPingPong(txOpts, portal.Client, portalAddr)
+		addr, _, pingPong, err := examples.DeployPingPong(txOpts, backend, portalAddr)
 		if err != nil {
 			return XDapp{}, errors.Wrap(err, "deploy ping pong contract")
 		}
 
-		contracts[chainID] = Contract{
-			Client:       portal.Client,
+		contracts[chainID] = contract{
 			Chain:        portal.Chain,
 			Address:      addr,
 			PingPong:     pingPong,
 			DeployHeight: height,
-			txOpts:       txOpts,
 		}
-
-		miner[chainID] = tx
 	}
 
-	if err := miner.WaitMined(ctx, contracts); err != nil {
-		return XDapp{}, errors.Wrap(err, "wait mined")
+	dapp := XDapp{
+		contracts: contracts,
+		sender:    sender,
+		edges:     edges(contracts),
 	}
 
-	resp := XDapp{contracts: contracts}
-
-	if err := resp.fund(ctx); err != nil {
+	if err := dapp.fund(ctx); err != nil {
 		return XDapp{}, errors.Wrap(err, "fund")
 	}
 
-	resp.setEdges()
-
-	return resp, nil
+	return dapp, nil
 }
 
-func (a *XDapp) ExportDeployInfo(resp types.DeployInfos) {
-	for chainID, contract := range a.contracts {
+func (d *XDapp) ExportDeployInfo(resp types.DeployInfos) {
+	for chainID, contract := range d.contracts {
 		resp.Set(chainID, types.ContractPingPong, contract.Address, contract.DeployHeight)
 	}
 }
 
-func (a *XDapp) fund(ctx context.Context) error {
-	for _, contract := range a.contracts {
-		fund := new(big.Int).Mul(big.NewInt(1_000_000), big.NewInt(params.GWei)) // Also fund it with 0.1 ETH
-		opts := contract.TxOpts(ctx, fund)
+func (d *XDapp) fund(ctx context.Context) error {
+	for _, contract := range d.contracts {
+		txOpts, backend, err := d.sender.BindOpts(ctx, contract.Chain.ID)
+		if err != nil {
+			return err
+		}
 
-		tx, err := contract.PingPong.Receive(opts)
+		fund := new(big.Int).Mul(big.NewInt(1_000_000), big.NewInt(params.GWei)) // Fund it with 0.1 ETH
+		txOpts.Value = fund
+
+		tx, err := contract.PingPong.Receive(txOpts)
 		if err != nil {
 			return errors.Wrap(err, "fund ping pong", "chain", contract.Chain.Name)
 		}
 
-		if _, err := bind.WaitMined(ctx, contract.Client, tx); err != nil {
+		if _, err := bind.WaitMined(ctx, backend, tx); err != nil {
 			return errors.Wrap(err, "wait mined", "chain", contract.Chain.Name, "tx", tx.Hash())
 		}
 	}
@@ -96,11 +97,11 @@ func (a *XDapp) fund(ctx context.Context) error {
 	return nil
 }
 
-func (a *XDapp) StartAllEdges(ctx context.Context, count uint64) error {
+func (d *XDapp) StartAllEdges(ctx context.Context, count uint64) error {
 	log.Info(ctx, "Starting ping pong contracts")
-	for _, edge := range a.edges {
-		from := a.contracts[edge.From]
-		to := a.contracts[edge.To]
+	for _, edge := range d.edges {
+		from := d.contracts[edge.From]
+		to := d.contracts[edge.To]
 
 		log.Debug(ctx, "Starting ping pong contract",
 			"from", from.Chain.Name,
@@ -108,13 +109,17 @@ func (a *XDapp) StartAllEdges(ctx context.Context, count uint64) error {
 			"count", count,
 		)
 
-		txOpts := from.TxOpts(ctx, nil)
+		txOpts, backend, err := d.sender.BindOpts(ctx, from.Chain.ID)
+		if err != nil {
+			return err
+		}
+
 		tx, err := from.PingPong.Start(txOpts, to.Chain.ID, to.Address, count)
 		if err != nil {
 			return errors.Wrap(err, "start ping pong", "from", from.Chain.Name, "to", to.Chain.Name)
 		}
 
-		if _, err := bind.WaitMined(ctx, from.Client, tx); err != nil {
+		if _, err := bind.WaitMined(ctx, backend, tx); err != nil {
 			return errors.Wrap(err, "wait mined", "chain", from.Chain.Name, "tx", tx.Hash())
 		}
 	}
@@ -124,11 +129,11 @@ func (a *XDapp) StartAllEdges(ctx context.Context, count uint64) error {
 
 // WaitDone waits for all ping pongs to be done.
 // Note this doesn't work on anvil since it doesn't support subscriptions.
-func (a *XDapp) WaitDone(ctx context.Context) error {
+func (d *XDapp) WaitDone(ctx context.Context) error {
 	log.Info(ctx, "Waiting for ping pongs to complete")
-	done := make(chan *examples.PingPongDone, len(a.edges))
-	for _, edge := range a.edges {
-		from := a.contracts[edge.From]
+	done := make(chan *examples.PingPongDone, len(d.edges))
+	for _, edge := range d.edges {
+		from := d.contracts[edge.From]
 		_, err := from.PingPong.WatchDone(&bind.WatchOpts{
 			Start:   &from.DeployHeight,
 			Context: ctx,
@@ -139,12 +144,12 @@ func (a *XDapp) WaitDone(ctx context.Context) error {
 	}
 
 	// Wait for all ping pongs to be done
-	for range a.edges {
+	for range d.edges {
 		select {
 		case <-ctx.Done():
 			return ctx.Err()
-		case d := <-done:
-			log.Debug(ctx, "Ping pong done", "to", a.contracts[d.DestChainID].Chain.Name, "count", d.Times)
+		case resp := <-done:
+			log.Debug(ctx, "Ping pong done", "to", d.contracts[resp.DestChainID].Chain.Name, "count", resp.Times)
 		}
 	}
 
@@ -156,12 +161,12 @@ type Edge struct {
 	To   uint64
 }
 
-// setEdges creates a deterministic map of unique edges between chains.
-func (a *XDapp) setEdges() {
+// edges creates a deterministic map of unique edges between chains.
+func edges(contracts map[uint64]contract) []Edge {
 	var resp []Edge
-	var arr []Contract
+	var arr []contract
 	// flatten contracts
-	for _, v := range a.contracts {
+	for _, v := range contracts {
 		arr = append(arr, v)
 	}
 
@@ -172,36 +177,13 @@ func (a *XDapp) setEdges() {
 		}
 	}
 
-	a.edges = resp
+	return resp
 }
 
-// Contract defines a deployed contract.
-type Contract struct {
-	Client       *ethclient.Client
+// contract defines a deployed contract.
+type contract struct {
 	Chain        types.EVMChain
 	Address      common.Address
 	PingPong     *examples.PingPong
-	txOpts       *bind.TransactOpts // TODO(corver): Replace this with a txmgr.
 	DeployHeight uint64
-}
-
-// TxOpts returns transaction options using the deploy key.
-func (p Contract) TxOpts(ctx context.Context, value *big.Int) *bind.TransactOpts {
-	clone := *p.txOpts
-	clone.Context = ctx
-	clone.Value = value
-
-	return &clone
-}
-
-type miner map[uint64]*etypes.Transaction
-
-func (m miner) WaitMined(ctx context.Context, contracts map[uint64]Contract) error {
-	for chainID, tx := range m {
-		if _, err := bind.WaitMined(ctx, contracts[chainID].Client, tx); err != nil {
-			return errors.Wrap(err, "wait mined", "chain", contracts[chainID].Chain.Name, "tx", tx.Hash())
-		}
-	}
-
-	return nil
 }

--- a/test/e2e/send/backend.go
+++ b/test/e2e/send/backend.go
@@ -1,0 +1,106 @@
+package send
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/rand"
+	"encoding/hex"
+
+	"github.com/omni-network/omni/lib/errors"
+	"github.com/omni-network/omni/lib/log"
+	"github.com/omni-network/omni/lib/txmgr"
+	"github.com/omni-network/omni/test/e2e/types"
+
+	"github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
+	ethtypes "github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/ethclient"
+)
+
+type Backend interface {
+	bind.ContractBackend
+	bind.DeployBackend
+	ethereum.BlockNumberReader
+	ethereum.ChainStateReader
+
+	// Send provides access to underlying txmgr directly.
+	Send(ctx context.Context, candidate txmgr.TxCandidate) (*ethtypes.Transaction, *ethtypes.Receipt, error)
+}
+
+var _ Backend = backend{}
+
+type backend struct {
+	*ethclient.Client
+
+	from  common.Address
+	txMgr txmgr.TxManager
+	name  string
+}
+
+func newBackend(chain types.EVMChain, rpcAddr string, privateKey *ecdsa.PrivateKey) (backend, error) {
+	ethCl, err := ethclient.Dial(rpcAddr)
+	if err != nil {
+		return backend{}, errors.Wrap(err, "dial")
+	}
+
+	txMgr, err := newTxMgr(ethCl, chain, privateKey)
+	if err != nil {
+		return backend{}, errors.Wrap(err, "deploy tx txMgr")
+	}
+
+	return backend{
+		Client: ethCl,
+		from:   crypto.PubkeyToAddress(privateKey.PublicKey),
+		txMgr:  txMgr,
+		name:   chain.Name,
+	}, nil
+}
+
+func (b backend) Send(ctx context.Context, candidate txmgr.TxCandidate) (*ethtypes.Transaction, *ethtypes.Receipt, error) {
+	return b.txMgr.Send(ctx, candidate)
+}
+
+// SendTransaction intercepts the tx that bindings generates, strips fields, and passes
+// it to the txmgr for reliable broadcasting.
+func (b backend) SendTransaction(ctx context.Context, in *ethtypes.Transaction) error {
+	candidate := txmgr.TxCandidate{
+		TxData:   in.Data(),
+		To:       in.To(),
+		GasLimit: in.Gas(),
+		Value:    in.Value(),
+	}
+
+	ctx = log.WithCtx(ctx, "req_id", randomHex7(), "chain", b.name)
+
+	out, resp, err := b.txMgr.Send(ctx, candidate)
+	if err != nil {
+		return errors.Wrap(err, "txmgr send tx")
+	}
+
+	// TODO(corver): Maybe remove this as it is very noisy.
+	log.Debug(ctx, "Backend sent tx",
+		"nonce", out.Nonce(),
+		"gas_used", resp.GasUsed,
+		"status", resp.Status,
+		"height", resp.BlockNumber.Uint64(),
+	)
+
+	*in = *out
+
+	return nil
+}
+
+func randomHex7() string {
+	bytes := make([]byte, 4)
+	_, _ = rand.Read(bytes)
+	hexString := hex.EncodeToString(bytes)
+
+	// Trim the string to 7 characters
+	if len(hexString) > 7 {
+		hexString = hexString[:7]
+	}
+
+	return hexString
+}

--- a/test/e2e/send/sender.go
+++ b/test/e2e/send/sender.go
@@ -1,0 +1,153 @@
+package send
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"math/big"
+	"strings"
+
+	"github.com/omni-network/omni/lib/errors"
+	"github.com/omni-network/omni/lib/netconf"
+	"github.com/omni-network/omni/lib/txmgr"
+	"github.com/omni-network/omni/test/e2e/types"
+
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
+	ethtypes "github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/ethclient"
+)
+
+const (
+	interval = 3
+
+	// keys of pre-funded anvil account 0.
+	privKeyHex0 = "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80"
+)
+
+//nolint:gochecknoglobals // Static mapping.
+var (
+	privateDeployKey = mustHexToKey(privKeyHex0)
+)
+
+// Sender is a wrapper around a set of adapted ethclients (backends)
+// that delegate transaction sending to a txmgr.TxManager for reliable sending.
+//
+// It should be used with bindings based contracts, as it provides bind.TransactOpts.
+type Sender struct {
+	backends map[uint64]backend
+}
+
+func New(testnet types.Testnet, deployKeyFile string) (Sender, error) {
+	var err error
+
+	var publicDeployKey *ecdsa.PrivateKey
+	if testnet.Network == netconf.Devnet {
+		if deployKeyFile != "" {
+			return Sender{}, errors.New("deploy key not supported in devnet")
+		}
+	} else if testnet.Network == netconf.Staging {
+		publicDeployKey, err = crypto.LoadECDSA(deployKeyFile)
+	} else {
+		return Sender{}, errors.New("unknown extNetwork")
+	}
+	if err != nil {
+		return Sender{}, errors.Wrap(err, "load deploy key")
+	}
+
+	backends := make(map[uint64]backend)
+
+	// Configure omni EVM backend
+	{
+		chain := testnet.OmniEVMs[0] // Connect to the first omni evm instance for now.
+		backends[chain.Chain.ID], err = newBackend(chain.Chain, chain.ExternalRPC, privateDeployKey)
+		if err != nil {
+			return Sender{}, errors.Wrap(err, "new omni backend")
+		}
+	}
+
+	// Configure anvil EVM backends
+	for _, chain := range testnet.AnvilChains {
+		backends[chain.Chain.ID], err = newBackend(chain.Chain, chain.ExternalRPC, privateDeployKey)
+		if err != nil {
+			return Sender{}, errors.Wrap(err, "new anvil backend")
+		}
+	}
+
+	// Configure public EVM backends
+	for _, chain := range testnet.PublicChains {
+		if publicDeployKey == nil {
+			return Sender{}, errors.New("public deploy key required")
+		}
+		backends[chain.Chain.ID], err = newBackend(chain.Chain, chain.RPCAddress, publicDeployKey)
+		if err != nil {
+			return Sender{}, errors.Wrap(err, "new public backend")
+		}
+	}
+
+	return Sender{
+		backends: backends,
+	}, nil
+}
+
+// BindOpts returns a new TransactOpts and Backend for interacting with bindings based contracts.
+// The TransactOpts are partially stubbed, since txmgr handles nonces and signing.
+// The returned backend is a normal ethclient, except that it delegates SendTransaction to txmgr.
+//
+// Do not cache or store the TransactOpts, as they are not safe for concurrent use (pointer).
+// Rather create a new TransactOpts for each transaction.
+func (s Sender) BindOpts(ctx context.Context, sourceChainID uint64) (*bind.TransactOpts, Backend, error) {
+	b, ok := s.backends[sourceChainID]
+	if !ok {
+		return nil, nil, errors.New("unknown backend")
+	}
+
+	if header, err := b.HeaderByNumber(ctx, nil); err != nil {
+		return nil, nil, errors.Wrap(err, "header by number")
+	} else if header.BaseFee == nil {
+		return nil, nil, errors.New("only dynamic transaction backends supported")
+	}
+
+	// Stub nonce and signer since txmgr will handle this.
+	// Bindings will estimate gas.
+	return &bind.TransactOpts{
+		From:  b.from,
+		Nonce: big.NewInt(1),
+		Signer: func(_ common.Address, tx *ethtypes.Transaction) (*ethtypes.Transaction, error) {
+			return tx, nil
+		},
+		Context: ctx,
+	}, b, nil
+}
+
+func newTxMgr(ethCl *ethclient.Client, chain types.EVMChain, privateKey *ecdsa.PrivateKey) (txmgr.TxManager, error) {
+	// creates our new CLI config for our tx manager
+	cliConfig := txmgr.NewCLIConfig(
+		chain.ID,
+		chain.BlockPeriod/interval,
+		txmgr.DefaultSenderFlagValues,
+	)
+
+	// get the config for our tx manager
+	cfg, err := txmgr.NewConfig(cliConfig, privateKey, ethCl)
+	if err != nil {
+		return nil, errors.Wrap(err, "new config")
+	}
+
+	// create a simple tx manager from our config
+	txMgr, err := txmgr.NewSimpleTxManagerFromConfig(chain.Name, cfg)
+	if err != nil {
+		return nil, errors.Wrap(err, "new simple")
+	}
+
+	return txMgr, nil
+}
+
+func mustHexToKey(privKeyHex string) *ecdsa.PrivateKey {
+	privKey, err := crypto.HexToECDSA(strings.TrimPrefix(privKeyHex, "0x"))
+	if err != nil {
+		panic(err)
+	}
+
+	return privKey
+}


### PR DESCRIPTION
Implement `send.Sender` that implements `bindings.TxOptions` and `bindings.DeployBackend` so that we can keep on using bindings but also txmgr for reliable sending in e2e.

task: none
