### PR TITLE
fix(lib/txmgr): handle wait mine edge case

### DIFF
--- a/lib/txmgr/txmgr.go
+++ b/lib/txmgr/txmgr.go
@@ -499,7 +499,9 @@ func (m *SimpleTxManager) queryReceipt(ctx context.Context, txHash common.Hash,
 	defer cancel()
 	receipt, err := m.backend.TransactionReceipt(ctx, txHash)
 	if err != nil {
-		if errors.Is(err, ethereum.NotFound) || strings.Contains(err.Error(), ethereum.NotFound.Error()) {
+		if strings.Contains(err.Error(), "transaction indexing is in progress") {
+			return nil, false, nil // Just back off here
+		} else if errors.Is(err, ethereum.NotFound) || strings.Contains(err.Error(), ethereum.NotFound.Error()) {
 			sendState.TxNotMined(txHash)
 			return nil, false, nil
 		}

--- a/lib/txmgr/txmgr.go
+++ b/lib/txmgr/txmgr.go
@@ -207,8 +207,6 @@ func (m *SimpleTxManager) doSend(ctx context.Context, candidate TxCandidate) (*t
 		tx, err := m.craftTx(ctx, candidate)
 		if err != nil {
 			log.Debug(ctx, "Failed to create a transaction, will retry", "err", err)
-		} else {
-			log.Debug(ctx, "Txmgr crafted new tx", txFields(tx, true)...)
 		}
 
 		return tx, err

--- a/lib/txmgr/txmgr.go
+++ b/lib/txmgr/txmgr.go
@@ -207,9 +207,9 @@ func (m *SimpleTxManager) doSend(ctx context.Context, candidate TxCandidate) (*t
 		tx, err := m.craftTx(ctx, candidate)
 		if err != nil {
 			log.Debug(ctx, "Failed to create a transaction, will retry", "err", err)
+		} else {
+			log.Debug(ctx, "Txmgr crafted new tx", txFields(tx, true)...)
 		}
-
-		log.Debug(ctx, "Txmgr crafted new tx", txFields(tx, true)...)
 
 		return tx, err
 	})

--- a/test/e2e/docker/compose.yaml.tmpl
+++ b/test/e2e/docker/compose.yaml.tmpl
@@ -105,6 +105,7 @@ services:
       - --nodekeyhex={{.NodeKeyHex}}
       - --bootnodes={{.BootNodesStr}}
       - --miner.recommit=500ms
+      - --verbosity=4
     ports:
       - {{ if $.BindAll }}8551:{{end}}8551
       - {{ if .ProxyPort }}{{ .ProxyPort }}:{{ end }}8545

--- a/test/e2e/docker/compose.yaml.tmpl
+++ b/test/e2e/docker/compose.yaml.tmpl
@@ -105,7 +105,6 @@ services:
       - --nodekeyhex={{.NodeKeyHex}}
       - --bootnodes={{.BootNodesStr}}
       - --miner.recommit=500ms
-      - --verbosity=4
     ports:
       - {{ if $.BindAll }}8551:{{end}}8551
       - {{ if .ProxyPort }}{{ .ProxyPort }}:{{ end }}8545


### PR DESCRIPTION
Fixes root cause of "nonce to low" in e2e tests. When quering txreceipts, geth sometimes returns "transaction indexing in progress". Old txmgr didn't handle this and tried resubmitting while the tx was then confirmed in most cases. Instead it should re-attempt fetching the receipt.

task: none