### PR TITLE
refactor(e2e/send): rename sender to backends

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -76,10 +76,6 @@
       "path": "detect_secrets.filters.allowlist.is_line_allowlisted"
     },
     {
-      "path": "detect_secrets.filters.common.is_baseline_file",
-      "filename": ".secrets.baseline"
-    },
-    {
       "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
       "min_level": 2
     },
@@ -730,20 +726,20 @@
         "line_number": 1
       }
     ],
+    "test/e2e/backend/backends.go": [
+      {
+        "type": "Secret Keyword",
+        "filename": "test/e2e/backend/backends.go",
+        "hashed_secret": "0738417b55905d283958aad3214022b2cf393911",
+        "is_verified": false,
+        "line_number": 25
+      }
+    ],
     "test/e2e/netman/manager.go": [
       {
         "type": "Secret Keyword",
         "filename": "test/e2e/netman/manager.go",
         "hashed_secret": "8ee08c52583f6381c175cdbcee94daf54e45e08d",
-        "is_verified": false,
-        "line_number": 25
-      }
-    ],
-    "test/e2e/send/sender.go": [
-      {
-        "type": "Secret Keyword",
-        "filename": "test/e2e/send/sender.go",
-        "hashed_secret": "0738417b55905d283958aad3214022b2cf393911",
         "is_verified": false,
         "line_number": 25
       }
@@ -781,5 +777,5 @@
       }
     ]
   },
-  "generated_at": "2024-02-24T10:36:23Z"
+  "generated_at": "2024-02-25T07:23:42Z"
 }

--- a/relayer/app/worker_test.go
+++ b/relayer/app/worker_test.go
@@ -84,7 +84,7 @@ func TestWorker_Run(t *testing.T) {
 		return nil, nil
 	}
 
-	// Sender should never be called, since we return empty slices from the creator.
+	// mockSender should never be called, since we return empty slices from the creator.
 	mockSender := &mockSender{
 		SendTransactionFn: func(ctx context.Context, submission xchain.Submission) error {
 			require.Fail(t, "should not be called")

--- a/test/e2e/app/avs.go
+++ b/test/e2e/app/avs.go
@@ -46,7 +46,7 @@ func deployAVS(ctx context.Context, def Definition, cfg DeployConfig, deployInfo
 		portal.DeployInfo.PortalAddress,
 		chain,
 		omniChainID,
-		def.Sender,
+		def.Backends,
 	)
 
 	if err := xdapp.Deploy(ctx); err != nil {

--- a/test/e2e/app/definition.go
+++ b/test/e2e/app/definition.go
@@ -9,9 +9,9 @@ import (
 
 	"github.com/omni-network/omni/lib/errors"
 	"github.com/omni-network/omni/lib/netconf"
+	"github.com/omni-network/omni/test/e2e/backend"
 	"github.com/omni-network/omni/test/e2e/docker"
 	"github.com/omni-network/omni/test/e2e/netman"
-	"github.com/omni-network/omni/test/e2e/send"
 	"github.com/omni-network/omni/test/e2e/types"
 	"github.com/omni-network/omni/test/e2e/vmcompose"
 
@@ -55,10 +55,10 @@ func DefaultDefinitionConfig() DefinitionConfig {
 // Definition defines a e2e network. All (sub)commands of the e2e cli requires a definition operate.
 // Armed with a definition, a e2e network can be deployed, started, tested, stopped, etc.
 type Definition struct {
-	Testnet types.Testnet // Note that testnet is the cometBFT term.
-	Infra   types.InfraProvider
-	Netman  netman.Manager
-	Sender  send.Sender
+	Testnet  types.Testnet // Note that testnet is the cometBFT term.
+	Infra    types.InfraProvider
+	Netman   netman.Manager
+	Backends backend.Backends
 }
 
 func MakeDefinition(cfg DefinitionConfig) (Definition, error) {
@@ -85,12 +85,12 @@ func MakeDefinition(cfg DefinitionConfig) (Definition, error) {
 		return Definition{}, errors.Wrap(err, "loading testnet")
 	}
 
-	sender, err := send.New(testnet, cfg.DeployKeyFile)
+	backends, err := backend.New(testnet, cfg.DeployKeyFile)
 	if err != nil {
-		return Definition{}, errors.Wrap(err, "new sender")
+		return Definition{}, errors.Wrap(err, "new backends")
 	}
 
-	netman, err := netman.NewManager(testnet, sender, cfg.RelayerKeyFile)
+	netman, err := netman.NewManager(testnet, backends, cfg.RelayerKeyFile)
 	if err != nil {
 		return Definition{}, errors.Wrap(err, "get network")
 	}
@@ -106,10 +106,10 @@ func MakeDefinition(cfg DefinitionConfig) (Definition, error) {
 	}
 
 	return Definition{
-		Testnet: testnet,
-		Infra:   infp,
-		Sender:  sender,
-		Netman:  netman,
+		Testnet:  testnet,
+		Infra:    infp,
+		Backends: backends,
+		Netman:   netman,
 	}, nil
 }
 

--- a/test/e2e/backend/backend.go
+++ b/test/e2e/backend/backend.go
@@ -1,4 +1,4 @@
-package send
+package backend
 
 import (
 	"context"

--- a/test/e2e/backend/wait.go
+++ b/test/e2e/backend/wait.go
@@ -1,0 +1,43 @@
+package backend
+
+import (
+	"context"
+
+	"github.com/omni-network/omni/lib/errors"
+
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	ethtypes "github.com/ethereum/go-ethereum/core/types"
+)
+
+// NewWaiter returns a new Waiter.
+func (b Backends) NewWaiter() *Waiter {
+	return &Waiter{
+		b:   b,
+		txs: make(map[uint64][]*ethtypes.Transaction),
+	}
+}
+
+// Waiter is a convenience struct to easily wait for multiple transactions to be mined.
+type Waiter struct {
+	b   Backends
+	txs map[uint64][]*ethtypes.Transaction
+}
+
+func (w *Waiter) Add(chainID uint64, tx *ethtypes.Transaction) {
+	w.txs[chainID] = append(w.txs[chainID], tx)
+}
+
+func (w *Waiter) Wait(ctx context.Context) error {
+	for chainID, txs := range w.txs {
+		for _, tx := range txs {
+			rec, err := bind.WaitMined(ctx, w.b.backends[chainID], tx)
+			if err != nil {
+				return errors.Wrap(err, "wait mined", "chain_id", chainID)
+			} else if rec.Status != ethtypes.ReceiptStatusSuccessful {
+				return errors.New("tx status unsuccessful", "chain_id", chainID)
+			}
+		}
+	}
+
+	return nil
+}


### PR DESCRIPTION
Refactor `send.Sender` to `backend.Backends` to align more with its use as a bindings "Backend". It is used for more things than sendings. It is a general bindings backend.

Also adds a handy struct to wait for multiple transactions to be mined in tests.

task: none