### PR TITLE
fix(docs): search

### DIFF
--- a/docs/site/docusaurus.config.ts
+++ b/docs/site/docusaurus.config.ts
@@ -134,9 +134,9 @@ const config: Config = {
       // The application ID provided by Algolia
       appId: "YGLZ6VW4T5", // pragma: allowlist secret
       // Public API key: it is safe to commit it
-      apiKey: "b2cac1111a5f723ffcc9b11008094448", // pragma: allowlist secret
+      apiKey: "64557e587da746830ff903f126eb134b", // pragma: allowlist secret
       indexName: "omni",
-      contextualSearch: true,
+      contextualSearch: false,
       searchParameters: {
         clickAnalytics: true,
         analytics: true,

--- a/docs/site/src/css/custom.css
+++ b/docs/site/src/css/custom.css
@@ -23,7 +23,7 @@
   --ifm-color-emphasis-200: var(--ifm-color-white);
   --ifm-code-font-size: 85%;
   --docusaurus-highlighted-code-line-bg: var(--ifm-color-primary-lightest);
-  --navbar-color: #fbfcffe2;
+  --navbar-color: #fbfcfff1;
   --footer-color: var(--navbar-color);
   --background-color: #ffffff;
   background-color: var(--ifm-background-color);
@@ -40,7 +40,7 @@
   --ifm-color-primary-lightest: #e7ebeb;
   --ifm-color-secondary: #183461;
   --docusaurus-highlighted-code-line-bg: #0000004d;
-  --navbar-color: #112346;
+  --navbar-color: #112346f0;
   --footer-color: var(--navbar-color);
   --background-color: #00122f;
   background-color: var(--background-color);
@@ -52,7 +52,7 @@
   --docsearch-muted-color: var(--ifm-color-secondary-darkest);
   --docsearch-container-background: rgba(94, 100, 112, 0.7);
   /* Modal */
-  --docsearch-modal-background: var(--ifm-background-color);
+  --docsearch-modal-background: var(--navbar-color);
   /* Search box */
   --docsearch-searchbox-background: var(--ifm-color-secondary);
   --docsearch-searchbox-focus-background: var(--ifm-color-white);


### PR DESCRIPTION
This PR does two things: 

1. Fixes the search bar, now yielding results which should be viewable from running the app locally or in the preview commented in this PR. 
    - A new viewing API key was created during debugging 
    - `contextualSearch` has been disabled, this was a param that would distinguish search results by language, but because of the default crawling settings in Algolia, the index would not exactly match the query params. This param will be required to be set to `true` again once the docs supports multiple languages and docs versions, and the Algolia crawler logic will need to be adjusted accordingly. 
2. Color fix for light mode search modal

task: none
