### PR TITLE
refactor(lib/txmgr): check if tx is pending first

### DIFF
--- a/lib/txmgr/txmgr_internal_test.go
+++ b/lib/txmgr/txmgr_internal_test.go
@@ -263,6 +263,12 @@ func (*mockBackend) ChainID(ctx context.Context) (*big.Int, error) {
 	return big.NewInt(1), nil
 }
 
+func (b *mockBackend) TransactionByHash(ctx context.Context, txHash common.Hash) (*types.Transaction, bool, error) {
+	// Hard-coded to return false for isPending since we only care
+	// if the tx with the given txHash is pending or not.
+	return &types.Transaction{}, false, nil
+}
+
 // TransactionReceipt queries the mockBackend for a mined txHash. If none is found, nil is returned
 // for both return values. Otherwise, it returns a receipt containing the txHash, the gasFeeCap
 // used in GasUsed, and the blobFeeCap in CumuluativeGasUsed to make the values accessible from our
@@ -731,6 +737,12 @@ func (b *failingBackend) BlockNumber(ctx context.Context) (uint64, error) {
 	}
 
 	return 1, nil
+}
+
+func (*failingBackend) TransactionByHash(ctx context.Context, txHash common.Hash) (*types.Transaction, bool, error) {
+	// Hard-coded to return false for isPending since we only care
+	// if the tx with the given txHash is pending or not.
+	return &types.Transaction{}, false, nil
 }
 
 // TransactionReceipt for the failingBackend returns errRPCFailure on the first


### PR DESCRIPTION
According to [the Ethereum docs](https://ethereum.org/en/developers/docs/apis/json-rpc#eth_gettransactionreceipt) a receipt is not available for a pending transaction. This PR refactors the txmgr so that it first checks if a transaction is pending before trying trying to get a receipt for it. The benefit of this is that we check it in a type-safe way. Otherwise, our code depends on an error message that is not documented and subject to change. If Ethereum's  error message changes, for example, from `transaction indexing is in progress` to `pending transaction` our code would stop working silently and we'd have no way to detect that.

task: none