### PR TITLE
test(e2e): add ci manifest with catchup node

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -96,6 +96,7 @@ issues:
         - wrapcheck   # Wrapping not required
         - gocognit    # Cognitive complexity not an issue here
         - prealloc    # Prealloc not an issue here
+        - perfsprint  # Performance not an issue here
     - path: 'scripts/.+\.go'
       linters:        # Relax linters for scripts only (non-production code)
         - forbidigo   # Allow debug printing

--- a/Makefile
+++ b/Makefile
@@ -91,7 +91,7 @@ devnet-clean: ## Deletes devnet1 containers
 .PHONY: e2e-ci
 e2e-ci: ## Runs all e2e CI tests
 	@go install github.com/omni-network/omni/test/e2e
-	@cd test/e2e && ./run-multiple.sh manifests/devnet1.toml manifests/simple.toml
+	@cd test/e2e && ./run-multiple.sh manifests/devnet1.toml manifests/simple.toml manifests/ci.toml
 
 .PHONY: e2e-run
 e2e-run: ## Run specific e2e manifest (MANIFEST=single, MANIFEST=simple, etc). Note container remain running after the test.

--- a/test/e2e/app/run.go
+++ b/test/e2e/app/run.go
@@ -50,7 +50,7 @@ func Deploy(ctx context.Context, def Definition, cfg DeployConfig) (types.Deploy
 		return nil, err
 	}
 
-	if err := Start(ctx, def.Testnet.Testnet, def.Infra); err != nil {
+	if err := StartInitial(ctx, def.Testnet.Testnet, def.Infra); err != nil {
 		return nil, err
 	}
 
@@ -112,6 +112,10 @@ func E2ETest(ctx context.Context, def Definition, cfg E2ETestConfig, prom PromSe
 
 	msgBatches := []int{3, 2, 1} // Send 6 msgs from each chain to each other chain
 	msgsErr := StartSendingXMsgs(ctx, def.Netman, def.Backends, msgBatches...)
+
+	if err := StartRemaining(ctx, def.Testnet.Testnet, def.Infra); err != nil {
+		return err
+	}
 
 	if err := Wait(ctx, def.Testnet.Testnet, 5); err != nil { // allow some txs to go through
 		return err

--- a/test/e2e/app/start.go
+++ b/test/e2e/app/start.go
@@ -2,6 +2,7 @@ package app
 
 import (
 	"context"
+	"slices"
 	"sort"
 	"time"
 
@@ -12,31 +13,12 @@ import (
 	"github.com/cometbft/cometbft/test/e2e/pkg/infra"
 )
 
-func Start(ctx context.Context, testnet *e2e.Testnet, p infra.Provider) error {
-	if len(testnet.Nodes) == 0 {
-		return errors.New("no nodes in testnet")
+// StartInitial starts the initial nodes (start_at==0).
+func StartInitial(ctx context.Context, testnet *e2e.Testnet, p infra.Provider) error {
+	nodeQueue, err := getSortedNodes(testnet)
+	if err != nil {
+		return err
 	}
-
-	// Nodes are already sorted by name. Sort them by name then startAt,
-	// which gives the overall order startAt, mode, name.
-	nodeQueue := testnet.Nodes
-	sort.SliceStable(nodeQueue, func(i, j int) bool {
-		a, b := nodeQueue[i], nodeQueue[j]
-		switch {
-		case a.Mode == b.Mode:
-			return false
-		case a.Mode == e2e.ModeSeed:
-			return true
-		case a.Mode == e2e.ModeValidator && b.Mode == e2e.ModeFull:
-			return true
-		}
-
-		return false
-	})
-
-	sort.SliceStable(nodeQueue, func(i, j int) bool {
-		return nodeQueue[i].StartAt < nodeQueue[j].StartAt
-	})
 
 	if nodeQueue[0].StartAt > 0 {
 		return errors.New("no initial nodes in testnet")
@@ -49,10 +31,11 @@ func Start(ctx context.Context, testnet *e2e.Testnet, p infra.Provider) error {
 		nodesAtZero = append(nodesAtZero, nodeQueue[0])
 		nodeQueue = nodeQueue[1:]
 	}
-	err := p.StartNodes(ctx, nodesAtZero...)
-	if err != nil {
+
+	if err = p.StartNodes(ctx, nodesAtZero...); err != nil {
 		return errors.Wrap(err, "starting initial nodes")
 	}
+
 	for _, node := range nodesAtZero {
 		if _, err := waitForNode(ctx, node, 0, 15*time.Second); err != nil {
 			return err
@@ -73,13 +56,42 @@ func Start(ctx context.Context, testnet *e2e.Testnet, p infra.Provider) error {
 		"nodes", len(testnet.Nodes)-len(nodeQueue),
 		"pending", len(nodeQueue))
 
-	block, blockID, err := waitForHeight(ctx, testnet, networkHeight)
+	_, _, err = waitForHeight(ctx, testnet, networkHeight)
 	if err != nil {
 		return err
 	}
 
-	// Update any state sync nodes with a trusted height and hash
+	return nil
+}
+
+// StartRemaining starts the remaining nodes (start_at>0).
+func StartRemaining(ctx context.Context, testnet *e2e.Testnet, p infra.Provider) error {
+	nodeQueue, err := getSortedNodes(testnet)
+	if err != nil {
+		return err
+	}
+
+	var remaining []*e2e.Node
 	for _, node := range nodeQueue {
+		if node.StartAt > 0 {
+			remaining = append(remaining, node)
+		}
+	}
+
+	if len(remaining) == 0 {
+		return nil
+	}
+
+	block, blockID, err := waitForHeight(ctx, testnet, testnet.InitialHeight)
+	if err != nil {
+		return err
+	}
+	networkHeight := block.Height
+
+	log.Debug(ctx, "Setting catchup node state sync", "height", block.Height, "catchup_nodes", len(remaining))
+
+	// Update any state sync nodes with a trusted height and hash
+	for _, node := range remaining {
 		if node.StateSync || node.Mode == e2e.ModeLight {
 			err = UpdateConfigStateSync(node, block.Height, blockID.Hash.Bytes())
 			if err != nil {
@@ -88,7 +100,7 @@ func Start(ctx context.Context, testnet *e2e.Testnet, p infra.Provider) error {
 		}
 	}
 
-	for _, node := range nodeQueue {
+	for _, node := range remaining {
 		if node.StartAt > networkHeight {
 			// if we're starting a node that's ahead of
 			// the last known height of the network, then
@@ -97,18 +109,19 @@ func Start(ctx context.Context, testnet *e2e.Testnet, p infra.Provider) error {
 			// that this node will start at before we
 			// start the node.
 
-			networkHeight = node.StartAt
-
-			log.Info(ctx, "Waiting for network to advance before starting catch up node",
+			log.Info(ctx, "Waiting for network to advance before starting catchup node",
 				"node", node.Name,
-				"height", networkHeight)
+				"current_height", networkHeight,
+				"wait_for_height", node.StartAt)
+
+			networkHeight = node.StartAt
 
 			if _, _, err := waitForHeight(ctx, testnet, networkHeight); err != nil {
 				return err
 			}
 		}
 
-		log.Info(ctx, "Starting catch up node", "node", node.Name, "height", node.StartAt)
+		log.Info(ctx, "Starting catchup node", "node", node.Name, "height", node.StartAt)
 
 		err := p.StartNodes(ctx, node)
 		if err != nil {
@@ -118,8 +131,36 @@ func Start(ctx context.Context, testnet *e2e.Testnet, p infra.Provider) error {
 		if err != nil {
 			return err
 		}
-		log.Info(ctx, "Started node", "name", node.Name, "hiehgt", status.SyncInfo.LatestBlockHeight)
+		log.Info(ctx, "Started catchup node", "name", node.Name, "height", status.SyncInfo.LatestBlockHeight)
 	}
 
 	return nil
+}
+
+// getSortedNodes returns a copy of the testnet nodes by startAt, then mode, then name.
+func getSortedNodes(testnet *e2e.Testnet) ([]*e2e.Node, error) {
+	if len(testnet.Nodes) == 0 {
+		return nil, errors.New("no nodes in testnet")
+	}
+
+	nodeQueue := slices.Clone(testnet.Nodes)
+	sort.SliceStable(nodeQueue, func(i, j int) bool {
+		a, b := nodeQueue[i], nodeQueue[j]
+		switch {
+		case a.Mode == b.Mode:
+			return false
+		case a.Mode == e2e.ModeSeed:
+			return true
+		case a.Mode == e2e.ModeValidator && b.Mode == e2e.ModeFull:
+			return true
+		}
+
+		return false
+	})
+
+	sort.SliceStable(nodeQueue, func(i, j int) bool {
+		return nodeQueue[i].StartAt < nodeQueue[j].StartAt
+	})
+
+	return nodeQueue, nil
 }

--- a/test/e2e/manifests/ci.toml
+++ b/test/e2e/manifests/ci.toml
@@ -1,0 +1,9 @@
+network = "devnet"
+anvil_chains = ["mock_rollup", "mock_l1"]
+avs_target = "mock_l1"
+
+[node.validator01]
+[node.validator02]
+[node.validator03]
+[node.validator04]
+start_at = 20


### PR DESCRIPTION
Adds the start of our "ci" manifest that will do a lot of non-happy path tests. v0 just starts one validator late.

task: none