### PR TITLE
chore(relayer): monitor attested height from relayer

### DIFF
--- a/halo/app/start_test.go
+++ b/halo/app/start_test.go
@@ -54,6 +54,10 @@ func TestSmoke(t *testing.T) {
 	}, time.Second*time.Duration(target*2), time.Millisecond*100)
 
 	srcChain := uint64(999)
+	att, err := cprov.LatestAttestation(ctx, srcChain)
+	require.NoError(t, err)
+	require.Equal(t, srcChain, att.SourceChainID)
+
 	// Ensure all blocks are attested and approved.
 	cprov.Subscribe(ctx, srcChain, 0, "test", func(ctx context.Context, approved xchain.Attestation) error {
 		require.Equal(t, srcChain, approved.SourceChainID)

--- a/halo/attest/keeper/keeper.go
+++ b/halo/attest/keeper/keeper.go
@@ -21,6 +21,7 @@ import (
 	ormv1alpha1 "cosmossdk.io/api/cosmos/orm/v1alpha1"
 	"cosmossdk.io/core/store"
 	"cosmossdk.io/orm/model/ormdb"
+	"cosmossdk.io/orm/model/ormlist"
 	"cosmossdk.io/orm/types/ormerrors"
 	"github.com/cosmos/cosmos-sdk/codec"
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -266,6 +267,53 @@ func (k *Keeper) attestationFrom(ctx context.Context, chainID uint64, height uin
 	}
 
 	return resp, nil
+}
+
+// latestAttestation returns the latest approved attestation for the given chain.
+func (k *Keeper) latestAttestation(ctx context.Context, chainID uint64) (*types.Attestation, error) {
+	idx := AttestationStatusChainIdHeightIndexKey{}.WithStatusChainId(int32(Status_Approved), chainID)
+	iter, err := k.attTable.List(ctx, idx, ormlist.Reverse(), ormlist.DefaultLimit(1))
+	if err != nil {
+		return nil, errors.Wrap(err, "list")
+	}
+	defer iter.Close()
+
+	if !iter.Next() {
+		return nil, errors.New("no attestation found")
+	}
+
+	att, err := iter.Value()
+	if err != nil {
+		return nil, errors.Wrap(err, "value")
+	}
+
+	if iter.Next() {
+		return nil, errors.New("multiple attestation found")
+	}
+
+	pbsigs, err := k.getSigs(ctx, att.GetId())
+	if err != nil {
+		return nil, errors.Wrap(err, "get att sigs")
+	}
+
+	var sigs []*types.SigTuple
+	for _, pbsig := range pbsigs {
+		sigs = append(sigs, &types.SigTuple{
+			ValidatorAddress: pbsig.GetValidatorAddress(),
+			Signature:        pbsig.GetSignature(),
+		})
+	}
+
+	return &types.Attestation{
+		BlockHeader: &types.BlockHeader{
+			ChainId: att.GetChainId(),
+			Height:  att.GetHeight(),
+			Hash:    att.GetHash(),
+		},
+		ValidatorsHash: att.GetValidatorsHash(),
+		BlockRoot:      att.GetBlockRoot(),
+		Signatures:     sigs,
+	}, nil
 }
 
 // getSigs returns the signatures for the given attestation ID.

--- a/halo/attest/keeper/query.go
+++ b/halo/attest/keeper/query.go
@@ -25,3 +25,16 @@ func (k *Keeper) AttestationsFrom(ctx context.Context, req *types.AttestationsFr
 
 	return &types.AttestationsFromResponse{Attestations: atts}, nil
 }
+
+func (k *Keeper) LatestAttestation(ctx context.Context, req *types.LatestAttestationRequest) (*types.LatestAttestationResponse, error) {
+	if req == nil {
+		return nil, status.Error(codes.InvalidArgument, "invalid request")
+	}
+
+	att, err := k.latestAttestation(ctx, req.ChainId)
+	if err != nil {
+		return nil, status.Error(codes.Internal, err.Error())
+	}
+
+	return &types.LatestAttestationResponse{Attestation: att}, nil
+}

--- a/halo/attest/types/query.pb.go
+++ b/halo/attest/types/query.pb.go
@@ -126,15 +126,105 @@ func (m *AttestationsFromResponse) GetAttestations() []*Attestation {
 	return nil
 }
 
+type LatestAttestationRequest struct {
+	ChainId uint64 `protobuf:"varint,1,opt,name=chain_id,json=chainId,proto3" json:"chain_id,omitempty"`
+}
+
+func (m *LatestAttestationRequest) Reset()         { *m = LatestAttestationRequest{} }
+func (m *LatestAttestationRequest) String() string { return proto.CompactTextString(m) }
+func (*LatestAttestationRequest) ProtoMessage()    {}
+func (*LatestAttestationRequest) Descriptor() ([]byte, []int) {
+	return fileDescriptor_93d3f1745081aabb, []int{2}
+}
+func (m *LatestAttestationRequest) XXX_Unmarshal(b []byte) error {
+	return m.Unmarshal(b)
+}
+func (m *LatestAttestationRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	if deterministic {
+		return xxx_messageInfo_LatestAttestationRequest.Marshal(b, m, deterministic)
+	} else {
+		b = b[:cap(b)]
+		n, err := m.MarshalToSizedBuffer(b)
+		if err != nil {
+			return nil, err
+		}
+		return b[:n], nil
+	}
+}
+func (m *LatestAttestationRequest) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_LatestAttestationRequest.Merge(m, src)
+}
+func (m *LatestAttestationRequest) XXX_Size() int {
+	return m.Size()
+}
+func (m *LatestAttestationRequest) XXX_DiscardUnknown() {
+	xxx_messageInfo_LatestAttestationRequest.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_LatestAttestationRequest proto.InternalMessageInfo
+
+func (m *LatestAttestationRequest) GetChainId() uint64 {
+	if m != nil {
+		return m.ChainId
+	}
+	return 0
+}
+
+type LatestAttestationResponse struct {
+	Attestation *Attestation `protobuf:"bytes,1,opt,name=attestation,proto3" json:"attestation,omitempty"`
+}
+
+func (m *LatestAttestationResponse) Reset()         { *m = LatestAttestationResponse{} }
+func (m *LatestAttestationResponse) String() string { return proto.CompactTextString(m) }
+func (*LatestAttestationResponse) ProtoMessage()    {}
+func (*LatestAttestationResponse) Descriptor() ([]byte, []int) {
+	return fileDescriptor_93d3f1745081aabb, []int{3}
+}
+func (m *LatestAttestationResponse) XXX_Unmarshal(b []byte) error {
+	return m.Unmarshal(b)
+}
+func (m *LatestAttestationResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	if deterministic {
+		return xxx_messageInfo_LatestAttestationResponse.Marshal(b, m, deterministic)
+	} else {
+		b = b[:cap(b)]
+		n, err := m.MarshalToSizedBuffer(b)
+		if err != nil {
+			return nil, err
+		}
+		return b[:n], nil
+	}
+}
+func (m *LatestAttestationResponse) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_LatestAttestationResponse.Merge(m, src)
+}
+func (m *LatestAttestationResponse) XXX_Size() int {
+	return m.Size()
+}
+func (m *LatestAttestationResponse) XXX_DiscardUnknown() {
+	xxx_messageInfo_LatestAttestationResponse.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_LatestAttestationResponse proto.InternalMessageInfo
+
+func (m *LatestAttestationResponse) GetAttestation() *Attestation {
+	if m != nil {
+		return m.Attestation
+	}
+	return nil
+}
+
 func init() {
 	proto.RegisterType((*AttestationsFromRequest)(nil), "halo.attest.types.AttestationsFromRequest")
 	proto.RegisterType((*AttestationsFromResponse)(nil), "halo.attest.types.AttestationsFromResponse")
+	proto.RegisterType((*LatestAttestationRequest)(nil), "halo.attest.types.LatestAttestationRequest")
+	proto.RegisterType((*LatestAttestationResponse)(nil), "halo.attest.types.LatestAttestationResponse")
 }
 
 func init() { proto.RegisterFile("halo/attest/types/query.proto", fileDescriptor_93d3f1745081aabb) }
 
 var fileDescriptor_93d3f1745081aabb = []byte{
-	// 248 bytes of a gzipped FileDescriptorProto
+	// 302 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xe2, 0x92, 0xcd, 0x48, 0xcc, 0xc9,
 	0xd7, 0x4f, 0x2c, 0x29, 0x49, 0x2d, 0x2e, 0xd1, 0x2f, 0xa9, 0x2c, 0x48, 0x2d, 0xd6, 0x2f, 0x2c,
 	0x4d, 0x2d, 0xaa, 0xd4, 0x2b, 0x28, 0xca, 0x2f, 0xc9, 0x17, 0x12, 0x04, 0x49, 0xeb, 0x41, 0xa4,
@@ -145,12 +235,15 @@ var fileDescriptor_93d3f1745081aabb = []byte{
 	0x51, 0x7e, 0x6e, 0x7c, 0x46, 0x6a, 0x66, 0x7a, 0x46, 0x89, 0x04, 0x13, 0x58, 0x96, 0x0b, 0x24,
 	0xe4, 0x01, 0x16, 0x51, 0x8a, 0xe3, 0x92, 0xc0, 0x34, 0xb6, 0xb8, 0x20, 0x3f, 0xaf, 0x38, 0x55,
 	0xc8, 0x89, 0x8b, 0x27, 0x11, 0x49, 0x4e, 0x82, 0x51, 0x81, 0x59, 0x83, 0xdb, 0x48, 0x4e, 0x0f,
-	0xc3, 0xe1, 0x7a, 0x48, 0x46, 0x04, 0xa1, 0xe8, 0x31, 0x2a, 0xe3, 0x62, 0x0d, 0x04, 0x79, 0x5a,
-	0x28, 0x97, 0x4b, 0x00, 0xdd, 0x22, 0x21, 0x2d, 0xfc, 0x46, 0x21, 0x7b, 0x52, 0x4a, 0x9b, 0x28,
-	0xb5, 0x10, 0x97, 0x2b, 0x31, 0x38, 0x69, 0x9f, 0x78, 0x24, 0xc7, 0x78, 0xe1, 0x91, 0x1c, 0xe3,
-	0x83, 0x47, 0x72, 0x8c, 0x13, 0x1e, 0xcb, 0x31, 0x5c, 0x78, 0x2c, 0xc7, 0x70, 0xe3, 0xb1, 0x1c,
-	0x43, 0x94, 0x20, 0x46, 0x20, 0x27, 0xb1, 0x81, 0x83, 0xd8, 0x18, 0x10, 0x00, 0x00, 0xff, 0xff,
-	0x29, 0xdd, 0x82, 0xd5, 0xb2, 0x01, 0x00, 0x00,
+	0xc3, 0xe1, 0x7a, 0x48, 0x46, 0x04, 0xa1, 0xe8, 0x51, 0x32, 0xe5, 0x92, 0xf0, 0x49, 0x04, 0xf1,
+	0x91, 0x95, 0x10, 0x74, 0xb7, 0x52, 0x2c, 0x97, 0x24, 0x16, 0x6d, 0x50, 0x77, 0x39, 0x70, 0x71,
+	0x23, 0xd9, 0x01, 0xd6, 0x4a, 0xd8, 0x59, 0xc8, 0x5a, 0x8c, 0x5e, 0x30, 0x72, 0xb1, 0x06, 0x82,
+	0xe2, 0x42, 0x28, 0x97, 0x4b, 0x00, 0xdd, 0xff, 0x42, 0x5a, 0xf8, 0x8d, 0x42, 0x0e, 0x7b, 0x29,
+	0x6d, 0xa2, 0xd4, 0x42, 0x1c, 0xae, 0xc4, 0x20, 0x54, 0xc0, 0x25, 0x88, 0xe1, 0x2f, 0x21, 0x6c,
+	0x66, 0xe0, 0x0a, 0x34, 0x29, 0x1d, 0xe2, 0x14, 0xc3, 0x6c, 0x74, 0xd2, 0x3e, 0xf1, 0x48, 0x8e,
+	0xf1, 0xc2, 0x23, 0x39, 0xc6, 0x07, 0x8f, 0xe4, 0x18, 0x27, 0x3c, 0x96, 0x63, 0xb8, 0xf0, 0x58,
+	0x8e, 0xe1, 0xc6, 0x63, 0x39, 0x86, 0x28, 0x41, 0x8c, 0xd4, 0x96, 0xc4, 0x06, 0x4e, 0x6b, 0xc6,
+	0x80, 0x00, 0x00, 0x00, 0xff, 0xff, 0x4e, 0xa4, 0xcd, 0x53, 0xbb, 0x02, 0x00, 0x00,
 }
 
 // Reference imports to suppress errors if they are not otherwise used.
@@ -169,6 +262,8 @@ type QueryClient interface {
 	// and from the given height (inclusive). The response will contain at most max attestations sequentially
 	// following from_height.
 	AttestationsFrom(ctx context.Context, in *AttestationsFromRequest, opts ...grpc.CallOption) (*AttestationsFromResponse, error)
+	// LatestAttestation queries halo for the latest approved attestations for the given chain_id.
+	LatestAttestation(ctx context.Context, in *LatestAttestationRequest, opts ...grpc.CallOption) (*LatestAttestationResponse, error)
 }
 
 type queryClient struct {
@@ -188,12 +283,23 @@ func (c *queryClient) AttestationsFrom(ctx context.Context, in *AttestationsFrom
 	return out, nil
 }
 
+func (c *queryClient) LatestAttestation(ctx context.Context, in *LatestAttestationRequest, opts ...grpc.CallOption) (*LatestAttestationResponse, error) {
+	out := new(LatestAttestationResponse)
+	err := c.cc.Invoke(ctx, "/halo.attest.types.Query/LatestAttestation", in, out, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 // QueryServer is the server API for Query service.
 type QueryServer interface {
 	// AttestationsFrom queries halo for approved attestations for the given chain_id
 	// and from the given height (inclusive). The response will contain at most max attestations sequentially
 	// following from_height.
 	AttestationsFrom(context.Context, *AttestationsFromRequest) (*AttestationsFromResponse, error)
+	// LatestAttestation queries halo for the latest approved attestations for the given chain_id.
+	LatestAttestation(context.Context, *LatestAttestationRequest) (*LatestAttestationResponse, error)
 }
 
 // UnimplementedQueryServer can be embedded to have forward compatible implementations.
@@ -202,6 +308,9 @@ type UnimplementedQueryServer struct {
 
 func (*UnimplementedQueryServer) AttestationsFrom(ctx context.Context, req *AttestationsFromRequest) (*AttestationsFromResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method AttestationsFrom not implemented")
+}
+func (*UnimplementedQueryServer) LatestAttestation(ctx context.Context, req *LatestAttestationRequest) (*LatestAttestationResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method LatestAttestation not implemented")
 }
 
 func RegisterQueryServer(s grpc1.Server, srv QueryServer) {
@@ -226,6 +335,24 @@ func _Query_AttestationsFrom_Handler(srv interface{}, ctx context.Context, dec f
 	return interceptor(ctx, in, info, handler)
 }
 
+func _Query_LatestAttestation_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(LatestAttestationRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(QueryServer).LatestAttestation(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: "/halo.attest.types.Query/LatestAttestation",
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(QueryServer).LatestAttestation(ctx, req.(*LatestAttestationRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 var _Query_serviceDesc = grpc.ServiceDesc{
 	ServiceName: "halo.attest.types.Query",
 	HandlerType: (*QueryServer)(nil),
@@ -233,6 +360,10 @@ var _Query_serviceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "AttestationsFrom",
 			Handler:    _Query_AttestationsFrom_Handler,
+		},
+		{
+			MethodName: "LatestAttestation",
+			Handler:    _Query_LatestAttestation_Handler,
 		},
 	},
 	Streams:  []grpc.StreamDesc{},
@@ -309,6 +440,69 @@ func (m *AttestationsFromResponse) MarshalToSizedBuffer(dAtA []byte) (int, error
 	return len(dAtA) - i, nil
 }
 
+func (m *LatestAttestationRequest) Marshal() (dAtA []byte, err error) {
+	size := m.Size()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *LatestAttestationRequest) MarshalTo(dAtA []byte) (int, error) {
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *LatestAttestationRequest) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.ChainId != 0 {
+		i = encodeVarintQuery(dAtA, i, uint64(m.ChainId))
+		i--
+		dAtA[i] = 0x8
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *LatestAttestationResponse) Marshal() (dAtA []byte, err error) {
+	size := m.Size()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *LatestAttestationResponse) MarshalTo(dAtA []byte) (int, error) {
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *LatestAttestationResponse) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.Attestation != nil {
+		{
+			size, err := m.Attestation.MarshalToSizedBuffer(dAtA[:i])
+			if err != nil {
+				return 0, err
+			}
+			i -= size
+			i = encodeVarintQuery(dAtA, i, uint64(size))
+		}
+		i--
+		dAtA[i] = 0xa
+	}
+	return len(dAtA) - i, nil
+}
+
 func encodeVarintQuery(dAtA []byte, offset int, v uint64) int {
 	offset -= sovQuery(v)
 	base := offset
@@ -346,6 +540,31 @@ func (m *AttestationsFromResponse) Size() (n int) {
 			l = e.Size()
 			n += 1 + l + sovQuery(uint64(l))
 		}
+	}
+	return n
+}
+
+func (m *LatestAttestationRequest) Size() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	if m.ChainId != 0 {
+		n += 1 + sovQuery(uint64(m.ChainId))
+	}
+	return n
+}
+
+func (m *LatestAttestationResponse) Size() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	if m.Attestation != nil {
+		l = m.Attestation.Size()
+		n += 1 + l + sovQuery(uint64(l))
 	}
 	return n
 }
@@ -504,6 +723,161 @@ func (m *AttestationsFromResponse) Unmarshal(dAtA []byte) error {
 			}
 			m.Attestations = append(m.Attestations, &Attestation{})
 			if err := m.Attestations[len(m.Attestations)-1].Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := skipQuery(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return ErrInvalidLengthQuery
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *LatestAttestationRequest) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowQuery
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: LatestAttestationRequest: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: LatestAttestationRequest: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field ChainId", wireType)
+			}
+			m.ChainId = 0
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowQuery
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				m.ChainId |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+		default:
+			iNdEx = preIndex
+			skippy, err := skipQuery(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return ErrInvalidLengthQuery
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *LatestAttestationResponse) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowQuery
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: LatestAttestationResponse: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: LatestAttestationResponse: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Attestation", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowQuery
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthQuery
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return ErrInvalidLengthQuery
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.Attestation == nil {
+				m.Attestation = &Attestation{}
+			}
+			if err := m.Attestation.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
 				return err
 			}
 			iNdEx = postIndex

--- a/halo/attest/types/query.proto
+++ b/halo/attest/types/query.proto
@@ -12,6 +12,9 @@ service Query {
   // and from the given height (inclusive). The response will contain at most max attestations sequentially
   // following from_height.
   rpc AttestationsFrom(AttestationsFromRequest) returns (AttestationsFromResponse) {}
+
+  // LatestAttestation queries halo for the latest approved attestations for the given chain_id.
+  rpc LatestAttestation(LatestAttestationRequest) returns (LatestAttestationResponse) {}
 }
 
 // ApprovedFromRequest queries halo for approved attestations for the given chain_id
@@ -24,4 +27,12 @@ message AttestationsFromRequest {
 
 message AttestationsFromResponse{
   repeated Attestation attestations = 1;
+}
+
+message LatestAttestationRequest {
+  uint64 chain_id = 1; // Chain ID as per https://chainlist.org
+}
+
+message LatestAttestationResponse {
+  Attestation attestation = 1;
 }

--- a/lib/cchain/provider.go
+++ b/lib/cchain/provider.go
@@ -27,4 +27,7 @@ type Provider interface {
 	// AttestationsFrom returns the subsequent approved attestations for the provided source chain
 	// and height (inclusive). It will return max 100 attestations per call.
 	AttestationsFrom(ctx context.Context, sourceChainID uint64, sourceHeight uint64) ([]xchain.Attestation, error)
+
+	// LatestAttestation returns the latest approved attestation for the provided source chain.
+	LatestAttestation(ctx context.Context, sourceChainID uint64) (xchain.Attestation, error)
 }

--- a/lib/cchain/provider/provider_test.go
+++ b/lib/cchain/provider/provider_test.go
@@ -28,7 +28,7 @@ func TestProvider(t *testing.T) {
 	var backoff testBackOff
 	fetcher := &testFetcher{errs: errs}
 
-	p := provider.NewProviderForT(t, fetcher.Fetch, backoff.BackOff)
+	p := provider.NewProviderForT(t, fetcher.Fetch, nil, backoff.BackOff)
 
 	var actual []xchain.Attestation
 	p.Subscribe(ctx, chainID, fromHeight, "test", func(ctx context.Context, approved xchain.Attestation) error {

--- a/relayer/app/app.go
+++ b/relayer/app/app.go
@@ -66,7 +66,7 @@ func Run(ctx context.Context, cfg Config) error {
 		go worker.Run(ctx)
 	}
 
-	startMonitoring(ctx, network, xprov, ethcrypto.PubkeyToAddress(privateKey.PublicKey), rpcClientPerChain)
+	startMonitoring(ctx, network, xprov, cprov, ethcrypto.PubkeyToAddress(privateKey.PublicKey), rpcClientPerChain)
 
 	select {
 	case <-ctx.Done():

--- a/relayer/app/metrics.go
+++ b/relayer/app/metrics.go
@@ -75,4 +75,11 @@ var (
 		Name:      "head_height",
 		Help:      "The latest height of different types of head blocks on a specific chain",
 	}, []string{"chain", "type"})
+
+	attestedHeight = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: "relayer",
+		Subsystem: "monitor",
+		Name:      "halo_attested_height",
+		Help:      "The latest halo attested height of a specific chain",
+	}, []string{"chain"})
 )


### PR DESCRIPTION
Monitor "latest attested height" from relayer. This ensures consistent/synchronised reporting of key cross-chain metrics and avoids prometheus scrap offset issues resulting in negative lag in grafana.

Added a `LatestAttestation` query endpoint to `halo's` `attest` module.

task: none
