### PR TITLE
fix(e2e): fix upgrade command

### DIFF
--- a/test/e2e/app/run.go
+++ b/test/e2e/app/run.go
@@ -156,6 +156,16 @@ func E2ETest(ctx context.Context, def Definition, cfg E2ETestConfig, prom PromSe
 	return nil
 }
 
+// Upgrade generates all local artifacts, but only copies the docker-compose file to the VMs.
+// It them calls docker-compose up.
+func Upgrade(ctx context.Context, def Definition) error {
+	if err := Setup(ctx, def, PromSecrets{}); err != nil {
+		return err
+	}
+
+	return def.Infra.Upgrade(ctx)
+}
+
 // toPortalValidators returns the provided validator set as a lice of portal validators.
 func toPortalValidators(validators map[*e2e.Node]int64) ([]bindings.Validator, error) {
 	vals := make([]bindings.Validator, 0, len(validators))

--- a/test/e2e/cmd/cmd.go
+++ b/test/e2e/cmd/cmd.go
@@ -115,7 +115,7 @@ func newUpgradeCmd(def *app.Definition) *cobra.Command {
 		Use:   "upgrade",
 		Short: "Upgrades docker containers of a previously preserved network",
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			return def.Infra.Upgrade(cmd.Context())
+			return app.Upgrade(cmd.Context(), *def)
 		},
 	}
 }


### PR DESCRIPTION
In order to copy the docker-compose file, it has to be generated by `Setup`.

task: none