### PR TITLE
chore(e2e/prometheus): update prometheus command

### DIFF
--- a/test/e2e/docker/compose.yaml.tmpl
+++ b/test/e2e/docker/compose.yaml.tmpl
@@ -146,6 +146,13 @@ services:
       e2e: true
     container_name: prometheus
     image: prom/prometheus:latest
+    command:
+      - --config.file=/etc/prometheus/prometheus.yml
+      - --storage.tsdb.path=/prometheus
+      - --web.console.libraries=/usr/share/prometheus/console_libraries
+      - --web.console.templates=/usr/share/prometheus/consoles
+      - --enable-feature=exemplar-storage
+      - --enable-feature=agent
     restart: unless-stopped
     volumes:
       - ./prometheus/prometheus.yml:/etc/prometheus/prometheus.yml

--- a/test/e2e/docker/testdata/TestComposeTemplate_image_tag_7d1ae53.golden
+++ b/test/e2e/docker/testdata/TestComposeTemplate_image_tag_7d1ae53.golden
@@ -151,6 +151,13 @@ services:
       e2e: true
     container_name: prometheus
     image: prom/prometheus:latest
+    command:
+      - --config.file=/etc/prometheus/prometheus.yml
+      - --storage.tsdb.path=/prometheus
+      - --web.console.libraries=/usr/share/prometheus/console_libraries
+      - --web.console.templates=/usr/share/prometheus/consoles
+      - --enable-feature=exemplar-storage
+      - --enable-feature=agent
     restart: unless-stopped
     volumes:
       - ./prometheus/prometheus.yml:/etc/prometheus/prometheus.yml

--- a/test/e2e/docker/testdata/TestComposeTemplate_image_tag_main.golden
+++ b/test/e2e/docker/testdata/TestComposeTemplate_image_tag_main.golden
@@ -151,6 +151,13 @@ services:
       e2e: true
     container_name: prometheus
     image: prom/prometheus:latest
+    command:
+      - --config.file=/etc/prometheus/prometheus.yml
+      - --storage.tsdb.path=/prometheus
+      - --web.console.libraries=/usr/share/prometheus/console_libraries
+      - --web.console.templates=/usr/share/prometheus/consoles
+      - --enable-feature=exemplar-storage
+      - --enable-feature=agent
     restart: unless-stopped
     volumes:
       - ./prometheus/prometheus.yml:/etc/prometheus/prometheus.yml


### PR DESCRIPTION
Until now we were running Prometheus with the default settings (command flags). With this PR we set those explicitly and enable 2 new flags:
- Instruct Prometheus to scrape and store metrics exemplars
- Disable the Prometheus UI on our staging env and only run it in agent mode. This way it consumes a lot less resources. The agent mode can be potentially conditional and on localhost we can run the full Prometheus UI.

task: none