### PR TITLE
fix(halo/attest): use current validator set for approvals

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -76,10 +76,6 @@
       "path": "detect_secrets.filters.allowlist.is_line_allowlisted"
     },
     {
-      "path": "detect_secrets.filters.common.is_baseline_file",
-      "filename": ".secrets.baseline"
-    },
-    {
       "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
       "min_level": 2
     },
@@ -504,7 +500,7 @@
         "filename": "test/e2e/app/run.go",
         "hashed_secret": "cd4c02f97387f2ac1da2b9ad4ccffa5978d887eb",
         "is_verified": false,
-        "line_number": 104
+        "line_number": 105
       }
     ],
     "test/e2e/app/setup.go": [
@@ -520,14 +516,14 @@
         "filename": "test/e2e/app/setup.go",
         "hashed_secret": "55abc9109d5ea8a77be16bf3c76b4b199b524b12",
         "is_verified": false,
-        "line_number": 375
+        "line_number": 387
       },
       {
         "type": "Secret Keyword",
         "filename": "test/e2e/app/setup.go",
         "hashed_secret": "da57af224108e98e24d1e2a86221121990fa6478",
         "is_verified": false,
-        "line_number": 400
+        "line_number": 412
       }
     ],
     "test/e2e/app/static/geth-genesis.json": [
@@ -781,5 +777,5 @@
       }
     ]
   },
-  "generated_at": "2024-02-26T09:19:08Z"
+  "generated_at": "2024-02-27T12:20:59Z"
 }

--- a/halo/Dockerfile
+++ b/halo/Dockerfile
@@ -3,6 +3,9 @@ FROM scratch
 # Install ca-certificates (for https to rollups)
 COPY --from=alpine:latest /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 
+# Create /tmp directory (default cometBFT --temp-dir)
+COPY --from=alpine:latest /tmp /tmp
+
 COPY halo /app
 
 # Mount home directory at /halo

--- a/halo/attest/keeper/msg_server.go
+++ b/halo/attest/keeper/msg_server.go
@@ -29,11 +29,7 @@ func (s msgServer) AddVotes(ctx context.Context, msg *types.MsgAddVotes,
 		return nil, errors.New("only allowed in finalize mode")
 	}
 
-	sdkContext := sdk.UnwrapSDKContext(ctx)
-	vals := s.validatorsByAddress(ctx, sdkContext.BlockHeight()-1)
-	if err := verifyAggVotes(ctx, vals, s.windower, msg.Votes); err != nil {
-		return nil, errors.Wrap(err, "verify votes")
-	}
+	// Not verifying votes here since this block is now finalized, so it is too late to reject votes.
 
 	err := s.Keeper.Add(ctx, msg)
 	if err != nil {

--- a/halo/cmd/flags.go
+++ b/halo/cmd/flags.go
@@ -10,7 +10,6 @@ import (
 func bindRunFlags(flags *pflag.FlagSet, cfg *halocfg.Config) {
 	libcmd.BindHomeFlag(flags, &cfg.HomeDir)
 	flags.StringVar(&cfg.EngineJWTFile, "engine-jwt-file", cfg.EngineJWTFile, "The path to the Engine API JWT file")
-	flags.Uint64Var(&cfg.AppStatePersistInterval, "state-persist-interval", cfg.AppStatePersistInterval, "The interval (in blocks) at which to persist the app state")
 	flags.Uint64Var(&cfg.SnapshotInterval, "snapshot-interval", cfg.SnapshotInterval, "The interval (in blocks) at which to create snapshots")
 	flags.Uint64Var(&cfg.MinRetainBlocks, "min-retain-blocks", cfg.MinRetainBlocks, "Minimum block height offset during ABCI commit to prune CometBFT blocks")
 	flags.StringVar(&cfg.BackendType, "app-db-backend", cfg.BackendType, "The type of database for application and snapshots databases")

--- a/halo/cmd/testdata/TestCLIReference_run.golden
+++ b/halo/cmd/testdata/TestCLIReference_run.golden
@@ -4,16 +4,15 @@ Usage:
   halo run [flags]
 
 Flags:
-      --app-db-backend string         The type of database for application and snapshots databases (default "goleveldb")
-      --engine-jwt-file string        The path to the Engine API JWT file
-      --evm-build-delay duration      Minimum delay between triggering and fetching a EVM payload build (default 600ms)
-      --evm-build-optimistic          Enables optimistic building of EVM payloads on previous block finalize (default true)
-  -h, --help                          help for run
-      --home string                   The application home directory containing config and data (default "./halo")
-      --log-color string              Log color (only applicable to console format); auto, force, disable (default "auto")
-      --log-format string             Log format; console, json (default "console")
-      --log-level string              Log level; debug, info, warn, error (default "info")
-      --min-retain-blocks uint        Minimum block height offset during ABCI commit to prune CometBFT blocks
-      --pruning string                Pruning strategy (default|nothing|everything) (default "nothing")
-      --snapshot-interval uint        The interval (in blocks) at which to create snapshots (default 1000)
-      --state-persist-interval uint   The interval (in blocks) at which to persist the app state (default 1)
+      --app-db-backend string      The type of database for application and snapshots databases (default "goleveldb")
+      --engine-jwt-file string     The path to the Engine API JWT file
+      --evm-build-delay duration   Minimum delay between triggering and fetching a EVM payload build (default 600ms)
+      --evm-build-optimistic       Enables optimistic building of EVM payloads on previous block finalize (default true)
+  -h, --help                       help for run
+      --home string                The application home directory containing config and data (default "./halo")
+      --log-color string           Log color (only applicable to console format); auto, force, disable (default "auto")
+      --log-format string          Log format; console, json (default "console")
+      --log-level string           Log level; debug, info, warn, error (default "info")
+      --min-retain-blocks uint     Minimum block height offset during ABCI commit to prune CometBFT blocks
+      --pruning string             Pruning strategy (default|nothing|everything) (default "nothing")
+      --snapshot-interval uint     The interval (in blocks) at which to create snapshots (default 1000)

--- a/halo/cmd/testdata/TestRunCmd_defaults.golden
+++ b/halo/cmd/testdata/TestRunCmd_defaults.golden
@@ -1,7 +1,6 @@
 {
  "HomeDir": "./halo",
  "EngineJWTFile": "",
- "AppStatePersistInterval": 1,
  "SnapshotInterval": 1000,
  "BackendType": "goleveldb",
  "MinRetainBlocks": 0,

--- a/halo/cmd/testdata/TestRunCmd_flags.golden
+++ b/halo/cmd/testdata/TestRunCmd_flags.golden
@@ -1,7 +1,6 @@
 {
  "HomeDir": "foo",
  "EngineJWTFile": "bar",
- "AppStatePersistInterval": 1,
  "SnapshotInterval": 1000,
  "BackendType": "goleveldb",
  "MinRetainBlocks": 0,

--- a/halo/cmd/testdata/TestRunCmd_json_files.golden
+++ b/halo/cmd/testdata/TestRunCmd_json_files.golden
@@ -1,7 +1,6 @@
 {
  "HomeDir": "testinput/input2",
  "EngineJWTFile": "jwt.json",
- "AppStatePersistInterval": 12,
  "SnapshotInterval": 123,
  "BackendType": "goleveldb",
  "MinRetainBlocks": 0,

--- a/halo/cmd/testdata/TestRunCmd_toml_files.golden
+++ b/halo/cmd/testdata/TestRunCmd_toml_files.golden
@@ -1,7 +1,6 @@
 {
  "HomeDir": "testinput/input1",
  "EngineJWTFile": "jwt.toml",
- "AppStatePersistInterval": 99,
  "SnapshotInterval": 999,
  "BackendType": "goleveldb",
  "MinRetainBlocks": 0,

--- a/halo/config/config.go
+++ b/halo/config/config.go
@@ -25,10 +25,9 @@ const (
 	networkFile     = "network.json"
 	attestStateFile = "xattestations_state.json"
 
-	DefaultHomeDir                 = "./halo" // Defaults to "halo" in current directory
-	defaultAppStatePersistInterval = 1        // Persist app state every block. Set to 0 to disable persistence.
-	defaultSnapshotInterval        = 1000     // Roughly once an hour (given 3s blocks)
-	defaultMinRetainBlocks         = 0        // Retain all blocks
+	DefaultHomeDir          = "./halo" // Defaults to "halo" in current directory
+	defaultSnapshotInterval = 1000     // Roughly once an hour (given 3s blocks)
+	defaultMinRetainBlocks  = 0        // Retain all blocks
 
 	defaultPruningOption      = pruningtypes.PruningOptionNothing // Prune nothing
 	defaultDBBackend          = db.GoLevelDBBackend
@@ -39,29 +38,27 @@ const (
 // DefaultConfig returns the default halo config.
 func DefaultConfig() Config {
 	return Config{
-		HomeDir:                 DefaultHomeDir,
-		EngineJWTFile:           "", // No default
-		AppStatePersistInterval: defaultAppStatePersistInterval,
-		SnapshotInterval:        defaultSnapshotInterval,
-		BackendType:             string(defaultDBBackend),
-		MinRetainBlocks:         defaultMinRetainBlocks,
-		PruningOption:           defaultPruningOption,
-		EVMBuildDelay:           defaultEVMBuildDelay,
-		EVMBuildOptimistic:      defaultEVMBuildOptimistic,
+		HomeDir:            DefaultHomeDir,
+		EngineJWTFile:      "", // No default
+		SnapshotInterval:   defaultSnapshotInterval,
+		BackendType:        string(defaultDBBackend),
+		MinRetainBlocks:    defaultMinRetainBlocks,
+		PruningOption:      defaultPruningOption,
+		EVMBuildDelay:      defaultEVMBuildDelay,
+		EVMBuildOptimistic: defaultEVMBuildOptimistic,
 	}
 }
 
 // Config defines all halo specific config.
 type Config struct {
-	HomeDir                 string
-	EngineJWTFile           string
-	AppStatePersistInterval uint64
-	SnapshotInterval        uint64 // See cosmossdk.io/store/snapshots/types/options.go
-	BackendType             string // See cosmos-db/db.go
-	MinRetainBlocks         uint64
-	PruningOption           string // See cosmossdk.io/store/pruning/types/options.go
-	EVMBuildDelay           time.Duration
-	EVMBuildOptimistic      bool
+	HomeDir            string
+	EngineJWTFile      string
+	SnapshotInterval   uint64 // See cosmossdk.io/store/snapshots/types/options.go
+	BackendType        string // See cosmos-db/db.go
+	MinRetainBlocks    uint64
+	PruningOption      string // See cosmossdk.io/store/pruning/types/options.go
+	EVMBuildDelay      time.Duration
+	EVMBuildOptimistic bool
 }
 
 // ConfigFile returns the default path to the toml halo config file.

--- a/halo/config/config.toml.tmpl
+++ b/halo/config/config.toml.tmpl
@@ -12,11 +12,6 @@ version = "unknown"
 # Omni chain execution client JWT file used for authentication.
 engine-jwt-file = "{{ .EngineJWTFile }}"
 
-# PersistInterval specifies the block interval at which the halo
-# will persist state to disk. Defaults to 1 (every height), setting this to
-# 0 disables state persistence.
-state-persist-interval = {{ .AppStatePersistInterval }}
-
 # SnapshotInterval specifies the height interval at which halo
 # will take state sync snapshots. Defaults to 1000 (roughly once an hour), setting this to
 # 0 disables state snapshots.

--- a/halo/config/testdata/default_halo.toml
+++ b/halo/config/testdata/default_halo.toml
@@ -12,11 +12,6 @@ version = "unknown"
 # Omni chain execution client JWT file used for authentication.
 engine-jwt-file = ""
 
-# PersistInterval specifies the block interval at which the halo
-# will persist state to disk. Defaults to 1 (every height), setting this to
-# 0 disables state persistence.
-state-persist-interval = 1
-
 # SnapshotInterval specifies the height interval at which halo
 # will take state sync snapshots. Defaults to 1000 (roughly once an hour), setting this to
 # 0 disables state snapshots.

--- a/halo/evmengine/keeper/keeper.go
+++ b/halo/evmengine/keeper/keeper.go
@@ -94,9 +94,11 @@ func (k *Keeper) isNextProposer(ctx context.Context) (bool, uint64, error) {
 	header := sdkCtx.BlockHeader()
 	nextHeight := header.Height + 1
 
-	valset, err := k.cmtAPI.Validators(ctx, header.Height)
+	valset, ok, err := k.cmtAPI.Validators(ctx, header.Height)
 	if err != nil {
 		return false, 0, err
+	} else if !ok {
+		return false, 0, errors.New("validators not available")
 	}
 
 	idx, _ := valset.GetByAddress(header.ProposerAddress)

--- a/test/e2e/app/run.go
+++ b/test/e2e/app/run.go
@@ -25,8 +25,9 @@ func DefaultDeployConfig() DeployConfig {
 
 type DeployConfig struct {
 	PromSecrets
-	EigenFile string
-	PingPongN uint64
+	EigenFile  string
+	PingPongN  uint64
+	testConfig bool // Internal use only (no command line flag).
 }
 
 // Deploy a new e2e network. It also starts all services in order to deploy private portals.
@@ -46,7 +47,7 @@ func Deploy(ctx context.Context, def Definition, cfg DeployConfig) (types.Deploy
 		return nil, err
 	}
 
-	if err := Setup(ctx, def, cfg.PromSecrets); err != nil {
+	if err := Setup(ctx, def, cfg.PromSecrets, cfg.testConfig); err != nil {
 		return nil, err
 	}
 
@@ -103,6 +104,7 @@ func E2ETest(ctx context.Context, def Definition, cfg E2ETestConfig, prom PromSe
 	depCfg := DeployConfig{
 		PromSecrets: prom,
 		PingPongN:   pingpongN,
+		testConfig:  true,
 	}
 
 	deployInfo, err := Deploy(ctx, def, depCfg)
@@ -131,8 +133,13 @@ func E2ETest(ctx context.Context, def Definition, cfg E2ETestConfig, prom PromSe
 
 	// Wait for all messages to be sent
 	log.Info(ctx, "Waiting for all cross chain messages to be sent")
-	if err := <-msgsErr; err != nil {
-		return err
+	select {
+	case <-ctx.Done():
+		return errors.Wrap(ctx.Err(), "cancel")
+	case err := <-msgsErr:
+		if err != nil {
+			return err
+		}
 	}
 
 	if err := WaitAllSubmissions(ctx, def.Netman.Portals(), sum(msgBatches)); err != nil {
@@ -159,7 +166,7 @@ func E2ETest(ctx context.Context, def Definition, cfg E2ETestConfig, prom PromSe
 // Upgrade generates all local artifacts, but only copies the docker-compose file to the VMs.
 // It them calls docker-compose up.
 func Upgrade(ctx context.Context, def Definition) error {
-	if err := Setup(ctx, def, PromSecrets{}); err != nil {
+	if err := Setup(ctx, def, PromSecrets{}, false); err != nil {
 		return err
 	}
 

--- a/test/e2e/app/setup_internal_test.go
+++ b/test/e2e/app/setup_internal_test.go
@@ -1,0 +1,48 @@
+package app
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/omni-network/omni/test/tutil"
+
+	"github.com/stretchr/testify/require"
+)
+
+//go:generate go test . -golden -clean
+
+func TestUpdateConfigStateSync(t *testing.T) {
+	t.Parallel()
+	config := `
+# Database directory
+db_dir = "data"
+
+# Output level for logging, including package level options
+log_level = "error"
+
+# Output format: 'plain' (colored text) or 'json'
+log_format = "plain"
+
+# For Cosmos SDK-based chains, trust_period should usually be about 2/3 of the unbonding time (~2
+# weeks) during which they can be financially punished (slashed) for misbehavior.
+rpc_servers = ""
+trust_height = 0
+trust_hash = ""
+trust_period = "168h0m0s"
+`
+
+	dir := os.TempDir()
+	configFile := filepath.Join(dir, "config", "config.toml")
+	require.NoError(t, os.MkdirAll(filepath.Dir(configFile), 0o755))
+	err := os.WriteFile(configFile, []byte(config), 0o644)
+	require.NoError(t, err)
+
+	err = updateConfigStateSync(dir, 1, []byte("test"))
+	require.NoError(t, err)
+
+	bz, err := os.ReadFile(configFile)
+	require.NoError(t, err)
+
+	tutil.RequireGoldenBytes(t, bz)
+}

--- a/test/e2e/app/start.go
+++ b/test/e2e/app/start.go
@@ -2,6 +2,7 @@ package app
 
 import (
 	"context"
+	"path/filepath"
 	"slices"
 	"sort"
 	"time"
@@ -93,7 +94,8 @@ func StartRemaining(ctx context.Context, testnet *e2e.Testnet, p infra.Provider)
 	// Update any state sync nodes with a trusted height and hash
 	for _, node := range remaining {
 		if node.StateSync || node.Mode == e2e.ModeLight {
-			err = UpdateConfigStateSync(node, block.Height, blockID.Hash.Bytes())
+			nodeDir := filepath.Join(testnet.Dir, node.Name)
+			err = updateConfigStateSync(nodeDir, block.Height, blockID.Hash.Bytes())
 			if err != nil {
 				return err
 			}

--- a/test/e2e/app/testdata/TestUpdateConfigStateSync.golden
+++ b/test/e2e/app/testdata/TestUpdateConfigStateSync.golden
@@ -1,0 +1,16 @@
+
+# Database directory
+db_dir = "data"
+
+# Output level for logging, including package level options
+log_level = "info"
+
+# Output format: 'plain' (colored text) or 'json'
+log_format = "plain"
+
+# For Cosmos SDK-based chains, trust_period should usually be about 2/3 of the unbonding time (~2
+# weeks) during which they can be financially punished (slashed) for misbehavior.
+rpc_servers = ""
+trust_height = 1
+trust_hash = "74657374"
+trust_period = "168h0m0s"

--- a/test/e2e/backend/backends.go
+++ b/test/e2e/backend/backends.go
@@ -49,7 +49,7 @@ func New(testnet types.Testnet, deployKeyFile string) (Backends, error) {
 	} else if testnet.Network == netconf.Staging {
 		publicDeployKey, err = crypto.LoadECDSA(deployKeyFile)
 	} else {
-		return Backends{}, errors.New("unknown extNetwork")
+		return Backends{}, errors.New("unknown network")
 	}
 	if err != nil {
 		return Backends{}, errors.Wrap(err, "load deploy key")

--- a/test/e2e/manifests/ci.toml
+++ b/test/e2e/manifests/ci.toml
@@ -7,3 +7,4 @@ avs_target = "mock_l1"
 [node.validator03]
 [node.validator04]
 start_at = 20
+state_sync = true

--- a/test/e2e/netman/manager.go
+++ b/test/e2e/netman/manager.go
@@ -33,7 +33,7 @@ var (
 	privateRelayerKey = mustHexToKey(privKeyHex1)
 )
 
-// Manager abstract logic to deploy and bootstrap a extNetwork.
+// Manager abstract logic to deploy and bootstrap a network.
 type Manager interface {
 	// DeployPublicPortals deploys portals to public chains, like arb-goerli.
 	DeployPublicPortals(ctx context.Context, valSetID uint64, validators []bindings.Validator) error
@@ -110,7 +110,7 @@ func NewManager(testnet types.Testnet, backends backend.Backends, relayerKeyFile
 			backends:    backends,
 		}, nil
 	default:
-		return nil, errors.New("unknown extNetwork")
+		return nil, errors.New("unknown network")
 	}
 }
 


### PR DESCRIPTION
Adds `state_sync=true` to ci manifest.

This highlighted the following issue in our attest module design:
- Snapshot sync restores the consensus chain at a certain height. Both the application state AND cometBFT state.
- That means that for the first block after a snapshot restore, there is no information about the previous block’s app/cometBFT state. 
- This is a problem for our current attest module logic, since we rely on “previous block validator set”.
- Which is not available immediately after a restore.

Solution:
- Just use current validator set
- Only drawback is that last votes from outgoing validators will be dropped
- This shouldn’t be a problem, unless validators get evicted from the set very regularly.

Considered solutions:
- Track previous validator set
- We manually keep track of the previous validator set in our app state
- On restore, it will be there
- (maybe staking keeper can be wrangled to do this?)

task: none