### PR TITLE
chore(docs): fix style search modal

### DIFF
--- a/docs/site/src/css/custom.css
+++ b/docs/site/src/css/custom.css
@@ -20,7 +20,7 @@
   --ifm-color-primary-light: #3e88ff;
   --ifm-color-primary-lighter: #6ca5ff;
   --ifm-color-primary-lightest: #93bdff;
-  --ifm-color-secondary: #ffffff;
+  --ifm-color-secondary: #f1f4f9;
   --ifm-color-gray-200: #93bdff;
   --ifm-code-font-size: 85%;
   --ifm-heading-color: #003b99;
@@ -52,7 +52,7 @@
   --docsearch-muted-color: var(--ifm-color-secondary-darkest);
   --docsearch-container-background: rgba(94, 100, 112, 0.7);
   /* Modal */
-  --docsearch-modal-background: var(--navbar-color);
+  --docsearch-modal-background: var(--ifm-navbar-background-color);
   /* Search box */
   --docsearch-searchbox-background: var(--ifm-color-secondary);
   --docsearch-searchbox-focus-background: var(--ifm-color-white);
@@ -69,7 +69,7 @@
   --docsearch-muted-color: var(--ifm-color-secondary-darkest);
   --docsearch-container-background: rgba(47, 55, 69, 0.7);
   /* Modal */
-  --docsearch-modal-background: var(--navbar-color);
+  --docsearch-modal-background: var(--ifm-navbar-background-color);
   /* Search box */
   --docsearch-searchbox-background: var(--ifm-color-secondary);
   --docsearch-searchbox-focus-background: var(--ifm-color-black);


### PR DESCRIPTION
Fix the modal color which used to be transparent, and the search bar background color for light mode

task: none
