### PR TITLE
fix(e2e): remove storage.tsdb.path flag

### DIFF
--- a/test/e2e/docker/compose.yaml.tmpl
+++ b/test/e2e/docker/compose.yaml.tmpl
@@ -148,7 +148,6 @@ services:
     image: prom/prometheus:latest
     command:
       - --config.file=/etc/prometheus/prometheus.yml
-      - --storage.tsdb.path=/prometheus
       - --web.console.libraries=/usr/share/prometheus/console_libraries
       - --web.console.templates=/usr/share/prometheus/consoles
       - --enable-feature=exemplar-storage

--- a/test/e2e/docker/testdata/TestComposeTemplate_image_tag_7d1ae53.golden
+++ b/test/e2e/docker/testdata/TestComposeTemplate_image_tag_7d1ae53.golden
@@ -153,7 +153,6 @@ services:
     image: prom/prometheus:latest
     command:
       - --config.file=/etc/prometheus/prometheus.yml
-      - --storage.tsdb.path=/prometheus
       - --web.console.libraries=/usr/share/prometheus/console_libraries
       - --web.console.templates=/usr/share/prometheus/consoles
       - --enable-feature=exemplar-storage

--- a/test/e2e/docker/testdata/TestComposeTemplate_image_tag_main.golden
+++ b/test/e2e/docker/testdata/TestComposeTemplate_image_tag_main.golden
@@ -153,7 +153,6 @@ services:
     image: prom/prometheus:latest
     command:
       - --config.file=/etc/prometheus/prometheus.yml
-      - --storage.tsdb.path=/prometheus
       - --web.console.libraries=/usr/share/prometheus/console_libraries
       - --web.console.templates=/usr/share/prometheus/consoles
       - --enable-feature=exemplar-storage


### PR DESCRIPTION
This PR fixes the e2e deployment command. In my previous PR I forgot to remove on flag from the prometheus docker compose yaml. 

task: none
