### PR TITLE
chore(docs): add clarifying comment

### DIFF
--- a/docs/site/docs/develop/introduction.md
+++ b/docs/site/docs/develop/introduction.md
@@ -18,7 +18,7 @@ When receiving an `xcall`, you can read its context through the current `xmsg`.
 
 ```solidity
 omni.xmsg().sourceChainId // where this xcall came from
-omni.xmsg().sender        // who sent it
+omni.xmsg().sender        // who sent it (msg.sender of the source xcall)
 ```
 
 <br />


### PR DESCRIPTION
Clarify xmsg.sender as the msg.sender of the source xcall

task: none