### PR TITLE
feat(halo/config): support snapshot keep recent flag

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -76,6 +76,10 @@
       "path": "detect_secrets.filters.allowlist.is_line_allowlisted"
     },
     {
+      "path": "detect_secrets.filters.common.is_baseline_file",
+      "filename": ".secrets.baseline"
+    },
+    {
       "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
       "min_level": 2
     },
@@ -516,14 +520,14 @@
         "filename": "test/e2e/app/setup.go",
         "hashed_secret": "55abc9109d5ea8a77be16bf3c76b4b199b524b12",
         "is_verified": false,
-        "line_number": 387
+        "line_number": 388
       },
       {
         "type": "Secret Keyword",
         "filename": "test/e2e/app/setup.go",
         "hashed_secret": "da57af224108e98e24d1e2a86221121990fa6478",
         "is_verified": false,
-        "line_number": 412
+        "line_number": 413
       }
     ],
     "test/e2e/app/static/geth-genesis.json": [
@@ -777,5 +781,5 @@
       }
     ]
   },
-  "generated_at": "2024-02-27T12:20:59Z"
+  "generated_at": "2024-02-28T07:18:07Z"
 }

--- a/halo/app/start.go
+++ b/halo/app/start.go
@@ -223,8 +223,7 @@ func makeBaseAppOpts(cfg Config) ([]func(*baseapp.BaseApp), error) {
 		return nil, err
 	}
 
-	const snapshotCount = 4
-	snapshotOptions := snapshottypes.NewSnapshotOptions(cfg.SnapshotInterval, snapshotCount)
+	snapshotOptions := snapshottypes.NewSnapshotOptions(cfg.SnapshotInterval, uint32(cfg.SnapshotKeepRecent))
 
 	return []func(*baseapp.BaseApp){
 		baseapp.SetChainID(chainID),

--- a/halo/cmd/flags.go
+++ b/halo/cmd/flags.go
@@ -10,7 +10,8 @@ import (
 func bindRunFlags(flags *pflag.FlagSet, cfg *halocfg.Config) {
 	libcmd.BindHomeFlag(flags, &cfg.HomeDir)
 	flags.StringVar(&cfg.EngineJWTFile, "engine-jwt-file", cfg.EngineJWTFile, "The path to the Engine API JWT file")
-	flags.Uint64Var(&cfg.SnapshotInterval, "snapshot-interval", cfg.SnapshotInterval, "The interval (in blocks) at which to create snapshots")
+	flags.Uint64Var(&cfg.SnapshotInterval, "snapshot-interval", cfg.SnapshotInterval, "State sync snapshot interval")
+	flags.Uint64Var(&cfg.SnapshotKeepRecent, "snapshot-keep-recent", cfg.SnapshotKeepRecent, "State sync snapshot to keep")
 	flags.Uint64Var(&cfg.MinRetainBlocks, "min-retain-blocks", cfg.MinRetainBlocks, "Minimum block height offset during ABCI commit to prune CometBFT blocks")
 	flags.StringVar(&cfg.BackendType, "app-db-backend", cfg.BackendType, "The type of database for application and snapshots databases")
 	flags.StringVar(&cfg.PruningOption, "pruning", cfg.PruningOption, "Pruning strategy (default|nothing|everything)")

--- a/halo/cmd/testdata/TestCLIReference_run.golden
+++ b/halo/cmd/testdata/TestCLIReference_run.golden
@@ -4,15 +4,16 @@ Usage:
   halo run [flags]
 
 Flags:
-      --app-db-backend string      The type of database for application and snapshots databases (default "goleveldb")
-      --engine-jwt-file string     The path to the Engine API JWT file
-      --evm-build-delay duration   Minimum delay between triggering and fetching a EVM payload build (default 600ms)
-      --evm-build-optimistic       Enables optimistic building of EVM payloads on previous block finalize (default true)
-  -h, --help                       help for run
-      --home string                The application home directory containing config and data (default "./halo")
-      --log-color string           Log color (only applicable to console format); auto, force, disable (default "auto")
-      --log-format string          Log format; console, json (default "console")
-      --log-level string           Log level; debug, info, warn, error (default "info")
-      --min-retain-blocks uint     Minimum block height offset during ABCI commit to prune CometBFT blocks
-      --pruning string             Pruning strategy (default|nothing|everything) (default "nothing")
-      --snapshot-interval uint     The interval (in blocks) at which to create snapshots (default 1000)
+      --app-db-backend string       The type of database for application and snapshots databases (default "goleveldb")
+      --engine-jwt-file string      The path to the Engine API JWT file
+      --evm-build-delay duration    Minimum delay between triggering and fetching a EVM payload build (default 600ms)
+      --evm-build-optimistic        Enables optimistic building of EVM payloads on previous block finalize (default true)
+  -h, --help                        help for run
+      --home string                 The application home directory containing config and data (default "./halo")
+      --log-color string            Log color (only applicable to console format); auto, force, disable (default "auto")
+      --log-format string           Log format; console, json (default "console")
+      --log-level string            Log level; debug, info, warn, error (default "info")
+      --min-retain-blocks uint      Minimum block height offset during ABCI commit to prune CometBFT blocks
+      --pruning string              Pruning strategy (default|nothing|everything) (default "nothing")
+      --snapshot-interval uint      State sync snapshot interval (default 1000)
+      --snapshot-keep-recent uint   State sync snapshot to keep (default 2)

--- a/halo/cmd/testdata/TestRunCmd_defaults.golden
+++ b/halo/cmd/testdata/TestRunCmd_defaults.golden
@@ -2,6 +2,7 @@
  "HomeDir": "./halo",
  "EngineJWTFile": "",
  "SnapshotInterval": 1000,
+ "SnapshotKeepRecent": 2,
  "BackendType": "goleveldb",
  "MinRetainBlocks": 0,
  "PruningOption": "nothing",

--- a/halo/cmd/testdata/TestRunCmd_flags.golden
+++ b/halo/cmd/testdata/TestRunCmd_flags.golden
@@ -2,6 +2,7 @@
  "HomeDir": "foo",
  "EngineJWTFile": "bar",
  "SnapshotInterval": 1000,
+ "SnapshotKeepRecent": 2,
  "BackendType": "goleveldb",
  "MinRetainBlocks": 0,
  "PruningOption": "nothing",

--- a/halo/cmd/testdata/TestRunCmd_json_files.golden
+++ b/halo/cmd/testdata/TestRunCmd_json_files.golden
@@ -2,6 +2,7 @@
  "HomeDir": "testinput/input2",
  "EngineJWTFile": "jwt.json",
  "SnapshotInterval": 123,
+ "SnapshotKeepRecent": 2,
  "BackendType": "goleveldb",
  "MinRetainBlocks": 0,
  "PruningOption": "nothing",

--- a/halo/cmd/testdata/TestRunCmd_toml_files.golden
+++ b/halo/cmd/testdata/TestRunCmd_toml_files.golden
@@ -2,6 +2,7 @@
  "HomeDir": "testinput/input1",
  "EngineJWTFile": "jwt.toml",
  "SnapshotInterval": 999,
+ "SnapshotKeepRecent": 2,
  "BackendType": "goleveldb",
  "MinRetainBlocks": 0,
  "PruningOption": "nothing",

--- a/halo/config/config.go
+++ b/halo/config/config.go
@@ -25,9 +25,10 @@ const (
 	networkFile     = "network.json"
 	attestStateFile = "xattestations_state.json"
 
-	DefaultHomeDir          = "./halo" // Defaults to "halo" in current directory
-	defaultSnapshotInterval = 1000     // Roughly once an hour (given 3s blocks)
-	defaultMinRetainBlocks  = 0        // Retain all blocks
+	DefaultHomeDir            = "./halo" // Defaults to "halo" in current directory
+	defaultSnapshotInterval   = 1000     // Roughly once an hour (given 3s blocks)
+	defaultSnapshotKeepRecent = 2
+	defaultMinRetainBlocks    = 0 // Retain all blocks
 
 	defaultPruningOption      = pruningtypes.PruningOptionNothing // Prune nothing
 	defaultDBBackend          = db.GoLevelDBBackend
@@ -41,6 +42,7 @@ func DefaultConfig() Config {
 		HomeDir:            DefaultHomeDir,
 		EngineJWTFile:      "", // No default
 		SnapshotInterval:   defaultSnapshotInterval,
+		SnapshotKeepRecent: defaultSnapshotKeepRecent,
 		BackendType:        string(defaultDBBackend),
 		MinRetainBlocks:    defaultMinRetainBlocks,
 		PruningOption:      defaultPruningOption,
@@ -54,6 +56,7 @@ type Config struct {
 	HomeDir            string
 	EngineJWTFile      string
 	SnapshotInterval   uint64 // See cosmossdk.io/store/snapshots/types/options.go
+	SnapshotKeepRecent uint64 // See cosmossdk.io/store/snapshots/types/options.go
 	BackendType        string // See cosmos-db/db.go
 	MinRetainBlocks    uint64
 	PruningOption      string // See cosmossdk.io/store/pruning/types/options.go

--- a/halo/config/config.toml.tmpl
+++ b/halo/config/config.toml.tmpl
@@ -17,6 +17,9 @@ engine-jwt-file = "{{ .EngineJWTFile }}"
 # 0 disables state snapshots.
 snapshot-interval = {{ .SnapshotInterval }}
 
+# snapshot-keep-recent specifies the number of recent snapshots to keep and serve (0 to keep all).
+snapshot-keep-recent = {{ .SnapshotKeepRecent }}
+
 # MinRetainBlocks defines the minimum block height offset from the current
 # block being committed, such that all blocks past this offset are pruned
 # from CometBFT. It is used as part of the process of determining the

--- a/halo/config/testdata/default_halo.toml
+++ b/halo/config/testdata/default_halo.toml
@@ -17,6 +17,9 @@ engine-jwt-file = ""
 # 0 disables state snapshots.
 snapshot-interval = 1000
 
+# snapshot-keep-recent specifies the number of recent snapshots to keep and serve (0 to keep all).
+snapshot-keep-recent = 2
+
 # MinRetainBlocks defines the minimum block height offset from the current
 # block being committed, such that all blocks past this offset are pruned
 # from CometBFT. It is used as part of the process of determining the

--- a/test/e2e/app/setup.go
+++ b/test/e2e/app/setup.go
@@ -310,7 +310,8 @@ func writeHaloConfig(nodeDir string, logCfg log.Config, testCfg bool) error {
 	cfg.HomeDir = nodeDir
 	cfg.EngineJWTFile = "/geth/jwtsecret" // As per docker-compose mount
 	if testCfg {
-		cfg.SnapshotInterval = 1 // Write snapshots each block in e2e tests
+		cfg.SnapshotInterval = 1   // Write snapshots each block in e2e tests
+		cfg.SnapshotKeepRecent = 0 // Keep all snapshots in e2e tests
 	}
 
 	return halocfg.WriteConfigTOML(cfg, logCfg)


### PR DESCRIPTION
Adds a `--snapshot-keep-recent` flag to halo to configure the number of snapshots to keep on disk.

Disable snapshot pruning in e2e tests to avoid [flapping](https://github.com/omni-network/omni/actions/runs/8073387873/job/22057172343) test if restoring a snapshot is slow (due to network blips).

task: none