### PR TITLE
chore(lib/provider): add fetch error metrics to providers

### DIFF
--- a/halo/attest/voter/metrics.go
+++ b/halo/attest/voter/metrics.go
@@ -10,7 +10,7 @@ var (
 		Namespace: "halo",
 		Subsystem: "voter",
 		Name:      "create_lag_seconds",
-		Help: "Latest lag between attestation creation and xblock timestamp (in seconds) per source chain. " +
+		Help: "Latest lag between vote creation and xblock timestamp (in seconds) per source chain. " +
 			"Alert if too high.",
 	}, []string{"chain"})
 
@@ -18,27 +18,34 @@ var (
 		Namespace: "halo",
 		Subsystem: "voter",
 		Name:      "create_height",
-		Help:      "Latest created attestation height per source chain. Alert if not growing.",
+		Help:      "Latest created vote height per source chain. Alert if not growing.",
 	}, []string{"chain"})
 
 	commitHeight = promauto.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: "halo",
 		Subsystem: "voter",
 		Name:      "commit_height",
-		Help:      "Latest committed attestation height per source chain. Alert if not growing.",
+		Help:      "Latest committed vote height per source chain. Alert if not growing.",
 	}, []string{"chain"})
 
 	availableCount = promauto.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: "halo",
 		Subsystem: "voter",
-		Name:      "available_attestations",
-		Help:      "Current number of available attestations per source chain. Alert if growing.",
+		Name:      "available_votes",
+		Help:      "Current number of available votes per source chain. Alert if growing.",
 	}, []string{"chain"})
 
 	proposedCount = promauto.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: "halo",
 		Subsystem: "voter",
-		Name:      "proposed_attestations",
-		Help:      "Current number of proposed attestations per source chain. Alert if growing.",
+		Name:      "proposed_votes",
+		Help:      "Current number of proposed votes per source chain. Alert if growing.",
+	}, []string{"chain"})
+
+	trimTotal = promauto.NewCounterVec(prometheus.CounterOpts{
+		Namespace: "halo",
+		Subsystem: "voter",
+		Name:      "trim_total",
+		Help:      "Total number of votes trimmed per source chain.",
 	}, []string{"chain"})
 )

--- a/halo/attest/voter/voter.go
+++ b/halo/attest/voter/voter.go
@@ -231,7 +231,8 @@ func (a *Voter) TrimBehind(thresholds map[uint64]uint64) int {
 	for _, vote := range a.available {
 		threshold, ok := thresholds[vote.BlockHeader.ChainId]
 		if ok && vote.BlockHeader.Height < threshold {
-			continue // Skip
+			trimTotal.WithLabelValues(a.chains[vote.BlockHeader.ChainId]).Inc()
+			continue // Skip/Trim
 		}
 		stillAvailable = append(stillAvailable, vote) // Retain all others
 	}

--- a/lib/cchain/provider/metrics.go
+++ b/lib/cchain/provider/metrics.go
@@ -13,6 +13,13 @@ var (
 		Help:      "Total number of callback errors per worker per source chain. Alert if growing.",
 	}, []string{"worker", "chain"})
 
+	fetchErrTotal = promauto.NewCounterVec(prometheus.CounterOpts{
+		Namespace: "lib",
+		Subsystem: "cprovider",
+		Name:      "fetch_error_total",
+		Help:      "Total number of fetch errors per worker per source chain. Alert if growing.",
+	}, []string{"worker", "chain"})
+
 	streamHeight = promauto.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: "lib",
 		Subsystem: "cprovider",

--- a/lib/cchain/provider/provider.go
+++ b/lib/cchain/provider/provider.go
@@ -73,6 +73,7 @@ func (p Provider) Subscribe(in context.Context, srcChainID uint64, height uint64
 				return // Don't backoff or log on ctx cancel, just return.
 			} else if err != nil {
 				log.Warn(ctx, "Failed fetching attestation; will retry", err, "height", height)
+				fetchErrTotal.WithLabelValues(workerName, srcChain).Inc()
 				backoff()
 
 				continue

--- a/lib/xchain/provider/metrics.go
+++ b/lib/xchain/provider/metrics.go
@@ -13,6 +13,13 @@ var (
 		Help:      "Total number of callback errors per source chain. Alert if growing.",
 	}, []string{"chain"})
 
+	fetchErrTotal = promauto.NewCounterVec(prometheus.CounterOpts{
+		Namespace: "lib",
+		Subsystem: "xprovider",
+		Name:      "fetch_error_total",
+		Help:      "Total number of fetch errors per source chain. Alert if growing.",
+	}, []string{"chain"})
+
 	streamHeight = promauto.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: "lib",
 		Subsystem: "xprovider",


### PR DESCRIPTION
Adds `*_fetch_error_total` metrics to xprovider and cprovider. Align implementations so they look the same.

task: none