### PR TITLE
chore(relayer): improve relayer metrics

### DIFF
--- a/test/e2e/app/definition.go
+++ b/test/e2e/app/definition.go
@@ -55,6 +55,7 @@ func DefaultDefinitionConfig() DefinitionConfig {
 // Definition defines a e2e network. All (sub)commands of the e2e cli requires a definition operate.
 // Armed with a definition, a e2e network can be deployed, started, tested, stopped, etc.
 type Definition struct {
+	Manifest types.Manifest
 	Testnet  types.Testnet // Note that testnet is the cometBFT term.
 	Infra    types.InfraProvider
 	Netman   netman.Manager
@@ -106,6 +107,7 @@ func MakeDefinition(cfg DefinitionConfig) (Definition, error) {
 	}
 
 	return Definition{
+		Manifest: manifest,
 		Testnet:  testnet,
 		Infra:    infp,
 		Backends: backends,

--- a/test/e2e/app/test.go
+++ b/test/e2e/app/test.go
@@ -2,6 +2,7 @@ package app
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"path/filepath"
 
@@ -72,7 +73,7 @@ func Test(ctx context.Context, def Definition, deployInfo types.DeployInfos, ver
 		"INFRASTRUCTURE_FILE", infd.Path,
 		"E2E_DEPLOY_INFO", deployInfoFile)
 
-	args := []string{"go", "test", "-timeout", "60s", "-count", "1"}
+	args := []string{"go", "test", "-timeout", "60s", "-count", "1", "-slow", fmt.Sprint(def.Manifest.SlowTests)}
 	if verbose {
 		args = append(args, "-v")
 	}

--- a/test/e2e/manifests/simple.toml
+++ b/test/e2e/manifests/simple.toml
@@ -1,6 +1,7 @@
 network = "devnet"
 anvil_chains = ["mock_rollup", "mock_l1"]
 avs_target = "mock_l1"
+slow_tests = true
 
 [node.validator01]
 [node.validator02]

--- a/test/e2e/tests/e2e_test.go
+++ b/test/e2e/tests/e2e_test.go
@@ -25,15 +25,19 @@ import (
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
 
+	flag "github.com/spf13/pflag"
 	"github.com/stretchr/testify/require"
 )
 
-// This can be used to manually specify a testnet manifest and/or node to
-// run tests against. The testnet must have been started by the runner first.
-// func init() {
-//	os.Setenv("E2E_MANIFEST", "networks/ci.toml")
-//	os.Setenv("E2E_NODE", "validator01")
-//}
+//nolint:gochecknoglobals // Tests flags need to use globals.
+var slow = flag.Bool("slow", false, "run slow tests")
+
+func SkipUnlessSlow(t *testing.T) {
+	t.Helper()
+	if !*slow {
+		t.Skip("skipping slow test, since --slow=false")
+	}
+}
 
 const (
 	EnvInfraType     = "INFRASTRUCTURE_TYPE"

--- a/test/e2e/tests/eigen_test.go
+++ b/test/e2e/tests/eigen_test.go
@@ -54,6 +54,7 @@ const (
 )
 
 func TestEigenAndOmniAVS(t *testing.T) {
+	SkipUnlessSlow(t)
 	t.Parallel()
 	testAVS(t, func(t *testing.T, avs AVS, deployInfo map[types.ContractName]types.DeployInfo) {
 		t.Helper()

--- a/test/e2e/types/manifest.go
+++ b/test/e2e/types/manifest.go
@@ -22,6 +22,9 @@ type Manifest struct {
 
 	// MultiOmniEVMs defines whether to deploy one or multiple Omni EVMs.
 	MultiOmniEVMs bool `toml:"multi_omni_evms"`
+
+	// SlowTests defines whether to run slow tests (e.g. tests/eigen_tests.go)
+	SlowTests bool `toml:"slow_tests"`
 }
 
 // OmniEVMs returns the names Omni EVMs to deploy.


### PR DESCRIPTION
Improve relayer metrics:
- Query in correct order (from back to front)
- Instrument metrics atomically.
- Instrument `xfinal` head which is the `FinalisationStrategy` height.

Also add `slow_tests` flag to e2e manifest and only run slow AVS tests in `simple` manifest.

task: none
