### PR TITLE
ci(e2e): include anvil chain in staging

### DIFF
--- a/test/e2e/manifests/staging.toml
+++ b/test/e2e/manifests/staging.toml
@@ -1,5 +1,6 @@
 network = "staging"
 public_chains = ["arb_goerli", "goerli"]
+anvil_chains = ["chain_a"]
 avs_target = "goerli"
 multi_omni_evms = true
 prometheus = true


### PR DESCRIPTION
Include anvil chain in staging, chain_a. It will run on vm3.

task: none

