### PR TITLE
ci(e2e): run single devnet1 e2e test in PRs

### DIFF
--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -19,3 +19,5 @@ jobs:
     uses: ./.github/workflows/golangci-lint.yml
   sol-tests:
     uses: ./.github/workflows/soltest.yml
+  e2e-tests:
+    uses: ./.github/workflows/pr-e2etest.yml

--- a/.github/workflows/pr-e2etest.yml
+++ b/.github/workflows/pr-e2etest.yml
@@ -1,0 +1,46 @@
+name: PR e2e test
+
+on:
+  workflow_call:
+
+jobs:
+  pr_e2e_tests:
+    runs-on: namespace-profile-default
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v4
+      - name: Install Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: 'stable'
+
+      - name: Build halo and relayer binaries
+        uses: goreleaser/goreleaser-action@v5
+        env:
+          GOOS: linux
+        with:
+          version: latest
+          args: build --single-target --snapshot --clean --id=halo --id=relayer
+
+      - name: Build halo image
+        run: |
+          cd dist/halo_linux_amd64_v1
+          docker build -f "../../halo/Dockerfile" . -t "omniops/halo:${GITHUB_SHA::7}"
+
+      - name: Build relayer image
+        run: |
+          cd dist/relayer_linux_amd64_v1
+          docker build -f "../../relayer/Dockerfile" . -t "omniops/relayer:${GITHUB_SHA::7}"
+
+      - name: Run devnet1 e2e test
+        run: |
+          go install github.com/omni-network/omni/test/e2e
+          cd test/e2e && ./run-multiple.sh manifests/devnet1.toml
+
+      - name: Upload failed logs
+        uses: actions/upload-artifact@v4
+        if: failure()
+        with:
+          name: failed-logs
+          path: test/e2e/failed-logs.txt
+          retention-days: 3


### PR DESCRIPTION
Enables running a single devnet1 e2e test in PRs. It also fast-builds the halo and relayer images locally (no pushing to dockerhub). 

This is a test. We can disable it if too slow or resource heavy.

task: none