### PR TITLE
fix(e2e): fix missing anvil finalisation strategy

### DIFF
--- a/lib/ethclient/ethclient.go
+++ b/lib/ethclient/ethclient.go
@@ -20,6 +20,23 @@ func (h HeadType) String() string {
 	return string(h)
 }
 
+func (h HeadType) Verify() error {
+	if !allHeadTypes[h] {
+		return errors.New("invalid head type", "head", h)
+	}
+
+	return nil
+}
+
+//nolint:gochecknoglobals // Static mappings
+var allHeadTypes = map[HeadType]bool{
+	HeadLatest:    true,
+	HeadEarliest:  true,
+	HeadPending:   true,
+	HeadSafe:      true,
+	HeadFinalized: true,
+}
+
 const (
 	HeadLatest    HeadType = "latest"
 	HeadEarliest  HeadType = "earliest"

--- a/lib/netconf/netconf.go
+++ b/lib/netconf/netconf.go
@@ -96,6 +96,20 @@ func (n Network) Chain(id uint64) (Chain, bool) {
 // it, like zkEVM chains which would need a much more involved strategy.
 type FinalizationStrat string
 
+func (h FinalizationStrat) Verify() error {
+	if !allStrats[h] {
+		return errors.New("invalid finalization strategy", "start", h)
+	}
+
+	return nil
+}
+
+//nolint:gochecknoglobals // Static mappings
+var allStrats = map[FinalizationStrat]bool{
+	StratFinalized: true,
+	StartLatest:    true,
+}
+
 const (
 	StratFinalized = FinalizationStrat(ethclient.HeadFinalized)
 	StartLatest    = FinalizationStrat(ethclient.HeadLatest)

--- a/test/e2e/app/definition.go
+++ b/test/e2e/app/definition.go
@@ -326,12 +326,13 @@ func externalNetwork(testnet types.Testnet, deployInfo map[types.EVMChain]netman
 	// Add all anvil chains
 	for _, anvil := range testnet.AnvilChains {
 		chains = append(chains, netconf.Chain{
-			ID:            anvil.Chain.ID,
-			Name:          anvil.Chain.Name,
-			RPCURL:        anvil.ExternalRPC,
-			PortalAddress: deployInfo[anvil.Chain].PortalAddress.Hex(),
-			DeployHeight:  deployInfo[anvil.Chain].DeployHeight,
-			BlockPeriod:   anvil.Chain.BlockPeriod,
+			ID:                anvil.Chain.ID,
+			Name:              anvil.Chain.Name,
+			RPCURL:            anvil.ExternalRPC,
+			PortalAddress:     deployInfo[anvil.Chain].PortalAddress.Hex(),
+			DeployHeight:      deployInfo[anvil.Chain].DeployHeight,
+			BlockPeriod:       anvil.Chain.BlockPeriod,
+			FinalizationStrat: anvil.Chain.FinalizationStrat,
 		})
 	}
 
@@ -346,6 +347,12 @@ func externalNetwork(testnet types.Testnet, deployInfo map[types.EVMChain]netman
 			BlockPeriod:       public.Chain.BlockPeriod,
 			FinalizationStrat: public.Chain.FinalizationStrat,
 		})
+	}
+
+	for _, chain := range chains {
+		if err := chain.FinalizationStrat.Verify(); err != nil {
+			panic(err) // Ok to panic since this e2e and is build-time issue.
+		}
 	}
 
 	return netconf.Network{


### PR DESCRIPTION
Anvil chains didn't have a finalisation strategy in staging. Not sure why this wasn't caught in e2e, need to confirm.

task: none