### PR TITLE
chore(ci): push e2e logs to Loki

### DIFF
--- a/.github/workflows/e2etest.yml
+++ b/.github/workflows/e2etest.yml
@@ -22,3 +22,12 @@ jobs:
           name: failed-logs
           path: test/e2e/failed-logs.txt
           retention-days: 3
+
+      - name: e2e-logs
+        if: failure()
+        uses: metrico/loki-action@V3.1
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          endpoint: ${{ secrets.LOGQL_ENDPOINT }}
+          username: ${{ secrets.LOGQL_USER }}
+          password: ${{ secrets.LOGQL_PASS }}

--- a/.github/workflows/pr-e2etest.yml
+++ b/.github/workflows/pr-e2etest.yml
@@ -9,50 +9,38 @@ jobs:
     steps:
       - name: Check out the repo
         uses: actions/checkout@v4
-      # - name: Install Go
-      #   uses: actions/setup-go@v5
-      #   with:
-      #     go-version: 'stable'
-
-      # - name: Build halo and relayer binaries
-      #   uses: goreleaser/goreleaser-action@v5
-      #   env:
-      #     GOOS: linux
-      #   with:
-      #     version: latest
-      #     args: build --single-target --snapshot --clean --id=halo --id=relayer
-
-      # - name: Build halo image
-      #   run: |
-      #     cd dist/halo_linux_amd64_v1
-      #     docker build -f "../../halo/Dockerfile" . -t "omniops/halo:${GITHUB_SHA::7}"
-
-      # - name: Build relayer image
-      #   run: |
-      #     cd dist/relayer_linux_amd64_v1
-      #     docker build -f "../../relayer/Dockerfile" . -t "omniops/relayer:${GITHUB_SHA::7}"
-
-      # - name: Run devnet1 e2e test
-      #   run: |
-      #     go install github.com/omni-network/omni/test/e2e
-      #     cd test/e2e && ./run-multiple.sh manifests/devnet1.toml
-
-      # - name: Upload failed logs
-      #   uses: actions/upload-artifact@v4
-      #   if: failure()
-      #   with:
-      #     name: failed-logs
-      #     path: test/e2e/failed-logs.txt
-      #     retention-days: 3
-
-      - name: build
-        run: this-will-fail
-
-      - name: loki-logs
-        if: failure()
-        uses: metrico/loki-action@V3.1
+      - name: Install Go
+        uses: actions/setup-go@v5
         with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-          endpoint: ${{ secrets.LOGQL_ENDPOINT }}
-          username: ${{ secrets.LOGQL_USER }}
-          password: ${{ secrets.LOGQL_PASS }}
+          go-version: 'stable'
+
+      - name: Build halo and relayer binaries
+        uses: goreleaser/goreleaser-action@v5
+        env:
+          GOOS: linux
+        with:
+          version: latest
+          args: build --single-target --snapshot --clean --id=halo --id=relayer
+
+      - name: Build halo image
+        run: |
+          cd dist/halo_linux_amd64_v1
+          docker build -f "../../halo/Dockerfile" . -t "omniops/halo:${GITHUB_SHA::7}"
+
+      - name: Build relayer image
+        run: |
+          cd dist/relayer_linux_amd64_v1
+          docker build -f "../../relayer/Dockerfile" . -t "omniops/relayer:${GITHUB_SHA::7}"
+
+      - name: Run devnet1 e2e test
+        run: |
+          go install github.com/omni-network/omni/test/e2e
+          cd test/e2e && ./run-multiple.sh manifests/devnet1.toml
+
+      - name: Upload failed logs
+        uses: actions/upload-artifact@v4
+        if: failure()
+        with:
+          name: failed-logs
+          path: test/e2e/failed-logs.txt
+          retention-days: 3

--- a/.github/workflows/pr-e2etest.yml
+++ b/.github/workflows/pr-e2etest.yml
@@ -9,38 +9,50 @@ jobs:
     steps:
       - name: Check out the repo
         uses: actions/checkout@v4
-      - name: Install Go
-        uses: actions/setup-go@v5
-        with:
-          go-version: 'stable'
+      # - name: Install Go
+      #   uses: actions/setup-go@v5
+      #   with:
+      #     go-version: 'stable'
 
-      - name: Build halo and relayer binaries
-        uses: goreleaser/goreleaser-action@v5
-        env:
-          GOOS: linux
-        with:
-          version: latest
-          args: build --single-target --snapshot --clean --id=halo --id=relayer
+      # - name: Build halo and relayer binaries
+      #   uses: goreleaser/goreleaser-action@v5
+      #   env:
+      #     GOOS: linux
+      #   with:
+      #     version: latest
+      #     args: build --single-target --snapshot --clean --id=halo --id=relayer
 
-      - name: Build halo image
-        run: |
-          cd dist/halo_linux_amd64_v1
-          docker build -f "../../halo/Dockerfile" . -t "omniops/halo:${GITHUB_SHA::7}"
+      # - name: Build halo image
+      #   run: |
+      #     cd dist/halo_linux_amd64_v1
+      #     docker build -f "../../halo/Dockerfile" . -t "omniops/halo:${GITHUB_SHA::7}"
 
-      - name: Build relayer image
-        run: |
-          cd dist/relayer_linux_amd64_v1
-          docker build -f "../../relayer/Dockerfile" . -t "omniops/relayer:${GITHUB_SHA::7}"
+      # - name: Build relayer image
+      #   run: |
+      #     cd dist/relayer_linux_amd64_v1
+      #     docker build -f "../../relayer/Dockerfile" . -t "omniops/relayer:${GITHUB_SHA::7}"
 
-      - name: Run devnet1 e2e test
-        run: |
-          go install github.com/omni-network/omni/test/e2e
-          cd test/e2e && ./run-multiple.sh manifests/devnet1.toml
+      # - name: Run devnet1 e2e test
+      #   run: |
+      #     go install github.com/omni-network/omni/test/e2e
+      #     cd test/e2e && ./run-multiple.sh manifests/devnet1.toml
 
-      - name: Upload failed logs
-        uses: actions/upload-artifact@v4
+      # - name: Upload failed logs
+      #   uses: actions/upload-artifact@v4
+      #   if: failure()
+      #   with:
+      #     name: failed-logs
+      #     path: test/e2e/failed-logs.txt
+      #     retention-days: 3
+
+      - name: build
+        run: this-will-fail
+
+      - name: loki-logs
         if: failure()
+        uses: metrico/loki-action@V3.1
         with:
-          name: failed-logs
-          path: test/e2e/failed-logs.txt
-          retention-days: 3
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          endpoint: ${{ secrets.LOGQL_ENDPOINT }}
+          username: ${{ secrets.LOGQL_USER }}
+          password: ${{ secrets.LOGQL_PASS }}


### PR DESCRIPTION
Configure e2e GH actions to push logs to Loki on failure. This is configured only for e2e tests which are run as a result of merge to `main` branch.

task: https://app.asana.com/0/1206208509925075/1206729533969884/f
