### PR TITLE
fix(e2e): fix prometheus scrape configs in staging

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -76,6 +76,10 @@
       "path": "detect_secrets.filters.allowlist.is_line_allowlisted"
     },
     {
+      "path": "detect_secrets.filters.common.is_baseline_file",
+      "filename": ".secrets.baseline"
+    },
+    {
       "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
       "min_level": 2
     },
@@ -478,29 +482,52 @@
         "line_number": 1
       }
     ],
-    "test/e2e/app/prometheus.go": [
+    "test/e2e/app/agent/prometheus.go": [
       {
         "type": "Secret Keyword",
-        "filename": "test/e2e/app/prometheus.go",
+        "filename": "test/e2e/app/agent/prometheus.go",
         "hashed_secret": "647c5465599451a86da22727224e2c2f7eb61e3b",
         "is_verified": false,
-        "line_number": 74
+        "line_number": 78
+      }
+    ],
+    "test/e2e/app/agent/prometheus_internal_test.go": [
+      {
+        "type": "Secret Keyword",
+        "filename": "test/e2e/app/agent/prometheus_internal_test.go",
+        "hashed_secret": "7cb6efb98ba5972a9b5090dc2e517fe14d12cb04",
+        "is_verified": false,
+        "line_number": 36
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "test/e2e/app/agent/prometheus_internal_test.go",
+        "hashed_secret": "5ffe533b830f08a0326348a9160afafc8ada44db",
+        "is_verified": false,
+        "line_number": 45
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "test/e2e/app/agent/prometheus_internal_test.go",
+        "hashed_secret": "858b02bf93798fdd02736ef7ec278319018d1272",
+        "is_verified": false,
+        "line_number": 68
       }
     ],
     "test/e2e/app/run.go": [
       {
         "type": "Secret Keyword",
         "filename": "test/e2e/app/run.go",
-        "hashed_secret": "376a2a7b52def35209bfa152768c0962d435c80b",
+        "hashed_secret": "7c1a7493a09f09e4669f6b1f03719a2262e7b323",
         "is_verified": false,
-        "line_number": 21
+        "line_number": 22
       },
       {
         "type": "Secret Keyword",
         "filename": "test/e2e/app/run.go",
-        "hashed_secret": "cd4c02f97387f2ac1da2b9ad4ccffa5978d887eb",
+        "hashed_secret": "fe86558143c0bd528f649a153bdc32b8fa90301c",
         "is_verified": false,
-        "line_number": 105
+        "line_number": 106
       }
     ],
     "test/e2e/app/setup.go": [
@@ -509,21 +536,21 @@
         "filename": "test/e2e/app/setup.go",
         "hashed_secret": "7be029054a936fcb1827abd24388a53136be7b64",
         "is_verified": false,
-        "line_number": 120
+        "line_number": 117
       },
       {
         "type": "Secret Keyword",
         "filename": "test/e2e/app/setup.go",
         "hashed_secret": "55abc9109d5ea8a77be16bf3c76b4b199b524b12",
         "is_verified": false,
-        "line_number": 388
+        "line_number": 389
       },
       {
         "type": "Secret Keyword",
         "filename": "test/e2e/app/setup.go",
         "hashed_secret": "da57af224108e98e24d1e2a86221121990fa6478",
         "is_verified": false,
-        "line_number": 413
+        "line_number": 414
       }
     ],
     "test/e2e/app/static/geth-genesis.json": [
@@ -777,5 +804,5 @@
       }
     ]
   },
-  "generated_at": "2024-02-28T14:59:15Z"
+  "generated_at": "2024-03-01T07:39:55Z"
 }

--- a/test/e2e/app/agent/prometheus.yml.tmpl
+++ b/test/e2e/app/agent/prometheus.yml.tmpl
@@ -21,7 +21,8 @@ scrape_configs:
   - job_name: "{{ .JobName }}"
     metrics_path: "{{ .MetricsPath }}"
     static_configs:
-      - targets: [{{ .Targets }}]
+      - targets: [{{ .Targets }}] # {{ .JobName }} targets
         labels:
           network: '{{ $.Network }}'
+          host: '{{ $.Host }}'
 {{ end }}

--- a/test/e2e/app/agent/prometheus_internal_test.go
+++ b/test/e2e/app/agent/prometheus_internal_test.go
@@ -1,0 +1,91 @@
+package agent
+
+import (
+	"context"
+	"testing"
+
+	"github.com/omni-network/omni/lib/netconf"
+	"github.com/omni-network/omni/test/e2e/types"
+	"github.com/omni-network/omni/test/tutil"
+
+	e2e "github.com/cometbft/cometbft/test/e2e/pkg"
+
+	"github.com/stretchr/testify/require"
+)
+
+//go:generate go test . -golden -clean
+
+func TestPromGen(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name         string
+		network      string
+		nodes        []string
+		newNodes     []string
+		newRelayer   bool
+		hostname     string
+		agentSecrets bool
+	}{
+		{
+			name:         "manifest1",
+			network:      netconf.Devnet,
+			nodes:        []string{"validator01", "validator02"},
+			hostname:     "localhost",
+			newNodes:     []string{"validator01"},
+			newRelayer:   false,
+			agentSecrets: false,
+		},
+		{
+			name:         "manifest2",
+			network:      netconf.Staging,
+			nodes:        []string{"validator01", "validator02", "fullnode03"},
+			hostname:     "vm",
+			newNodes:     []string{"fullnode04"},
+			newRelayer:   true,
+			agentSecrets: true,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			ctx := context.Background()
+
+			var nodes []*e2e.Node
+			for _, name := range test.nodes {
+				nodes = append(nodes, &e2e.Node{Name: name})
+			}
+
+			testnet := types.Testnet{
+				Network: test.network,
+				Testnet: &e2e.Testnet{
+					Name:  test.name,
+					Nodes: nodes,
+				},
+			}
+
+			var agentSecrets Secrets
+			if test.agentSecrets {
+				agentSecrets = Secrets{
+					URL:  "https://grafana.com",
+					User: "admin",
+					Pass: "password",
+				}
+			}
+
+			cfg1, err := genPromConfig(ctx, testnet, agentSecrets, test.hostname)
+			require.NoError(t, err)
+
+			cfg2 := ConfigForHost(cfg1, test.hostname+"-2", test.newNodes, test.newRelayer)
+
+			t.Run("gen", func(t *testing.T) {
+				t.Parallel()
+				tutil.RequireGoldenBytes(t, cfg1)
+			})
+
+			t.Run("update", func(t *testing.T) {
+				t.Parallel()
+				tutil.RequireGoldenBytes(t, cfg2)
+			})
+		})
+	}
+}

--- a/test/e2e/app/agent/testdata/TestPromGen_manifest1_gen.golden
+++ b/test/e2e/app/agent/testdata/TestPromGen_manifest1_gen.golden
@@ -1,0 +1,21 @@
+global:
+  scrape_interval: 30s # Set the scrape interval to every 30 seconds.
+  evaluation_interval: 30s # Evaluate rules every 30 seconds.
+
+scrape_configs:
+  - job_name: "relayer"
+    metrics_path: "/metrics"
+    static_configs:
+      - targets: [relayer:26660] # relayer targets
+        labels:
+          network: 'manifest1-localhost'
+          host: 'localhost'
+
+  - job_name: "halo"
+    metrics_path: "/metrics"
+    static_configs:
+      - targets: [validator01:26660,validator02:26660] # halo targets
+        labels:
+          network: 'manifest1-localhost'
+          host: 'localhost'
+

--- a/test/e2e/app/agent/testdata/TestPromGen_manifest1_update.golden
+++ b/test/e2e/app/agent/testdata/TestPromGen_manifest1_update.golden
@@ -1,0 +1,21 @@
+global:
+  scrape_interval: 30s # Set the scrape interval to every 30 seconds.
+  evaluation_interval: 30s # Evaluate rules every 30 seconds.
+
+scrape_configs:
+  - job_name: "relayer"
+    metrics_path: "/metrics"
+    static_configs:
+      - targets: [] # relayer targets
+        labels:
+          network: 'manifest1-localhost'
+          host: 'localhost-2'
+
+  - job_name: "halo"
+    metrics_path: "/metrics"
+    static_configs:
+      - targets: ["validator01:26660"] # halo targets
+        labels:
+          network: 'manifest1-localhost'
+          host: 'localhost-2'
+

--- a/test/e2e/app/agent/testdata/TestPromGen_manifest2_gen.golden
+++ b/test/e2e/app/agent/testdata/TestPromGen_manifest2_gen.golden
@@ -1,0 +1,33 @@
+global:
+  scrape_interval: 30s # Set the scrape interval to every 30 seconds.
+  evaluation_interval: 30s # Evaluate rules every 30 seconds.
+remote_write:
+  - url: https://grafana.com
+    basic_auth:
+      username: admin
+      password: password
+    write_relabel_configs:
+      # Add 'container' label using 'instance without port'
+      - source_labels: [instance]
+        regex: '(.+):(\d+)'
+        target_label: container
+        replacement: '${1}'
+
+
+scrape_configs:
+  - job_name: "relayer"
+    metrics_path: "/metrics"
+    static_configs:
+      - targets: [relayer:26660] # relayer targets
+        labels:
+          network: 'staging'
+          host: 'vm'
+
+  - job_name: "halo"
+    metrics_path: "/metrics"
+    static_configs:
+      - targets: [validator01:26660,validator02:26660,fullnode03:26660] # halo targets
+        labels:
+          network: 'staging'
+          host: 'vm'
+

--- a/test/e2e/app/agent/testdata/TestPromGen_manifest2_update.golden
+++ b/test/e2e/app/agent/testdata/TestPromGen_manifest2_update.golden
@@ -1,0 +1,33 @@
+global:
+  scrape_interval: 30s # Set the scrape interval to every 30 seconds.
+  evaluation_interval: 30s # Evaluate rules every 30 seconds.
+remote_write:
+  - url: https://grafana.com
+    basic_auth:
+      username: admin
+      password: password
+    write_relabel_configs:
+      # Add 'container' label using 'instance without port'
+      - source_labels: [instance]
+        regex: '(.+):(\d+)'
+        target_label: container
+        replacement: '${1}'
+
+
+scrape_configs:
+  - job_name: "relayer"
+    metrics_path: "/metrics"
+    static_configs:
+      - targets: [relayer:26660] # relayer targets
+        labels:
+          network: 'staging'
+          host: 'vm-2'
+
+  - job_name: "halo"
+    metrics_path: "/metrics"
+    static_configs:
+      - targets: ["fullnode04:26660"] # halo targets
+        labels:
+          network: 'staging'
+          host: 'vm-2'
+

--- a/test/e2e/app/run.go
+++ b/test/e2e/app/run.go
@@ -7,6 +7,7 @@ import (
 	"github.com/omni-network/omni/lib/errors"
 	"github.com/omni-network/omni/lib/k1util"
 	"github.com/omni-network/omni/lib/log"
+	"github.com/omni-network/omni/test/e2e/app/agent"
 	"github.com/omni-network/omni/test/e2e/netman/pingpong"
 	"github.com/omni-network/omni/test/e2e/types"
 
@@ -18,16 +19,16 @@ const defaultPingPongN = 1000
 
 func DefaultDeployConfig() DeployConfig {
 	return DeployConfig{
-		PromSecrets: PromSecrets{}, // Empty secrets
-		PingPongN:   defaultPingPongN,
+		AgentSecrets: agent.Secrets{}, // Empty secrets
+		PingPongN:    defaultPingPongN,
 	}
 }
 
 type DeployConfig struct {
-	PromSecrets
-	EigenFile  string
-	PingPongN  uint64
-	testConfig bool // Internal use only (no command line flag).
+	AgentSecrets agent.Secrets
+	EigenFile    string
+	PingPongN    uint64
+	testConfig   bool // Internal use only (no command line flag).
 }
 
 // Deploy a new e2e network. It also starts all services in order to deploy private portals.
@@ -47,7 +48,7 @@ func Deploy(ctx context.Context, def Definition, cfg DeployConfig) (types.Deploy
 		return nil, err
 	}
 
-	if err := Setup(ctx, def, cfg.PromSecrets, cfg.testConfig); err != nil {
+	if err := Setup(ctx, def, cfg.AgentSecrets, cfg.testConfig); err != nil {
 		return nil, err
 	}
 
@@ -99,12 +100,12 @@ func DefaultE2ETestConfig() E2ETestConfig {
 }
 
 // E2ETest runs a full e2e test.
-func E2ETest(ctx context.Context, def Definition, cfg E2ETestConfig, prom PromSecrets) error {
+func E2ETest(ctx context.Context, def Definition, cfg E2ETestConfig, secrets agent.Secrets) error {
 	const pingpongN = 4 // Deploy and start ping pong
 	depCfg := DeployConfig{
-		PromSecrets: prom,
-		PingPongN:   pingpongN,
-		testConfig:  true,
+		AgentSecrets: secrets,
+		PingPongN:    pingpongN,
+		testConfig:   true,
 	}
 
 	deployInfo, err := Deploy(ctx, def, depCfg)
@@ -171,7 +172,7 @@ func E2ETest(ctx context.Context, def Definition, cfg E2ETestConfig, prom PromSe
 // Upgrade generates all local artifacts, but only copies the docker-compose file to the VMs.
 // It them calls docker-compose up.
 func Upgrade(ctx context.Context, def Definition) error {
-	if err := Setup(ctx, def, PromSecrets{}, false); err != nil {
+	if err := Setup(ctx, def, agent.Secrets{}, false); err != nil {
 		return err
 	}
 

--- a/test/e2e/app/setup.go
+++ b/test/e2e/app/setup.go
@@ -20,6 +20,7 @@ import (
 	"github.com/omni-network/omni/lib/log"
 	"github.com/omni-network/omni/lib/netconf"
 	relayapp "github.com/omni-network/omni/relayer/app"
+	"github.com/omni-network/omni/test/e2e/app/agent"
 	"github.com/omni-network/omni/test/e2e/types"
 	"github.com/omni-network/omni/test/e2e/vmcompose"
 
@@ -49,15 +50,11 @@ const (
 )
 
 // Setup sets up the testnet configuration.
-func Setup(ctx context.Context, def Definition, promSecrets PromSecrets, testCfg bool) error {
+func Setup(ctx context.Context, def Definition, agentSecrets agent.Secrets, testCfg bool) error {
 	log.Info(ctx, "Setup testnet", "dir", def.Testnet.Dir)
 
 	if err := os.MkdirAll(def.Testnet.Dir, os.ModePerm); err != nil {
 		return errors.Wrap(err, "mkdir")
-	}
-
-	if err := def.Infra.Setup(); err != nil {
-		return errors.Wrap(err, "setup provider")
 	}
 
 	var vals []crypto.PubKey
@@ -141,9 +138,13 @@ func Setup(ctx context.Context, def Definition, promSecrets PromSecrets, testCfg
 	}
 
 	if def.Testnet.Prometheus {
-		if err := writePrometheusConfig(ctx, def.Testnet, promSecrets); err != nil {
+		if err := agent.WriteConfig(ctx, def.Testnet, agentSecrets); err != nil {
 			return errors.Wrap(err, "write prom config")
 		}
+	}
+
+	if err := def.Infra.Setup(); err != nil {
+		return errors.Wrap(err, "setup provider")
 	}
 
 	return nil

--- a/test/e2e/cmd/cmd.go
+++ b/test/e2e/cmd/cmd.go
@@ -6,6 +6,7 @@ import (
 	libcmd "github.com/omni-network/omni/lib/cmd"
 	"github.com/omni-network/omni/lib/log"
 	"github.com/omni-network/omni/test/e2e/app"
+	"github.com/omni-network/omni/test/e2e/app/agent"
 	"github.com/omni-network/omni/test/e2e/types"
 
 	cmtdocker "github.com/cometbft/cometbft/test/e2e/pkg/infra/docker"
@@ -22,7 +23,7 @@ func New() *cobra.Command {
 	defCfg := app.DefaultDefinitionConfig()
 
 	var def app.Definition
-	var prom app.PromSecrets // Using empty prom secrets for e2e tests.
+	var secrets agent.Secrets
 
 	cmd := libcmd.NewRootCmd("e2e", "e2e network generator and test runner")
 	cmd.PersistentPreRunE = func(cmd *cobra.Command, args []string) error {
@@ -41,14 +42,14 @@ func New() *cobra.Command {
 	}
 
 	bindDefFlags(cmd.PersistentFlags(), &defCfg)
-	bindPromFlags(cmd.PersistentFlags(), &prom)
+	bindPromFlags(cmd.PersistentFlags(), &secrets)
 	log.BindFlags(cmd.PersistentFlags(), &logCfg)
 
 	// Root command runs the full E2E test.
 	e2eTestCfg := app.DefaultE2ETestConfig()
 	bindE2EFlags(cmd.Flags(), &e2eTestCfg)
 	cmd.RunE = func(cmd *cobra.Command, args []string) error {
-		return app.E2ETest(cmd.Context(), def, e2eTestCfg, prom)
+		return app.E2ETest(cmd.Context(), def, e2eTestCfg, secrets)
 	}
 
 	// Add subcommands

--- a/test/e2e/cmd/flags.go
+++ b/test/e2e/cmd/flags.go
@@ -3,6 +3,7 @@ package cmd
 
 import (
 	"github.com/omni-network/omni/test/e2e/app"
+	"github.com/omni-network/omni/test/e2e/app/agent"
 
 	"github.com/spf13/pflag"
 )
@@ -21,14 +22,14 @@ func bindE2EFlags(flags *pflag.FlagSet, cfg *app.E2ETestConfig) {
 	flags.BoolVar(&cfg.Preserve, "preserve", cfg.Preserve, "preserve infrastructure after test")
 }
 
-func bindPromFlags(flags *pflag.FlagSet, cfg *app.PromSecrets) {
+func bindPromFlags(flags *pflag.FlagSet, cfg *agent.Secrets) {
 	flags.StringVar(&cfg.URL, "prom-url", cfg.URL, "prometheus url (only required if prometheus==true)")
 	flags.StringVar(&cfg.User, "prom-user", cfg.User, "prometheus user")
 	flags.StringVar(&cfg.Pass, "prom-password", cfg.Pass, "prometheus password")
 }
 
 func bindDeployFlags(flags *pflag.FlagSet, cfg *app.DeployConfig) {
-	bindPromFlags(flags, &cfg.PromSecrets)
+	bindPromFlags(flags, &cfg.AgentSecrets)
 	flags.StringVar(&cfg.EigenFile, "eigen-file", cfg.EigenFile, "path to json file defining eigenlayer deployments. Defaults to ./e2e/app/static/el_deployments.json")
 	flags.Uint64Var(&cfg.PingPongN, "ping-pong", cfg.PingPongN, "Number of ping pongs messages to send. 0 disables it")
 }


### PR DESCRIPTION
Fixes `vmcompose` infra provider to deploy correct prometheus config that only tries to scrape services that are deployed on each specific host.

Previously, each prometheus tried to scrape all targets, even though they were not present on all hosts. This resulted in "relayer" down alerts.

Also add a "host" label to prometheus metrics so we can differentiate where the metric are coming from.

task: none