### PR TITLE
ci(goreleaser): release omni cli as github archive

### DIFF
--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -19,10 +19,10 @@ jobs:
     uses: ./.github/workflows/golangci-lint.yml
   sol-tests:
       uses: ./.github/workflows/soltest.yml
-  go-releaser:
-    uses: ./.github/workflows/goreleaser.yml
+  release-snapshot:
+    uses: ./.github/workflows/release-snapshot.yml
     needs: [pre-commit, go-tests, go-lint, sol-tests]
     secrets: inherit
   e2e:
     uses: ./.github/workflows/e2etest.yml
-    needs: [go-releaser]
+    needs: [release-snapshot]

--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -1,0 +1,15 @@
+name: ci release
+# continuous integration on git tagged release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write
+
+jobs:
+  release-official:
+    uses: ./.github/workflows/release-official.yml
+    secrets: inherit

--- a/.github/workflows/release-official.yml
+++ b/.github/workflows/release-official.yml
@@ -1,0 +1,26 @@
+name: release official
+# Official releases on tagged commits.
+
+on:
+  workflow_call:
+
+jobs:
+  release-official:
+    runs-on: namespace-profile-default
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: stable
+      - name: Login to Dockerhub container registry
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Build docker images
+        uses: goreleaser/goreleaser-action@v5
+        with:
+          version: latest
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-snapshot.yml
+++ b/.github/workflows/release-snapshot.yml
@@ -1,12 +1,11 @@
-name: go releaser
+name: release snapshot
+# Snapshot releases on push to main.
 
 on:
   workflow_call:
 
-# TODO(corver): Figure out which images to publish and how to do this via goreleaser.
-
 jobs:
-  goreleaser:
+  release-snapshot:
     runs-on: namespace-profile-default
     steps:
       - uses: actions/checkout@v4

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -84,6 +84,14 @@ archives:
       {{- else }}{{ .Arch }}{{ end }}
       {{- if .Arm }}v{{ .Arm }}{{ end }}
 
+release:
+  ids:
+    - omni # Only create release binary artefacts for omni cli.
+  draft: true
+  replace_existing_draft: true
+  prerelease: auto
+  mode: append
+
 changelog:
   sort: asc
   filters:

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -76,10 +76,6 @@
       "path": "detect_secrets.filters.allowlist.is_line_allowlisted"
     },
     {
-      "path": "detect_secrets.filters.common.is_baseline_file",
-      "filename": ".secrets.baseline"
-    },
-    {
       "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
       "min_level": 2
     },
@@ -125,6 +121,15 @@
         "hashed_secret": "3e26d6750975d678acb8fa35a0f69237881576b0",
         "is_verified": false,
         "line_number": 25
+      }
+    ],
+    ".github/workflows/ci-release.yml": [
+      {
+        "type": "Secret Keyword",
+        "filename": ".github/workflows/ci-release.yml",
+        "hashed_secret": "3e26d6750975d678acb8fa35a0f69237881576b0",
+        "is_verified": false,
+        "line_number": 15
       }
     ],
     "cli/cmd/devnet.go": [
@@ -845,5 +850,5 @@
       }
     ]
   },
-  "generated_at": "2024-03-05T10:32:19Z"
+  "generated_at": "2024-03-05T12:41:18Z"
 }

--- a/scripts/install_omni_cli.sh
+++ b/scripts/install_omni_cli.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+set -e
+
+OS=$(uname -s)
+ARCH=$(uname -m)
+URL="https://github.com/omni-network/omni/releases/latest/download/omni_${OS}_${ARCH}.tar.gz"
+TARGET="$HOME/bin/omni"
+
+echo "ℹ️ Downloading omni from $URL"
+echo "ℹ️ Installing omni to $TARGET"
+
+mkdir -p "$(dirname "${TARGET}")"
+
+curl -L -s "$URL" | tar -xz -C "$(dirname "${TARGET}")" omni
+chmod +x "$TARGET"
+
+
+which -s omni || echo "$HOME/bin is not in your PATH. You can add it by running 'export PATH=\$PATH:$HOME/bin'"
+
+echo "✅ omni is now installed: try running 'omni --help' to get started"


### PR DESCRIPTION
Configures goreleaser for official releases on git tags.

task: none