### PR TITLE
refactor(relayer/app): unexport functions

### DIFF
--- a/relayer/app/buffer.go
+++ b/relayer/app/buffer.go
@@ -32,6 +32,7 @@ func newActiveBuffer(chainName string, mempoolLimit int64, sender SendFunc) *act
 	}
 }
 
+// AddInput adds a new submission to the buffer.
 func (b *activeBuffer) AddInput(ctx context.Context, submission xchain.Submission) error {
 	select {
 	case <-ctx.Done():
@@ -44,6 +45,7 @@ func (b *activeBuffer) AddInput(ctx context.Context, submission xchain.Submissio
 	return nil
 }
 
+// Run processes the buffer, sending submissions to the opsender.
 func (b *activeBuffer) Run(ctx context.Context) error {
 	sema := semaphore.NewWeighted(b.mempoolLimit)
 	for {

--- a/relayer/app/buffer_internal_test.go
+++ b/relayer/app/buffer_internal_test.go
@@ -17,7 +17,7 @@ func Test_activeBuffer_AddInput(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
 	defer cancel()
 	limit := int64(5)
-	sender := &mockSender{}
+	sender := &mockBufSender{}
 	buffer := newActiveBuffer("test", limit, sender.Send)
 
 	// Have a reader ready as we are unbuffered and blocking
@@ -36,22 +36,22 @@ func Test_activeBuffer_AddInput(t *testing.T) {
 	}
 }
 
-type mockSender struct {
+type mockBufSender struct {
 	sendChan chan xchain.Submission
 }
 
-func newMockSender() *mockSender {
-	return &mockSender{
+func newMockSender() *mockBufSender {
+	return &mockBufSender{
 		sendChan: make(chan xchain.Submission),
 	}
 }
 
-func (m *mockSender) Send(_ context.Context, sub xchain.Submission) error {
+func (m *mockBufSender) Send(_ context.Context, sub xchain.Submission) error {
 	m.sendChan <- sub
 	return nil
 }
 
-func (m *mockSender) Next() xchain.Submission {
+func (m *mockBufSender) Next() xchain.Submission {
 	return <-m.sendChan
 }
 

--- a/relayer/app/cursors.go
+++ b/relayer/app/cursors.go
@@ -44,6 +44,9 @@ func mapByStreamID(msgs []xchain.Msg) map[xchain.StreamID][]xchain.Msg {
 	return m
 }
 
+// filterMsgs filters messages based on offsets for a specific stream.
+// It takes a slice of messages, offsets indexed by stream ID, and the target stream ID,
+// and returns a filtered slice containing only messages with offsets greater than the specified offset.
 func filterMsgs(msgs []xchain.Msg, offsets map[xchain.StreamID]uint64, streamID xchain.StreamID) []xchain.Msg {
 	offset, ok := offsets[streamID]
 	if !ok {
@@ -62,7 +65,10 @@ func filterMsgs(msgs []xchain.Msg, offsets map[xchain.StreamID]uint64, streamID 
 	return res
 }
 
-func FromHeights(cursors []xchain.StreamCursor, destChain netconf.Chain, chains []netconf.Chain,
+// fromHeights calculates the starting heights for streaming from source chains to a destination chain.
+// It takes stream cursors, destination and source chains, and the current state, and returns
+// a map where keys are source chain IDs and values are the starting heights for streaming.
+func fromHeights(cursors []xchain.StreamCursor, destChain netconf.Chain, chains []netconf.Chain,
 	state *State) map[uint64]uint64 {
 	res := make(map[uint64]uint64)
 

--- a/relayer/app/cursors_internal_test.go
+++ b/relayer/app/cursors_internal_test.go
@@ -1,4 +1,4 @@
-package relayer_test
+package relayer
 
 import (
 	"context"
@@ -8,15 +8,14 @@ import (
 	"github.com/omni-network/omni/lib/cchain"
 	"github.com/omni-network/omni/lib/netconf"
 	"github.com/omni-network/omni/lib/xchain"
-	relayer "github.com/omni-network/omni/relayer/app"
 
 	"github.com/stretchr/testify/require"
 )
 
-func Test_FromHeights(t *testing.T) {
+func Test_fromHeights(t *testing.T) {
 	t.Parallel()
 
-	state := relayer.NewEmptyState(filepath.Join(t.TempDir(), "state.json"))
+	state := NewEmptyState(filepath.Join(t.TempDir(), "state.json"))
 	err := state.Persist(4, 1, 300)
 	require.NoError(t, err)
 	err = state.Persist(4, 2, 53)
@@ -27,7 +26,7 @@ func Test_FromHeights(t *testing.T) {
 	type args struct {
 		cursors []xchain.StreamCursor
 		chains  []netconf.Chain
-		state   *relayer.State
+		state   *State
 	}
 	tests := []struct {
 		name string
@@ -41,7 +40,7 @@ func Test_FromHeights(t *testing.T) {
 					{StreamID: xchain.StreamID{SourceChainID: 2, DestChainID: 3}, SourceBlockHeight: 250},
 				},
 				chains: []netconf.Chain{{ID: 1}, {ID: 2}, {ID: 3}},
-				state:  relayer.NewEmptyState(filepath.Join(t.TempDir(), "state.json")),
+				state:  NewEmptyState(filepath.Join(t.TempDir(), "state.json")),
 			}, want: map[uint64]uint64{
 				1: 200,
 				2: 250,
@@ -55,7 +54,7 @@ func Test_FromHeights(t *testing.T) {
 					{StreamID: xchain.StreamID{SourceChainID: 2, DestChainID: 3}, SourceBlockHeight: 100},
 				},
 				chains: []netconf.Chain{{ID: 1}, {ID: 2, DeployHeight: 55}, {ID: 3}},
-				state:  relayer.NewEmptyState(filepath.Join(t.TempDir(), "state.json")),
+				state:  NewEmptyState(filepath.Join(t.TempDir(), "state.json")),
 			}, want: map[uint64]uint64{
 				1: 200,
 				2: 100,
@@ -68,7 +67,7 @@ func Test_FromHeights(t *testing.T) {
 					{StreamID: xchain.StreamID{SourceChainID: 1, DestChainID: 2}, SourceBlockHeight: 200},
 				},
 				chains: []netconf.Chain{{ID: 1}, {ID: 2, DeployHeight: 55}, {ID: 3}},
-				state:  relayer.NewEmptyState(filepath.Join(t.TempDir(), "state.json")),
+				state:  NewEmptyState(filepath.Join(t.TempDir(), "state.json")),
 			}, want: map[uint64]uint64{
 				1: 200,
 				2: 55,
@@ -93,7 +92,7 @@ func Test_FromHeights(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			got := relayer.FromHeights(tt.args.cursors, netconf.Chain{ID: 4}, tt.args.chains, tt.args.state)
+			got := fromHeights(tt.args.cursors, netconf.Chain{ID: 4}, tt.args.chains, tt.args.state)
 			require.Equal(t, tt.want, got)
 		})
 	}

--- a/relayer/app/opsender.go
+++ b/relayer/app/opsender.go
@@ -89,7 +89,7 @@ func (o OpSender) SendTransaction(ctx context.Context, submission xchain.Submiss
 
 	const gasLimit = 1_000_000 // TODO(lazar): make configurable
 
-	txData, err := o.getXSubmitBytes(SubmissionToBinding(submission))
+	txData, err := o.getXSubmitBytes(submissionToBinding(submission))
 	if err != nil {
 		return err
 	}

--- a/relayer/app/state.go
+++ b/relayer/app/state.go
@@ -17,6 +17,7 @@ type State struct {
 	cursors  map[uint64]map[uint64]uint64 // destChainID -> srcChainID -> height
 }
 
+// NewEmptyState creates a new empty state with the given file path.
 func NewEmptyState(filePath string) *State {
 	return &State{
 		filePath: filePath,

--- a/relayer/app/types.go
+++ b/relayer/app/types.go
@@ -23,8 +23,8 @@ type CreateFunc func(streamUpdate StreamUpdate) ([]xchain.Submission, error)
 // SendFunc sends a submission to the destination chain by invoking "xsubmit" on portal contract.
 type SendFunc func(ctx context.Context, submission xchain.Submission) error
 
-// SubmissionToBinding converts a go xchain submission to a solidity binding submission.
-func SubmissionToBinding(sub xchain.Submission) bindings.XSubmission {
+// submissionToBinding converts a go xchain submission to a solidity binding submission.
+func submissionToBinding(sub xchain.Submission) bindings.XSubmission {
 	// Sort the signatures by validator address to ensure deterministic ordering.
 	sort.Slice(sub.Signatures, func(i, j int) bool {
 		return sub.Signatures[i].ValidatorAddress.Cmp(sub.Signatures[j].ValidatorAddress) < 0
@@ -66,6 +66,7 @@ func SubmissionToBinding(sub xchain.Submission) bindings.XSubmission {
 	}
 }
 
+// randomHex7 returns a random 7-character hex string.
 func randomHex7() string {
 	bytes := make([]byte, 4)
 	_, _ = rand.Read(bytes)

--- a/relayer/app/types_internal_test.go
+++ b/relayer/app/types_internal_test.go
@@ -1,11 +1,10 @@
-package relayer_test
+package relayer
 
 import (
 	"testing"
 
 	"github.com/omni-network/omni/contracts/bindings"
 	"github.com/omni-network/omni/lib/xchain"
-	relayer "github.com/omni-network/omni/relayer/app"
 
 	"github.com/ethereum/go-ethereum/common"
 
@@ -18,7 +17,7 @@ func Test_translateSubmission(t *testing.T) {
 	var sub xchain.Submission
 	fuzz.New().NilChance(0).Fuzz(&sub)
 
-	xsub := relayer.SubmissionToBinding(sub)
+	xsub := submissionToBinding(sub)
 	reversedSub := submissionFromBinding(xsub, sub.DestChainID)
 
 	// Zero TxHash for comparison since it isn't translated.

--- a/relayer/app/worker.go
+++ b/relayer/app/worker.go
@@ -75,7 +75,7 @@ func (w *Worker) runOnce(ctx context.Context) error {
 	buf := newActiveBuffer(w.destChain.Name, mempoolLimit, sender)
 
 	var logAttrs []any //nolint:prealloc // Not worth it
-	for srcChainID, fromHeight := range FromHeights(cursors, w.destChain, w.network.Chains, w.state) {
+	for srcChainID, fromHeight := range fromHeights(cursors, w.destChain, w.network.Chains, w.state) {
 		if srcChainID == w.destChain.ID { // Sanity check
 			return errors.New("unexpected cursor [BUG]")
 		}

--- a/relayer/app/worker_internal_test.go
+++ b/relayer/app/worker_internal_test.go
@@ -1,4 +1,4 @@
-package relayer_test
+package relayer
 
 import (
 	"context"
@@ -8,7 +8,6 @@ import (
 	"github.com/omni-network/omni/lib/cchain"
 	"github.com/omni-network/omni/lib/netconf"
 	"github.com/omni-network/omni/lib/xchain"
-	relayer "github.com/omni-network/omni/relayer/app"
 
 	"github.com/stretchr/testify/require"
 )
@@ -69,10 +68,10 @@ func TestWorker_Run(t *testing.T) {
 	var mutex = &sync.Mutex{}
 	submissionsChan := make(chan xchain.Submission)
 
-	mockCreateFunc := func(streamUpdate relayer.StreamUpdate) ([]xchain.Submission, error) {
+	mockCreateFunc := func(streamUpdate StreamUpdate) ([]xchain.Submission, error) {
 		mutex.Lock()
 		defer mutex.Unlock()
-		subs, err := relayer.CreateSubmissions(streamUpdate)
+		subs, err := CreateSubmissions(streamUpdate)
 		if err != nil {
 			return nil, err
 		}
@@ -124,10 +123,10 @@ func TestWorker_Run(t *testing.T) {
 		{ID: destChainB, Name: "chain_b"},
 	}}
 
-	state := relayer.NewEmptyState("/tmp/relayer-state.json")
+	state := NewEmptyState("/tmp/relayer-state.json")
 
 	for _, chain := range network.Chains {
-		w := relayer.NewWorker(chain, network, mockProvider, mockXClient, mockCreateFunc, func() (relayer.SendFunc, error) {
+		w := NewWorker(chain, network, mockProvider, mockXClient, mockCreateFunc, func() (SendFunc, error) {
 			return mockSender.SendTransaction, nil
 		}, state)
 		go w.Run(ctx)


### PR DESCRIPTION
Housekeeping:
- unexports functions that don't need to be exported
- filename changes

task: none