### PR TITLE
ci(gorelease): fix missing omni release artefacts

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -85,9 +85,6 @@ archives:
       {{- if .Arm }}v{{ .Arm }}{{ end }}
 
 release:
-  # Only create release binary artefacts for omni cli.
-  ids:
-    - omni
   draft: true
   replace_existing_draft: true
   prerelease: auto

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -85,8 +85,9 @@ archives:
       {{- if .Arm }}v{{ .Arm }}{{ end }}
 
 release:
+  # Only create release binary artefacts for omni cli.
   ids:
-    - omni # Only create release binary artefacts for omni cli.
+    - omni
   draft: true
   replace_existing_draft: true
   prerelease: auto


### PR DESCRIPTION
Fixes missing `omni` cil artefacts for github triggered release.

task: none