### PR TITLE
fix(scripts): cli install script for linux

### DIFF
--- a/scripts/install_omni_cli.sh
+++ b/scripts/install_omni_cli.sh
@@ -4,31 +4,48 @@ set -e
 
 OS=$(uname -s)
 ARCH=$(uname -m)
+
+case $ARCH in
+    arm64) ARCH="arm64" ;;
+    aarch64) ARCH="arm64" ;;
+    x86_64) ARCH="x86_64" ;;
+    *) echo "Unsupported architecture"; exit 1 ;;
+esac
+
 URL="https://github.com/omni-network/omni/releases/latest/download/omni_${OS}_${ARCH}.tar.gz"
 TARGET="$HOME/bin/omni"
 SHELL_PROFILE=""
+FILE=""
 
 echo "ℹ️ Downloading omni from $URL"
-echo "ℹ️ Installing omni to $TARGET"
 
+# Create target directory
 mkdir -p "$(dirname "${TARGET}")"
 
 curl -L -s "$URL" | tar -xz -C "$(dirname "${TARGET}")" omni
 chmod +x "$TARGET"
 
+# Add to PATH if not already there
 if ! echo $PATH | grep -q "$HOME/bin"; then
     if [[ $SHELL == *"zsh"* ]]; then
-        SHELL_PROFILE="$HOME/.zshrc"
+        FILE=".zshrc"
+        SHELL_PROFILE="$HOME/$FILE"
     elif [[ $SHELL == *"bash"* ]]; then
-        SHELL_PROFILE="$HOME/.bashrc"
+        FILE=".bashrc"
+        SHELL_PROFILE="$HOME/$FILE"
     else
-        echo "Unknown shell: $SHELL, you may need to add $HOME/bin to your PATH manually"
+        echo "Unknown shell: $SHELL. Please add $HOME/bin to your PATH manually."
         exit 1
     fi
 
-    echo "ℹ️ Adding $HOME/bin to your PATH in $SHELL_PROFILE"
+    echo "ℹ️ Adding '\$HOME/bin' to your PATH in $SHELL_PROFILE"
     echo 'export PATH="$PATH:$HOME/bin"' >> "$SHELL_PROFILE"
     export PATH=\$PATH:$HOME/bin
 fi
 
-which omni &> /dev/null && echo "✅ omni is now installed: try running 'omni --help' to get started" || echo "Error: omni executable not found in PATH, you may need to run 'source $SHELL_PROFILE' or open a new terminal to use omni"
+# Check if omni is correctly installed
+if command -v omni &> /dev/null; then
+    echo "✅ omni is now installed. Run first 'source ~/$FILE' and then 'omni --help' to get started."
+else
+    echo "Error: omni executable not found in PATH. You may need to add '\$HOME/bin' to your PATH manually."
+fi

--- a/scripts/install_omni_cli.sh
+++ b/scripts/install_omni_cli.sh
@@ -27,7 +27,7 @@ if ! echo $PATH | grep -q "$HOME/bin"; then
     fi
 
     echo "ℹ️ Adding $HOME/bin to your PATH in $SHELL_PROFILE"
-    echo "export PATH="$PATH:$HOME/bin"" >> "$SHELL_PROFILE"
+    echo 'export PATH="$PATH:$HOME/bin"' >> "$SHELL_PROFILE"
     export PATH=\$PATH:$HOME/bin
 fi
 

--- a/scripts/install_omni_cli.sh
+++ b/scripts/install_omni_cli.sh
@@ -6,6 +6,7 @@ OS=$(uname -s)
 ARCH=$(uname -m)
 URL="https://github.com/omni-network/omni/releases/latest/download/omni_${OS}_${ARCH}.tar.gz"
 TARGET="$HOME/bin/omni"
+SHELL_PROFILE=""
 
 echo "ℹ️ Downloading omni from $URL"
 echo "ℹ️ Installing omni to $TARGET"
@@ -15,7 +16,19 @@ mkdir -p "$(dirname "${TARGET}")"
 curl -L -s "$URL" | tar -xz -C "$(dirname "${TARGET}")" omni
 chmod +x "$TARGET"
 
+if ! echo $PATH | grep -q "$HOME/bin"; then
+    if [[ $SHELL == *"zsh"* ]]; then
+        SHELL_PROFILE="$HOME/.zshrc"
+    elif [[ $SHELL == *"bash"* ]]; then
+        SHELL_PROFILE="$HOME/.bashrc"
+    else
+        echo "Unknown shell: $SHELL, you may need to add $HOME/bin to your PATH manually"
+        exit 1
+    fi
 
-which -s omni || echo "$HOME/bin is not in your PATH. You can add it by running 'export PATH=\$PATH:$HOME/bin'"
+    echo "ℹ️ Adding $HOME/bin to your PATH in $SHELL_PROFILE"
+    echo "export PATH="$PATH:$HOME/bin"" >> "$SHELL_PROFILE"
+    export PATH=\$PATH:$HOME/bin
+fi
 
-echo "✅ omni is now installed: try running 'omni --help' to get started"
+which omni &> /dev/null && echo "✅ omni is now installed: try running 'omni --help' to get started" || echo "Error: omni executable not found in PATH, you may need to add $HOME/bin to your PATH"

--- a/scripts/install_omni_cli.sh
+++ b/scripts/install_omni_cli.sh
@@ -31,4 +31,4 @@ if ! echo $PATH | grep -q "$HOME/bin"; then
     export PATH=\$PATH:$HOME/bin
 fi
 
-which omni &> /dev/null && echo "✅ omni is now installed: try running 'omni --help' to get started" || echo "Error: omni executable not found in PATH, you may need to add $HOME/bin to your PATH"
+which omni &> /dev/null && echo "✅ omni is now installed: try running 'omni --help' to get started" || echo "Error: omni executable not found in PATH, you may need to run 'source $SHELL_PROFILE' or open a new terminal to use omni"

--- a/scripts/install_omni_cli.sh
+++ b/scripts/install_omni_cli.sh
@@ -48,5 +48,5 @@ fi
 if command -v omni &> /dev/null; then
     echo "✅ omni is now installed. Run first 'source ~/$FILE' and then 'omni --help' to get started."
 else
-    echo "Error: omni executable not found in PATH. You may need to add '\$HOME/bin' to your PATH manually."
+    echo "❌ Error: omni executable not found in PATH. You may need to add '\$HOME/bin' to your PATH manually."
 fi

--- a/scripts/install_omni_cli.sh
+++ b/scripts/install_omni_cli.sh
@@ -20,6 +20,7 @@ FILE=""
 echo "ℹ️ Downloading omni from $URL"
 
 # Create target directory
+echo "ℹ️ Installing omni to $TARGET"
 mkdir -p "$(dirname "${TARGET}")"
 
 curl -L -s "$URL" | tar -xz -C "$(dirname "${TARGET}")" omni


### PR DESCRIPTION
This PR makes the install script compatible for linux and adds the export of `$HOME/bin` to the PATH in the shell run commands file

task: none
