### PR TITLE
refactor(monitor/avs): add and use reset gauge

### DIFF
--- a/lib/promutil/resetgauge.go
+++ b/lib/promutil/resetgauge.go
@@ -1,0 +1,71 @@
+// Copyright © 2022-2023 Obol Labs Inc. Licensed under the terms of a Business Source License 1.1
+
+// Package promutil provides Prometheus utilities.
+// This was copied from Obol's Charon repo.
+package promutil
+
+import (
+	"strings"
+	"sync"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+const separator = "|"
+
+// NewResetGaugeVec creates a new ResetGaugeVec.
+func NewResetGaugeVec(opts prometheus.GaugeOpts, labelNames []string) *ResetGaugeVec {
+	return &ResetGaugeVec{
+		inner:  promauto.NewGaugeVec(opts, labelNames),
+		labels: make(map[string]bool),
+	}
+}
+
+// ResetGaugeVec is a GaugeVec that can be reset which deletes all previously set labels.
+// This is useful to clear out labels that are no longer present.
+type ResetGaugeVec struct {
+	inner *prometheus.GaugeVec
+
+	mu     sync.Mutex
+	labels map[string]bool
+}
+
+func (g *ResetGaugeVec) WithLabelValues(lvs ...string) prometheus.Gauge {
+	for _, lv := range lvs {
+		if strings.Contains(lv, separator) {
+			panic("label value cannot contain separator")
+		}
+	}
+
+	g.mu.Lock()
+	defer g.mu.Unlock()
+
+	g.labels[strings.Join(lvs, separator)] = true
+
+	return g.inner.WithLabelValues(lvs...)
+}
+
+// Reset deletes all previously set labels that match all the given label values.
+// An empty slice will delete all previously set labels.
+func (g *ResetGaugeVec) Reset(lvs ...string) {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+
+	for label := range g.labels {
+		match := true
+		for _, check := range lvs {
+			if !strings.Contains(label, check) {
+				match = false
+				break
+			}
+		}
+
+		if !match {
+			continue
+		}
+
+		g.inner.DeleteLabelValues(strings.Split(label, separator)...)
+		delete(g.labels, label)
+	}
+}

--- a/lib/promutil/resetgauge_test.go
+++ b/lib/promutil/resetgauge_test.go
@@ -1,0 +1,76 @@
+// Copyright © 2022-2023 Obol Labs Inc. Licensed under the terms of a Business Source License 1.1
+
+package promutil_test
+
+import (
+	"testing"
+
+	"github.com/omni-network/omni/lib/promutil"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/require"
+)
+
+//nolint:paralleltest // This test uses global prometheus registry so concurrent tests are not safe.
+func TestResetGaugeVec(t *testing.T) {
+	const resetTest = "reset_test"
+
+	var testResetGauge = promutil.NewResetGaugeVec(prometheus.GaugeOpts{
+		Name: resetTest,
+		Help: "",
+	}, []string{"label0", "label1"})
+
+	testResetGauge.WithLabelValues("1", "a").Set(0)
+	assertVecLen(t, resetTest, 1)
+
+	// Same labels, should not increase length
+	testResetGauge.WithLabelValues("1", "a").Set(1)
+	assertVecLen(t, resetTest, 1)
+
+	testResetGauge.WithLabelValues("2", "b").Set(2)
+	assertVecLen(t, resetTest, 2)
+
+	testResetGauge.Reset()
+	assertVecLen(t, resetTest, 0)
+
+	testResetGauge.WithLabelValues("3", "c").Set(3)
+	assertVecLen(t, resetTest, 1)
+
+	testResetGauge.WithLabelValues("3", "d").Set(3)
+	assertVecLen(t, resetTest, 2)
+
+	testResetGauge.WithLabelValues("3", "e").Set(3)
+	assertVecLen(t, resetTest, 3)
+
+	testResetGauge.WithLabelValues("4", "z").Set(4)
+	assertVecLen(t, resetTest, 4)
+
+	testResetGauge.Reset("3", "c")
+	assertVecLen(t, resetTest, 3)
+
+	testResetGauge.Reset("3")
+	assertVecLen(t, resetTest, 1)
+}
+
+func assertVecLen(t *testing.T, name string, l int) { //nolint:unparam // abstracting name is fine even though it is always currently constant
+	t.Helper()
+
+	metrics, err := prometheus.DefaultGatherer.Gather()
+	require.NoError(t, err)
+
+	for _, metricFam := range metrics {
+		if metricFam.GetName() != name {
+			continue
+		}
+
+		require.Len(t, metricFam.GetMetric(), l)
+
+		return
+	}
+
+	if l == 0 {
+		return
+	}
+
+	require.Fail(t, "metric not found")
+}

--- a/monitor/avs/metrics.go
+++ b/monitor/avs/metrics.go
@@ -1,6 +1,8 @@
 package avs
 
 import (
+	"github.com/omni-network/omni/lib/promutil"
+
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 )
@@ -20,14 +22,14 @@ var (
 		Help:      "The total amount of delegations made all operators registered with the AVS",
 	})
 
-	operatorStake = promauto.NewGaugeVec(prometheus.GaugeOpts{
+	operatorStake = promutil.NewResetGaugeVec(prometheus.GaugeOpts{
 		Namespace: "monitor",
 		Subsystem: "avs",
 		Name:      "operator_stake",
 		Help:      "The total amount staked (self-delegations) by operators registered with the AVS",
 	}, []string{"operator"})
 
-	operatorDelegations = promauto.NewGaugeVec(prometheus.GaugeOpts{
+	operatorDelegations = promutil.NewResetGaugeVec(prometheus.GaugeOpts{
 		Namespace: "monitor",
 		Subsystem: "avs",
 		Name:      "operator_delegations",


### PR DESCRIPTION
Adds a `promutil.ResetGaugeVec` and use in `monitor/avs` to support operator removals from metrics.

task: none