### PR TITLE
fix(lib/ethbackend): fix leading zero bug in stub signer

### DIFF
--- a/lib/avs/anvil/anvil.go
+++ b/lib/avs/anvil/anvil.go
@@ -24,7 +24,7 @@ import (
 // If useLogProxy is true, all requests are routed via a reserve proxy that logs all requests, which will be printed
 // at stop.
 func Start(ctx context.Context, dir string, chainID uint64) (ethclient.Client, func(), error) {
-	ctx, cancel := context.WithTimeout(ctx, time.Second*15)
+	ctx, cancel := context.WithTimeout(ctx, time.Minute) // Allow 1 minute for edge case of pulling images.
 	defer cancel()
 	if !composeDown(ctx, dir) {
 		return nil, nil, errors.New("failure to clean up previous anvil instance")

--- a/lib/ethclient/ethbackend/backend.go
+++ b/lib/ethclient/ethbackend/backend.go
@@ -223,7 +223,9 @@ func (backendStubSigner) Sender(tx *ethtypes.Transaction) (common.Address, error
 
 	v, r, s := tx.RawSignatureValues()
 
-	if len(r.Bytes()) != 20 {
+	addrLen := len(common.Address{})
+
+	if len(r.Bytes()) > addrLen {
 		return common.Address{}, errors.New("invalid r length", "length", len(r.Bytes()))
 	}
 	if s.Uint64() != 0 {
@@ -233,8 +235,10 @@ func (backendStubSigner) Sender(tx *ethtypes.Transaction) (common.Address, error
 		return common.Address{}, errors.New("non-empty v [BUG]", "length", len(v.Bytes()))
 	}
 
-	addr := make([]byte, 20)
-	copy(addr, r.Bytes())
+	addr := make([]byte, addrLen)
+	// big.Int.Bytes() truncates leading zeros, so we need to left pad the address to 20 bytes.
+	pad := addrLen - len(r.Bytes())
+	copy(addr[pad:], r.Bytes())
 
 	return common.Address(addr), nil
 }

--- a/lib/ethclient/ethbackend/backend_internal_test.go
+++ b/lib/ethclient/ethbackend/backend_internal_test.go
@@ -13,8 +13,9 @@ import (
 func Test(t *testing.T) {
 	t.Parallel()
 	tests := []struct {
-		name   string
-		txData ethtypes.TxData
+		name    string
+		txData  ethtypes.TxData
+		fromHex string
 	}{
 		{
 			name:   "legacy tx",
@@ -23,6 +24,11 @@ func Test(t *testing.T) {
 		{
 			name:   "dynamic fee tx",
 			txData: &ethtypes.DynamicFeeTx{},
+		},
+		{
+			name:    "legacy tx with zero prefix",
+			txData:  &ethtypes.LegacyTx{},
+			fromHex: "0x002985c832a67c0b31a05e909f443b641624da52",
 		},
 	}
 	for _, test := range tests {
@@ -34,6 +40,10 @@ func Test(t *testing.T) {
 			var from common.Address
 			f.Fuzz(&from)
 			f.Fuzz(test.txData)
+
+			if test.fromHex != "" {
+				from = common.HexToAddress(test.fromHex)
+			}
 
 			signer := backendStubSigner{}
 


### PR DESCRIPTION
Fix sporadic flapping tests due to leading zeros being stripped in `backendStubSigner`

task: none