### PR TITLE
ci(e2e): decrease staging anvil block period

### DIFF
--- a/monitor/avs/avs.go
+++ b/monitor/avs/avs.go
@@ -30,7 +30,7 @@ func Monitor(ctx context.Context, network netconf.Network) error {
 
 	addr := common.HexToAddress(devnetAVSAddr)
 	// monitor goerli avs in staging, for now
-	if network.Name == "staging" {
+	if network.Name == netconf.Staging {
 		addr = common.HexToAddress(goerliAVSAddr)
 	}
 

--- a/test/e2e/app/definition.go
+++ b/test/e2e/app/definition.go
@@ -216,6 +216,9 @@ func TestnetFromManifest(manifest types.Manifest, infd types.InfrastructureData,
 		if infd.Provider == docker.ProviderName {
 			internalIP = chain.Name // For docker, we use container names
 		}
+		if infd.Provider == vmcompose.ProviderName {
+			chain.BlockPeriod = time.Second * 12 // Slow block times for anvils on long-lived VMs to reduce disk usage.
+		}
 
 		anvils = append(anvils, types.AnvilChain{
 			Chain:       chain,

--- a/test/e2e/docker/compose.yaml.tmpl
+++ b/test/e2e/docker/compose.yaml.tmpl
@@ -50,7 +50,7 @@ services:
       - anvil
       - --host=0.0.0.0
       - --chain-id={{ .Chain.ID }}
-      - --block-time=1
+      - --block-time={{.Chain.BlockPeriod.Seconds}}
       - --silent
       {{ if .LoadState }}- --load-state=/anvil/state.json{{ end }}
     ports:

--- a/test/e2e/docker/docker.go
+++ b/test/e2e/docker/docker.go
@@ -141,9 +141,10 @@ type ComposeDef struct {
 	NetworkCIDR string
 	BindAll     bool
 
-	Nodes         []*e2e.Node
-	OmniEVMs      []types.OmniEVM
-	Anvils        []types.AnvilChain
+	Nodes    []*e2e.Node
+	OmniEVMs []types.OmniEVM
+	Anvils   []types.AnvilChain
+
 	Relayer       bool
 	Prometheus    bool
 	RelayerTag    string

--- a/test/e2e/docker/docker_test.go
+++ b/test/e2e/docker/docker_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/omni-network/omni/test/e2e/docker"
 	"github.com/omni-network/omni/test/e2e/types"
@@ -62,12 +63,12 @@ func TestComposeTemplate(t *testing.T) {
 				},
 				AnvilChains: []types.AnvilChain{
 					{
-						Chain:      types.EVMChain{Name: "mock_rollup", ID: 99},
+						Chain:      types.EVMChain{Name: "mock_rollup", ID: 99, BlockPeriod: time.Second},
 						InternalIP: ipNet.IP,
 						ProxyPort:  9000,
 					},
 					{
-						Chain:      types.EVMChain{Name: "mock_l1", ID: 1},
+						Chain:      types.EVMChain{Name: "mock_l1", ID: 1, BlockPeriod: time.Hour},
 						InternalIP: ipNet.IP,
 						ProxyPort:  9000,
 						LoadState:  "path/to/anvil/state.json",

--- a/test/e2e/docker/testdata/TestComposeTemplate_image_tag_7d1ae53.golden
+++ b/test/e2e/docker/testdata/TestComposeTemplate_image_tag_7d1ae53.golden
@@ -61,7 +61,7 @@ services:
       - anvil
       - --host=0.0.0.0
       - --chain-id=1
-      - --block-time=1
+      - --block-time=3600
       - --silent
       - --load-state=/anvil/state.json
     ports:

--- a/test/e2e/docker/testdata/TestComposeTemplate_image_tag_main.golden
+++ b/test/e2e/docker/testdata/TestComposeTemplate_image_tag_main.golden
@@ -61,7 +61,7 @@ services:
       - anvil
       - --host=0.0.0.0
       - --chain-id=1
-      - --block-time=1
+      - --block-time=3600
       - --silent
       - --load-state=/anvil/state.json
     ports:

--- a/test/e2e/vmcompose/testdata/TestSetup_127_0_0_3_compose.yaml.golden
+++ b/test/e2e/vmcompose/testdata/TestSetup_127_0_0_3_compose.yaml.golden
@@ -16,7 +16,7 @@ services:
       - anvil
       - --host=0.0.0.0
       - --chain-id=100
-      - --block-time=1
+      - --block-time=12
       - --silent
       - --load-state=/anvil/state.json
     ports:


### PR DESCRIPTION
Decreases anvil blocks times on staging (or any VM deployment) from 1s to 12s to reduce disk usage by 10x. 

task: none