### PR TITLE
test(e2e): add restarted full node to ci manifest

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -76,10 +76,6 @@
       "path": "detect_secrets.filters.allowlist.is_line_allowlisted"
     },
     {
-      "path": "detect_secrets.filters.common.is_baseline_file",
-      "filename": ".secrets.baseline"
-    },
-    {
       "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
       "min_level": 2
     },
@@ -595,21 +591,21 @@
         "filename": "test/e2e/app/setup.go",
         "hashed_secret": "7be029054a936fcb1827abd24388a53136be7b64",
         "is_verified": false,
-        "line_number": 118
+        "line_number": 116
       },
       {
         "type": "Secret Keyword",
         "filename": "test/e2e/app/setup.go",
         "hashed_secret": "55abc9109d5ea8a77be16bf3c76b4b199b524b12",
         "is_verified": false,
-        "line_number": 387
+        "line_number": 385
       },
       {
         "type": "Secret Keyword",
         "filename": "test/e2e/app/setup.go",
         "hashed_secret": "da57af224108e98e24d1e2a86221121990fa6478",
         "is_verified": false,
-        "line_number": 412
+        "line_number": 410
       }
     ],
     "test/e2e/app/static/geth-genesis.json": [
@@ -854,5 +850,5 @@
       }
     ]
   },
-  "generated_at": "2024-03-06T14:26:09Z"
+  "generated_at": "2024-03-06T15:36:42Z"
 }

--- a/test/e2e/app/perturb.go
+++ b/test/e2e/app/perturb.go
@@ -1,0 +1,89 @@
+package app
+
+import (
+	"context"
+	"time"
+
+	"github.com/omni-network/omni/lib/errors"
+	"github.com/omni-network/omni/lib/log"
+
+	rpctypes "github.com/cometbft/cometbft/rpc/core/types"
+	e2e "github.com/cometbft/cometbft/test/e2e/pkg"
+	"github.com/cometbft/cometbft/test/e2e/pkg/infra/docker"
+)
+
+// perturb the running testnet.
+func perturb(ctx context.Context, testnet *e2e.Testnet) error {
+	for _, node := range testnet.Nodes {
+		for _, perturbation := range node.Perturbations {
+			_, err := perturbNode(ctx, node, perturbation)
+			if err != nil {
+				return err
+			}
+			time.Sleep(3 * time.Second) // Give network some time to recover between each
+		}
+	}
+
+	return nil
+}
+
+// perturbNode perturbs a node with a given perturbation, returning its status
+// after recovering.
+func perturbNode(ctx context.Context, node *e2e.Node, perturbation e2e.Perturbation) (*rpctypes.ResultStatus, error) {
+	testnet := node.Testnet
+	name := node.Name
+	ctx = log.WithCtx(ctx, "name", name)
+
+	switch perturbation {
+	case e2e.PerturbationDisconnect:
+		networkName := testnet.Name + "_" + testnet.Name
+		log.Info(ctx, "Perturb node: disconnect")
+		if err := docker.Exec(ctx, "network", "disconnect", networkName, name); err != nil {
+			return nil, errors.Wrap(err, "disconnect node from network")
+		}
+		time.Sleep(10 * time.Second)
+		if err := docker.Exec(ctx, "network", "connect", networkName, name); err != nil {
+			return nil, errors.Wrap(err, "connect node tp network")
+		}
+
+	case e2e.PerturbationKill:
+		log.Info(ctx, "Perturb node: kill")
+		if err := docker.ExecCompose(ctx, testnet.Dir, "kill", "-s", "SIGKILL", name); err != nil {
+			return nil, errors.Wrap(err, "kill node")
+		}
+		if err := docker.ExecCompose(ctx, testnet.Dir, "start", name); err != nil {
+			return nil, errors.Wrap(err, "start node")
+		}
+
+	case e2e.PerturbationPause:
+		log.Info(ctx, "Perturb node: pause")
+		if err := docker.ExecCompose(ctx, testnet.Dir, "pause", name); err != nil {
+			return nil, errors.Wrap(err, "pause node")
+		}
+		time.Sleep(10 * time.Second)
+		if err := docker.ExecCompose(ctx, testnet.Dir, "unpause", name); err != nil {
+			return nil, errors.Wrap(err, "unpause node")
+		}
+
+	case e2e.PerturbationRestart:
+		log.Info(ctx, "Perturb node: restart")
+		if err := docker.ExecCompose(ctx, testnet.Dir, "restart", name); err != nil {
+			return nil, errors.Wrap(err, "restart node")
+		}
+
+	case e2e.PerturbationUpgrade:
+		return nil, errors.New("upgrade perturbation not supported")
+
+	default:
+		return nil, errors.New("unexpected perturbation type", "type", perturbation)
+	}
+
+	status, err := waitForNode(ctx, node, 0, 20*time.Second)
+	if err != nil {
+		return nil, err
+	}
+
+	log.Info(ctx, "Node recovered from perturbation", "height", status.SyncInfo.LatestBlockHeight)
+
+	return status, nil
+}

--- a/test/e2e/app/run.go
+++ b/test/e2e/app/run.go
@@ -132,7 +132,9 @@ func E2ETest(ctx context.Context, def Definition, cfg E2ETestConfig, secrets age
 	}
 
 	if def.Testnet.HasPerturbations() {
-		return errors.New("perturbations not supported yet")
+		if err := perturb(ctx, def.Testnet.Testnet); err != nil {
+			return err
+		}
 	}
 
 	if def.Testnet.Evidence > 0 {

--- a/test/e2e/app/setup.go
+++ b/test/e2e/app/setup.go
@@ -41,13 +41,11 @@ const (
 	AppAddressTCP  = "tcp://127.0.0.1:30000"
 	AppAddressUNIX = "unix:///var/run/app.sock"
 
-	PrivvalAddressTCP     = "tcp://0.0.0.0:27559"
-	PrivvalAddressUNIX    = "unix:///var/run/privval.sock"
-	PrivvalKeyFile        = "config/priv_validator_key.json"
-	PrivvalStateFile      = "data/priv_validator_state.json"
-	PrivvalDummyKeyFile   = "config/dummy_validator_key.json"
-	PrivvalDummyStateFile = "data/dummy_validator_state.json"
-	NetworkConfigFile     = "config/network.json"
+	PrivvalAddressTCP  = "tcp://0.0.0.0:27559"
+	PrivvalAddressUNIX = "unix:///var/run/privval.sock"
+	PrivvalKeyFile     = "config/priv_validator_key.json"
+	PrivvalStateFile   = "data/priv_validator_state.json"
+	NetworkConfigFile  = "config/network.json"
 )
 
 // Setup sets up the testnet configuration.
@@ -59,8 +57,8 @@ func Setup(ctx context.Context, def Definition, agentSecrets agent.Secrets, test
 	}
 
 	var vals []crypto.PubKey
-	for _, node := range def.Testnet.Nodes {
-		vals = append(vals, node.PrivvalKey.PubKey())
+	for val := range def.Testnet.Validators {
+		vals = append(vals, val.PrivvalKey.PubKey())
 	}
 
 	cosmosGenesis, err := genutil.MakeGenesis(def.Testnet.Name, time.Now(), vals...)
@@ -242,8 +240,8 @@ func MakeConfig(node *e2e.Node, nodeDir string) (*config.Config, error) {
 	// key here by default, and use the real key for actual validators that should use
 	// the file privval.
 	cfg.PrivValidatorListenAddr = ""
-	cfg.PrivValidatorKey = PrivvalDummyKeyFile
-	cfg.PrivValidatorState = PrivvalDummyStateFile
+	cfg.PrivValidatorKey = PrivvalKeyFile
+	cfg.PrivValidatorState = PrivvalStateFile
 
 	switch node.Mode {
 	case e2e.ModeValidator:

--- a/test/e2e/manifests/ci.toml
+++ b/test/e2e/manifests/ci.toml
@@ -8,3 +8,7 @@ avs_target = "mock_l1"
 [node.validator04]
 start_at = 20
 state_sync = true
+
+[node.full01]
+mode = "full"
+perturb = ["restart"]


### PR DESCRIPTION
Adds a `fullnode01` node to ci manifest. Add a restart perturbation to it.

task: none