### PR TITLE
chore(config): add version to config toml

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -338,7 +338,7 @@
         "filename": "relayer/app/config.go",
         "hashed_secret": "8cc9404ee4a70f25fb3bc043bfcbb4288f644bc3",
         "is_verified": false,
-        "line_number": 25
+        "line_number": 26
       }
     ],
     "scripts/gethdevnet/execution/genesis.json": [
@@ -854,5 +854,5 @@
       }
     ]
   },
-  "generated_at": "2024-03-05T21:01:36Z"
+  "generated_at": "2024-03-06T14:26:09Z"
 }

--- a/halo/config/config.go
+++ b/halo/config/config.go
@@ -6,6 +6,7 @@ import (
 	"text/template"
 	"time"
 
+	"github.com/omni-network/omni/lib/buildinfo"
 	"github.com/omni-network/omni/lib/errors"
 	"github.com/omni-network/omni/lib/log"
 
@@ -103,10 +104,12 @@ func WriteConfigTOML(cfg Config, logCfg log.Config) error {
 
 	s := struct {
 		Config
-		Log log.Config
+		Log     log.Config
+		Version string
 	}{
-		Config: cfg,
-		Log:    logCfg,
+		Config:  cfg,
+		Log:     logCfg,
+		Version: buildinfo.Version(),
 	}
 
 	if err := t.Execute(&buffer, s); err != nil {

--- a/halo/config/config.toml.tmpl
+++ b/halo/config/config.toml.tmpl
@@ -3,7 +3,7 @@
 
 # The version of the Halo binary that created or
 # last modified the config file. Do not modify this.
-version = "unknown"
+version = "{{ .Version }}"
 
 #######################################################################
 ###                          Halo Options                           ###

--- a/lib/buildinfo/buildinfo.go
+++ b/lib/buildinfo/buildinfo.go
@@ -15,6 +15,11 @@ import (
 // This value is set by goreleaser at build-time and should be the git tag for official releases.
 var version = "unknown"
 
+// Version returns the version of the whole omni-monorepo and all binaries built from this git commit.
+func Version() string {
+	return version
+}
+
 // Instrument logs the version, git commit hash, and timestamp from the runtime build info.
 // It also sets metrics.
 func Instrument(ctx context.Context) {

--- a/relayer/app/config.go
+++ b/relayer/app/config.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"text/template"
 
+	"github.com/omni-network/omni/lib/buildinfo"
 	"github.com/omni-network/omni/lib/errors"
 	"github.com/omni-network/omni/lib/log"
 
@@ -44,10 +45,12 @@ func WriteConfigTOML(cfg Config, logCfg log.Config, path string) error {
 
 	s := struct {
 		Config
-		Log log.Config
+		Log     log.Config
+		Version string
 	}{
-		Config: cfg,
-		Log:    logCfg,
+		Config:  cfg,
+		Log:     logCfg,
+		Version: buildinfo.Version(),
 	}
 
 	if err := t.Execute(&buffer, s); err != nil {

--- a/relayer/app/config.toml.tmpl
+++ b/relayer/app/config.toml.tmpl
@@ -3,7 +3,7 @@
 
 # The version of the Halo binary that created or
 # last modified the config file. Do not modify this.
-version = "unknown"
+version = "{{ .Version}}"
 
 #######################################################################
 ###                         Relayer Options                         ###


### PR DESCRIPTION
Adds the current buildinfo version to halo and relayer config toml.

task: none