### PR TITLE
test(lib/k1util): ensure cometBFT privval compatible with web3signer

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -76,6 +76,10 @@
       "path": "detect_secrets.filters.allowlist.is_line_allowlisted"
     },
     {
+      "path": "detect_secrets.filters.common.is_baseline_file",
+      "filename": ".secrets.baseline"
+    },
+    {
       "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
       "min_level": 2
     },
@@ -297,35 +301,35 @@
         "filename": "lib/k1util/k1util_test.go",
         "hashed_secret": "958d1c2444d6fcb271801332187e50792b047851",
         "is_verified": false,
-        "line_number": 19
+        "line_number": 26
       },
       {
         "type": "Secret Keyword",
         "filename": "lib/k1util/k1util_test.go",
         "hashed_secret": "958d1c2444d6fcb271801332187e50792b047851",
         "is_verified": false,
-        "line_number": 19
+        "line_number": 26
       },
       {
         "type": "Hex High Entropy String",
         "filename": "lib/k1util/k1util_test.go",
         "hashed_secret": "f0b3a47d95d2d2ee98e97971760e5a3d88540d3d",
         "is_verified": false,
-        "line_number": 20
+        "line_number": 27
       },
       {
         "type": "Hex High Entropy String",
         "filename": "lib/k1util/k1util_test.go",
         "hashed_secret": "a255755528bd4eff06e5abe7cc5b4a0ea0ab7e0b",
         "is_verified": false,
-        "line_number": 21
+        "line_number": 28
       },
       {
         "type": "Hex High Entropy String",
         "filename": "lib/k1util/k1util_test.go",
         "hashed_secret": "d56a456dcbdc7663fe8d4b5af709b2f97d35f2a4",
         "is_verified": false,
-        "line_number": 22
+        "line_number": 29
       }
     ],
     "relayer/app/config.go": [
@@ -850,5 +854,5 @@
       }
     ]
   },
-  "generated_at": "2024-03-06T15:36:42Z"
+  "generated_at": "2024-03-08T05:48:23Z"
 }

--- a/lib/k1util/k1util.go
+++ b/lib/k1util/k1util.go
@@ -1,5 +1,4 @@
 // Package k1util provides functions to sign and verify Ethereum RSV style signatures.
-// It was copied from https://github.com/ObolNetwork/charon/blob/main/app/k1util/k1util.go.
 package k1util
 
 import (

--- a/lib/k1util/k1util_test.go
+++ b/lib/k1util/k1util_test.go
@@ -4,12 +4,19 @@ package k1util_test
 
 import (
 	"crypto/rand"
+	"crypto/sha256"
 	"encoding/hex"
+	"path/filepath"
 	"testing"
 
 	"github.com/omni-network/omni/lib/k1util"
+	"github.com/omni-network/omni/test/tutil"
 
 	k1 "github.com/cometbft/cometbft/crypto/secp256k1"
+	"github.com/cometbft/cometbft/privval"
+	cmtproto "github.com/cometbft/cometbft/proto/tendermint/types"
+	cmttypes "github.com/cometbft/cometbft/types"
+	cmttime "github.com/cometbft/cometbft/types/time"
 
 	"github.com/stretchr/testify/require"
 )
@@ -63,10 +70,72 @@ func TestRandom(t *testing.T) {
 	require.True(t, ok)
 }
 
+// TestCometBFT tests that CometBFT and k1util can produce the same signatures.
+// This ensures that we can use web3signer to sign votes and proposals.
+func TestCometBFT(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+
+	const chainID = "test"
+
+	// Create a key
+	key := k1.GenPrivKey()
+	pv := privval.NewFilePV(key, filepath.Join(dir, "key"), filepath.Join(dir, "state"))
+
+	// Create a vote
+	block := cmttypes.BlockID{Hash: tutil.RandomBytes(32)}
+	vote := newVote(pv.Key.Address, 1, 2, 3, cmtproto.PrecommitType, block, []byte("vote extension"))
+	votePB1 := vote.ToProto()
+	votePB2 := vote.ToProto()
+
+	// Sign it with CometBFT privval.
+	err := pv.SignVote(chainID, votePB1)
+	require.NoError(t, err)
+
+	require.Nil(t, votePB2.Signature) // Ensure no pointer shenanigans.
+
+	// Sign it with k1util.
+	signVote(t, key, chainID, votePB2)
+
+	require.Equal(t, votePB1.Signature, votePB2.Signature)
+	require.Equal(t, votePB1.ExtensionSignature, votePB2.ExtensionSignature)
+}
+
+func signVote(t *testing.T, key k1.PrivKey, chainID string, vote *cmtproto.Vote) {
+	t.Helper()
+
+	sigBytes := cmttypes.VoteSignBytes(chainID, vote)
+	hashed := sha256.Sum256(sigBytes)
+	sig, err := k1util.Sign(key, hashed)
+	require.NoError(t, err)
+
+	extSignBytes := cmttypes.VoteExtensionSignBytes(chainID, vote)
+	extHashed := sha256.Sum256(extSignBytes)
+	extSig, err := k1util.Sign(key, extHashed)
+	require.NoError(t, err)
+
+	vote.Signature = sig[:64]             // CometBFT drops recovery id.
+	vote.ExtensionSignature = extSig[:64] // CometBFT drops recovery id.
+}
+
 func fromHex(t *testing.T, hexStr string) []byte {
 	t.Helper()
 	b, err := hex.DecodeString(hexStr)
 	require.NoError(t, err)
 
 	return b
+}
+
+func newVote(addr cmttypes.Address, idx int32, height int64, round int32,
+	typ cmtproto.SignedMsgType, blockID cmttypes.BlockID, extension []byte) *cmttypes.Vote {
+	return &cmttypes.Vote{
+		ValidatorAddress: addr,
+		ValidatorIndex:   idx,
+		Height:           height,
+		Round:            round,
+		Type:             typ,
+		Timestamp:        cmttime.Now(),
+		BlockID:          blockID,
+		Extension:        extension,
+	}
 }

--- a/test/tutil/random.go
+++ b/test/tutil/random.go
@@ -1,0 +1,23 @@
+package tutil
+
+import (
+	"crypto/rand"
+
+	"github.com/ethereum/go-ethereum/common"
+)
+
+// RandomBytes returns a random byte slice of length l.
+func RandomBytes(l int) []byte {
+	resp := make([]byte, l)
+	_, _ = rand.Read(resp)
+
+	return resp
+}
+
+// RandomHash returns a random 32-byte 256-bit hash.
+func RandomHash() common.Hash {
+	var resp common.Hash
+	_, _ = rand.Read(resp[:])
+
+	return resp
+}


### PR DESCRIPTION
Adds a unit test that confirms that cometBFT privval signatures are compatible with ethereum RSV signatures. This confirms we can use web3signer as keystore.

We cannot use tendermint privval/kms since its signing interface is limited to tendermint votes and proposals and we need to sign attest votes as well.

task: none