### PR TITLE
feat(halo/evmengine): add evm logs to execution payload

### DIFF
--- a/halo/app/app.go
+++ b/halo/app/app.go
@@ -92,8 +92,9 @@ func newApp(
 		return nil, errors.Wrap(err, "dep inject")
 	}
 
-	// Add CProviders to evmengine keeper.
-	app.EVMEngKeeper.AddProvider(app.AttestKeeper)
+	// Set evmengine vote and evm msg providers.
+	app.EVMEngKeeper.SetVoteProvider(app.AttestKeeper)
+	app.EVMEngKeeper.AddLogProvider(evmengkeeper.NewPocLogProvider(app.EVMEngKeeper))
 
 	proposalHandler := makeProcessProposalHandler(app)
 

--- a/halo/attest/keeper/cpayload.go
+++ b/halo/attest/keeper/cpayload.go
@@ -19,12 +19,12 @@ import (
 	"github.com/cosmos/gogoproto/proto"
 )
 
-var _ evmenginetypes.CPayloadProvider = (*Keeper)(nil)
+var _ evmenginetypes.VoteExtensionProvider = (*Keeper)(nil)
 
-func (k *Keeper) PreparePayload(ctx context.Context, height uint64, commit abci.ExtendedCommitInfo) ([]sdk.Msg, error) {
+func (k *Keeper) PrepareVotes(ctx context.Context, commit abci.ExtendedCommitInfo) ([]sdk.Msg, error) {
 	sdkCtx := sdk.UnwrapSDKContext(ctx)
-	if err := baseapp.ValidateVoteExtensions(sdkCtx, k.skeeper, int64(height), sdkCtx.ChainID(), commit); err != nil {
-		log.Error(ctx, "Cannot include invalid vote extensions in payload", err, "height", height)
+	if err := baseapp.ValidateVoteExtensions(sdkCtx, k.skeeper, sdkCtx.BlockHeight(), sdkCtx.ChainID(), commit); err != nil {
+		log.Error(ctx, "Cannot include invalid vote extensions in payload", err, "height", sdkCtx.BlockHeight())
 		return nil, nil
 	}
 

--- a/halo/evmengine/keeper/abci.go
+++ b/halo/evmengine/keeper/abci.go
@@ -113,27 +113,28 @@ func (k *Keeper) PrepareProposal(ctx sdk.Context, req *abci.RequestPreparePropos
 		return nil, errors.Wrap(err, "encode")
 	}
 
-	// Collect all msgs to include in our single consensus transaction.
-	msgs := []sdk.Msg{
-		// First and most important is the execution payload.
-		&types.MsgExecutionPayload{
-			Authority: authtypes.NewModuleAddress(types.ModuleName).String(),
-			Data:      payloadData,
-		},
+	// First, collect all vote extension msgs from the vote provider.
+	voteMsgs, err := k.voteProvider.PrepareVotes(ctx, req.LocalLastCommit)
+	if err != nil {
+		return nil, errors.Wrap(err, "prepare votes")
 	}
 
-	// Next, collect all msgs from the CPayload providers.
-	// These include msgs from vote extensions and/or any msgs from EVM contracts.
-	for _, provider := range k.providers {
-		cmsgs, err := provider.PreparePayload(ctx, uint64(req.Height), req.LocalLastCommit)
-		if err != nil {
-			return nil, errors.Wrap(err, "prepare payload")
-		}
-		msgs = append(msgs, cmsgs...)
+	// Next, collect all prev payload evm logs.
+	evmLogs, err := k.evmLogs(ctx, payloadResp.ExecutionPayload.ParentHash)
+	if err != nil {
+		return nil, errors.Wrap(err, "prepare evm logs")
 	}
 
+	// Then construct the execution payload message.
+	payloadMsg := &types.MsgExecutionPayload{
+		Authority:        authtypes.NewModuleAddress(types.ModuleName).String(),
+		ExecutionPayload: payloadData,
+		PrevPayloadLogs:  evmLogs,
+	}
+
+	// Combine all the votes messages and the payload message into a single transaction.
 	b := k.txConfig.NewTxBuilder()
-	if err := b.SetMsgs(msgs...); err != nil {
+	if err := b.SetMsgs(append(voteMsgs, payloadMsg)...); err != nil {
 		return nil, errors.Wrap(err, "set tx builder msgs")
 	}
 
@@ -146,7 +147,8 @@ func (k *Keeper) PrepareProposal(ctx sdk.Context, req *abci.RequestPreparePropos
 	log.Info(ctx, "Proposing new block",
 		"height", req.Height,
 		log.Hex7("execution_block_hash", payloadResp.ExecutionPayload.BlockHash[:]),
-		"msgs", len(msgs),
+		"vote_msgs", len(voteMsgs),
+		"evm_logs", len(evmLogs),
 	)
 
 	return &abci.ResponsePrepareProposal{Txs: [][]byte{tx}}, nil

--- a/halo/evmengine/keeper/evmmsgs.go
+++ b/halo/evmengine/keeper/evmmsgs.go
@@ -1,0 +1,44 @@
+package keeper
+
+import (
+	"bytes"
+	"context"
+	"slices"
+	"sort"
+
+	"github.com/omni-network/omni/halo/evmengine/types"
+	"github.com/omni-network/omni/lib/errors"
+
+	"github.com/ethereum/go-ethereum/common"
+)
+
+// evmLogs returns all EVM logs from the provided block hash.
+func (k *Keeper) evmLogs(ctx context.Context, blockHash common.Hash) ([]*types.EVMLog, error) {
+	var logs []*types.EVMLog
+	for _, provider := range k.logProviders {
+		ll, err := provider.Logs(ctx, blockHash)
+		if err != nil {
+			return nil, errors.Wrap(err, "prepare msgs")
+		}
+
+		logs = append(logs, ll...)
+	}
+
+	// Sort by Address > Topics > Data
+	// This avoids dependency on runtime ordering.
+	sort.Slice(logs, func(i, j int) bool {
+		if cmp := bytes.Compare(logs[i].Address, logs[j].Address); cmp != 0 {
+			return cmp < 0
+		}
+
+		topicI := slices.Concat(logs[i].Topics...)
+		topicJ := slices.Concat(logs[j].Topics...)
+		if cmp := bytes.Compare(topicI, topicJ); cmp != 0 {
+			return cmp < 0
+		}
+
+		return bytes.Compare(logs[i].Data, logs[j].Data) < 0
+	})
+
+	return logs, nil
+}

--- a/halo/evmengine/keeper/keeper.go
+++ b/halo/evmengine/keeper/keeper.go
@@ -25,7 +25,8 @@ type Keeper struct {
 	storeService    store.KVStoreService
 	engineCl        ethclient.EngineClient
 	txConfig        client.TxConfig
-	providers       []types.CPayloadProvider
+	voteProvider    types.VoteExtensionProvider
+	logProviders    []types.EvmLogProvider
 	cmtAPI          comet.API
 	addrProvider    types.AddressProvider
 	buildDelay      time.Duration
@@ -57,8 +58,12 @@ func NewKeeper(
 }
 
 // TODO(corver): Figure out how to use depinject for this.
-func (k *Keeper) AddProvider(p types.CPayloadProvider) {
-	k.providers = append(k.providers, p)
+func (k *Keeper) AddLogProvider(p types.EvmLogProvider) {
+	k.logProviders = append(k.logProviders, p)
+}
+
+func (k *Keeper) SetVoteProvider(p types.VoteExtensionProvider) {
+	k.voteProvider = p
 }
 
 // SetCometAPI sets the comet API client.

--- a/halo/evmengine/keeper/logmsgprovider.go
+++ b/halo/evmengine/keeper/logmsgprovider.go
@@ -1,0 +1,63 @@
+package keeper
+
+import (
+	"context"
+
+	"github.com/omni-network/omni/halo/evmengine/types"
+	"github.com/omni-network/omni/lib/errors"
+
+	"github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/common"
+)
+
+var _ types.EvmLogProvider = pocLogProvider{}
+
+//nolint:gochecknoglobals // Will remove with PoC
+var zeroAddr common.Address
+
+func NewPocLogProvider(k *Keeper) types.EvmLogProvider {
+	return pocLogProvider{k: k}
+}
+
+// pocLogProvider is a temporary PoC that queries previous block EVM logs and includes
+// the total as cosmosSDK msg.
+type pocLogProvider struct {
+	k *Keeper
+}
+
+func (p pocLogProvider) Logs(ctx context.Context, blockHash common.Hash) ([]*types.EVMLog, error) {
+	logs, err := p.k.engineCl.FilterLogs(ctx, ethereum.FilterQuery{
+		BlockHash: &blockHash,
+	})
+	if err != nil {
+		return nil, errors.Wrap(err, "filter logs")
+	}
+
+	evmLogs := make([]*types.EVMLog, len(logs))
+	for i, l := range logs {
+		evmLogs[i] = &types.EVMLog{
+			Address: zeroAddr.Bytes(), // Stub addresses
+			Topics:  topicBytes(l.Topics),
+			Data:    l.Data,
+		}
+	}
+
+	return evmLogs, nil
+}
+
+func (pocLogProvider) Addresses() []common.Address {
+	return []common.Address{zeroAddr}
+}
+
+func (pocLogProvider) DeliverLog(context.Context, common.Hash, *types.EVMLog) error {
+	return nil
+}
+
+func topicBytes(topics []common.Hash) [][]byte {
+	t := make([][]byte, len(topics))
+	for i, h := range topics {
+		t[i] = h[:]
+	}
+
+	return t
+}

--- a/halo/evmengine/keeper/msg_server_internal_test.go
+++ b/halo/evmengine/keeper/msg_server_internal_test.go
@@ -74,8 +74,8 @@ func Test_msgServer_ExecutionPayload(t *testing.T) {
 
 	assertExecutionPayload := func() {
 		resp, err := msgSrv.ExecutionPayload(ctx, &types.MsgExecutionPayload{
-			Authority: authtypes.NewModuleAddress(types.ModuleName).String(),
-			Data:      payloadData,
+			Authority:        authtypes.NewModuleAddress(types.ModuleName).String(),
+			ExecutionPayload: payloadData,
 		})
 		require.NoError(t, err)
 		require.NotNil(t, resp)
@@ -141,7 +141,7 @@ func Test_pushPayload(t *testing.T) {
 		{
 			name: "fail to unmarshal",
 			args: args{
-				msg: &types.MsgExecutionPayload{Data: []byte("invalid")},
+				msg: &types.MsgExecutionPayload{ExecutionPayload: []byte("invalid")},
 			},
 			wantErr: true,
 		},
@@ -195,7 +195,7 @@ func Test_pushPayload(t *testing.T) {
 			payload, payloadID := newPayload(context.Background(), mockEngine, common.Address{})
 			if tt.args.msg == nil {
 				tt.args.msg = &types.MsgExecutionPayload{
-					Data: payload,
+					ExecutionPayload: payload,
 				}
 			}
 

--- a/halo/evmengine/keeper/proposal_server.go
+++ b/halo/evmengine/keeper/proposal_server.go
@@ -4,6 +4,9 @@ import (
 	"context"
 
 	"github.com/omni-network/omni/halo/evmengine/types"
+	"github.com/omni-network/omni/lib/errors"
+
+	"github.com/cosmos/gogoproto/proto"
 )
 
 type proposalServer struct {
@@ -14,9 +17,21 @@ type proposalServer struct {
 // ExecutionPayload handles a new execution payload proposed in a block.
 func (s proposalServer) ExecutionPayload(ctx context.Context, msg *types.MsgExecutionPayload,
 ) (*types.ExecutionPayloadResponse, error) {
-	_, err := pushPayload(ctx, s.engineCl, msg)
+	// Push the payload to the EVM, ensuring it is valid.
+	payload, err := pushPayload(ctx, s.engineCl, msg)
 	if err != nil {
 		return nil, err
+	}
+
+	// Collect local view of the evm logs from the previous payload.
+	evmLogs, err := s.evmLogs(ctx, payload.ParentHash)
+	if err != nil {
+		return nil, errors.Wrap(err, "prepare evm logs")
+	}
+
+	// Ensure the proposed evm logs are equal to the local view.
+	if err := evmLogsEqual(evmLogs, msg.PrevPayloadLogs); err != nil {
+		return nil, errors.Wrap(err, "verify prev payload logs")
 	}
 
 	return &types.ExecutionPayloadResponse{}, nil
@@ -29,3 +44,17 @@ func NewProposalServer(keeper *Keeper) types.MsgServiceServer {
 }
 
 var _ types.MsgServiceServer = proposalServer{}
+
+func evmLogsEqual(a, b []*types.EVMLog) error {
+	if len(a) != len(b) {
+		return errors.New("count mismatch")
+	}
+
+	for i := range a {
+		if !proto.Equal(a[i], b[i]) {
+			return errors.New("log mismatch", "index", i)
+		}
+	}
+
+	return nil
+}

--- a/halo/evmengine/keeper/proposal_server_internal_test.go
+++ b/halo/evmengine/keeper/proposal_server_internal_test.go
@@ -56,8 +56,8 @@ func Test_proposalServer_ExecutionPayload(t *testing.T) {
 
 	assertExecutionPayload := func() {
 		resp, err := propSrv.ExecutionPayload(ctx, &types.MsgExecutionPayload{
-			Authority: authtypes.NewModuleAddress(types.ModuleName).String(),
-			Data:      payloadData,
+			Authority:        authtypes.NewModuleAddress(types.ModuleName).String(),
+			ExecutionPayload: payloadData,
 		})
 		require.NoError(t, err)
 		require.NotNil(t, resp)
@@ -74,8 +74,8 @@ func Test_proposalServer_ExecutionPayload(t *testing.T) {
 	assertExecutionPayload()
 
 	_, err = propSrv.ExecutionPayload(ctx, &types.MsgExecutionPayload{
-		Authority: authtypes.NewModuleAddress(types.ModuleName).String(),
-		Data:      []byte("invalid"),
+		Authority:        authtypes.NewModuleAddress(types.ModuleName).String(),
+		ExecutionPayload: []byte("invalid"),
 	})
 	require.Error(t, err)
 }

--- a/halo/evmengine/types/cpayload.go
+++ b/halo/evmengine/types/cpayload.go
@@ -5,14 +5,28 @@ import (
 
 	abci "github.com/cometbft/cometbft/abci/types"
 
+	"github.com/ethereum/go-ethereum/common"
+
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
-// CPayloadProvider abstracts modules that provide consensus payload messages.
-// These include msgs from vote extensions and/or any msgs from EVM contracts.
+// VoteExtensionProvider abstracts logic that provides consensus payload messages
+// from the last commits vote extensions.
 //
-// EVMEngine calls this during PreparePayload to collect all msgs to include in
-// the single consensus transaction.
-type CPayloadProvider interface {
-	PreparePayload(ctx context.Context, height uint64, commit abci.ExtendedCommitInfo) ([]sdk.Msg, error)
+// EVMEngine calls this during PreparePayload to collect all vote extensions msgs to include in
+// the consensus block.
+type VoteExtensionProvider interface {
+	PrepareVotes(ctx context.Context, commit abci.ExtendedCommitInfo) ([]sdk.Msg, error)
+}
+
+// EvmLogProvider abstracts logic that provide EVM logs of the
+// previous execution payload (current head) identified by
+// the provided block hash.
+//
+// EVMEngine calls this during PreparePayload to collect all EVM-logs to include in
+// the consensus block. It is also called during ProcessPayload to verify the proposed EVM logs.
+type EvmLogProvider interface {
+	Logs(ctx context.Context, blockHash common.Hash) ([]*EVMLog, error)
+	Addresses() []common.Address
+	DeliverLog(ctx context.Context, blockHash common.Hash, log *EVMLog) error
 }

--- a/halo/evmengine/types/tx.go
+++ b/halo/evmengine/types/tx.go
@@ -1,0 +1,33 @@
+package types
+
+import (
+	"github.com/omni-network/omni/lib/errors"
+
+	"github.com/ethereum/go-ethereum/common"
+)
+
+func (l *EVMLog) Verify() error {
+	if l == nil {
+		return errors.New("nil log")
+	}
+
+	if l.Address == nil {
+		return errors.New("nil address")
+	}
+
+	if len(l.Topics) == 0 {
+		return errors.New("empty topics")
+	}
+
+	if len(l.Address) != len(common.Address{}) {
+		return errors.New("invalid address length")
+	}
+
+	for _, t := range l.Topics {
+		if len(t) != len(common.Hash{}) {
+			return errors.New("invalid topic length")
+		}
+	}
+
+	return nil
+}

--- a/halo/evmengine/types/tx.pb.go
+++ b/halo/evmengine/types/tx.pb.go
@@ -28,10 +28,12 @@ var _ = math.Inf
 // proto package needs to be updated.
 const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
-// MsgExecutionPayload defines a Omni EVM execution payload.
+// MsgExecutionPayload defines the  next EVM execution payload and the
+// logs from previous execution payload.
 type MsgExecutionPayload struct {
-	Authority string `protobuf:"bytes,1,opt,name=authority,proto3" json:"authority,omitempty"`
-	Data      []byte `protobuf:"bytes,2,opt,name=data,proto3" json:"data,omitempty"`
+	Authority        string    `protobuf:"bytes,1,opt,name=authority,proto3" json:"authority,omitempty"`
+	ExecutionPayload []byte    `protobuf:"bytes,2,opt,name=execution_payload,json=executionPayload,proto3" json:"execution_payload,omitempty"`
+	PrevPayloadLogs  []*EVMLog `protobuf:"bytes,3,rep,name=prev_payload_logs,json=prevPayloadLogs,proto3" json:"prev_payload_logs,omitempty"`
 }
 
 func (m *MsgExecutionPayload) Reset()         { *m = MsgExecutionPayload{} }
@@ -74,9 +76,16 @@ func (m *MsgExecutionPayload) GetAuthority() string {
 	return ""
 }
 
-func (m *MsgExecutionPayload) GetData() []byte {
+func (m *MsgExecutionPayload) GetExecutionPayload() []byte {
 	if m != nil {
-		return m.Data
+		return m.ExecutionPayload
+	}
+	return nil
+}
+
+func (m *MsgExecutionPayload) GetPrevPayloadLogs() []*EVMLog {
+	if m != nil {
+		return m.PrevPayloadLogs
 	}
 	return nil
 }
@@ -117,31 +126,100 @@ func (m *ExecutionPayloadResponse) XXX_DiscardUnknown() {
 
 var xxx_messageInfo_ExecutionPayloadResponse proto.InternalMessageInfo
 
+// EVMLog represents a contract log event.
+// Derived fields are not included in the protobuf.
+type EVMLog struct {
+	Address []byte   `protobuf:"bytes,1,opt,name=address,proto3" json:"address,omitempty"`
+	Topics  [][]byte `protobuf:"bytes,2,rep,name=topics,proto3" json:"topics,omitempty"`
+	Data    []byte   `protobuf:"bytes,3,opt,name=data,proto3" json:"data,omitempty"`
+}
+
+func (m *EVMLog) Reset()         { *m = EVMLog{} }
+func (m *EVMLog) String() string { return proto.CompactTextString(m) }
+func (*EVMLog) ProtoMessage()    {}
+func (*EVMLog) Descriptor() ([]byte, []int) {
+	return fileDescriptor_296c2c36824f00f5, []int{2}
+}
+func (m *EVMLog) XXX_Unmarshal(b []byte) error {
+	return m.Unmarshal(b)
+}
+func (m *EVMLog) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	if deterministic {
+		return xxx_messageInfo_EVMLog.Marshal(b, m, deterministic)
+	} else {
+		b = b[:cap(b)]
+		n, err := m.MarshalToSizedBuffer(b)
+		if err != nil {
+			return nil, err
+		}
+		return b[:n], nil
+	}
+}
+func (m *EVMLog) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_EVMLog.Merge(m, src)
+}
+func (m *EVMLog) XXX_Size() int {
+	return m.Size()
+}
+func (m *EVMLog) XXX_DiscardUnknown() {
+	xxx_messageInfo_EVMLog.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_EVMLog proto.InternalMessageInfo
+
+func (m *EVMLog) GetAddress() []byte {
+	if m != nil {
+		return m.Address
+	}
+	return nil
+}
+
+func (m *EVMLog) GetTopics() [][]byte {
+	if m != nil {
+		return m.Topics
+	}
+	return nil
+}
+
+func (m *EVMLog) GetData() []byte {
+	if m != nil {
+		return m.Data
+	}
+	return nil
+}
+
 func init() {
 	proto.RegisterType((*MsgExecutionPayload)(nil), "halo.evmengine.types.MsgExecutionPayload")
 	proto.RegisterType((*ExecutionPayloadResponse)(nil), "halo.evmengine.types.ExecutionPayloadResponse")
+	proto.RegisterType((*EVMLog)(nil), "halo.evmengine.types.EVMLog")
 }
 
 func init() { proto.RegisterFile("halo/evmengine/types/tx.proto", fileDescriptor_296c2c36824f00f5) }
 
 var fileDescriptor_296c2c36824f00f5 = []byte{
-	// 248 bytes of a gzipped FileDescriptorProto
-	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xe2, 0x92, 0xcd, 0x48, 0xcc, 0xc9,
-	0xd7, 0x4f, 0x2d, 0xcb, 0x4d, 0xcd, 0x4b, 0xcf, 0xcc, 0x4b, 0xd5, 0x2f, 0xa9, 0x2c, 0x48, 0x2d,
-	0xd6, 0x2f, 0xa9, 0xd0, 0x2b, 0x28, 0xca, 0x2f, 0xc9, 0x17, 0x12, 0x01, 0x49, 0xeb, 0xc1, 0xa5,
-	0xf5, 0xc0, 0xd2, 0x52, 0xe2, 0xc9, 0xf9, 0xc5, 0xb9, 0xf9, 0xc5, 0xfa, 0xb9, 0xc5, 0xe9, 0xfa,
-	0x65, 0x86, 0x20, 0x0a, 0xa2, 0x5c, 0x29, 0x9c, 0x4b, 0xd8, 0xb7, 0x38, 0xdd, 0xb5, 0x22, 0x35,
-	0xb9, 0xb4, 0x24, 0x33, 0x3f, 0x2f, 0x20, 0xb1, 0x32, 0x27, 0x3f, 0x31, 0x45, 0x48, 0x86, 0x8b,
-	0x33, 0xb1, 0xb4, 0x24, 0x23, 0xbf, 0x28, 0xb3, 0xa4, 0x52, 0x82, 0x51, 0x81, 0x51, 0x83, 0x33,
-	0x08, 0x21, 0x20, 0x24, 0xc4, 0xc5, 0x92, 0x92, 0x58, 0x92, 0x28, 0xc1, 0xa4, 0xc0, 0xa8, 0xc1,
-	0x13, 0x04, 0x66, 0x5b, 0xf1, 0x35, 0x3d, 0xdf, 0xa0, 0x85, 0x50, 0xa3, 0x24, 0xc5, 0x25, 0x81,
-	0x6e, 0x6a, 0x50, 0x6a, 0x71, 0x41, 0x7e, 0x5e, 0x71, 0xaa, 0x51, 0x13, 0x23, 0x17, 0x97, 0x6f,
-	0x71, 0x7a, 0x70, 0x6a, 0x51, 0x59, 0x66, 0x72, 0xaa, 0x50, 0x2e, 0x97, 0x00, 0x86, 0x03, 0x34,
-	0xf5, 0xb0, 0xf9, 0x43, 0x0f, 0x8b, 0x5b, 0xa5, 0xf4, 0xb0, 0x2b, 0xc5, 0x65, 0xbb, 0x14, 0x6b,
-	0xc3, 0xf3, 0x0d, 0x5a, 0x8c, 0x4e, 0x7a, 0x27, 0x1e, 0xc9, 0x31, 0x5e, 0x78, 0x24, 0xc7, 0xf8,
-	0xe0, 0x91, 0x1c, 0xe3, 0x84, 0xc7, 0x72, 0x0c, 0x17, 0x1e, 0xcb, 0x31, 0xdc, 0x78, 0x2c, 0xc7,
-	0x10, 0x25, 0x82, 0x2d, 0x84, 0x93, 0xd8, 0xc0, 0x01, 0x66, 0x0c, 0x08, 0x00, 0x00, 0xff, 0xff,
-	0xeb, 0x60, 0x07, 0xd6, 0x80, 0x01, 0x00, 0x00,
+	// 349 bytes of a gzipped FileDescriptorProto
+	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0x74, 0x52, 0xcf, 0x4e, 0xc2, 0x30,
+	0x1c, 0xa6, 0x4c, 0x31, 0x54, 0xa2, 0x50, 0x89, 0x36, 0x0b, 0x2e, 0x0b, 0xa7, 0x89, 0x49, 0x17,
+	0xf1, 0xe6, 0xd1, 0x84, 0xc4, 0x03, 0x18, 0x33, 0x13, 0x0f, 0x5e, 0x48, 0xdd, 0x9a, 0xb2, 0x84,
+	0xad, 0xcb, 0x5a, 0x16, 0xb8, 0x19, 0x9e, 0xc0, 0x47, 0xe1, 0xec, 0x13, 0x78, 0xe4, 0xe8, 0xd1,
+	0xc0, 0x81, 0xd7, 0x30, 0x0c, 0x90, 0x04, 0xc7, 0x69, 0xfb, 0xf5, 0xfb, 0x93, 0xef, 0xfb, 0xb5,
+	0xf0, 0xb2, 0x47, 0xfb, 0xc2, 0x66, 0x49, 0xc0, 0x42, 0xee, 0x87, 0xcc, 0x56, 0xa3, 0x88, 0x49,
+	0x5b, 0x0d, 0x49, 0x14, 0x0b, 0x25, 0x50, 0x75, 0x09, 0x93, 0x3f, 0x98, 0xa4, 0xb0, 0x7e, 0xe1,
+	0x0a, 0x19, 0x08, 0x69, 0x07, 0x92, 0xdb, 0xc9, 0xcd, 0xf2, 0xb3, 0xa2, 0xd7, 0x3f, 0x01, 0x3c,
+	0xeb, 0x48, 0xde, 0x1a, 0x32, 0x77, 0xa0, 0x7c, 0x11, 0x3e, 0xd1, 0x51, 0x5f, 0x50, 0x0f, 0xd5,
+	0x60, 0x91, 0x0e, 0x54, 0x4f, 0xc4, 0xbe, 0x1a, 0x61, 0x60, 0x02, 0xab, 0xe8, 0x6c, 0x0f, 0xd0,
+	0x35, 0xac, 0xb0, 0x8d, 0xa2, 0x1b, 0xad, 0x24, 0x38, 0x6f, 0x02, 0xab, 0xe4, 0x94, 0xd9, 0xae,
+	0xd5, 0x03, 0xac, 0x44, 0x31, 0x4b, 0x36, 0xbc, 0x6e, 0x5f, 0x70, 0x89, 0x35, 0x53, 0xb3, 0x8e,
+	0x9b, 0x35, 0x92, 0x95, 0x96, 0xb4, 0x5e, 0x3a, 0x6d, 0xc1, 0x9d, 0xd3, 0xa5, 0x6c, 0xed, 0xd2,
+	0x16, 0x5c, 0xde, 0x9d, 0x8c, 0x17, 0x93, 0xc6, 0x36, 0x46, 0x5d, 0x87, 0x78, 0x37, 0xb8, 0xc3,
+	0x64, 0x24, 0x42, 0xc9, 0xea, 0x8f, 0xb0, 0xb0, 0xb2, 0x41, 0x18, 0x1e, 0x51, 0xcf, 0x8b, 0x99,
+	0x94, 0x69, 0x91, 0x92, 0xb3, 0x19, 0xd1, 0x39, 0x2c, 0x28, 0x11, 0xf9, 0xae, 0xc4, 0x79, 0x53,
+	0xb3, 0x4a, 0xce, 0x7a, 0x42, 0x08, 0x1e, 0x78, 0x54, 0x51, 0xac, 0xa5, 0xf4, 0xf4, 0xbf, 0x39,
+	0x06, 0x10, 0x76, 0x24, 0x7f, 0x66, 0x71, 0xe2, 0xbb, 0x0c, 0x05, 0xb0, 0xfc, 0x6f, 0x67, 0x57,
+	0xd9, 0x6d, 0x32, 0xd6, 0xab, 0x93, 0x3d, 0xc5, 0xf7, 0xb4, 0xd1, 0x0f, 0xdf, 0x17, 0x93, 0x06,
+	0xb8, 0x27, 0x5f, 0x33, 0x03, 0x4c, 0x67, 0x06, 0xf8, 0x99, 0x19, 0xe0, 0x63, 0x6e, 0xe4, 0xa6,
+	0x73, 0x23, 0xf7, 0x3d, 0x37, 0x72, 0xaf, 0xd5, 0xac, 0x57, 0xf1, 0x56, 0x48, 0x2f, 0xf9, 0xf6,
+	0x37, 0x00, 0x00, 0xff, 0xff, 0xb2, 0x66, 0xc4, 0x36, 0x34, 0x02, 0x00, 0x00,
 }
 
 // Reference imports to suppress errors if they are not otherwise used.
@@ -246,10 +324,24 @@ func (m *MsgExecutionPayload) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 	_ = i
 	var l int
 	_ = l
-	if len(m.Data) > 0 {
-		i -= len(m.Data)
-		copy(dAtA[i:], m.Data)
-		i = encodeVarintTx(dAtA, i, uint64(len(m.Data)))
+	if len(m.PrevPayloadLogs) > 0 {
+		for iNdEx := len(m.PrevPayloadLogs) - 1; iNdEx >= 0; iNdEx-- {
+			{
+				size, err := m.PrevPayloadLogs[iNdEx].MarshalToSizedBuffer(dAtA[:i])
+				if err != nil {
+					return 0, err
+				}
+				i -= size
+				i = encodeVarintTx(dAtA, i, uint64(size))
+			}
+			i--
+			dAtA[i] = 0x1a
+		}
+	}
+	if len(m.ExecutionPayload) > 0 {
+		i -= len(m.ExecutionPayload)
+		copy(dAtA[i:], m.ExecutionPayload)
+		i = encodeVarintTx(dAtA, i, uint64(len(m.ExecutionPayload)))
 		i--
 		dAtA[i] = 0x12
 	}
@@ -286,6 +378,52 @@ func (m *ExecutionPayloadResponse) MarshalToSizedBuffer(dAtA []byte) (int, error
 	return len(dAtA) - i, nil
 }
 
+func (m *EVMLog) Marshal() (dAtA []byte, err error) {
+	size := m.Size()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *EVMLog) MarshalTo(dAtA []byte) (int, error) {
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *EVMLog) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if len(m.Data) > 0 {
+		i -= len(m.Data)
+		copy(dAtA[i:], m.Data)
+		i = encodeVarintTx(dAtA, i, uint64(len(m.Data)))
+		i--
+		dAtA[i] = 0x1a
+	}
+	if len(m.Topics) > 0 {
+		for iNdEx := len(m.Topics) - 1; iNdEx >= 0; iNdEx-- {
+			i -= len(m.Topics[iNdEx])
+			copy(dAtA[i:], m.Topics[iNdEx])
+			i = encodeVarintTx(dAtA, i, uint64(len(m.Topics[iNdEx])))
+			i--
+			dAtA[i] = 0x12
+		}
+	}
+	if len(m.Address) > 0 {
+		i -= len(m.Address)
+		copy(dAtA[i:], m.Address)
+		i = encodeVarintTx(dAtA, i, uint64(len(m.Address)))
+		i--
+		dAtA[i] = 0xa
+	}
+	return len(dAtA) - i, nil
+}
+
 func encodeVarintTx(dAtA []byte, offset int, v uint64) int {
 	offset -= sovTx(v)
 	base := offset
@@ -307,9 +445,15 @@ func (m *MsgExecutionPayload) Size() (n int) {
 	if l > 0 {
 		n += 1 + l + sovTx(uint64(l))
 	}
-	l = len(m.Data)
+	l = len(m.ExecutionPayload)
 	if l > 0 {
 		n += 1 + l + sovTx(uint64(l))
+	}
+	if len(m.PrevPayloadLogs) > 0 {
+		for _, e := range m.PrevPayloadLogs {
+			l = e.Size()
+			n += 1 + l + sovTx(uint64(l))
+		}
 	}
 	return n
 }
@@ -320,6 +464,29 @@ func (m *ExecutionPayloadResponse) Size() (n int) {
 	}
 	var l int
 	_ = l
+	return n
+}
+
+func (m *EVMLog) Size() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	l = len(m.Address)
+	if l > 0 {
+		n += 1 + l + sovTx(uint64(l))
+	}
+	if len(m.Topics) > 0 {
+		for _, b := range m.Topics {
+			l = len(b)
+			n += 1 + l + sovTx(uint64(l))
+		}
+	}
+	l = len(m.Data)
+	if l > 0 {
+		n += 1 + l + sovTx(uint64(l))
+	}
 	return n
 }
 
@@ -392,7 +559,7 @@ func (m *MsgExecutionPayload) Unmarshal(dAtA []byte) error {
 			iNdEx = postIndex
 		case 2:
 			if wireType != 2 {
-				return fmt.Errorf("proto: wrong wireType = %d for field Data", wireType)
+				return fmt.Errorf("proto: wrong wireType = %d for field ExecutionPayload", wireType)
 			}
 			var byteLen int
 			for shift := uint(0); ; shift += 7 {
@@ -419,9 +586,43 @@ func (m *MsgExecutionPayload) Unmarshal(dAtA []byte) error {
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
-			m.Data = append(m.Data[:0], dAtA[iNdEx:postIndex]...)
-			if m.Data == nil {
-				m.Data = []byte{}
+			m.ExecutionPayload = append(m.ExecutionPayload[:0], dAtA[iNdEx:postIndex]...)
+			if m.ExecutionPayload == nil {
+				m.ExecutionPayload = []byte{}
+			}
+			iNdEx = postIndex
+		case 3:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field PrevPayloadLogs", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowTx
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthTx
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return ErrInvalidLengthTx
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.PrevPayloadLogs = append(m.PrevPayloadLogs, &EVMLog{})
+			if err := m.PrevPayloadLogs[len(m.PrevPayloadLogs)-1].Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+				return err
 			}
 			iNdEx = postIndex
 		default:
@@ -474,6 +675,156 @@ func (m *ExecutionPayloadResponse) Unmarshal(dAtA []byte) error {
 			return fmt.Errorf("proto: ExecutionPayloadResponse: illegal tag %d (wire type %d)", fieldNum, wire)
 		}
 		switch fieldNum {
+		default:
+			iNdEx = preIndex
+			skippy, err := skipTx(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return ErrInvalidLengthTx
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *EVMLog) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowTx
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: EVMLog: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: EVMLog: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Address", wireType)
+			}
+			var byteLen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowTx
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				byteLen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if byteLen < 0 {
+				return ErrInvalidLengthTx
+			}
+			postIndex := iNdEx + byteLen
+			if postIndex < 0 {
+				return ErrInvalidLengthTx
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Address = append(m.Address[:0], dAtA[iNdEx:postIndex]...)
+			if m.Address == nil {
+				m.Address = []byte{}
+			}
+			iNdEx = postIndex
+		case 2:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Topics", wireType)
+			}
+			var byteLen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowTx
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				byteLen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if byteLen < 0 {
+				return ErrInvalidLengthTx
+			}
+			postIndex := iNdEx + byteLen
+			if postIndex < 0 {
+				return ErrInvalidLengthTx
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Topics = append(m.Topics, make([]byte, postIndex-iNdEx))
+			copy(m.Topics[len(m.Topics)-1], dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 3:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Data", wireType)
+			}
+			var byteLen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowTx
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				byteLen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if byteLen < 0 {
+				return ErrInvalidLengthTx
+			}
+			postIndex := iNdEx + byteLen
+			if postIndex < 0 {
+				return ErrInvalidLengthTx
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Data = append(m.Data[:0], dAtA[iNdEx:postIndex]...)
+			if m.Data == nil {
+				m.Data = []byte{}
+			}
+			iNdEx = postIndex
 		default:
 			iNdEx = preIndex
 			skippy, err := skipTx(dAtA[iNdEx:])

--- a/halo/evmengine/types/tx.proto
+++ b/halo/evmengine/types/tx.proto
@@ -14,11 +14,21 @@ service MsgService {
   rpc ExecutionPayload (MsgExecutionPayload) returns (ExecutionPayloadResponse);
 }
 
-// MsgExecutionPayload defines a Omni EVM execution payload.
+// MsgExecutionPayload defines the  next EVM execution payload and the
+// logs from previous execution payload.
 message MsgExecutionPayload {
   option (cosmos.msg.v1.signer) = "authority";
-  string authority = 1;
-  bytes  data      = 2;
+  string          authority         = 1;
+  bytes           execution_payload = 2;
+  repeated EVMLog prev_payload_logs = 3;
 }
 
 message ExecutionPayloadResponse {}
+
+// EVMLog represents a contract log event.
+// Derived fields are not included in the protobuf.
+message EVMLog {
+  bytes          address = 1; // Address of the contract that emitted the log (20 bytes).
+  repeated bytes topics  = 2; // List of topics provided by the contract (N * 32 bytes).
+  bytes          data    = 3; // Data supplied by the contract, usually ABI-encoded.
+}

--- a/lib/ethclient/enginemock.go
+++ b/lib/ethclient/enginemock.go
@@ -10,6 +10,7 @@ import (
 	"github.com/omni-network/omni/lib/errors"
 	"github.com/omni-network/omni/lib/log"
 
+	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/beacon/engine"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
@@ -56,6 +57,15 @@ func NewEngineMock() (EngineClient, error) {
 		head:     genesisBlock,
 		payloads: make(map[engine.PayloadID]engine.ExecutableData),
 	}, nil
+}
+
+func (*engineMock) FilterLogs(_ context.Context, q ethereum.FilterQuery) ([]types.Log, error) {
+	f := fuzz.NewWithSeed(int64(q.BlockHash[0])).NilChance(0).NumElements(1, 4)
+	var resp1, resp2 types.Log
+	f.Fuzz(&resp1)
+	f.Fuzz(&resp2)
+
+	return []types.Log{resp1, resp2}, nil
 }
 
 func (m *engineMock) BlockNumber(_ context.Context) (uint64, error) {


### PR DESCRIPTION
Adds evm logs of current EVM head as part of `MsgExecutionPayload` in `PrepareProposal`, verify it in `ProcessProposal`, deliver the logs to `EVMLogProviders` in `FinaliseBlock`.

Added a `pocLogProvider` to test the feature. 

task: none