### PR TITLE
chore(e2e): migrate to sepolia

### DIFF
--- a/monitor/avs/monitor.go
+++ b/monitor/avs/monitor.go
@@ -135,7 +135,7 @@ type monitorOnce func(ctx context.Context, avs *bindings.OmniAVS) error
 
 // monitorForever runs the given monitor function every 30 seconds until the context is canceled.
 func monitorForever(ctx context.Context, avs *bindings.OmniAVS, name string, f monitorOnce) {
-	interval := time.Second * 30
+	interval := time.Minute * 1
 	ticker := time.NewTicker(interval)
 	defer ticker.Stop()
 

--- a/test/e2e/manifests/staging.toml
+++ b/test/e2e/manifests/staging.toml
@@ -1,6 +1,7 @@
 network = "staging"
 public_chains = ["arb_sepolia", "op_sepolia"]
 anvil_chains = ["chain_a"]
+avs_target = "chain_a"
 multi_omni_evms = true
 prometheus = true
 

--- a/test/e2e/manifests/staging.toml
+++ b/test/e2e/manifests/staging.toml
@@ -1,7 +1,6 @@
 network = "staging"
-public_chains = ["goerli"]
+public_chains = ["arb_sepolia", "op_sepolia"]
 anvil_chains = ["chain_a"]
-avs_target = "goerli"
 multi_omni_evms = true
 prometheus = true
 

--- a/test/e2e/types/chain.go
+++ b/test/e2e/types/chain.go
@@ -31,6 +31,22 @@ var (
 		BlockPeriod:       15 * time.Second,
 		FinalizationStrat: netconf.StratFinalized,
 	}
+
+	chainArbSepolia = EVMChain{
+		Name:              "arb_sepolia",
+		ID:                421614,
+		IsPublic:          true,
+		BlockPeriod:       6 * time.Second,
+		FinalizationStrat: netconf.StratFinalized,
+	}
+
+	chainOpSepolia = EVMChain{
+		Name:              "op_sepolia",
+		ID:                11155420,
+		IsPublic:          true,
+		BlockPeriod:       6 * time.Second,
+		FinalizationStrat: netconf.StratFinalized,
+	}
 )
 
 const anvilChainIDFactor = 100
@@ -57,6 +73,10 @@ func PublicChainByName(name string) (EVMChain, error) {
 		return chainArbGoerli, nil
 	case chainGoerli.Name:
 		return chainGoerli, nil
+	case chainArbSepolia.Name:
+		return chainArbSepolia, nil
+	case chainOpSepolia.Name:
+		return chainOpSepolia, nil
 	default:
 		return EVMChain{}, errors.New("unknown chain name")
 	}
@@ -69,6 +89,10 @@ func PublicRPCByName(name string) string {
 		return "https://arbitrum-goerli.publicnode.com"
 	case chainGoerli.Name:
 		return "https://rpc.ankr.com/eth_goerli"
+	case chainArbSepolia.Name:
+		return "https://sepolia-rollup.arbitrum.io/rpc"
+	case chainOpSepolia.Name:
+		return "https://sepolia.optimism.io"
 	default:
 		return ""
 	}


### PR DESCRIPTION
Goerli stopped finalizing blocks, RIP.
- use arb sepolia and op sepolia for rollups
- we can't use Goerli for the AVS contracts anymore (we could, but wouldn't be able to pass restaking payloads to Omni), so let's just use our anvil chain for now

task: none
