### PR TITLE
chore(lib/buildinfo): bump buildinfo minor and patch version

### DIFF
--- a/halo/config/testdata/default_halo.toml
+++ b/halo/config/testdata/default_halo.toml
@@ -3,7 +3,7 @@
 
 # The version of the Halo binary that created or
 # last modified the config file. Do not modify this.
-version = "unknown"
+version = "v0.1.1"
 
 #######################################################################
 ###                          Halo Options                           ###

--- a/lib/buildinfo/buildinfo.go
+++ b/lib/buildinfo/buildinfo.go
@@ -13,7 +13,7 @@ import (
 
 // version of the whole omni-monorepo and all binaries built from this git commit.
 // This value is set by goreleaser at build-time and should be the git tag for official releases.
-var version = "unknown"
+var version = "v0.1.1"
 
 // Version returns the version of the whole omni-monorepo and all binaries built from this git commit.
 func Version() string {

--- a/relayer/app/testdata/default_relayer.toml
+++ b/relayer/app/testdata/default_relayer.toml
@@ -3,7 +3,7 @@
 
 # The version of the Halo binary that created or
 # last modified the config file. Do not modify this.
-version = "unknown"
+version = "v0.1.1"
 
 #######################################################################
 ###                         Relayer Options                         ###


### PR DESCRIPTION
Increases version in lib/buildinfo so version is shown when running version command on locally built CLI

task: https://app.asana.com/0/1206684215872507/1206806971862694/f
