### PR TITLE
feat(e2e): add avs-deploy subcommand

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -586,7 +586,7 @@
         "filename": "test/e2e/app/run.go",
         "hashed_secret": "fe86558143c0bd528f649a153bdc32b8fa90301c",
         "is_verified": false,
-        "line_number": 111
+        "line_number": 112
       }
     ],
     "test/e2e/app/setup.go": [
@@ -854,5 +854,5 @@
       }
     ]
   },
-  "generated_at": "2024-03-12T14:55:20Z"
+  "generated_at": "2024-03-12T15:27:27Z"
 }

--- a/test/e2e/app/avs.go
+++ b/test/e2e/app/avs.go
@@ -9,11 +9,40 @@ import (
 	"github.com/omni-network/omni/lib/log"
 	"github.com/omni-network/omni/test/e2e/app/static"
 	"github.com/omni-network/omni/test/e2e/types"
-
-	_ "embed"
 )
 
-func deployAVS(ctx context.Context, def Definition, cfg DeployConfig, deployInfo types.DeployInfos) error {
+func DefaultAVSDeployConfig() AVSDeployConfig {
+	return AVSDeployConfig{}
+}
+
+type AVSDeployConfig struct {
+	EigenFile string
+}
+
+// AVSDeploy deploys the Omni AVS contracts.
+func AVSDeploy(ctx context.Context, def Definition, cfg AVSDeployConfig) error {
+	info := make(types.DeployInfos)
+	err := deployAVS(ctx, def, cfg, info)
+	if err != nil {
+		return err
+	}
+
+	chain, err := def.Testnet.AVSChain()
+	if err != nil {
+		return err
+	}
+
+	addr, found := info.Addr(chain.ID, types.ContractOmniAVS)
+	if !found {
+		return errors.New("avs contract not found")
+	}
+
+	log.Info(ctx, "AVS contract deployed", "addr", addr.Hex())
+
+	return nil
+}
+
+func deployAVS(ctx context.Context, def Definition, cfg AVSDeployConfig, deployInfo types.DeployInfos) error {
 	var (
 		elDeps avs.EigenDeployments
 		err    error

--- a/test/e2e/app/run.go
+++ b/test/e2e/app/run.go
@@ -25,8 +25,9 @@ func DefaultDeployConfig() DeployConfig {
 }
 
 type DeployConfig struct {
+	AVSDeployConfig
+
 	AgentSecrets agent.Secrets
-	EigenFile    string
 	PingPongN    uint64
 
 	// Internal use parameters (no command line flags).
@@ -67,7 +68,7 @@ func Deploy(ctx context.Context, def Definition, cfg DeployConfig) (types.Deploy
 
 	deployInfo := make(types.DeployInfos)
 
-	if err := deployAVS(ctx, def, cfg, deployInfo); err != nil {
+	if err := deployAVS(ctx, def, cfg.AVSDeployConfig, deployInfo); err != nil {
 		return nil, nil, err
 	}
 

--- a/test/e2e/cmd/cmd.go
+++ b/test/e2e/cmd/cmd.go
@@ -54,6 +54,7 @@ func New() *cobra.Command {
 
 	// Add subcommands
 	cmd.AddCommand(
+		newAVSDeployCmd(&def),
 		newDeployCmd(&def),
 		newLogsCmd(&def),
 		newCleanCmd(&def),
@@ -119,4 +120,20 @@ func newUpgradeCmd(def *app.Definition) *cobra.Command {
 			return app.Upgrade(cmd.Context(), *def)
 		},
 	}
+}
+
+func newAVSDeployCmd(def *app.Definition) *cobra.Command {
+	cfg := app.DefaultAVSDeployConfig()
+
+	cmd := &cobra.Command{
+		Use:   "avs-deploy",
+		Short: "Deploys the Omni AVS contracts",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return app.AVSDeploy(cmd.Context(), *def, cfg)
+		},
+	}
+
+	bindAVSDeployFlags(cmd.Flags(), &cfg)
+
+	return cmd
 }

--- a/test/e2e/cmd/flags.go
+++ b/test/e2e/cmd/flags.go
@@ -30,6 +30,10 @@ func bindPromFlags(flags *pflag.FlagSet, cfg *agent.Secrets) {
 
 func bindDeployFlags(flags *pflag.FlagSet, cfg *app.DeployConfig) {
 	bindPromFlags(flags, &cfg.AgentSecrets)
-	flags.StringVar(&cfg.EigenFile, "eigen-file", cfg.EigenFile, "path to json file defining eigenlayer deployments. Defaults to ./e2e/app/static/el_deployments.json")
+	bindAVSDeployFlags(flags, &cfg.AVSDeployConfig)
 	flags.Uint64Var(&cfg.PingPongN, "ping-pong", cfg.PingPongN, "Number of ping pongs messages to send. 0 disables it")
+}
+
+func bindAVSDeployFlags(flags *pflag.FlagSet, cfg *app.AVSDeployConfig) {
+	flags.StringVar(&cfg.EigenFile, "eigen-file", cfg.EigenFile, "path to json file defining eigenlayer deployments. Defaults to ./e2e/app/static/el_deployments.json")
 }


### PR DESCRIPTION
Add `avs-deploy` subcommand to the e2e runner binary.

task: https://app.asana.com/0/1206208509925075/1206799220447925/f