### PR TITLE
fix(halo/attest): only approve sequentially

### DIFF
--- a/halo/attest/keeper/common_test.go
+++ b/halo/attest/keeper/common_test.go
@@ -44,7 +44,7 @@ func namerCalled(times int) expectation {
 func setupKeeper(t *testing.T, expectations ...expectation) (*keeper.Keeper, sdk.Context) {
 	t.Helper()
 
-	key := storetypes.NewKVStoreKey(types.StoreKey)
+	key := storetypes.NewKVStoreKey(types.ModuleName)
 	storeSvc := runtime.NewKVStoreService(key)
 	ctx := sdktestutil.DefaultContext(key, storetypes.NewTransientStoreKey("test_key"))
 	codec := moduletestutil.MakeTestEncodingConfig().Codec

--- a/halo/attest/types/helpers.go
+++ b/halo/attest/types/helpers.go
@@ -1,1 +1,0 @@
-package types

--- a/halo/attest/types/keys.go
+++ b/halo/attest/types/keys.go
@@ -3,10 +3,4 @@ package types
 const (
 	// ModuleName defines the module name.
 	ModuleName = "attest"
-
-	// StoreKey defines the primary module store key.
-	StoreKey = ModuleName
-
-	// MemStoreKey defines the in-memory store key.
-	MemStoreKey = "mem_attest"
 )

--- a/test/e2e/app/avs.go
+++ b/test/e2e/app/avs.go
@@ -59,7 +59,8 @@ func deployAVS(ctx context.Context, def Definition, cfg AVSDeployConfig, deployI
 
 	chain, err := def.Testnet.AVSChain()
 	if err != nil {
-		return err
+		log.Warn(ctx, "Not deploying AVS Contract", err)
+		return nil
 	}
 
 	portal := def.Netman.Portals()[chain.ID]


### PR DESCRIPTION
Approve attestations sequentially. 

I.e., so only approve 3, if the previously approved is 2. Do not allow approving 4 if previously approved is 2.

This fixes the following critical bug:
- Given a vote window of 10.
- If the last approved was 2 (so vote window is [0,12]
- If we skip 3 and approved 12 next, and then we approve 14, the vote window is [4,24]
- Which means 3 will never be approved.
- This will cause the cross chain protocol to stall forever.

task: none