### PR TITLE
test(halo/app): assert validator update in smoke test

### DIFF
--- a/e2e/app/definition.go
+++ b/e2e/app/definition.go
@@ -341,7 +341,7 @@ func internalNetwork(testnet types.Testnet, deployInfo map[types.EVMChain]netman
 			ID:   netconf.GetStatic(testnet.Network).OmniConsensusChainID,
 			Name: "omni_consensus",
 			// No RPC URLs, since we are going to remove it from netconf in any case.
-			DeployHeight:    0,
+			DeployHeight:    1,                         // Validator sets start at height 1, not 0.
 			BlockPeriod:     omniEVM.Chain.BlockPeriod, // Same block period as omniEVM
 			IsOmniConsensus: true,
 		})
@@ -406,7 +406,7 @@ func externalNetwork(testnet types.Testnet, deployInfo map[types.EVMChain]netman
 		ID:   netconf.GetStatic(testnet.Network).OmniConsensusChainID,
 		Name: "omni_consensus",
 		// No RPC URLs, since we are going to remove it from netconf in any case.
-		DeployHeight:    0,
+		DeployHeight:    1,                         // Validator sets start at height 1, not 0.
 		BlockPeriod:     omniEVM.Chain.BlockPeriod, // Same block period as omniEVM
 		IsOmniConsensus: true,
 	})

--- a/e2e/manifests/ci.toml
+++ b/e2e/manifests/ci.toml
@@ -15,4 +15,5 @@ perturb = ["restart"]
 
 # Trigger validator updates at height 20
 [validator_update.20]
+validator01 = 2 # Additional self-delegation of 2 ether $OMNI by validator01
 full01 = 2 # Add full01 as validator by depositing 2 ether $OMNI

--- a/halo/cmd/init.go
+++ b/halo/cmd/init.go
@@ -187,15 +187,23 @@ func InitFiles(ctx context.Context, initCfg InitConfig) error {
 	if cmtos.FileExists(networkFile) {
 		log.Info(ctx, "Found network config", "path", networkFile)
 	} else if initCfg.Network == netconf.Simnet {
+		static := netconf.GetStatic(initCfg.Network)
 		// Create a simnet (single binary with mocked clients).
 		network := netconf.Network{
 			Name: initCfg.Network,
 			Chains: []netconf.Chain{
 				{
-					ID:          999,
-					Name:        "omni",
+					ID:          static.OmniExecutionChainID,
+					Name:        "omni_evm",
 					IsOmniEVM:   true,
 					BlockPeriod: time.Millisecond * 500, // Speed up block times for testing
+				},
+				{
+					ID:              static.OmniConsensusChainID,
+					Name:            "omni_consensus",
+					IsOmniConsensus: true,
+					DeployHeight:    1,                      // Validator sets start at height 1, not 0.
+					BlockPeriod:     time.Millisecond * 500, // Speed up block times for testing
 				},
 				{
 					ID:         100, // todo(Lazar): make it dynamic. this is coming from lib/xchain/provider/mock.go

--- a/lib/xchain/provider/mock_internal_test.go
+++ b/lib/xchain/provider/mock_internal_test.go
@@ -20,7 +20,7 @@ func TestMock(t *testing.T) {
 		total      = 5
 	)
 
-	mock := NewMock(time.Millisecond)
+	mock := NewMock(time.Millisecond, 0, nil)
 
 	var blocks []xchain.Block
 	err := mock.StreamAsync(ctx, chainID, fromHeight, func(ctx context.Context, block xchain.Block) error {


### PR DESCRIPTION
- Adds support for "increased self-delegation" if deposit by existing validator.
- Add cprovider to xprovider mock since it can query the local halo instance
- Add a "wait for cometBFT validator set to change" assertion in smoke test
- Add a "mock deposit" to "engine mock" so we trigger validator updates in smoke test.

task: none