### PR TITLE
chore(docs): explain EVM client can be vanilla

### DIFF
--- a/docs/site/docs/operate/testnet/client.md
+++ b/docs/site/docs/operate/testnet/client.md
@@ -6,7 +6,7 @@ sidebar_position: 4
 
 This is the component that participates in network validation. Our consensus clients track delegations and stake from our AVS contracts.
 
-Similar to Ethereum, Omni validators run 2 components: our consensus client, `halo`, and an EVM execution client `geth`, `erigon`, `nethermind`, etc.
+Similar to Ethereum, Omni validators run 2 components: our consensus client, `halo`, and an EVM execution client `geth`, `erigon`, `nethermind`, etc. The EVM execution client does not require any modifications.
 
 :::info
 


### PR DESCRIPTION
Adds line explaining EVM client does not require modifications

task: none
