### PR TITLE
refactor(lib/txmgr): add support for fireblocks signer

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -83,6 +83,7 @@ linters-settings:
     ignoreSigs:
       - github.com/omni-network/omni/
       - google.golang.org/grpc/status # No point wrapping gRPC/network errors.
+      - github.com/ethereum/go-ethereum # We wrap these automatically in lib/ethclient
 
 issues:
   fix: true

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -76,6 +76,10 @@
       "path": "detect_secrets.filters.allowlist.is_line_allowlisted"
     },
     {
+      "path": "detect_secrets.filters.common.is_baseline_file",
+      "filename": ".secrets.baseline"
+    },
+    {
       "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
       "min_level": 2
     },
@@ -527,14 +531,7 @@
         "filename": "lib/fireblocks/jsonhttp.go",
         "hashed_secret": "fca71afec681b7c2932610046e8e524820317e47",
         "is_verified": false,
-        "line_number": 26
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "lib/fireblocks/jsonhttp.go",
-        "hashed_secret": "9b8b876c2782fa992fab14095267bb8757b9fabc",
-        "is_verified": false,
-        "line_number": 27
+        "line_number": 25
       }
     ],
     "lib/k1util/k1util_test.go": [
@@ -816,5 +813,5 @@
       }
     ]
   },
-  "generated_at": "2024-03-22T11:29:25Z"
+  "generated_at": "2024-03-22T12:31:28Z"
 }

--- a/lib/ethclient/ethbackend/backends.go
+++ b/lib/ethclient/ethbackend/backends.go
@@ -159,7 +159,7 @@ func newTxMgr(ethCl ethclient.Client, chainName string, chainID uint64, blockPer
 	}
 
 	// create a simple tx manager from our config
-	txMgr, err := txmgr.NewSimpleTxManagerFromConfig(chainName, cfg)
+	txMgr, err := txmgr.NewSimple(chainName, cfg)
 	if err != nil {
 		return nil, errors.Wrap(err, "new simple")
 	}

--- a/lib/fireblocks/client.go
+++ b/lib/fireblocks/client.go
@@ -47,7 +47,7 @@ func New(apiKey string, privateKey *rsa.PrivateKey, opts ...func(*options)) (Cli
 	return Client{
 		apiKey:     apiKey,
 		privateKey: privateKey,
-		jsonHTTP:   newJSONHTTP(o.host(), apiKey, ""),
+		jsonHTTP:   newJSONHTTP(o.host(), apiKey),
 		opts:       o,
 	}, nil
 }

--- a/lib/fireblocks/client_test.go
+++ b/lib/fireblocks/client_test.go
@@ -76,7 +76,6 @@ func TestSignOK(t *testing.T) {
 	actualSig, err := client.Sign(ctx, [32]byte(digest), crypto.PubkeyToAddress(privKey.PublicKey))
 	require.NoError(t, err)
 
-	expectSig[64] += 27 // convert expected V to 27 or 28
 	require.Equal(t, [65]byte(expectSig), actualSig)
 }
 

--- a/lib/fireblocks/jsonhttp.go
+++ b/lib/fireblocks/jsonhttp.go
@@ -13,18 +13,16 @@ import (
 
 // jsonHTTP provides a simple interface for sending JSON HTTP requests.
 type jsonHTTP struct {
-	apiKey       string
-	clientSecret string
-	host         string
-	http         http.Client
+	apiKey string
+	host   string
+	http   http.Client
 }
 
 // newJSONHTTP creates a new jsonHTTP.
-func newJSONHTTP(host string, apiKey string, clientSecret string) jsonHTTP {
+func newJSONHTTP(host string, apiKey string) jsonHTTP {
 	return jsonHTTP{
-		host:         host,
-		apiKey:       apiKey,
-		clientSecret: clientSecret,
+		host:   host,
+		apiKey: apiKey,
 	}
 }
 

--- a/lib/txmgr/config.go
+++ b/lib/txmgr/config.go
@@ -100,12 +100,33 @@ func (m CLIConfig) Check() error {
 	return nil
 }
 
-// privateKeySignerFn returns a SignerFn that signs transactions with the given private key.
-func privateKeySignerFn(key *ecdsa.PrivateKey, chainID *big.Int) bind.SignerFn {
-	from := crypto.PubkeyToAddress(key.PublicKey)
-	signer := types.LatestSignerForChainID(chainID)
+func externalSignerFn(external ExternalSigner, address common.Address, chainID uint64) SignerFn {
+	signer := types.LatestSignerForChainID(big.NewInt(int64(chainID)))
+	return func(ctx context.Context, from common.Address, tx *types.Transaction) (*types.Transaction, error) {
+		if address != from {
+			return nil, bind.ErrNotAuthorized
+		}
 
-	return func(address common.Address, tx *types.Transaction) (*types.Transaction, error) {
+		sig, err := external(ctx, signer.Hash(tx), from)
+		if err != nil {
+			return nil, errors.Wrap(err, "external sign")
+		}
+
+		res, err := tx.WithSignature(signer, sig[:])
+		if err != nil {
+			return nil, errors.Wrap(err, "set signature")
+		}
+
+		return res, nil
+	}
+}
+
+// privateKeySignerFn returns a SignerFn that signs transactions with the given private key.
+func privateKeySignerFn(key *ecdsa.PrivateKey, chainID uint64) SignerFn {
+	from := crypto.PubkeyToAddress(key.PublicKey)
+	signer := types.LatestSignerForChainID(big.NewInt(int64(chainID)))
+
+	return func(_ context.Context, address common.Address, tx *types.Transaction) (*types.Transaction, error) {
 		if address != from {
 			return nil, bind.ErrNotAuthorized
 		}
@@ -122,6 +143,9 @@ func privateKeySignerFn(key *ecdsa.PrivateKey, chainID *big.Int) bind.SignerFn {
 	}
 }
 
+// ExternalSigner is a function that signs a transaction with a given address and returns the signature.
+type ExternalSigner func(context.Context, common.Hash, common.Address) ([65]byte, error)
+
 // SignerFn is a generic transaction signing function. It may be a remote signer so it takes a context.
 // It also takes the address that should be used to sign the transaction with.
 type SignerFn func(context.Context, common.Address, *types.Transaction) (*types.Transaction, error)
@@ -129,9 +153,10 @@ type SignerFn func(context.Context, common.Address, *types.Transaction) (*types.
 // SignerFactory creates a SignerFn that is bound to a specific chainID.
 type SignerFactory func(chainID *big.Int) SignerFn
 
-// Config houses parameters for altering the behavior of a SimpleTxManager.
+// Config houses parameters for altering the behavior of a simple.
 type Config struct {
-	Backend ETHBackend
+	Backend ethclient.Client
+
 	// ResubmissionTimeout is the interval at which, if no previously
 	// published transaction has been mined, the new tx with a bumped gas
 	// price will be published. Only one publication at MaxGasPrice will be
@@ -184,20 +209,28 @@ type Config struct {
 
 	// Signer is used to sign transactions when the gas price is increased.
 	Signer SignerFn
-	From   common.Address
+
+	From common.Address
 }
 
-// NewConfig - creates a new txmgr config from the given CLI config and private key. This is taken and modified from op.
+// NewConfigWithSigner returns a new txmgr config from the given CLI config and external signer.
+func NewConfigWithSigner(cfg CLIConfig, external ExternalSigner, from common.Address, client ethclient.Client) (Config, error) {
+	signer := externalSignerFn(external, from, cfg.ChainID)
+
+	return newConfig(cfg, signer, from, client)
+}
+
+// NewConfig returns a new txmgr config from the given CLI config and private key.
 func NewConfig(cfg CLIConfig, privateKey *ecdsa.PrivateKey, client ethclient.Client) (Config, error) {
+	signer := privateKeySignerFn(privateKey, cfg.ChainID)
+	addr := crypto.PubkeyToAddress(privateKey.PublicKey)
+
+	return newConfig(cfg, signer, addr, client)
+}
+
+func newConfig(cfg CLIConfig, signer SignerFn, from common.Address, client ethclient.Client) (Config, error) {
 	if err := cfg.Check(); err != nil {
 		return Config{}, errors.New("invalid config", err)
-	}
-
-	signer := func(chainID *big.Int) SignerFn {
-		s := privateKeySignerFn(privateKey, chainID)
-		return func(_ context.Context, addr common.Address, tx *types.Transaction) (*types.Transaction, error) {
-			return s(addr, tx)
-		}
 	}
 
 	feeLimitThreshold, err := GweiToWei(cfg.FeeLimitThresholdGwei)
@@ -231,8 +264,8 @@ func NewConfig(cfg CLIConfig, privateKey *ecdsa.PrivateKey, client ethclient.Cli
 		ReceiptQueryInterval:      cfg.ReceiptQueryInterval,
 		NumConfirmations:          cfg.NumConfirmations,
 		SafeAbortNonceTooLowCount: cfg.SafeAbortNonceTooLowCount,
-		Signer:                    signer(chainID),
-		From:                      crypto.PubkeyToAddress(privateKey.PublicKey),
+		Signer:                    signer,
+		From:                      from,
 	}, nil
 }
 

--- a/lib/txmgr/txmgr_internal_test.go
+++ b/lib/txmgr/txmgr_internal_test.go
@@ -9,6 +9,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/omni-network/omni/lib/ethclient"
+
 	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core"
@@ -28,10 +30,10 @@ func testSendState() *SendState {
 	return NewSendState(100, time.Hour)
 }
 
-// testHarness houses the necessary resources to test the SimpleTxManager.
+// testHarness houses the necessary resources to test the simple.
 type testHarness struct {
 	cfg       Config
-	mgr       *SimpleTxManager
+	mgr       *simple
 	backend   *mockBackend
 	gasPricer *gasPricer
 }
@@ -42,7 +44,7 @@ func newTestHarnessWithConfig(_ *testing.T, cfg Config) *testHarness {
 	g := newGasPricer(3)
 	backend := newMockBackend(g)
 	cfg.Backend = backend
-	mgr := &SimpleTxManager{
+	mgr := &simple{
 		chainID:   cfg.ChainID,
 		chainName: "TEST",
 		cfg:       cfg,
@@ -158,6 +160,7 @@ type minedTxInfo struct {
 // mockBackend implements ReceiptSource that tracks mined transactions
 // along with the gas price used.
 type mockBackend struct {
+	ethclient.Client
 	mu sync.RWMutex
 
 	g    *gasPricer
@@ -206,11 +209,6 @@ func (b *mockBackend) BlockNumber(ctx context.Context) (uint64, error) {
 	defer b.mu.RUnlock()
 
 	return b.blockHeight, nil
-}
-
-// Call mocks a call to the EVM.
-func (b *mockBackend) CallContract(ctx context.Context, call ethereum.CallMsg, blockNumber *big.Int) ([]byte, error) {
-	return nil, nil
 }
 
 func (b *mockBackend) HeaderByNumber(ctx context.Context, number *big.Int) (*types.Header, error) {
@@ -719,6 +717,7 @@ func TestWaitMinedMultipleConfs(t *testing.T) {
 // first call but a success on the second call. This allows us to test that the
 // inner loop of waitMined properly handles this case.
 type failingBackend struct {
+	ethclient.Client
 	returnSuccessBlockNumber bool
 	returnSuccessHeader      bool
 	returnSuccessReceipt     bool
@@ -728,7 +727,7 @@ type failingBackend struct {
 
 // BlockNumber for the failingBackend returns errRPCFailure on the first
 // invocation and a fixed block height on subsequent calls.
-func (b *failingBackend) BlockNumber(ctx context.Context) (uint64, error) {
+func (b *failingBackend) BlockNumber(_ context.Context) (uint64, error) {
 	if !b.returnSuccessBlockNumber {
 		b.returnSuccessBlockNumber = true
 		return 0, errRPCFailure
@@ -740,7 +739,7 @@ func (b *failingBackend) BlockNumber(ctx context.Context) (uint64, error) {
 // TransactionReceipt for the failingBackend returns errRPCFailure on the first
 // invocation, and a receipt containing the passed TxHash on the second.
 func (b *failingBackend) TransactionReceipt(
-	ctx context.Context, txHash common.Hash,
+	_ context.Context, txHash common.Hash,
 ) (*types.Receipt, error) {
 	if !b.returnSuccessReceipt {
 		b.returnSuccessReceipt = true
@@ -753,20 +752,12 @@ func (b *failingBackend) TransactionReceipt(
 	}, nil
 }
 
-func (b *failingBackend) HeaderByNumber(ctx context.Context, _ *big.Int) (*types.Header, error) {
+func (b *failingBackend) HeaderByNumber(_ context.Context, _ *big.Int) (*types.Header, error) {
 	return &types.Header{
 		Number:        big.NewInt(1),
 		BaseFee:       b.baseFee,
 		ExcessBlobGas: b.excessBlobGas,
 	}, nil
-}
-
-func (b *failingBackend) CallContract(_ context.Context, _ ethereum.CallMsg, _ *big.Int) ([]byte, error) {
-	return nil, errors.New("unimplemented")
-}
-
-func (b *failingBackend) SendTransaction(_ context.Context, _ *types.Transaction) error {
-	return errors.New("unimplemented")
 }
 
 func (b *failingBackend) SuggestGasTipCap(_ context.Context) (*big.Int, error) {
@@ -777,21 +768,6 @@ func (b *failingBackend) EstimateGas(_ context.Context, msg ethereum.CallMsg) (u
 	return b.baseFee.Uint64(), nil
 }
 
-func (b *failingBackend) NonceAt(_ context.Context, _ common.Address, _ *big.Int) (uint64, error) {
-	return 0, errors.New("unimplemented")
-}
-
-func (b *failingBackend) PendingNonceAt(_ context.Context, _ common.Address) (uint64, error) {
-	return 0, errors.New("unimplemented")
-}
-
-func (b *failingBackend) ChainID(ctx context.Context) (*big.Int, error) {
-	return nil, errors.New("unimplemented")
-}
-
-func (b *failingBackend) Close() {
-}
-
 // TestWaitMinedReturnsReceiptAfterNotFound asserts that waitMined is able to
 // recover from failed calls to the backend. It uses the failedBackend to
 // simulate an rpc call failure, followed by the successful return of a receipt.
@@ -800,7 +776,7 @@ func TestWaitMinedReturnsReceiptAfterNotFound(t *testing.T) {
 
 	var borkedBackend failingBackend
 
-	mgr := &SimpleTxManager{
+	mgr := &simple{
 		cfg: Config{
 			ResubmissionTimeout:       time.Second,
 			ReceiptQueryInterval:      50 * time.Millisecond,
@@ -832,7 +808,7 @@ func doGasPriceIncrease(_ *testing.T, txTipCap, txFeeCap, newTip,
 		returnSuccessHeader: true,
 	}
 
-	mgr := &SimpleTxManager{
+	mgr := &simple{
 		cfg: Config{
 			ResubmissionTimeout:       time.Second,
 			ReceiptQueryInterval:      50 * time.Millisecond,
@@ -1018,7 +994,7 @@ func testIncreaseGasPriceLimit(t *testing.T, lt gasPriceLimitTest) {
 		returnSuccessHeader: true,
 	}
 
-	mgr := &SimpleTxManager{
+	mgr := &simple{
 		cfg: Config{
 			ResubmissionTimeout:       time.Second,
 			ReceiptQueryInterval:      50 * time.Millisecond,

--- a/relayer/app/sender.go
+++ b/relayer/app/sender.go
@@ -44,9 +44,9 @@ func NewSender(chain netconf.Chain, rpcClient ethclient.Client,
 		return Sender{}, err
 	}
 
-	txMgr, err := initTxMgr(cfg, chain.Name)
+	txMgr, err := txmgr.NewSimple(chain.Name, cfg)
 	if err != nil {
-		return Sender{}, err
+		return Sender{}, errors.Wrap(err, "create tx mgr")
 	}
 
 	// Create ABI
@@ -134,16 +134,6 @@ func (o Sender) SendTransaction(ctx context.Context, submission xchain.Submissio
 	log.Info(ctx, "Sent submission", receiptAttrs...)
 
 	return nil
-}
-
-// initTxMgr creates a new txmgr.TxManager from the given config.
-func initTxMgr(cfg txmgr.Config, chainName string) (txmgr.TxManager, error) {
-	txMgr, err := txmgr.NewSimpleTxManagerFromConfig(chainName, cfg)
-	if err != nil {
-		return nil, errors.New("failed to create tx mgr", "error", err)
-	}
-
-	return txMgr, nil
 }
 
 // getXSubmitBytes returns the byte representation of the xsubmit function call.


### PR DESCRIPTION
Adds support for `externalSigners` to txmgr. This is the interface that `fireblocks.Sign` provides.

Also do some general renaming and cleanup.

task: none