### PR TITLE
feat(lib/ethbackend): add fireblocks backend and wire e2e

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -461,14 +461,21 @@
         "filename": "lib/ethclient/ethbackend/backend.go",
         "hashed_secret": "6924110cde4fa051bfdc600a60620dc7aa9d3c6a",
         "is_verified": false,
-        "line_number": 51
+        "line_number": 85
       },
       {
         "type": "Secret Keyword",
         "filename": "lib/ethclient/ethbackend/backend.go",
         "hashed_secret": "0dd0da07feae08ca6e2aebb6d43a404292ba868c",
         "is_verified": false,
-        "line_number": 75
+        "line_number": 111
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "lib/ethclient/ethbackend/backend.go",
+        "hashed_secret": "44e17306b837162269a410204daaa5ecee4ec22c",
+        "is_verified": false,
+        "line_number": 126
       }
     ],
     "lib/ethclient/ethbackend/backends.go": [
@@ -477,7 +484,7 @@
         "filename": "lib/ethclient/ethbackend/backends.go",
         "hashed_secret": "0738417b55905d283958aad3214022b2cf393911",
         "is_verified": false,
-        "line_number": 24
+        "line_number": 25
       }
     ],
     "lib/ethclient/jwt.go": [
@@ -495,21 +502,21 @@
         "filename": "lib/fireblocks/client.go",
         "hashed_secret": "44e17306b837162269a410204daaa5ecee4ec22c",
         "is_verified": false,
-        "line_number": 40
+        "line_number": 43
       },
       {
         "type": "Secret Keyword",
         "filename": "lib/fireblocks/client.go",
         "hashed_secret": "fca71afec681b7c2932610046e8e524820317e47",
         "is_verified": false,
-        "line_number": 53
+        "line_number": 56
       },
       {
         "type": "Secret Keyword",
         "filename": "lib/fireblocks/client.go",
         "hashed_secret": "2331919a92cbb5c2d530947171fa5e1a1415af2f",
         "is_verified": false,
-        "line_number": 54
+        "line_number": 57
       }
     ],
     "lib/fireblocks/jsonhttp.go": [
@@ -800,5 +807,5 @@
       }
     ]
   },
-  "generated_at": "2024-03-22T14:33:16Z"
+  "generated_at": "2024-03-22T15:51:27Z"
 }

--- a/e2e/cmd/cmd.go
+++ b/e2e/cmd/cmd.go
@@ -28,16 +28,17 @@ func New() *cobra.Command {
 
 	cmd := libcmd.NewRootCmd("e2e", "e2e network generator and test runner")
 	cmd.PersistentPreRunE = func(cmd *cobra.Command, args []string) error {
-		if _, err := log.Init(cmd.Context(), logCfg); err != nil {
+		ctx := cmd.Context()
+		if _, err := log.Init(ctx, logCfg); err != nil {
 			return err
 		}
 
-		if err := libcmd.LogFlags(cmd.Context(), cmd.Flags()); err != nil {
+		if err := libcmd.LogFlags(ctx, cmd.Flags()); err != nil {
 			return err
 		}
 
 		var err error
-		def, err = app.MakeDefinition(defCfg)
+		def, err = app.MakeDefinition(ctx, defCfg)
 
 		return err
 	}

--- a/e2e/cmd/flags.go
+++ b/e2e/cmd/flags.go
@@ -14,6 +14,8 @@ func bindDefFlags(flags *pflag.FlagSet, cfg *app.DefinitionConfig) {
 	flags.StringVar(&cfg.InfraDataFile, "infra-file", cfg.InfraDataFile, "infrastructure data file (not required for docker provider)")
 	flags.StringVar(&cfg.DeployKeyFile, "deploy-key", cfg.DeployKeyFile, "path to deploy private key file")
 	flags.StringVar(&cfg.RelayerKeyFile, "relayer-key", cfg.RelayerKeyFile, "path to relayer private key file")
+	flags.StringVar(&cfg.FireAPIKey, "fireblocks-api-key", cfg.FireAPIKey, "FireBlocks api key")
+	flags.StringVar(&cfg.FireKeyPath, "fireblocks-key-path", cfg.FireKeyPath, "FireBlocks RSA private key path")
 	flags.StringVar(&cfg.OmniImgTag, "omni-image-tag", cfg.OmniImgTag, "Omni docker images tag (halo, relayer). Defaults to working dir git commit.")
 	flags.StringToStringVar(&cfg.RPCOverrides, "rpc-overrides", cfg.RPCOverrides, "Pubilc chain rpc overrides: '<chain1>=<url1>'")
 }

--- a/e2e/netman/pingpong/pingpong.go
+++ b/e2e/netman/pingpong/pingpong.go
@@ -62,8 +62,8 @@ func Deploy(ctx context.Context, netMgr netman.Manager, backends ethbackend.Back
 	}
 
 	// Start forkjoin for all portals
-
-	results, cancel := forkjoin.NewWithInputs(ctx, deployFunc, flatten(netMgr.Portals()))
+	portals := flatten[uint64, netman.Portal](netMgr.Portals())
+	results, cancel := forkjoin.NewWithInputs(ctx, deployFunc, portals)
 	defer cancel()
 
 	// Collect the resulting contracts

--- a/e2e/vmcompose/provider_test.go
+++ b/e2e/vmcompose/provider_test.go
@@ -1,6 +1,7 @@
 package vmcompose_test
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -19,7 +20,7 @@ func TestSetup(t *testing.T) {
 	t.Parallel()
 	manifestFile, dataFile := vmcompose.SetupDataFixtures(t)
 
-	def, err := app.MakeDefinition(app.DefinitionConfig{
+	def, err := app.MakeDefinition(context.Background(), app.DefinitionConfig{
 		ManifestFile:  manifestFile,
 		InfraProvider: vmcompose.ProviderName,
 		InfraDataFile: dataFile,

--- a/lib/contracts/avs/register.go
+++ b/lib/contracts/avs/register.go
@@ -47,7 +47,7 @@ func RegisterOperatorWithAVS(ctx context.Context, addr common.Address, backend *
 		return errors.Wrap(err, "calculate digest hash")
 	}
 
-	sig, err := backend.Sign(operator, digestHash)
+	sig, err := backend.Sign(ctx, operator, digestHash)
 	if err != nil {
 		return errors.Wrap(err, "sign")
 	}

--- a/lib/fireblocks/client_test.go
+++ b/lib/fireblocks/client_test.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/omni-network/omni/lib/fireblocks"
+	"github.com/omni-network/omni/lib/netconf"
 	"github.com/omni-network/omni/lib/tutil"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -68,7 +69,7 @@ func TestSignOK(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	client, err := fireblocks.New(apiKey, parseKey(t, testPrivateKey),
+	client, err := fireblocks.New(netconf.Simnet, apiKey, parseKey(t, testPrivateKey),
 		fireblocks.WithHost(ts.URL),                    // Use the test server for all requests.
 		fireblocks.WithQueryInterval(time.Millisecond), // Fast timeout and interval for testing
 		fireblocks.WithLogFreqFactor(1),
@@ -113,7 +114,7 @@ func TestSmoke(t *testing.T) {
 	privKey, err := os.ReadFile(privKeyFile)
 	require.NoError(t, err)
 
-	client, err := fireblocks.New(apiKey, parseKey(t, privKey))
+	client, err := fireblocks.New(netconf.Simnet, apiKey, parseKey(t, privKey))
 	require.NoError(t, err)
 
 	addr := common.BytesToAddress(hexutil.MustDecode("0x9914cb686527261B52B614E43D0db7bCDAB5bC50"))

--- a/lib/fireblocks/key.go
+++ b/lib/fireblocks/key.go
@@ -1,0 +1,32 @@
+package fireblocks
+
+import (
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/pem"
+	"fmt"
+	"os"
+
+	"github.com/omni-network/omni/lib/errors"
+)
+
+// LoadKey loads and returns the RSA256 from disk.
+func LoadKey(path string) (*rsa.PrivateKey, error) {
+	bz, err := os.ReadFile(path)
+	if err != nil {
+		return nil, errors.Wrap(err, "load fireblocks key", "path", path)
+	}
+
+	p, _ := pem.Decode(bz)
+	k, err := x509.ParsePKCS8PrivateKey(p.Bytes)
+	if err != nil {
+		return nil, errors.Wrap(err, "parse fireblocks key")
+	}
+
+	resp, ok := k.(*rsa.PrivateKey)
+	if !ok {
+		return nil, errors.New("invalid fireblocks key type", "type", fmt.Sprintf("%T", resp))
+	}
+
+	return resp, nil
+}


### PR DESCRIPTION
- Adds a Fireblocks based `ethbackend`.
- Refactor fireblocks.Environment to use netconf.Network.
- Wire fireblocks backend into e2e using flags.

task: none