### PR TITLE
feat(lib/contracts): deploy avs via create3

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -186,7 +186,7 @@
         "filename": "e2e/app/run.go",
         "hashed_secret": "fe86558143c0bd528f649a153bdc32b8fa90301c",
         "is_verified": false,
-        "line_number": 119
+        "line_number": 123
       }
     ],
     "e2e/app/setup.go": [
@@ -427,14 +427,14 @@
         "filename": "lib/contracts/avs/avs_test.go",
         "hashed_secret": "b58933a64ae8823252ddb937888c22a99bdb065f",
         "is_verified": false,
-        "line_number": 616
+        "line_number": 612
       },
       {
         "type": "Secret Keyword",
         "filename": "lib/contracts/avs/avs_test.go",
         "hashed_secret": "04e110541a2e8b44bc10939bfaf5d82adfe45158",
         "is_verified": false,
-        "line_number": 627
+        "line_number": 623
       }
     ],
     "lib/create3/create3_test.go": [
@@ -461,21 +461,21 @@
         "filename": "lib/ethclient/ethbackend/backend.go",
         "hashed_secret": "6924110cde4fa051bfdc600a60620dc7aa9d3c6a",
         "is_verified": false,
-        "line_number": 85
+        "line_number": 91
       },
       {
         "type": "Secret Keyword",
         "filename": "lib/ethclient/ethbackend/backend.go",
         "hashed_secret": "0dd0da07feae08ca6e2aebb6d43a404292ba868c",
         "is_verified": false,
-        "line_number": 111
+        "line_number": 117
       },
       {
         "type": "Secret Keyword",
         "filename": "lib/ethclient/ethbackend/backend.go",
         "hashed_secret": "44e17306b837162269a410204daaa5ecee4ec22c",
         "is_verified": false,
-        "line_number": 126
+        "line_number": 132
       }
     ],
     "lib/ethclient/ethbackend/backends.go": [
@@ -807,5 +807,5 @@
       }
     ]
   },
-  "generated_at": "2024-03-22T15:51:27Z"
+  "generated_at": "2024-03-22T21:11:34Z"
 }

--- a/e2e/app/run.go
+++ b/e2e/app/run.go
@@ -63,6 +63,10 @@ func Deploy(ctx context.Context, def Definition, cfg DeployConfig) (types.Deploy
 		return nil, nil, err
 	}
 
+	if err := deployCreate3Factories(ctx, def); err != nil {
+		return nil, nil, err
+	}
+
 	if err := def.Netman.DeployPrivatePortals(ctx, genesisValSetID, genesisVals); err != nil {
 		return nil, nil, err
 	}

--- a/e2e/netman/manager.go
+++ b/e2e/netman/manager.go
@@ -24,8 +24,9 @@ const (
 	// privKeyHex1 of pre-funded anvil account 1.
 	privKeyHex1 = "0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d"
 
-	// Fifth contract address of privKeyHex0 (ProxyAdmin, FeeOracleV1Impl, FeeOracleV1Proxy, PortalImpl come first).
-	privatePortalAddr = "0xDc64a140Aa3E981100a9becA4E685f962f0cF6C9"
+	// Sixth contract address of privKeyHex0 (Create3, ProxyAdmin, FeeOracleV1Impl, FeeOracleV1Proxy, PortalImpl come first).
+	// TODO: replace with static network address from lib/contracts, requires refactoring deployment flow.
+	privatePortalAddr = "0x5FC8d32690cc91D4c39d9d3abcBD16989F875707"
 )
 
 //nolint:gochecknoglobals // Static mapping.

--- a/halo/genutil/evm/evm.go
+++ b/halo/genutil/evm/evm.go
@@ -4,6 +4,7 @@ import (
 	"math/big"
 
 	"github.com/omni-network/omni/halo/genutil/evm/predeploys"
+	"github.com/omni-network/omni/lib/netconf"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core"
@@ -15,7 +16,7 @@ func newUint64(val uint64) *uint64 { return &val }
 
 func DefaultDevConfig() params.ChainConfig {
 	return params.ChainConfig{
-		ChainID:                       big.NewInt(1), // TODO: choose new dev chain id
+		ChainID:                       big.NewInt(int64(netconf.GetStatic(netconf.Devnet).OmniExecutionChainID)),
 		HomesteadBlock:                big.NewInt(0),
 		EIP150Block:                   big.NewInt(0),
 		EIP155Block:                   big.NewInt(0),

--- a/halo/genutil/evm/testdata/TestMakeGenesis.golden
+++ b/halo/genutil/evm/testdata/TestMakeGenesis.golden
@@ -1,6 +1,6 @@
 {
  "config": {
-  "chainId": 1,
+  "chainId": 16561,
   "homesteadBlock": 0,
   "eip150Block": 0,
   "eip155Block": 0,

--- a/lib/anvil/accounts.go
+++ b/lib/anvil/accounts.go
@@ -3,10 +3,6 @@ package anvil
 import (
 	"crypto/ecdsa"
 	"strings"
-	"time"
-
-	"github.com/omni-network/omni/lib/ethclient"
-	"github.com/omni-network/omni/lib/ethclient/ethbackend"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
@@ -36,15 +32,11 @@ var (
 	Account8Pk = mustHexToKey("0xdbda1821b80551c9d65939329250298aa3472ba22feea921c0cf5d620ea67b97")
 	Account9Pk = mustHexToKey("0x2a871d0798f97d79848a013d4936a73bf4cc922c825d33c1cf7073dff6d409c6")
 
-	pks = []*ecdsa.PrivateKey{
+	DevPrivateKeys = []*ecdsa.PrivateKey{
 		Account0Pk, Account1Pk, Account2Pk, Account3Pk, Account4Pk,
 		Account5Pk, Account6Pk, Account7Pk, Account8Pk, Account9Pk,
 	}
 )
-
-func NewBackend(chainName string, chainID uint64, blockPeriod time.Duration, ethCl ethclient.Client) (*ethbackend.Backend, error) {
-	return ethbackend.NewBackend(chainName, chainID, blockPeriod, ethCl, pks...)
-}
 
 func mustHexToKey(privKeyHex string) *ecdsa.PrivateKey {
 	privKey, err := crypto.HexToECDSA(strings.TrimPrefix(privKeyHex, "0x"))

--- a/lib/contracts/avs/avs_test.go
+++ b/lib/contracts/avs/avs_test.go
@@ -16,10 +16,13 @@ import (
 	"github.com/omni-network/omni/contracts/bindings"
 	"github.com/omni-network/omni/e2e/app/static"
 	"github.com/omni-network/omni/lib/anvil"
+	"github.com/omni-network/omni/lib/contracts"
 	"github.com/omni-network/omni/lib/contracts/avs"
+	"github.com/omni-network/omni/lib/contracts/create3"
 	"github.com/omni-network/omni/lib/errors"
 	"github.com/omni-network/omni/lib/ethclient"
 	"github.com/omni-network/omni/lib/ethclient/ethbackend"
+	"github.com/omni-network/omni/lib/netconf"
 	"github.com/omni-network/omni/lib/tutil"
 	"github.com/omni-network/omni/lib/txmgr"
 
@@ -45,12 +48,6 @@ const (
 
 //nolint:gochecknoglobals // These are test constants.
 var (
-	// account used to deploy omniAVS contracts.
-	avsOwnerPk = anvil.Account0Pk
-
-	// account used to deploy eigen contracts.
-	eigenOwnerPk = anvil.Account9Pk
-
 	// eigen strategy manger, and test weth strategy.
 	stratMngrAddr = common.HexToAddress("0xe1DA8919f262Ee86f9BE05059C9280142CF23f48")
 	wethStratAddr = common.HexToAddress("0xdBD296711eC8eF9Aacb623ee3F1C0922dce0D7b2")
@@ -67,12 +64,15 @@ func setup(t *testing.T) (context.Context, *ethbackend.Backend, Contracts, EOAS)
 	require.NoError(t, err)
 	t.Cleanup(stop)
 
-	backend, err := ethbackend.NewBackend(chainName, chainID, blockPeriod, ethCl)
+	backend, err := ethbackend.NewAnvilBackend(chainName, chainID, blockPeriod, ethCl)
 	require.NoError(t, err)
 
 	eoas := makeEOAS(t, backend)
 
-	addr, _, err := avs.DeployDevnet(ctx, backend)
+	_, _, err = create3.Deploy(ctx, netconf.Devnet, backend)
+	require.NoError(t, err)
+
+	addr, _, err := avs.Deploy(ctx, netconf.Devnet, backend)
 	require.NoError(t, err)
 
 	contracts, err := makeContracts(addr, devnetEigenDeployments(t), backend)
@@ -185,10 +185,6 @@ func makeEOAS(t *testing.T, backend *ethbackend.Backend) EOAS {
 	t.Helper()
 
 	// setup accounts
-	avsOwner, err := backend.AddAccount(avsOwnerPk)
-	require.NoError(t, err)
-	eigenOwner, err := backend.AddAccount(eigenOwnerPk)
-	require.NoError(t, err)
 	operator1Key := genPrivKey(t)
 	operator1, err := backend.AddAccount(operator1Key)
 	require.NoError(t, err)
@@ -201,8 +197,8 @@ func makeEOAS(t *testing.T, backend *ethbackend.Backend) EOAS {
 	require.NoError(t, err)
 
 	return EOAS{
-		AVSOwner:     avsOwner,
-		EigenOwner:   eigenOwner,
+		AVSOwner:     contracts.DevnetAVSAdmin,
+		EigenOwner:   anvil.Account9, // account used to deploy eigen contracts
 		Operator1:    operator1,
 		Operator1Key: operator1Key,
 		Operator2:    operator2,

--- a/lib/contracts/avs/deploy.go
+++ b/lib/contracts/avs/deploy.go
@@ -5,8 +5,9 @@ import (
 	"math/big"
 
 	"github.com/omni-network/omni/contracts/bindings"
-	"github.com/omni-network/omni/lib/anvil"
 	"github.com/omni-network/omni/lib/chainids"
+	"github.com/omni-network/omni/lib/contracts"
+	"github.com/omni-network/omni/lib/create3"
 	"github.com/omni-network/omni/lib/errors"
 	"github.com/omni-network/omni/lib/ethclient/ethbackend"
 	"github.com/omni-network/omni/lib/netconf"
@@ -22,7 +23,10 @@ const (
 )
 
 //nolint:gochecknoglobals // static abi type
-var avsABI = mustGetABI(bindings.OmniAVSMetaData)
+var (
+	avsABI   = mustGetABI(bindings.OmniAVSMetaData)
+	proxyABI = mustGetABI(bindings.TransparentUpgradeableProxyMetaData)
+)
 
 type DeploymentConfig struct {
 	Create3Factory   common.Address
@@ -39,6 +43,7 @@ type DeploymentConfig struct {
 	MinOperatorStake *big.Int
 	MaxOperatorCount uint32
 	AllowlistEnabled bool
+	ExpectedAddr     common.Address
 }
 
 func (cfg DeploymentConfig) Validate() error {
@@ -73,54 +78,63 @@ func (cfg DeploymentConfig) Validate() error {
 	return nil
 }
 
-func getDeployCfg(chainID uint64) (DeploymentConfig, error) {
-	if chainID == chainids.Holesky {
-		return holeskeyDeployCfg(), nil
+func getDeployCfg(chainID uint64, network string) (DeploymentConfig, error) {
+	if !chainids.IsMainnetOrTestnet(chainID) && network == netconf.Devnet {
+		return devnetCfg(), nil
 	}
 
-	return DeploymentConfig{}, errors.New("unsupported chain")
+	if chainID == chainids.Holesky && network == netconf.Testnet {
+		return testnetCfg(), nil
+	}
+
+	return DeploymentConfig{}, errors.New("unsupported chain for network", "chain_id", chainID, "network", network)
 }
 
-func holeskeyDeployCfg() DeploymentConfig {
+func testnetCfg() DeploymentConfig {
 	return DeploymentConfig{
-		Create3Salt:      "holesky-avs",
+		Create3Factory:   contracts.TestnetCreate3Factory,
+		Create3Salt:      contracts.AVSSalt(netconf.Testnet),
+		Deployer:         contracts.TestnetDeployer,
+		Owner:            contracts.TestnetAVSAdmin,
+		ProxyAdmin:       contracts.TestnetProxyAdmin,
 		Eigen:            holeskyEigenDeployments(),
 		StrategyParams:   holeskeyStrategyParams(),
 		MetadataURI:      metadataURI,
+		OmniChainID:      netconf.GetStatic(netconf.Devnet).OmniExecutionChainID,
 		MinOperatorStake: big.NewInt(1e18), // 1 ETH
 		MaxOperatorCount: 200,
 		AllowlistEnabled: false,
-		// TODO: fill in the rest
 	}
 }
 
-func devnetDeployCfg() DeploymentConfig {
+func devnetCfg() DeploymentConfig {
 	return DeploymentConfig{
-		Create3Factory:   common.HexToAddress("0x1234"), // TODO: currently unused
-		Create3Salt:      "devnet-avs",                  // TODO: currently unused
-		Deployer:         anvil.Account0,
-		Owner:            anvil.Account0,
+		Create3Factory:   contracts.DevnetCreate3Factory,
+		Create3Salt:      contracts.AVSSalt(netconf.Devnet),
+		Deployer:         contracts.DevnetDeployer,
+		Owner:            contracts.DevnetAVSAdmin,
+		ProxyAdmin:       contracts.DevnetProxyAdmin,
 		Eigen:            devnetEigenDeployments,
-		ProxyAdmin:       anvil.Account1, // should not be an eoa, but does not matter for devnet (yet)
 		MetadataURI:      "https://test.com",
-		OmniChainID:      netconf.GetStatic("Devnet").OmniExecutionChainID,
-		AllowlistEnabled: true,
+		OmniChainID:      netconf.GetStatic(netconf.Devnet).OmniExecutionChainID,
 		StrategyParams:   devnetStrategyParams(),
 		EthStakeInbox:    common.HexToAddress("0x1234"), // TODO: replace with actual address
 		MinOperatorStake: big.NewInt(1e18),              // 1 ETH
 		MaxOperatorCount: 10,
+		AllowlistEnabled: true,
+		ExpectedAddr:     contracts.DevnetAVS,
 	}
 }
 
 // Deploy deploys the AVS contract and returns the address and receipt.
 // It only allows deployments to explicitly supported chains.
-func Deploy(ctx context.Context, backend *ethbackend.Backend) (common.Address, *ethtypes.Receipt, error) {
+func Deploy(ctx context.Context, network string, backend *ethbackend.Backend) (common.Address, *ethtypes.Receipt, error) {
 	chainID, err := backend.ChainID(ctx)
 	if err != nil {
 		return common.Address{}, nil, errors.Wrap(err, "chain id")
 	}
 
-	cfg, err := getDeployCfg(chainID.Uint64())
+	cfg, err := getDeployCfg(chainID.Uint64(), network)
 	if err != nil {
 		return common.Address{}, nil, errors.Wrap(err, "get deployment config")
 	}
@@ -128,21 +142,6 @@ func Deploy(ctx context.Context, backend *ethbackend.Backend) (common.Address, *
 	return deploy(ctx, cfg, backend)
 }
 
-// DeployDevnet deploys the devnet AVS contract and returns the address receipt.
-func DeployDevnet(ctx context.Context, backend *ethbackend.Backend) (common.Address, *ethtypes.Receipt, error) {
-	chainID, err := backend.ChainID(ctx)
-	if err != nil {
-		return common.Address{}, nil, errors.Wrap(err, "chain id")
-	}
-
-	if chainids.IsMainnetOrTestnet(chainID.Uint64()) {
-		return common.Address{}, nil, errors.New("not a devnet")
-	}
-
-	return deploy(ctx, devnetDeployCfg(), backend)
-}
-
-// Deploy deploys the AVS contract and returns the deployed contract's address and the transaction receipt.
 func deploy(ctx context.Context, cfg DeploymentConfig, backend *ethbackend.Backend) (common.Address, *ethtypes.Receipt, error) {
 	if err := cfg.Validate(); err != nil {
 		return common.Address{}, nil, errors.Wrap(err, "validate config")
@@ -158,43 +157,59 @@ func deploy(ctx context.Context, cfg DeploymentConfig, backend *ethbackend.Backe
 		return common.Address{}, nil, errors.Wrap(err, "bind owner opts")
 	}
 
-	enc, err := packInitialzer(cfg)
+	factory, err := bindings.NewCreate3(cfg.Create3Factory, backend)
 	if err != nil {
-		return common.Address{}, nil, err
+		return common.Address{}, nil, errors.Wrap(err, "new create3")
+	}
+
+	salt := create3.HashSalt(cfg.Create3Salt)
+
+	addr, err := factory.GetDeployed(nil, deployerTxOpts.From, salt)
+	if err != nil {
+		return common.Address{}, nil, errors.Wrap(err, "get deployed")
+	} else if (cfg.ExpectedAddr != common.Address{}) && addr != cfg.ExpectedAddr {
+		return common.Address{}, nil, errors.New("unexpected address", "expected", cfg.ExpectedAddr, "actual", addr)
 	}
 
 	impl, tx, _, err := bindings.DeployOmniAVS(deployerTxOpts, backend, cfg.Eigen.DelegationManager, cfg.Eigen.AVSDirectory)
 	if err != nil {
-		return common.Address{}, nil, errors.Wrap(err, "deploy avs impl")
-	}
-	_, err = backend.WaitMined(ctx, tx)
-	if err != nil {
-		return common.Address{}, nil, errors.Wrap(err, "wait mined avs proxy")
+		return common.Address{}, nil, errors.Wrap(err, "deploy impl")
 	}
 
-	proxy, tx, _, err := bindings.DeployTransparentUpgradeableProxy(deployerTxOpts, backend, impl, cfg.ProxyAdmin, enc)
+	deployReceipt, err := backend.WaitMined(ctx, tx)
 	if err != nil {
-		return common.Address{}, nil, errors.Wrap(err, "deploy avs proxy")
+		return common.Address{}, nil, errors.Wrap(err, "wait mined portal")
+	} else if deployReceipt.Status != ethtypes.ReceiptStatusSuccessful {
+		return common.Address{}, nil, errors.New("deploy impl failed")
 	}
+
+	initCode, err := packInitCode(cfg, impl)
+	if err != nil {
+		return common.Address{}, nil, errors.Wrap(err, "pack init code")
+	}
+
+	tx, err = factory.Deploy(deployerTxOpts, salt, initCode)
+	if err != nil {
+		return common.Address{}, nil, errors.Wrap(err, "deploy proxy")
+	}
+
 	receipt, err := backend.WaitMined(ctx, tx)
 	if err != nil {
-		return common.Address{}, nil, errors.Wrap(err, "wait mined avs proxy")
+		return common.Address{}, nil, errors.Wrap(err, "wait mined proxy")
+	} else if receipt.Status != ethtypes.ReceiptStatusSuccessful {
+		return common.Address{}, nil, errors.New("deploy proxy failed")
 	}
 
-	avs, err := bindings.NewOmniAVS(proxy, backend)
+	avs, err := bindings.NewOmniAVS(addr, backend)
 	if err != nil {
 		return common.Address{}, nil, errors.Wrap(err, "bind avs")
 	}
 
 	if !cfg.AllowlistEnabled {
-		tx, err = avs.DisableAllowlist(ownerTxOpts)
+		// only wait mained second admin call below (SetMetadataURI)
+		_, err = avs.DisableAllowlist(ownerTxOpts)
 		if err != nil {
 			return common.Address{}, nil, errors.Wrap(err, "disable allowlist")
-		}
-
-		_, err = backend.WaitMined(ctx, tx)
-		if err != nil {
-			return common.Address{}, nil, errors.Wrap(err, "wait mined disable allowlist")
 		}
 	}
 
@@ -203,12 +218,24 @@ func deploy(ctx context.Context, cfg DeploymentConfig, backend *ethbackend.Backe
 		return common.Address{}, nil, errors.Wrap(err, "set metadata uri")
 	}
 
-	_, err = backend.WaitMined(ctx, tx)
+	receipt, err = backend.WaitMined(ctx, tx)
 	if err != nil {
 		return common.Address{}, nil, errors.Wrap(err, "wait mined set metadata uri")
 	}
+	if receipt.Status != ethtypes.ReceiptStatusSuccessful {
+		return common.Address{}, nil, errors.New("set metadata uri failed")
+	}
 
-	return proxy, receipt, nil
+	return addr, deployReceipt, nil
+}
+
+func packInitCode(cfg DeploymentConfig, impl common.Address) ([]byte, error) {
+	initializer, err := packInitialzer(cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	return contracts.PackInitCode(proxyABI, bindings.TransparentUpgradeableProxyBin, impl, cfg.ProxyAdmin, initializer)
 }
 
 // packInitializer encodes the initializer parameters for the AVS contract.

--- a/lib/contracts/portal/deploy_test.go
+++ b/lib/contracts/portal/deploy_test.go
@@ -10,6 +10,8 @@ import (
 	"github.com/omni-network/omni/lib/contracts"
 	"github.com/omni-network/omni/lib/contracts/create3"
 	"github.com/omni-network/omni/lib/contracts/portal"
+	"github.com/omni-network/omni/lib/ethclient/ethbackend"
+	"github.com/omni-network/omni/lib/netconf"
 	"github.com/omni-network/omni/lib/tutil"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -32,11 +34,11 @@ func TestDeployDevnet(t *testing.T) {
 	require.NoError(t, err)
 	t.Cleanup(stop)
 
-	backend, err := anvil.NewBackend(chainName, chainID, blockPeriod, client)
+	backend, err := ethbackend.NewAnvilBackend(chainName, chainID, blockPeriod, client)
 	require.NoError(t, err)
 
 	// devnet create3 factory is required
-	addr, _, err := create3.DeployDevnet(ctx, backend)
+	addr, _, err := create3.Deploy(ctx, netconf.Devnet, backend)
 	require.NoError(t, err)
 	require.Equal(t, contracts.DevnetCreate3Factory, addr)
 
@@ -46,7 +48,7 @@ func TestDeployDevnet(t *testing.T) {
 		{Addr: common.HexToAddress("0x3333"), Power: 100},
 	}
 
-	addr, _, err = portal.DeployDevnet(ctx, backend, vals)
+	addr, _, err = portal.Deploy(ctx, netconf.Devnet, backend, vals)
 	require.NoError(t, err)
 	require.Equal(t, contracts.DevnetPortal, addr)
 

--- a/lib/contracts/proxyadmin/deploy_test.go
+++ b/lib/contracts/proxyadmin/deploy_test.go
@@ -10,6 +10,8 @@ import (
 	"github.com/omni-network/omni/lib/contracts"
 	"github.com/omni-network/omni/lib/contracts/create3"
 	"github.com/omni-network/omni/lib/contracts/proxyadmin"
+	"github.com/omni-network/omni/lib/ethclient/ethbackend"
+	"github.com/omni-network/omni/lib/netconf"
 	"github.com/omni-network/omni/lib/tutil"
 
 	"github.com/stretchr/testify/require"
@@ -30,15 +32,15 @@ func TestDeployDevnet(t *testing.T) {
 	require.NoError(t, err)
 	t.Cleanup(stop)
 
-	backend, err := anvil.NewBackend(chainName, chainID, blockPeriod, client)
+	backend, err := ethbackend.NewAnvilBackend(chainName, chainID, blockPeriod, client)
 	require.NoError(t, err)
 
 	// devnet create3 factory is required
-	addr, _, err := create3.DeployDevnet(ctx, backend)
+	addr, _, err := create3.Deploy(ctx, netconf.Devnet, backend)
 	require.NoError(t, err)
 	require.Equal(t, contracts.DevnetCreate3Factory, addr)
 
-	addr, _, err = proxyadmin.DeployDevnet(ctx, backend)
+	addr, _, err = proxyadmin.Deploy(ctx, netconf.Devnet, backend)
 	require.NoError(t, err)
 	require.Equal(t, contracts.DevnetProxyAdmin, addr)
 

--- a/lib/contracts/static.go
+++ b/lib/contracts/static.go
@@ -43,9 +43,9 @@ var (
 	TestnetPortalAdmin = addr("0x0")
 
 	// AVS Admin.
-	DevnetAVSAAdmin  = anvil.Account2
-	MainnetAVSAAdmin = addr("0x0")
-	TestnetAVSAAdmin = addr("0x0")
+	DevnetAVSAdmin  = anvil.Account2
+	MainnetAVSAdmin = addr("0x0")
+	TestnetAVSAdmin = addr("0x0")
 
 	// Omni Portal.
 	DevnetPortal  = create3.Address(DevnetCreate3Factory, PortalSalt(netconf.Devnet), DevnetDeployer)
@@ -56,6 +56,11 @@ var (
 	DevnetFeeOracleV1  = addr("0x1234") // TODO: stubbed for now, so portal tests don't fail
 	MainnetFeeOracleV1 = addr("0x0")
 	TestnetFeeOracleV1 = addr("0x0")
+
+	// AVS.
+	DevnetAVS  = create3.Address(DevnetCreate3Factory, AVSSalt(netconf.Devnet), DevnetDeployer)
+	MainnetAVS = create3.Address(MainnetCreate3Factory, AVSSalt(netconf.Mainnet), MainnetDeployer)
+	TestnetAVS = create3.Address(TestnetCreate3Factory, AVSSalt(netconf.Testnet), TestnetDeployer)
 )
 
 func ProxyAdminSalt(network string) string {
@@ -64,6 +69,10 @@ func ProxyAdminSalt(network string) string {
 
 func PortalSalt(network string) string {
 	return salt(network, "portal")
+}
+
+func AVSSalt(network string) string {
+	return salt(network, "avs")
 }
 
 // salt generates a salt for a contract deployment, adding git build info for staging.

--- a/lib/ethclient/ethbackend/backend.go
+++ b/lib/ethclient/ethbackend/backend.go
@@ -8,6 +8,7 @@ import (
 	"math/big"
 	"time"
 
+	"github.com/omni-network/omni/lib/anvil"
 	"github.com/omni-network/omni/lib/errors"
 	"github.com/omni-network/omni/lib/ethclient"
 	"github.com/omni-network/omni/lib/fireblocks"
@@ -68,6 +69,11 @@ func NewFireBackend(ctx context.Context, chainName string, chainID uint64, block
 		chainID:     chainID,
 		blockPeriod: blockPeriod,
 	}, nil
+}
+
+// NewAnvilBackend returns a backend with all pre-funded anvil dev accounts.
+func NewAnvilBackend(chainName string, chainID uint64, blockPeriod time.Duration, ethCl ethclient.Client) (*Backend, error) {
+	return NewBackend(chainName, chainID, blockPeriod, ethCl, anvil.DevPrivateKeys...)
 }
 
 // NewBackend returns a new backend backed by in-memory private keys.

--- a/lib/ethclient/ethbackend/backends.go
+++ b/lib/ethclient/ethbackend/backends.go
@@ -165,6 +165,15 @@ func NewBackends(testnet types.Testnet, deployKeyFile string) (Backends, error) 
 	}, nil
 }
 
+func (b Backends) Backend(sourceChainID uint64) (*Backend, error) {
+	backend, ok := b.backends[sourceChainID]
+	if !ok {
+		return nil, errors.New("unknown chain", "chain", sourceChainID)
+	}
+
+	return backend, nil
+}
+
 // BindOpts is a convenience function that returns the single account and bind.TransactOpts and Backend for a given chain.
 func (b Backends) BindOpts(ctx context.Context, sourceChainID uint64) (common.Address, *bind.TransactOpts, *Backend, error) {
 	backend, ok := b.backends[sourceChainID]

--- a/lib/netconf/static.go
+++ b/lib/netconf/static.go
@@ -9,15 +9,15 @@ type Static struct {
 //nolint:gochecknoglobals // Static mappings.
 var statics = map[string]Static{
 	Simnet: {
-		OmniExecutionChainID: 1,
+		OmniExecutionChainID: 16561,
 		OmniConsensusChainID: 2,
 	},
 	Devnet: {
-		OmniExecutionChainID: 1,
+		OmniExecutionChainID: 16561,
 		OmniConsensusChainID: 2,
 	},
 	Staging: {
-		OmniExecutionChainID: 1,
+		OmniExecutionChainID: 16561,
 		OmniConsensusChainID: 2,
 	},
 }


### PR DESCRIPTION
Deploy AVS via Create3. 

Also refactor all lib/contracts deployments, to only expose a single network based Deploy func.

task: https://app.asana.com/0/1206208509925075/1206909416405983
