### PR TITLE
ci(monitor/loadgen): add auto validator self-delegation

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -186,7 +186,7 @@
         "filename": "e2e/app/run.go",
         "hashed_secret": "fe86558143c0bd528f649a153bdc32b8fa90301c",
         "is_verified": false,
-        "line_number": 123
+        "line_number": 127
       }
     ],
     "e2e/app/setup.go": [
@@ -195,21 +195,28 @@
         "filename": "e2e/app/setup.go",
         "hashed_secret": "7be029054a936fcb1827abd24388a53136be7b64",
         "is_verified": false,
-        "line_number": 130
+        "line_number": 133
       },
       {
         "type": "Secret Keyword",
         "filename": "e2e/app/setup.go",
         "hashed_secret": "55abc9109d5ea8a77be16bf3c76b4b199b524b12",
         "is_verified": false,
-        "line_number": 443
+        "line_number": 446
       },
       {
         "type": "Secret Keyword",
         "filename": "e2e/app/setup.go",
         "hashed_secret": "da57af224108e98e24d1e2a86221121990fa6478",
         "is_verified": false,
-        "line_number": 468
+        "line_number": 471
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "e2e/app/setup.go",
+        "hashed_secret": "b11b6052ab454c167964c5b836faf0053a711b90",
+        "is_verified": false,
+        "line_number": 506
       }
     ],
     "e2e/app/static/geth-keystore.json": [
@@ -807,5 +814,5 @@
       }
     ]
   },
-  "generated_at": "2024-03-22T21:11:34Z"
+  "generated_at": "2024-03-25T12:07:11Z"
 }

--- a/e2e/app/run.go
+++ b/e2e/app/run.go
@@ -99,6 +99,10 @@ func Deploy(ctx context.Context, def Definition, cfg DeployConfig) (types.Deploy
 
 	pp.ExportDeployInfo(deployInfo)
 
+	if err := FundValidatorsForTesting(ctx, def); err != nil {
+		return nil, nil, err
+	}
+
 	return deployInfo, &pp, nil
 }
 

--- a/halo/genutil/evm/evm.go
+++ b/halo/genutil/evm/evm.go
@@ -55,7 +55,7 @@ func precompilesAlloc() types.GenesisAlloc {
 // devPrefundAlloc returns allocs for pre-funded geth dev accounts.
 func devPrefundAlloc() types.GenesisAlloc {
 	eth1k := new(big.Int).Mul(
-		big.NewInt(1000),
+		big.NewInt(1_000_000),
 		big.NewInt(params.Ether),
 	)
 

--- a/halo/genutil/evm/testdata/TestMakeGenesis.golden
+++ b/halo/genutil/evm/testdata/TestMakeGenesis.golden
@@ -58,34 +58,34 @@
    "balance": "0x1"
   },
   "14dc79964da2c08b23698b3d3cc7ca32193d9955": {
-   "balance": "0x3635c9adc5dea00000"
+   "balance": "0xd3c21bcecceda1000000"
   },
   "15d34aaf54267db7d7c367839aaf71a00a2c6a65": {
-   "balance": "0x3635c9adc5dea00000"
+   "balance": "0xd3c21bcecceda1000000"
   },
   "23618e81e3f5cdf7f54c3d65f7fbc0abf5b21e8f": {
-   "balance": "0x3635c9adc5dea00000"
+   "balance": "0xd3c21bcecceda1000000"
   },
   "3c44cdddb6a900fa2b585dd299e03d12fa4293bc": {
-   "balance": "0x3635c9adc5dea00000"
+   "balance": "0xd3c21bcecceda1000000"
   },
   "70997970c51812dc3a010c7d01b50e0d17dc79c8": {
-   "balance": "0x3635c9adc5dea00000"
+   "balance": "0xd3c21bcecceda1000000"
   },
   "90f79bf6eb2c4f870365e785982e1f101e93b906": {
-   "balance": "0x3635c9adc5dea00000"
+   "balance": "0xd3c21bcecceda1000000"
   },
   "976ea74026e726554db657fa54763abd0c3a0aa9": {
-   "balance": "0x3635c9adc5dea00000"
+   "balance": "0xd3c21bcecceda1000000"
   },
   "9965507d1a55bcc2695c58ba16fb37d819b0a4dc": {
-   "balance": "0x3635c9adc5dea00000"
+   "balance": "0xd3c21bcecceda1000000"
   },
   "a0ee7a142d267c1f36714e4a8f75612f20a79720": {
-   "balance": "0x3635c9adc5dea00000"
+   "balance": "0xd3c21bcecceda1000000"
   },
   "f39fd6e51aad88f6f4ce6ab8827279cfffb92266": {
-   "balance": "0x3635c9adc5dea00000"
+   "balance": "0xd3c21bcecceda1000000"
   }
  },
  "number": "0x0",

--- a/lib/k1util/k1util.go
+++ b/lib/k1util/k1util.go
@@ -79,6 +79,20 @@ func PubKeyToAddress(pubkey crypto.PubKey) (common.Address, error) {
 	return ethcrypto.PubkeyToAddress(*ethPubKey), nil
 }
 
+func StdPrivKeyFromComet(privkey crypto.PrivKey) (*stdecdsa.PrivateKey, error) {
+	bz := privkey.Bytes()
+	if len(bz) != privKeyLen {
+		return nil, errors.New("invalid private key length")
+	}
+
+	resp, err := ethcrypto.ToECDSA(bz)
+	if err != nil {
+		return nil, errors.Wrap(err, "convert to ECDSA")
+	}
+
+	return resp, nil
+}
+
 func StdPubKeyToCosmos(pubkey *stdecdsa.PublicKey) (cosmoscrypto.PubKey, error) {
 	pubkeyBytes := ethcrypto.CompressPubkey(pubkey)
 	if len(pubkeyBytes) != pubkeyCompressedLen {

--- a/monitor/app/app.go
+++ b/monitor/app/app.go
@@ -10,6 +10,7 @@ import (
 	"github.com/omni-network/omni/lib/log"
 	"github.com/omni-network/omni/lib/netconf"
 	"github.com/omni-network/omni/monitor/avs"
+	"github.com/omni-network/omni/monitor/loadgen"
 
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
@@ -27,6 +28,10 @@ func Run(ctx context.Context, cfg Config) error {
 
 	if err := avs.Monitor(ctx, network); err != nil {
 		return errors.Wrap(err, "monitor AVS")
+	}
+
+	if err := startLoadGen(ctx, cfg, network); err != nil {
+		return errors.Wrap(err, "start load generator")
 	}
 
 	select {
@@ -57,4 +62,12 @@ func serveMonitoring(address string) <-chan error {
 	}()
 
 	return errChan
+}
+
+func startLoadGen(ctx context.Context, cfg Config, network netconf.Network) error {
+	if err := loadgen.Start(ctx, network, cfg.LoadGen); err != nil {
+		return errors.Wrap(err, "start load generator")
+	}
+
+	return nil
 }

--- a/monitor/app/config.go
+++ b/monitor/app/config.go
@@ -2,11 +2,12 @@ package monitor
 
 import (
 	"bytes"
-	"html/template"
+	"text/template"
 
 	"github.com/omni-network/omni/lib/buildinfo"
 	"github.com/omni-network/omni/lib/errors"
 	"github.com/omni-network/omni/lib/log"
+	"github.com/omni-network/omni/monitor/loadgen"
 
 	cmtos "github.com/cometbft/cometbft/libs/os"
 
@@ -16,6 +17,8 @@ import (
 type Config struct {
 	NetworkFile    string
 	MonitoringAddr string
+
+	LoadGen loadgen.Config
 }
 
 func DefaultConfig() Config {
@@ -30,8 +33,6 @@ var tomlTemplate []byte
 
 // WriteConfigTOML writes the toml halo config to disk.
 func WriteConfigTOML(cfg Config, logCfg log.Config, path string) error {
-	var buffer bytes.Buffer
-
 	t, err := template.New("").Parse(string(tomlTemplate))
 	if err != nil {
 		return errors.Wrap(err, "parse template")
@@ -47,6 +48,7 @@ func WriteConfigTOML(cfg Config, logCfg log.Config, path string) error {
 		Version: buildinfo.Version(),
 	}
 
+	var buffer bytes.Buffer
 	if err := t.Execute(&buffer, s); err != nil {
 		return errors.Wrap(err, "execute template")
 	}

--- a/monitor/app/config_test.go
+++ b/monitor/app/config_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/omni-network/omni/lib/log"
 	"github.com/omni-network/omni/lib/tutil"
 	monitor "github.com/omni-network/omni/monitor/app"
+	"github.com/omni-network/omni/monitor/loadgen"
 
 	"github.com/stretchr/testify/require"
 )
@@ -19,6 +20,9 @@ func TestDefaultConfigReference(t *testing.T) {
 	tempDir := t.TempDir()
 
 	cfg := monitor.DefaultConfig()
+	cfg.LoadGen = loadgen.Config{
+		ValidatorKeysGlob: "path/*/1",
+	}
 
 	path := filepath.Join(tempDir, "monitor.toml")
 

--- a/monitor/app/monitor.toml
+++ b/monitor/app/monitor.toml
@@ -3,17 +3,17 @@
 
 # The version of the Halo binary that created or
 # last modified the config file. Do not modify this.
-version = "{{ .Version}}"
+version = "v0.1.1"
 
 #######################################################################
 ###                         Monitor Options                         ###
 #######################################################################
 
 # The path to the Omni network configuration file.
-network-file = "{{ .NetworkFile }}"
+network-file = "network.json"
 
 # The address that the monitor listens for metric scrape requests.
-monitoring-addr = "{{ .MonitoringAddr }}"
+monitoring-addr = ":26660"
 
 #######################################################################
 ###                         Logging Options                         ###
@@ -22,13 +22,13 @@ monitoring-addr = "{{ .MonitoringAddr }}"
 [log]
 # Logging level. Note cometBFT internal logs are configured in config.yaml.
 # Options are: debug, info, warn, error.
-level = "{{ .Log.Level }}"
+level = "info"
 
 # Logging format. Options are: console, json.
-format = "{{ .Log.Format }}"
+format = "console"
 
 # Logging color if console format is chosen. Options are: auto, force, disable.
-color = "{{ .Log.Color }}"
+color = "auto"
 
 #######################################################################
 ###                         Load Generation                         ###
@@ -36,5 +36,4 @@ color = "{{ .Log.Color }}"
 
 # Note that load generation is only used for testing purposes; ie on devent or staging.
 [loadgen]
-# Validator keys glob defines the validator keys to use for self-delegation.
-validator-keys-glob = "{{ .LoadGen.ValidatorKeysGlob }}"
+validator-keys = ["path/1", "path/2"]

--- a/monitor/app/testdata/default_monitor.toml
+++ b/monitor/app/testdata/default_monitor.toml
@@ -29,3 +29,12 @@ format = "console"
 
 # Logging color if console format is chosen. Options are: auto, force, disable.
 color = "auto"
+
+#######################################################################
+###                         Load Generation                         ###
+#######################################################################
+
+# Note that load generation is only used for testing purposes; ie on devent or staging.
+[loadgen]
+# Validator keys glob defines the validator keys to use for self-delegation.
+validator-keys-glob = "path/*/1"

--- a/monitor/cmd/cmd.go
+++ b/monitor/cmd/cmd.go
@@ -18,6 +18,7 @@ func New() *cobra.Command {
 
 	cfg := monitor.DefaultConfig()
 	bindRunFlags(cmd.Flags(), &cfg)
+	bindLoadGenFlags(cmd.Flags(), &cfg.LoadGen)
 
 	logCfg := log.DefaultConfig()
 	log.BindFlags(cmd.Flags(), &logCfg)

--- a/monitor/cmd/flags.go
+++ b/monitor/cmd/flags.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	monitor "github.com/omni-network/omni/monitor/app"
+	"github.com/omni-network/omni/monitor/loadgen"
 
 	"github.com/spf13/pflag"
 )
@@ -9,4 +10,8 @@ import (
 func bindRunFlags(flags *pflag.FlagSet, cfg *monitor.Config) {
 	flags.StringVar(&cfg.NetworkFile, "network-file", cfg.NetworkFile, "The path to the network file e.g path/network.json")
 	flags.StringVar(&cfg.MonitoringAddr, "monitoring-addr", cfg.MonitoringAddr, "The address to bind the monitoring server")
+}
+
+func bindLoadGenFlags(flags *pflag.FlagSet, cfg *loadgen.Config) {
+	flags.StringVar(&cfg.ValidatorKeysGlob, "loadgen-validator-keys-glob", cfg.ValidatorKeysGlob, "Glob path to the validator keys used for self-delegation load generation. Only applicable to devnet and staging")
 }

--- a/monitor/loadgen/loadgen.go
+++ b/monitor/loadgen/loadgen.go
@@ -1,0 +1,82 @@
+package loadgen
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"path/filepath"
+	"time"
+
+	"github.com/omni-network/omni/contracts/bindings"
+	"github.com/omni-network/omni/halo/genutil/evm/predeploys"
+	"github.com/omni-network/omni/lib/errors"
+	"github.com/omni-network/omni/lib/ethclient"
+	"github.com/omni-network/omni/lib/ethclient/ethbackend"
+	"github.com/omni-network/omni/lib/netconf"
+
+	"github.com/ethereum/go-ethereum/common"
+	ethcrypto "github.com/ethereum/go-ethereum/crypto"
+)
+
+// Config is the configuration for the load generator.
+type Config struct {
+	// ValidatorKeysGlob defines the paths to the validator keys used for self-delegation.
+	ValidatorKeysGlob string
+}
+
+// Start starts the validator self delegation load generator.
+// It does:
+// - Validator self-delegation on periodic basis.
+func Start(ctx context.Context, network netconf.Network, cfg Config) error {
+	// Only generate load in ephemeral networks, devnet and staging.
+	if network.Name == netconf.Testnet || network.Name == netconf.Mainnet {
+		return nil
+	} else if cfg.ValidatorKeysGlob == "" {
+		// Skip if no validator keys are provided.
+		return nil
+	}
+
+	var keys []*ecdsa.PrivateKey
+	keysPaths, err := filepath.Glob(cfg.ValidatorKeysGlob)
+	if err != nil {
+		return errors.Wrap(err, "glob validator keys", "glob", cfg.ValidatorKeysGlob)
+	}
+	for _, keyPath := range keysPaths {
+		key, err := ethcrypto.LoadECDSA(keyPath)
+		if err != nil {
+			return errors.Wrap(err, "load validator key", "path", keyPath)
+		}
+
+		keys = append(keys, key)
+	}
+
+	omniEVM, ok := network.OmniEVMChain()
+	if !ok {
+		return errors.New("omniEVM chain not found")
+	}
+
+	ethCl, err := ethclient.Dial(omniEVM.Name, omniEVM.RPCURL)
+	if err != nil {
+		return err
+	}
+
+	backend, err := ethbackend.NewBackend(omniEVM.Name, omniEVM.ID, omniEVM.BlockPeriod, ethCl, keys...)
+	if err != nil {
+		return err
+	}
+
+	contract, err := bindings.NewOmniStake(common.HexToAddress(predeploys.OmniStake), backend)
+	if err != nil {
+		return errors.Wrap(err, "new omni stake")
+	}
+
+	var period = time.Hour
+	if network.Name == netconf.Devnet {
+		period = time.Second * 10
+	}
+
+	for _, key := range keys {
+		go selfDelegateForever(ctx, contract, backend, &key.PublicKey, period)
+	}
+
+	return nil
+}

--- a/monitor/loadgen/stake.go
+++ b/monitor/loadgen/stake.go
@@ -1,0 +1,67 @@
+package loadgen
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"math/big"
+	"time"
+
+	"github.com/omni-network/omni/contracts/bindings"
+	"github.com/omni-network/omni/lib/errors"
+	"github.com/omni-network/omni/lib/ethclient/ethbackend"
+	"github.com/omni-network/omni/lib/k1util"
+	"github.com/omni-network/omni/lib/log"
+
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/params"
+)
+
+const selfDelegateJitter = 0.2 // 20% jitter
+
+func selfDelegateForever(ctx context.Context, contract *bindings.OmniStake, backend *ethbackend.Backend, validator *ecdsa.PublicKey, period time.Duration) {
+	log.Info(ctx, "Starting periodic self-delegation", "validator", crypto.PubkeyToAddress(*validator).Hex(), "period", period)
+
+	nextPeriod := func() time.Duration {
+		jitter := time.Duration(float64(period) * selfDelegateJitter)
+		return period + jitter
+	}
+
+	timer := time.NewTimer(nextPeriod())
+	defer timer.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-timer.C:
+			if err := selfDelegateOnce(ctx, contract, backend, validator); err != nil {
+				log.Error(ctx, "Failed to self-delegate (will retry)", err)
+			}
+			timer.Reset(nextPeriod())
+		}
+	}
+}
+
+func selfDelegateOnce(ctx context.Context, contract *bindings.OmniStake, backend *ethbackend.Backend, validator *ecdsa.PublicKey) error {
+	addr := crypto.PubkeyToAddress(*validator)
+
+	txOpts, err := backend.BindOpts(ctx, addr)
+	if err != nil {
+		return err
+	}
+	txOpts.Value = big.NewInt(params.Ether) // 1 ETH (in wei)
+
+	tx, err := contract.Deposit(txOpts, k1util.PubKeyToBytes64(validator))
+	if err != nil {
+		return errors.Wrap(err, "deposit")
+	}
+
+	rec, err := backend.WaitMined(ctx, tx)
+	if err != nil {
+		return err
+	}
+
+	log.Info(ctx, "Deposited validator self-delegation", "height", rec.BlockNumber, "validator", addr.Hex())
+
+	return nil
+}


### PR DESCRIPTION
Add a `loadgen` package to `monitor` service that periodically self-delegates validator stake to test validator updates in staging/devnet.

Update monitor config to load those keys and e2e app to wire it.

task: none