### PR TITLE
test(ci): fix failing CI after automerge

### DIFF
--- a/halo/genutil/testdata/TestMakeGenesis.golden
+++ b/halo/genutil/testdata/TestMakeGenesis.golden
@@ -2,7 +2,7 @@
  "app_name": "halo",
  "app_version": "TBD",
  "genesis_time": "1970-01-01T00:00:01Z",
- "chain_id": "omni-1016561",
+ "chain_id": "omni-2",
  "initial_height": 1,
  "app_hash": null,
  "app_state": {

--- a/lib/netconf/static.go
+++ b/lib/netconf/static.go
@@ -9,7 +9,7 @@ import (
 )
 
 const consensusIDPrefix = "omni-"
-const consensusIDOffset = 1_000_000
+const consensusIDOffset = 1_000_000 //nolint:unused // Will use
 
 // Static defines static config and data for a network.
 type Static struct {
@@ -24,8 +24,9 @@ func (s Static) OmniConsensusChainIDStr() string {
 
 // OmniConsensusChainIDUint64 returns the chain ID uint64 for the Omni consensus chain.
 // It is calculated as 1_000_000 + OmniExecutionChainID.
-func (s Static) OmniConsensusChainIDUint64() uint64 {
-	return consensusIDOffset + s.OmniExecutionChainID
+func (Static) OmniConsensusChainIDUint64() uint64 {
+	// return consensusIDOffset + s.OmniExecutionChainID
+	return 2 // TODO(corver): Fix this once portal takes ID in constructor.
 }
 
 //nolint:gochecknoglobals // Static mappings.
@@ -49,10 +50,12 @@ func ConsensusChainIDStr2Uint64(id string) (uint64, error) {
 
 	suffix := strings.TrimPrefix(id, consensusIDPrefix)
 
-	resp, err := strconv.ParseUint(suffix, 10, 64)
+	_, err := strconv.ParseUint(suffix, 10, 64)
 	if err != nil {
 		return 0, errors.Wrap(err, "parse consensus chain ID", "id", id)
 	}
 
-	return resp, nil
+	// return resp, nil
+
+	return 2, nil // TODO(corver): Fix this once portal takes ID in constructor.
 }


### PR DESCRIPTION
We didn't require e2e tests to pass in PRs, so automerge merged it before I could fix it.

task: none