### PR TITLE
fix(lib/contracts): use git hash for ephemeral salts

### DIFF
--- a/lib/buildinfo/buildinfo.go
+++ b/lib/buildinfo/buildinfo.go
@@ -59,6 +59,12 @@ func NewVersionCmd() *cobra.Command {
 	}
 }
 
+// Get returns the git commit short sha hash.
+func ShortSha() string {
+	commit, _ := get()
+	return commit
+}
+
 // get returns the git commit hash and timestamp from the runtime build info.
 func get() (hash string, timestamp string) { //nolint:nonamedreturns // Disambiguate identical return types.
 	hash, timestamp = "unknown", "unknown"

--- a/lib/contracts/addrs.go
+++ b/lib/contracts/addrs.go
@@ -261,7 +261,11 @@ func AVSSalt(network netconf.ID) string {
 
 // salt generates a salt for a contract deployment, adding git build info.
 func salt(network netconf.ID, contract string) string {
-	return string(network) + "-" + contract + "-" + buildinfo.Version()
+	if network.IsEphemeral() {
+		return string(network) + "-" + contract + "-" + buildinfo.ShortSha()
+	}
+
+	return string(network) + "-" + contract
 }
 
 func addr(hex string) common.Address {


### PR DESCRIPTION
Use git hash in salt for ephemeral deployments. Use static salt for long term deployments.

task: none