### PR TITLE
fix(e2e/manifest): fix staging manifest evm key

### DIFF
--- a/e2e/manifests/staging.toml
+++ b/e2e/manifests/staging.toml
@@ -18,4 +18,6 @@ mode = "full"
 [keys.validator01]
 validator = "0xD6CD71dF91a6886f69761826A9C4D123178A8d9D"
 p2p_consensus = "324F0A865DB7EAFBF53A387FC74E58169EDFA6C4"
+
+[keys.validator01_evm]
 p2p_execution = "0x86e640Ac9c8c693BBFFd2E31f91522b95c1274BF"


### PR DESCRIPTION
Fixes staging manifest. p2p_exection keys must be defined on the EVM node itself, not on the halo node.

task: none