### PR TITLE
ci(e2e): improve geth config

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -76,6 +76,10 @@
       "path": "detect_secrets.filters.allowlist.is_line_allowlisted"
     },
     {
+      "path": "detect_secrets.filters.common.is_baseline_file",
+      "filename": ".secrets.baseline"
+    },
+    {
       "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
       "min_level": 2
     },
@@ -195,28 +199,28 @@
         "filename": "e2e/app/setup.go",
         "hashed_secret": "7be029054a936fcb1827abd24388a53136be7b64",
         "is_verified": false,
-        "line_number": 128
+        "line_number": 134
       },
       {
         "type": "Secret Keyword",
         "filename": "e2e/app/setup.go",
         "hashed_secret": "55abc9109d5ea8a77be16bf3c76b4b199b524b12",
         "is_verified": false,
-        "line_number": 404
+        "line_number": 398
       },
       {
         "type": "Secret Keyword",
         "filename": "e2e/app/setup.go",
         "hashed_secret": "da57af224108e98e24d1e2a86221121990fa6478",
         "is_verified": false,
-        "line_number": 429
+        "line_number": 423
       },
       {
         "type": "Secret Keyword",
         "filename": "e2e/app/setup.go",
         "hashed_secret": "b11b6052ab454c167964c5b836faf0053a711b90",
         "is_verified": false,
-        "line_number": 464
+        "line_number": 458
       }
     ],
     "e2e/app/static/geth-keystore.json": [
@@ -826,5 +830,5 @@
       }
     ]
   },
-  "generated_at": "2024-03-28T09:56:53Z"
+  "generated_at": "2024-04-01T12:04:49Z"
 }

--- a/e2e/app/geth.toml.tmpl
+++ b/e2e/app/geth.toml.tmpl
@@ -1,3 +1,31 @@
+[Eth]
+NetworkId = {{ .ChainID }}
+SyncMode = {{ if .IsArchive }}"full"{{else}}"snap"{{end}}
+NoPruning = {{ .IsArchive }}
+
+[Eth.Miner]
+# Recommit defines the time interval for miner to re-create mining work. Required for fast block times.
+Recommit = 500000000 # 500ms
+
+[Node]
+DataDir = "/geth"
+HTTPHost = "0.0.0.0"
+HTTPPort = 8545
+HTTPVirtualHosts = ["*"]
+HTTPModules = ["net", "web3", "eth"]
+AuthAddr = "0.0.0.0"
+AuthPort = 8551
+AuthVirtualHosts = ["*"]
+WSHost = "0.0.0.0"
+WSPort = 8546
+WSModules = ["net", "web3", "eth"]
+
 [Node.P2P]
-BootstrapNodes = [{{ .BootstrapNodes }}]
-StaticNodes = [{{ .StaticNodes }}]
+NoDiscovery = false
+DiscoveryV4 = true
+BootstrapNodes = {{ .BootstrapNodes }}
+TrustedNodes = {{ .TrustedNodes }}
+ListenAddr = "0.0.0.0:30303"
+
+# TODO(corver): Enable prometheus metrics.
+# [Metrics]

--- a/e2e/app/setup_internal_test.go
+++ b/e2e/app/setup_internal_test.go
@@ -1,11 +1,15 @@
 package app
 
 import (
+	"net"
 	"os"
 	"path/filepath"
 	"testing"
 
 	"github.com/omni-network/omni/lib/tutil"
+
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/p2p/enode"
 
 	"github.com/stretchr/testify/require"
 )
@@ -42,6 +46,30 @@ trust_period = "168h0m0s"
 	require.NoError(t, err)
 
 	bz, err := os.ReadFile(configFile)
+	require.NoError(t, err)
+
+	tutil.RequireGoldenBytes(t, bz)
+}
+
+func TestWriteGethConfigTOML(t *testing.T) {
+	t.Parallel()
+
+	testKey, _ := crypto.HexToECDSA("45a915e4d060149eb4365960e6a7a45f334393093061116b197e3240065ff2d8")
+	node1 := enode.NewV4(&testKey.PublicKey, net.IP{127, 0, 0, 1}, 1, 1)
+	node2 := enode.NewV4(&testKey.PublicKey, net.IP{127, 0, 0, 2}, 2, 2)
+
+	cfg := GethConfig{
+		peers:     []*enode.Node{node1, node2},
+		ChainID:   15651,
+		IsArchive: true,
+	}
+
+	tempFile := filepath.Join(t.TempDir(), "geth.toml")
+
+	err := WriteGethConfigTOML(cfg, tempFile)
+	require.NoError(t, err)
+
+	bz, err := os.ReadFile(tempFile)
 	require.NoError(t, err)
 
 	tutil.RequireGoldenBytes(t, bz)

--- a/e2e/app/testdata/TestWriteGethConfigTOML.golden
+++ b/e2e/app/testdata/TestWriteGethConfigTOML.golden
@@ -1,0 +1,31 @@
+[Eth]
+NetworkId = 15651
+SyncMode = "full"
+NoPruning = true
+
+[Eth.Miner]
+# Recommit defines the time interval for miner to re-create mining work. Required for fast block times.
+Recommit = 500000000 # 500ms
+
+[Node]
+DataDir = "/geth"
+HTTPHost = "0.0.0.0"
+HTTPPort = 8545
+HTTPVirtualHosts = ["*"]
+HTTPModules = ["net", "web3", "eth"]
+AuthAddr = "0.0.0.0"
+AuthPort = 8551
+AuthVirtualHosts = ["*"]
+WSHost = "0.0.0.0"
+WSPort = 8546
+WSModules = ["net", "web3", "eth"]
+
+[Node.P2P]
+NoDiscovery = false
+DiscoveryV4 = true
+BootstrapNodes = ["enode://3a514176466fa815ed481ffad09110a2d344f6c9b78c1d14afc351c3a51be33d8072e77939dc03ba44790779b7a1025baf3003f6732430e20cd9b76d953391b3@127.0.0.1:1","enode://3a514176466fa815ed481ffad09110a2d344f6c9b78c1d14afc351c3a51be33d8072e77939dc03ba44790779b7a1025baf3003f6732430e20cd9b76d953391b3@127.0.0.2:2"]
+TrustedNodes = ["enode://3a514176466fa815ed481ffad09110a2d344f6c9b78c1d14afc351c3a51be33d8072e77939dc03ba44790779b7a1025baf3003f6732430e20cd9b76d953391b3@127.0.0.1:1","enode://3a514176466fa815ed481ffad09110a2d344f6c9b78c1d14afc351c3a51be33d8072e77939dc03ba44790779b7a1025baf3003f6732430e20cd9b76d953391b3@127.0.0.2:2"]
+ListenAddr = "0.0.0.0:30303"
+
+# TODO(corver): Enable prometheus metrics.
+# [Metrics]

--- a/e2e/docker/compose.yaml.tmpl
+++ b/e2e/docker/compose.yaml.tmpl
@@ -30,7 +30,6 @@ services:
     - HALO_LOG_FORMAT={{ $.OmniLogFormat }}
     volumes:
     - ./{{ .Name }}:/halo
-    - ./{{ index $.NodeOmniEVMs .Name }}/jwtsecret:/geth/jwtsecret
     depends_on:
       {{ index $.NodeOmniEVMs .Name }}:
         condition: service_healthy
@@ -72,7 +71,7 @@ services:
       e2e: true
     container_name: {{ .InstanceName }}-init
     image: "ethereum/client-go:{{ $.GethTag }}"
-    command: {{ if eq .GcMode "archive" }}--state.scheme=hash {{ end }}--datadir=/geth init /geth/genesis.json
+    command: --state.scheme={{ if .IsArchive }}hash{{ else }}path{{ end }} --datadir=/geth init /geth/genesis.json
     volumes:
       - ./{{ .InstanceName }}:/geth
     networks:
@@ -82,31 +81,12 @@ services:
     labels:
       e2e: true
     container_name: {{ .InstanceName }}
-    image: "ethereum/client-go:latest"
+    image: "ethereum/client-go:{{ $.GethTag }}"
     command:
       - --config=/geth/config.toml
-      - --http
-      - --http.vhosts=*
-      - --http.api=eth,net,web3
-      - --http.addr=0.0.0.0
-      - --http.corsdomain=*
-      - --ws
-      - --ws.api=eth,net,web3
-      - --ws.addr=0.0.0.0
-      - --ws.origins=*
-      - --authrpc.vhosts=*
-      - --authrpc.addr=0.0.0.0
-      - --authrpc.jwtsecret=/geth/jwtsecret
-      - --datadir=/geth
-      - --unlock=0x123463a4b065722e99115d6c222f267d9cabb524
-      - --allow-insecure-unlock
-      - --password=/geth/geth_password.txt
-      - --nodiscover
-      - --syncmode=full
-      - --gcmode={{.GcMode}}
-      - --nodekeyhex={{.NodeKeyHex}}
-      - --miner.recommit=500ms
-      - --nat=extip:{{.ExternalIP}}
+      # Flags not available via config.toml
+      - --nat=extip:{{ .AdvertisedIP }}
+      {{ if .IsArchive }}- --gcmode=archive{{ end }}
     ports:
       - {{ if $.BindAll }}8551:{{end}}8551
       - {{ if .ProxyPort }}{{ .ProxyPort }}:{{ end }}8545
@@ -123,7 +103,7 @@ services:
       - ./{{ .InstanceName }}:/geth
     networks:
       {{ $.NetworkName }}:
-        {{ if $.Network }}ipv4_address: {{ .InternalIP }}{{ end }}
+        {{ if $.Network }}ipv4_address: {{ .AdvertisedIP }}{{ end }}
 {{end}}
 
 {{- if .Relayer }}

--- a/e2e/docker/docker_test.go
+++ b/e2e/docker/docker_test.go
@@ -55,11 +55,11 @@ func TestComposeTemplate(t *testing.T) {
 					{
 						Chain:        types.OmniEVMByNetwork(netconf.Simnet),
 						InstanceName: "omni_evm_0",
-						InternalIP:   ipNet.IP,
+						AdvertisedIP: ipNet.IP,
 						ProxyPort:    8000,
 						NodeKey:      key,
 						Enode:        en,
-						BootNodes:    []*enode.Node{en},
+						Peers:        []*enode.Node{en},
 					},
 				},
 				AnvilChains: []types.AnvilChain{

--- a/e2e/docker/testdata/TestComposeTemplate_image_tag_7d1ae53.golden
+++ b/e2e/docker/testdata/TestComposeTemplate_image_tag_7d1ae53.golden
@@ -24,7 +24,6 @@ services:
     - HALO_LOG_FORMAT=console
     volumes:
     - ./node0:/halo
-    - ./omni_evm_0/jwtsecret:/geth/jwtsecret
     depends_on:
       omni_evm_0:
         condition: service_healthy
@@ -81,7 +80,7 @@ services:
       e2e: true
     container_name: omni_evm_0-init
     image: "ethereum/client-go:v1.13.14"
-    command: --datadir=/geth init /geth/genesis.json
+    command: --state.scheme=path --datadir=/geth init /geth/genesis.json
     volumes:
       - ./omni_evm_0:/geth
     networks:
@@ -91,31 +90,12 @@ services:
     labels:
       e2e: true
     container_name: omni_evm_0
-    image: "ethereum/client-go:latest"
+    image: "ethereum/client-go:v1.13.14"
     command:
       - --config=/geth/config.toml
-      - --http
-      - --http.vhosts=*
-      - --http.api=eth,net,web3
-      - --http.addr=0.0.0.0
-      - --http.corsdomain=*
-      - --ws
-      - --ws.api=eth,net,web3
-      - --ws.addr=0.0.0.0
-      - --ws.origins=*
-      - --authrpc.vhosts=*
-      - --authrpc.addr=0.0.0.0
-      - --authrpc.jwtsecret=/geth/jwtsecret
-      - --datadir=/geth
-      - --unlock=0x123463a4b065722e99115d6c222f267d9cabb524
-      - --allow-insecure-unlock
-      - --password=/geth/geth_password.txt
-      - --nodiscover
-      - --syncmode=full
-      - --gcmode=
-      - --nodekeyhex=59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d
-      - --miner.recommit=500ms
-      - --nat=extip:<nil>
+      # Flags not available via config.toml
+      - --nat=extip:10.186.73.0
+      
     ports:
       - 8551
       - 8000:8545

--- a/e2e/docker/testdata/TestComposeTemplate_image_tag_main.golden
+++ b/e2e/docker/testdata/TestComposeTemplate_image_tag_main.golden
@@ -24,7 +24,6 @@ services:
     - HALO_LOG_FORMAT=console
     volumes:
     - ./node0:/halo
-    - ./omni_evm_0/jwtsecret:/geth/jwtsecret
     depends_on:
       omni_evm_0:
         condition: service_healthy
@@ -81,7 +80,7 @@ services:
       e2e: true
     container_name: omni_evm_0-init
     image: "ethereum/client-go:v1.13.14"
-    command: --datadir=/geth init /geth/genesis.json
+    command: --state.scheme=path --datadir=/geth init /geth/genesis.json
     volumes:
       - ./omni_evm_0:/geth
     networks:
@@ -91,31 +90,12 @@ services:
     labels:
       e2e: true
     container_name: omni_evm_0
-    image: "ethereum/client-go:latest"
+    image: "ethereum/client-go:v1.13.14"
     command:
       - --config=/geth/config.toml
-      - --http
-      - --http.vhosts=*
-      - --http.api=eth,net,web3
-      - --http.addr=0.0.0.0
-      - --http.corsdomain=*
-      - --ws
-      - --ws.api=eth,net,web3
-      - --ws.addr=0.0.0.0
-      - --ws.origins=*
-      - --authrpc.vhosts=*
-      - --authrpc.addr=0.0.0.0
-      - --authrpc.jwtsecret=/geth/jwtsecret
-      - --datadir=/geth
-      - --unlock=0x123463a4b065722e99115d6c222f267d9cabb524
-      - --allow-insecure-unlock
-      - --password=/geth/geth_password.txt
-      - --nodiscover
-      - --syncmode=full
-      - --gcmode=
-      - --nodekeyhex=59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d
-      - --miner.recommit=500ms
-      - --nat=extip:<nil>
+      # Flags not available via config.toml
+      - --nat=extip:10.186.73.0
+      
     ports:
       - 8551
       - 8000:8545

--- a/e2e/manifests/staging.toml
+++ b/e2e/manifests/staging.toml
@@ -12,7 +12,7 @@ prometheus = true
 mode = "seed"
 
 [node.fullnode01]
-mode = "full"
+mode = "archive"
 
 # Testing long-lived keys on staging while testnet doens't exist. Remove this.
 [keys.validator01]

--- a/e2e/types/manifest.go
+++ b/e2e/types/manifest.go
@@ -6,6 +6,42 @@ import (
 	e2e "github.com/cometbft/cometbft/test/e2e/pkg"
 )
 
+// Mode defines the halo consensus node mode.
+// Nodes are in general full nodes (light nodes are not supported yet).
+// In some cases, additional roles are defined: validator, archive, seed.
+//
+// Note that the execution clients only have two modes: "default" and "archive".
+//
+// e2e.Mode is extended so ModeArchive can be added transparently.
+type Mode = e2e.Mode
+
+const (
+	// ModeValidator defines a validator node.
+	// [genesis_validator_set=true,pruning=default,consensus=default,special_p2p=false].
+	// Note technically a validator node is also a "full node".
+	ModeValidator = e2e.ModeValidator
+
+	// ModeArchive defines an archive node.∂
+	// [genesis_validator_set=false,pruning=none,consensus=default,special_p2p=false].
+	// Note technically an archive node is also a "full node".
+	ModeArchive Mode = "archive"
+
+	// ModeSeed defines a seed node. It must have a long lived pubkey and address (encoded in repo).
+	// It trawls the network regularly, making it available to new nodes.
+	// [genesis_validator_set=false,pruning=default,consensus=default,special_p2p=true].
+	// Note technically a seed node is also a "full node".
+	ModeSeed = e2e.ModeSeed
+
+	// ModeFull defines a full node. A full node a normal node without a special role.
+	// [genesis_validator_set=false,pruning=default,consensus=default,special_p2p=false].
+	ModeFull = e2e.ModeFull
+
+	// ModeLight defines a light node. This isn't used yet.
+	// [genesis_validator_set=false,pruning=no_data,consensus=light,special_p2p=false]
+	// Only light nodes are not also full nodes.
+	ModeLight = e2e.ModeLight
+)
+
 // Manifest wraps e2e.Manifest with additional omni-specific fields.
 type Manifest struct {
 	e2e.Manifest
@@ -47,29 +83,19 @@ type NodeKeys struct {
 	P2PExecution string `toml:"p2p_execution"`
 }
 
-// OmniEVMs returns the map names and GcMode of Omni EVMs to deploy.
+// OmniEVMs returns a map of omni evm instances names by <IsArchive> to deploy.
 // If only a single Omni EVM is to be deployed, the name is "omni_evm".
 // Otherwise, the names are "<node>_evm".
-func (m Manifest) OmniEVMs() map[string]GcMode {
+func (m Manifest) OmniEVMs() map[string]bool {
 	if !m.MultiOmniEVMs {
-		return map[string]GcMode{
-			"omni_evm": GcModeFull,
+		return map[string]bool{
+			"omni_evm": false,
 		}
 	}
 
-	resp := make(map[string]GcMode)
+	resp := make(map[string]bool)
 	for name, node := range m.Nodes {
-		var gcmode GcMode
-		switch node.Mode {
-		case "full":
-			gcmode = GcModeArchive
-		case "seed":
-			gcmode = GcModeFull
-		default:
-			gcmode = GcModeFull
-		}
-
-		resp[name+"_evm"] = gcmode
+		resp[name+"_evm"] = Mode(node.Mode) == ModeArchive
 	}
 
 	return resp

--- a/e2e/types/testnet.go
+++ b/e2e/types/testnet.go
@@ -3,7 +3,6 @@ package types
 import (
 	"crypto/ecdsa"
 	"encoding/hex"
-	"fmt"
 	"net"
 	"strings"
 	"time"
@@ -16,14 +15,6 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/p2p/enode"
-)
-
-// GcMode represents the garbage collection mode for geth. Either "full" or "archive".
-type GcMode string
-
-const (
-	GcModeFull    GcMode = "full"    // default mode for geth
-	GcModeArchive GcMode = "archive" // archival mode for geth
 )
 
 // Testnet wraps e2e.Testnet with additional omni-specific fields.
@@ -52,16 +43,18 @@ func (t Testnet) AVSChain() (EVMChain, error) {
 	return EVMChain{}, errors.New("avs target chain found")
 }
 
-// FirstOmniValidatorEVM returns the first validator's evm.
-func (t Testnet) FirstOmniValidatorEVM() (OmniEVM, error) {
+// BroadcastOmniEVM returns a Omni EVM to use for e2e app tx broadcasts.
+// It prefers a full or archive node to ensure evm p2p-networking is set up correctly.
+// Since without networking, the txs will be stuck in the geth mempool.
+func (t Testnet) BroadcastOmniEVM() OmniEVM {
 	for _, evm := range t.OmniEVMs {
-		if strings.Contains(evm.InstanceName, "validator") ||
-			strings.Contains(evm.InstanceName, "omni_evm") {
-			return evm, nil
+		if strings.Contains(evm.InstanceName, "full") ||
+			strings.Contains(evm.InstanceName, "archive") {
+			return evm
 		}
 	}
 
-	return OmniEVM{}, errors.New("first omni evm validator not found", "omni_evms", t.OmniEVMs)
+	return t.OmniEVMs[0]
 }
 
 func (t Testnet) HasOmniEVM() bool {
@@ -83,33 +76,23 @@ type EVMChain struct {
 type OmniEVM struct {
 	Chain           EVMChain // For netconf (all instances must have the same chain)
 	InstanceName    string   // For docker container name
-	InternalIP      net.IP   // For docker container IP
-	ExternalIP      net.IP   // For setting up NAT on geth bootnode
+	AdvertisedIP    net.IP   // For setting up NAT on geth bootnode
 	ProxyPort       uint32   // For binding
 	InternalRPC     string   // For JSON-RPC queries from halo/relayer
 	InternalAuthRPC string   // For engine API queries from halo
 	ExternalRPC     string   // For JSON-RPC queries from e2e app.
-	GcMode          GcMode   // Geth config for archive or full mode
+	IsArchive       bool     // Whether this instance is in archive mode
+	JWTSecret       string   // JWT secret for authentication
 
 	// P2P networking
-	NodeKey   *ecdsa.PrivateKey // Private key
-	Enode     *enode.Node       // Public key
-	BootNodes []*enode.Node     // Peer public keys
+	NodeKey *ecdsa.PrivateKey // Private key
+	Enode   *enode.Node       // Public key
+	Peers   []*enode.Node     // Peer public keys
 }
 
 // NodeKeyHex returns the hex-encoded node key. Used for geth's config.
 func (o OmniEVM) NodeKeyHex() string {
 	return hex.EncodeToString(crypto.FromECDSA(o.NodeKey))
-}
-
-// BootNodesStrArr returns a string array of bootnodes for use in geth's config for bootnodes.
-func (o OmniEVM) BootNodesStrArr() string {
-	var resp []string
-	for _, b := range o.BootNodes {
-		resp = append(resp, fmt.Sprintf(`"%s"`, b.String()))
-	}
-
-	return strings.Join(resp, ",")
 }
 
 // AnvilChain represents an anvil chain instance in a omni network.
@@ -126,15 +109,4 @@ type AnvilChain struct {
 type PublicChain struct {
 	Chain      EVMChain // For netconf
 	RPCAddress string   // For JSON-RPC queries from halo/relayer/e2e app.
-}
-
-// GethConfig represents part of the geth configuration that can't be initialized through the command line args.
-type GethConfig struct {
-	// BootstrapNodes are used to establish connectivity
-	// with the rest of the network.
-	BootstrapNodes string
-
-	// Static nodes are used as pre-configured connections which are always
-	// maintained and re-connected on disconnects.
-	StaticNodes string
 }

--- a/e2e/vmcompose/testdata/TestSetup_127_0_0_1_compose.yaml.golden
+++ b/e2e/vmcompose/testdata/TestSetup_127_0_0_1_compose.yaml.golden
@@ -20,7 +20,6 @@ services:
     - HALO_LOG_FORMAT=logfmt
     volumes:
     - ./validator01:/halo
-    - ./validator01_evm/jwtsecret:/geth/jwtsecret
     depends_on:
       validator01_evm:
         condition: service_healthy
@@ -36,7 +35,7 @@ services:
       e2e: true
     container_name: validator01_evm-init
     image: "ethereum/client-go:v1.13.14"
-    command: --datadir=/geth init /geth/genesis.json
+    command: --state.scheme=path --datadir=/geth init /geth/genesis.json
     volumes:
       - ./validator01_evm:/geth
     networks:
@@ -46,31 +45,12 @@ services:
     labels:
       e2e: true
     container_name: validator01_evm
-    image: "ethereum/client-go:latest"
+    image: "ethereum/client-go:v1.13.14"
     command:
       - --config=/geth/config.toml
-      - --http
-      - --http.vhosts=*
-      - --http.api=eth,net,web3
-      - --http.addr=0.0.0.0
-      - --http.corsdomain=*
-      - --ws
-      - --ws.api=eth,net,web3
-      - --ws.addr=0.0.0.0
-      - --ws.origins=*
-      - --authrpc.vhosts=*
-      - --authrpc.addr=0.0.0.0
-      - --authrpc.jwtsecret=/geth/jwtsecret
-      - --datadir=/geth
-      - --unlock=0x123463a4b065722e99115d6c222f267d9cabb524
-      - --allow-insecure-unlock
-      - --password=/geth/geth_password.txt
-      - --nodiscover
-      - --syncmode=full
-      - --gcmode=full
-      - --nodekeyhex=<nodekeyhex>
-      - --miner.recommit=500ms
+      # Flags not available via config.toml
       - --nat=extip:<nil>
+      
     ports:
       - 8551:8551
       - 8545:8545

--- a/e2e/vmcompose/testdata/TestSetup_127_0_0_2_compose.yaml.golden
+++ b/e2e/vmcompose/testdata/TestSetup_127_0_0_2_compose.yaml.golden
@@ -20,7 +20,6 @@ services:
     - HALO_LOG_FORMAT=logfmt
     volumes:
     - ./validator02:/halo
-    - ./validator02_evm/jwtsecret:/geth/jwtsecret
     depends_on:
       validator02_evm:
         condition: service_healthy
@@ -36,7 +35,7 @@ services:
       e2e: true
     container_name: validator02_evm-init
     image: "ethereum/client-go:v1.13.14"
-    command: --datadir=/geth init /geth/genesis.json
+    command: --state.scheme=path --datadir=/geth init /geth/genesis.json
     volumes:
       - ./validator02_evm:/geth
     networks:
@@ -46,31 +45,12 @@ services:
     labels:
       e2e: true
     container_name: validator02_evm
-    image: "ethereum/client-go:latest"
+    image: "ethereum/client-go:v1.13.14"
     command:
       - --config=/geth/config.toml
-      - --http
-      - --http.vhosts=*
-      - --http.api=eth,net,web3
-      - --http.addr=0.0.0.0
-      - --http.corsdomain=*
-      - --ws
-      - --ws.api=eth,net,web3
-      - --ws.addr=0.0.0.0
-      - --ws.origins=*
-      - --authrpc.vhosts=*
-      - --authrpc.addr=0.0.0.0
-      - --authrpc.jwtsecret=/geth/jwtsecret
-      - --datadir=/geth
-      - --unlock=0x123463a4b065722e99115d6c222f267d9cabb524
-      - --allow-insecure-unlock
-      - --password=/geth/geth_password.txt
-      - --nodiscover
-      - --syncmode=full
-      - --gcmode=full
-      - --nodekeyhex=<nodekeyhex>
-      - --miner.recommit=500ms
+      # Flags not available via config.toml
       - --nat=extip:<nil>
+      
     ports:
       - 8551:8551
       - 8545:8545

--- a/e2e/vmcompose/testdata/TestSetup_127_0_0_4_compose.yaml.golden
+++ b/e2e/vmcompose/testdata/TestSetup_127_0_0_4_compose.yaml.golden
@@ -20,7 +20,6 @@ services:
     - HALO_LOG_FORMAT=logfmt
     volumes:
     - ./seed01:/halo
-    - ./seed01_evm/jwtsecret:/geth/jwtsecret
     depends_on:
       seed01_evm:
         condition: service_healthy
@@ -36,7 +35,7 @@ services:
       e2e: true
     container_name: seed01_evm-init
     image: "ethereum/client-go:v1.13.14"
-    command: --datadir=/geth init /geth/genesis.json
+    command: --state.scheme=path --datadir=/geth init /geth/genesis.json
     volumes:
       - ./seed01_evm:/geth
     networks:
@@ -46,31 +45,12 @@ services:
     labels:
       e2e: true
     container_name: seed01_evm
-    image: "ethereum/client-go:latest"
+    image: "ethereum/client-go:v1.13.14"
     command:
       - --config=/geth/config.toml
-      - --http
-      - --http.vhosts=*
-      - --http.api=eth,net,web3
-      - --http.addr=0.0.0.0
-      - --http.corsdomain=*
-      - --ws
-      - --ws.api=eth,net,web3
-      - --ws.addr=0.0.0.0
-      - --ws.origins=*
-      - --authrpc.vhosts=*
-      - --authrpc.addr=0.0.0.0
-      - --authrpc.jwtsecret=/geth/jwtsecret
-      - --datadir=/geth
-      - --unlock=0x123463a4b065722e99115d6c222f267d9cabb524
-      - --allow-insecure-unlock
-      - --password=/geth/geth_password.txt
-      - --nodiscover
-      - --syncmode=full
-      - --gcmode=full
-      - --nodekeyhex=<nodekeyhex>
-      - --miner.recommit=500ms
+      # Flags not available via config.toml
       - --nat=extip:<nil>
+      
     ports:
       - 8551:8551
       - 8545:8545

--- a/e2e/vmcompose/testdata/TestSetup_127_0_0_5_compose.yaml.golden
+++ b/e2e/vmcompose/testdata/TestSetup_127_0_0_5_compose.yaml.golden
@@ -20,7 +20,6 @@ services:
     - HALO_LOG_FORMAT=logfmt
     volumes:
     - ./fullnode01:/halo
-    - ./fullnode01_evm/jwtsecret:/geth/jwtsecret
     depends_on:
       fullnode01_evm:
         condition: service_healthy
@@ -36,7 +35,7 @@ services:
       e2e: true
     container_name: fullnode01_evm-init
     image: "ethereum/client-go:v1.13.14"
-    command: --state.scheme=hash --datadir=/geth init /geth/genesis.json
+    command: --state.scheme=path --datadir=/geth init /geth/genesis.json
     volumes:
       - ./fullnode01_evm:/geth
     networks:
@@ -46,31 +45,12 @@ services:
     labels:
       e2e: true
     container_name: fullnode01_evm
-    image: "ethereum/client-go:latest"
+    image: "ethereum/client-go:v1.13.14"
     command:
       - --config=/geth/config.toml
-      - --http
-      - --http.vhosts=*
-      - --http.api=eth,net,web3
-      - --http.addr=0.0.0.0
-      - --http.corsdomain=*
-      - --ws
-      - --ws.api=eth,net,web3
-      - --ws.addr=0.0.0.0
-      - --ws.origins=*
-      - --authrpc.vhosts=*
-      - --authrpc.addr=0.0.0.0
-      - --authrpc.jwtsecret=/geth/jwtsecret
-      - --datadir=/geth
-      - --unlock=0x123463a4b065722e99115d6c222f267d9cabb524
-      - --allow-insecure-unlock
-      - --password=/geth/geth_password.txt
-      - --nodiscover
-      - --syncmode=full
-      - --gcmode=archive
-      - --nodekeyhex=<nodekeyhex>
-      - --miner.recommit=500ms
+      # Flags not available via config.toml
       - --nat=extip:<nil>
+      
     ports:
       - 8551:8551
       - 8545:8545

--- a/lib/ethclient/ethbackend/backends.go
+++ b/lib/ethclient/ethbackend/backends.go
@@ -35,12 +35,7 @@ func NewFireBackends(ctx context.Context, testnet types.Testnet, fireCl firebloc
 
 	// Configure omni EVM Backend
 	if testnet.HasOmniEVM() {
-		// todo(lazar): remove this when we figure out why txs are stuck in geth mempool upon initial run
-		// task https://app.asana.com/0/1206208509925075/1206887969751598/f
-		chain, err := testnet.FirstOmniValidatorEVM() // Connect to a geth node connected to a validator
-		if err != nil {
-			return Backends{}, errors.Wrap(err, "omni evm validator")
-		}
+		chain := testnet.BroadcastOmniEVM()
 		ethCl, err := ethclient.Dial(chain.Chain.Name, chain.ExternalRPC)
 		if err != nil {
 			return Backends{}, errors.Wrap(err, "dial")
@@ -105,12 +100,7 @@ func NewBackends(testnet types.Testnet, deployKeyFile string) (Backends, error) 
 
 	// Configure omni EVM Backend
 	{
-		// todo(lazar): remove this when we figure out why txs are stuck in geth mempool upon initial run
-		// task https://app.asana.com/0/1206208509925075/1206887969751598/f
-		chain, err := testnet.FirstOmniValidatorEVM() // Connect to a geth node connected to a validator
-		if err != nil {
-			return Backends{}, errors.Wrap(err, "omni evm validator")
-		}
+		chain := testnet.BroadcastOmniEVM()
 		ethCl, err := ethclient.Dial(chain.Chain.Name, chain.ExternalRPC)
 		if err != nil {
 			return Backends{}, errors.Wrap(err, "dial")


### PR DESCRIPTION
Improves geth config:
- Use internal IPs for nat when using docker
- Enable p2p discovery
- Switch static nodes to trusted nodes
- Use IsArchive instead of GcMode
- Move most flags to config file
- Store nodekey as file instead of "test only" flag
- Copy jwtsecret to halo config instead of sharing mount.
- Add explicit `archive` mode to manifest.
- Clarify what each mode means.
- Always broadcast e2e txs via full or archive node if available (seems like txs stuck in  mempool is now solved?).

task: none
