### PR TITLE
ci(e2e): refactor manifest key type

### DIFF
--- a/e2e/app/definition.go
+++ b/e2e/app/definition.go
@@ -373,21 +373,8 @@ func TestnetFromManifest(ctx context.Context, manifest types.Manifest, infd type
 
 // getOrGenKey gets (based on manifest) or creates a private key for the given node and type.
 func getOrGenKey(ctx context.Context, manifest types.Manifest, nodeName string, typ key.Type) (key.Key, error) {
-	keys := manifest.Keys[nodeName]
-
-	var addr string
-	switch typ {
-	case key.P2PExecution:
-		addr = keys.P2PExecution
-	case key.P2PConsensus:
-		addr = keys.P2PConsensus
-	case key.Validator:
-		addr = keys.Validator
-	default:
-		return key.Key{}, errors.New("unsupported key type", "type", typ)
-	}
-
-	if addr == "" {
+	addr, ok := manifest.Keys[nodeName][typ]
+	if !ok {
 		// No key in manifest, generate a new one.
 		return key.Generate(typ), nil
 	}

--- a/e2e/types/manifest.go
+++ b/e2e/types/manifest.go
@@ -1,6 +1,7 @@
 package types
 
 import (
+	"github.com/omni-network/omni/e2e/app/key"
 	"github.com/omni-network/omni/lib/netconf"
 
 	e2e "github.com/cometbft/cometbft/test/e2e/pkg"
@@ -34,17 +35,8 @@ type Manifest struct {
 	// PingPongN defines the number of ping pong messages to send. Defaults 3 if 0.
 	PingPongN uint64 `toml:"pingpong_n"`
 
-	// Keys contains long-lived private keys by node name.
-	Keys map[string]NodeKeys `toml:"keys"`
-}
-
-// NodeKeys defines long-lived private keys by address.
-// If configured, these keys will be fetched from GCP.
-// If not configured, new keys will be generated.
-type NodeKeys struct {
-	Validator    string `toml:"validator"`
-	P2PConsensus string `toml:"p2p_consensus"`
-	P2PExecution string `toml:"p2p_execution"`
+	// Keys contains long-lived private keys (address by type) by node name.
+	Keys map[string]map[key.Type]string `toml:"keys"`
 }
 
 // OmniEVMs returns the map names and GcMode of Omni EVMs to deploy.


### PR DESCRIPTION
Simplifies manifest key type into a map of typed keys.

task: none