### PR TITLE
ci(e2e): enable geth metrics and revert broadcast evm

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -151,7 +151,7 @@
         "filename": "e2e/app/agent/prometheus.go",
         "hashed_secret": "647c5465599451a86da22727224e2c2f7eb61e3b",
         "is_verified": false,
-        "line_number": 78
+        "line_number": 84
       }
     ],
     "e2e/app/agent/prometheus_internal_test.go": [
@@ -160,21 +160,21 @@
         "filename": "e2e/app/agent/prometheus_internal_test.go",
         "hashed_secret": "7cb6efb98ba5972a9b5090dc2e517fe14d12cb04",
         "is_verified": false,
-        "line_number": 38
+        "line_number": 42
       },
       {
         "type": "Secret Keyword",
         "filename": "e2e/app/agent/prometheus_internal_test.go",
         "hashed_secret": "5ffe533b830f08a0326348a9160afafc8ada44db",
         "is_verified": false,
-        "line_number": 48
+        "line_number": 54
       },
       {
         "type": "Secret Keyword",
         "filename": "e2e/app/agent/prometheus_internal_test.go",
         "hashed_secret": "858b02bf93798fdd02736ef7ec278319018d1272",
         "is_verified": false,
-        "line_number": 91
+        "line_number": 103
       }
     ],
     "e2e/app/run.go": [
@@ -830,5 +830,5 @@
       }
     ]
   },
-  "generated_at": "2024-04-01T12:04:49Z"
+  "generated_at": "2024-04-01T14:59:24Z"
 }

--- a/e2e/app/agent/prometheus_internal_test.go
+++ b/e2e/app/agent/prometheus_internal_test.go
@@ -22,6 +22,8 @@ func TestPromGen(t *testing.T) {
 		network      netconf.ID
 		nodes        []string
 		newNodes     []string
+		geths        []string
+		newGeths     []string
 		newRelayer   bool
 		newMonitor   bool
 		hostname     string
@@ -33,6 +35,8 @@ func TestPromGen(t *testing.T) {
 			nodes:        []string{"validator01", "validator02"},
 			hostname:     "localhost",
 			newNodes:     []string{"validator01"},
+			geths:        []string{"omni_evm"},
+			newGeths:     []string{"omni_evm"},
 			newRelayer:   false,
 			newMonitor:   false,
 			agentSecrets: false,
@@ -43,6 +47,8 @@ func TestPromGen(t *testing.T) {
 			nodes:        []string{"validator01", "validator02", "fullnode03"},
 			hostname:     "vm",
 			newNodes:     []string{"fullnode04"},
+			geths:        []string{"validator01_evm", "validator02_evm", "validator03_evm"},
+			newGeths:     []string{"fullnode04_evm"},
 			newRelayer:   true,
 			newMonitor:   false,
 			agentSecrets: true,
@@ -78,12 +84,18 @@ func TestPromGen(t *testing.T) {
 				nodes = append(nodes, &e2e.Node{Name: name})
 			}
 
+			var geths []types.OmniEVM
+			for _, name := range test.geths {
+				geths = append(geths, types.OmniEVM{InstanceName: name})
+			}
+
 			testnet := types.Testnet{
 				Network: test.network,
 				Testnet: &e2e.Testnet{
 					Name:  test.name,
 					Nodes: nodes,
 				},
+				OmniEVMs: geths,
 			}
 
 			var agentSecrets Secrets
@@ -98,7 +110,7 @@ func TestPromGen(t *testing.T) {
 			cfg1, err := genPromConfig(ctx, testnet, agentSecrets, test.hostname)
 			require.NoError(t, err)
 
-			cfg2 := ConfigForHost(cfg1, test.hostname+"-2", test.newNodes, test.newRelayer, test.newMonitor)
+			cfg2 := ConfigForHost(cfg1, test.hostname+"-2", test.newNodes, test.newGeths, test.newRelayer, test.newMonitor)
 
 			t.Run("gen", func(t *testing.T) {
 				t.Parallel()

--- a/e2e/app/agent/testdata/TestPromGen_manifest1_gen.golden
+++ b/e2e/app/agent/testdata/TestPromGen_manifest1_gen.golden
@@ -19,6 +19,14 @@ scrape_configs:
           network: 'manifest1-localhost'
           host: 'localhost'
 
+  - job_name: "geth"
+    metrics_path: "/debug/metrics/prometheus"
+    static_configs:
+      - targets: [omni_evm:6060] # geth targets
+        labels:
+          network: 'manifest1-localhost'
+          host: 'localhost'
+
   - job_name: "monitor"
     metrics_path: "/metrics"
     static_configs:

--- a/e2e/app/agent/testdata/TestPromGen_manifest1_update.golden
+++ b/e2e/app/agent/testdata/TestPromGen_manifest1_update.golden
@@ -19,6 +19,14 @@ scrape_configs:
           network: 'manifest1-localhost'
           host: 'localhost-2'
 
+  - job_name: "geth"
+    metrics_path: "/debug/metrics/prometheus"
+    static_configs:
+      - targets: ["omni_evm:6060"] # geth targets
+        labels:
+          network: 'manifest1-localhost'
+          host: 'localhost-2'
+
   - job_name: "monitor"
     metrics_path: "/metrics"
     static_configs:

--- a/e2e/app/agent/testdata/TestPromGen_manifest2_gen.golden
+++ b/e2e/app/agent/testdata/TestPromGen_manifest2_gen.golden
@@ -31,6 +31,14 @@ scrape_configs:
           network: 'staging'
           host: 'vm'
 
+  - job_name: "geth"
+    metrics_path: "/debug/metrics/prometheus"
+    static_configs:
+      - targets: [validator01_evm:6060,validator02_evm:6060,validator03_evm:6060] # geth targets
+        labels:
+          network: 'staging'
+          host: 'vm'
+
   - job_name: "monitor"
     metrics_path: "/metrics"
     static_configs:

--- a/e2e/app/agent/testdata/TestPromGen_manifest2_update.golden
+++ b/e2e/app/agent/testdata/TestPromGen_manifest2_update.golden
@@ -31,6 +31,14 @@ scrape_configs:
           network: 'staging'
           host: 'vm-2'
 
+  - job_name: "geth"
+    metrics_path: "/debug/metrics/prometheus"
+    static_configs:
+      - targets: ["fullnode04_evm:6060"] # geth targets
+        labels:
+          network: 'staging'
+          host: 'vm-2'
+
   - job_name: "monitor"
     metrics_path: "/metrics"
     static_configs:

--- a/e2e/app/agent/testdata/TestPromGen_manifest3_gen.golden
+++ b/e2e/app/agent/testdata/TestPromGen_manifest3_gen.golden
@@ -19,6 +19,14 @@ scrape_configs:
           network: 'manifest3-localhost'
           host: 'localhost'
 
+  - job_name: "geth"
+    metrics_path: "/debug/metrics/prometheus"
+    static_configs:
+      - targets: [] # geth targets
+        labels:
+          network: 'manifest3-localhost'
+          host: 'localhost'
+
   - job_name: "monitor"
     metrics_path: "/metrics"
     static_configs:

--- a/e2e/app/agent/testdata/TestPromGen_manifest3_update.golden
+++ b/e2e/app/agent/testdata/TestPromGen_manifest3_update.golden
@@ -19,6 +19,14 @@ scrape_configs:
           network: 'manifest3-localhost'
           host: 'localhost-2'
 
+  - job_name: "geth"
+    metrics_path: "/debug/metrics/prometheus"
+    static_configs:
+      - targets: [] # geth targets
+        labels:
+          network: 'manifest3-localhost'
+          host: 'localhost-2'
+
   - job_name: "monitor"
     metrics_path: "/metrics"
     static_configs:

--- a/e2e/app/agent/testdata/TestPromGen_manifest4_gen.golden
+++ b/e2e/app/agent/testdata/TestPromGen_manifest4_gen.golden
@@ -31,6 +31,14 @@ scrape_configs:
           network: 'staging'
           host: 'vm'
 
+  - job_name: "geth"
+    metrics_path: "/debug/metrics/prometheus"
+    static_configs:
+      - targets: [] # geth targets
+        labels:
+          network: 'staging'
+          host: 'vm'
+
   - job_name: "monitor"
     metrics_path: "/metrics"
     static_configs:

--- a/e2e/app/agent/testdata/TestPromGen_manifest4_update.golden
+++ b/e2e/app/agent/testdata/TestPromGen_manifest4_update.golden
@@ -31,6 +31,14 @@ scrape_configs:
           network: 'staging'
           host: 'vm-2'
 
+  - job_name: "geth"
+    metrics_path: "/debug/metrics/prometheus"
+    static_configs:
+      - targets: [] # geth targets
+        labels:
+          network: 'staging'
+          host: 'vm-2'
+
   - job_name: "monitor"
     metrics_path: "/metrics"
     static_configs:

--- a/e2e/app/geth.toml.tmpl
+++ b/e2e/app/geth.toml.tmpl
@@ -27,5 +27,7 @@ BootstrapNodes = {{ .BootstrapNodes }}
 TrustedNodes = {{ .TrustedNodes }}
 ListenAddr = "0.0.0.0:30303"
 
-# TODO(corver): Enable prometheus metrics.
-# [Metrics]
+[Metrics]
+Enabled = true
+HTTP = "0.0.0.0"
+Port = 6060

--- a/e2e/app/testdata/TestWriteGethConfigTOML.golden
+++ b/e2e/app/testdata/TestWriteGethConfigTOML.golden
@@ -27,5 +27,7 @@ BootstrapNodes = ["enode://3a514176466fa815ed481ffad09110a2d344f6c9b78c1d14afc35
 TrustedNodes = ["enode://3a514176466fa815ed481ffad09110a2d344f6c9b78c1d14afc351c3a51be33d8072e77939dc03ba44790779b7a1025baf3003f6732430e20cd9b76d953391b3@127.0.0.1:1","enode://3a514176466fa815ed481ffad09110a2d344f6c9b78c1d14afc351c3a51be33d8072e77939dc03ba44790779b7a1025baf3003f6732430e20cd9b76d953391b3@127.0.0.2:2"]
 ListenAddr = "0.0.0.0:30303"
 
-# TODO(corver): Enable prometheus metrics.
-# [Metrics]
+[Metrics]
+Enabled = true
+HTTP = "0.0.0.0"
+Port = 6060

--- a/e2e/docker/compose.yaml.tmpl
+++ b/e2e/docker/compose.yaml.tmpl
@@ -86,12 +86,14 @@ services:
       - --config=/geth/config.toml
       # Flags not available via config.toml
       - --nat=extip:{{ .AdvertisedIP }}
+      - --metrics
       {{ if .IsArchive }}- --gcmode=archive{{ end }}
     ports:
       - {{ if $.BindAll }}8551:{{end}}8551
       - {{ if .ProxyPort }}{{ .ProxyPort }}:{{ end }}8545
       - {{ if $.BindAll }}30303:{{end}}30303
       - 8546
+      - 6060
     depends_on:
       {{ .InstanceName }}-init:
         condition: service_completed_successfully

--- a/e2e/docker/testdata/TestComposeTemplate_image_tag_7d1ae53.golden
+++ b/e2e/docker/testdata/TestComposeTemplate_image_tag_7d1ae53.golden
@@ -95,12 +95,14 @@ services:
       - --config=/geth/config.toml
       # Flags not available via config.toml
       - --nat=extip:10.186.73.0
+      - --metrics
       
     ports:
       - 8551
       - 8000:8545
       - 30303
       - 8546
+      - 6060
     depends_on:
       omni_evm_0-init:
         condition: service_completed_successfully

--- a/e2e/docker/testdata/TestComposeTemplate_image_tag_main.golden
+++ b/e2e/docker/testdata/TestComposeTemplate_image_tag_main.golden
@@ -95,12 +95,14 @@ services:
       - --config=/geth/config.toml
       # Flags not available via config.toml
       - --nat=extip:10.186.73.0
+      - --metrics
       
     ports:
       - 8551
       - 8000:8545
       - 30303
       - 8546
+      - 6060
     depends_on:
       omni_evm_0-init:
         condition: service_completed_successfully

--- a/e2e/types/testnet.go
+++ b/e2e/types/testnet.go
@@ -44,12 +44,11 @@ func (t Testnet) AVSChain() (EVMChain, error) {
 }
 
 // BroadcastOmniEVM returns a Omni EVM to use for e2e app tx broadcasts.
-// It prefers a full or archive node to ensure evm p2p-networking is set up correctly.
-// Since without networking, the txs will be stuck in the geth mempool.
+// It prefers a validator nodes since we have an issue with mempool+p2p+startup where
+// txs get stuck in non-validator mempool immediately after startup if not connected to peers yet.
 func (t Testnet) BroadcastOmniEVM() OmniEVM {
 	for _, evm := range t.OmniEVMs {
-		if strings.Contains(evm.InstanceName, "full") ||
-			strings.Contains(evm.InstanceName, "archive") {
+		if strings.Contains(evm.InstanceName, "validator") {
 			return evm
 		}
 	}

--- a/e2e/vmcompose/provider.go
+++ b/e2e/vmcompose/provider.go
@@ -51,6 +51,13 @@ func (p *Provider) Setup() error {
 			}
 		}
 
+		var geths []string
+		for _, omniEVM := range p.Testnet.OmniEVMs {
+			if services[omniEVM.InstanceName] {
+				geths = append(geths, omniEVM.InstanceName)
+			}
+		}
+
 		// Get all omniEVMs in this VM
 		var omniEVMs []types.OmniEVM
 		for _, omniEVM := range p.Testnet.OmniEVMs {
@@ -103,7 +110,7 @@ func (p *Provider) Setup() error {
 		}
 
 		hostname := vmIP // TODO(corver): Add hostnames to infra instances.
-		agentCfg = agent.ConfigForHost(agentCfg, hostname, halos, services["relayer"], services["monitor"])
+		agentCfg = agent.ConfigForHost(agentCfg, hostname, halos, geths, services["relayer"], services["monitor"])
 		err = os.WriteFile(filepath.Join(p.Testnet.Dir, vmAgentFile(vmIP)), agentCfg, 0o644)
 		if err != nil {
 			return errors.Wrap(err, "write compose file")

--- a/e2e/vmcompose/testdata/TestSetup_127_0_0_1_compose.yaml.golden
+++ b/e2e/vmcompose/testdata/TestSetup_127_0_0_1_compose.yaml.golden
@@ -50,12 +50,14 @@ services:
       - --config=/geth/config.toml
       # Flags not available via config.toml
       - --nat=extip:<nil>
+      - --metrics
       
     ports:
       - 8551:8551
       - 8545:8545
       - 30303:30303
       - 8546
+      - 6060
     depends_on:
       validator01_evm-init:
         condition: service_completed_successfully

--- a/e2e/vmcompose/testdata/TestSetup_127_0_0_2_compose.yaml.golden
+++ b/e2e/vmcompose/testdata/TestSetup_127_0_0_2_compose.yaml.golden
@@ -50,12 +50,14 @@ services:
       - --config=/geth/config.toml
       # Flags not available via config.toml
       - --nat=extip:<nil>
+      - --metrics
       
     ports:
       - 8551:8551
       - 8545:8545
       - 30303:30303
       - 8546
+      - 6060
     depends_on:
       validator02_evm-init:
         condition: service_completed_successfully

--- a/e2e/vmcompose/testdata/TestSetup_127_0_0_4_compose.yaml.golden
+++ b/e2e/vmcompose/testdata/TestSetup_127_0_0_4_compose.yaml.golden
@@ -50,12 +50,14 @@ services:
       - --config=/geth/config.toml
       # Flags not available via config.toml
       - --nat=extip:<nil>
+      - --metrics
       
     ports:
       - 8551:8551
       - 8545:8545
       - 30303:30303
       - 8546
+      - 6060
     depends_on:
       seed01_evm-init:
         condition: service_completed_successfully

--- a/e2e/vmcompose/testdata/TestSetup_127_0_0_5_compose.yaml.golden
+++ b/e2e/vmcompose/testdata/TestSetup_127_0_0_5_compose.yaml.golden
@@ -50,12 +50,14 @@ services:
       - --config=/geth/config.toml
       # Flags not available via config.toml
       - --nat=extip:<nil>
+      - --metrics
       
     ports:
       - 8551:8551
       - 8545:8545
       - 30303:30303
       - 8546
+      - 6060
     depends_on:
       fullnode01_evm-init:
         condition: service_completed_successfully


### PR DESCRIPTION
Enables geth metrics. Also reverts the broadcast node to validators since "tx stuck in mempool" obviously isn't fixed. This [deploy](https://github.com/omni-network/ops/actions/runs/8509402994/job/23304866875) got stuck with it.

task: none