### PR TITLE
ci(e2e): improve container log config

### DIFF
--- a/e2e/app/setup.go
+++ b/e2e/app/setup.go
@@ -84,7 +84,7 @@ func Setup(ctx context.Context, def Definition, agentSecrets agent.Secrets, test
 		return err
 	}
 
-	logCfg := logConfig()
+	logCfg := logConfig(def)
 	if err := writeMonitorConfig(def, logCfg, valPrivKeys); err != nil {
 		return err
 	}
@@ -168,7 +168,7 @@ func Setup(ctx context.Context, def Definition, agentSecrets agent.Secrets, test
 }
 
 func SetupOnlyMonitor(ctx context.Context, def Definition, agentSecrets agent.Secrets) error {
-	logCfg := logConfig()
+	logCfg := logConfig(def)
 	if err := writeMonitorConfig(def, logCfg, nil); err != nil {
 		return err
 	}
@@ -483,9 +483,15 @@ func writeMonitorConfig(def Definition, logCfg log.Config, valPrivKeys []crypto.
 }
 
 // logConfig returns a default e2e log config.
-func logConfig() log.Config {
+// Default format is console (local dev), but vmcompose uses logfmt.
+func logConfig(def Definition) log.Config {
+	format := log.FormatConsole
+	if def.Infra.GetInfrastructureData().Provider == vmcompose.ProviderName {
+		format = log.FormatLogfmt
+	}
+
 	return log.Config{
-		Format: log.FormatConsole,
+		Format: format,
 		Level:  slog.LevelDebug.String(),
 		Color:  log.ColorForce,
 	}

--- a/e2e/docker/compose.yaml.tmpl
+++ b/e2e/docker/compose.yaml.tmpl
@@ -26,8 +26,6 @@ services:
     - {{ .PrometheusProxyPort }}:26660
 {{- end }}
     - 6060
-    environment:
-    - HALO_LOG_FORMAT={{ $.OmniLogFormat }}
     volumes:
     - ./{{ .Name }}:/halo
     depends_on:
@@ -116,8 +114,6 @@ services:
     container_name: relayer
     image: omniops/relayer:{{or .OmniTag "main"}}
     restart: unless-stopped # Restart on crash to mitigate startup race issues
-    environment:
-    - RELAYER_LOG_FORMAT={{ $.OmniLogFormat }}
     volumes:
       - ./relayer:/relayer
     networks:
@@ -132,8 +128,6 @@ services:
     container_name: monitor
     image: omniops/monitor:{{or .OmniTag "main"}}
     restart: unless-stopped # Restart on crash to mitigate startup race issues
-    environment:
-      - LOG_FORMAT={{ $.OmniLogFormat }}
     volumes:
       - ./monitor:/monitor
     networks:

--- a/e2e/docker/docker.go
+++ b/e2e/docker/docker.go
@@ -73,18 +73,17 @@ func NewProvider(testnet types.Testnet, infd types.InfrastructureData, imgTag st
 // any of these operations fail. It writes.
 func (p *Provider) Setup() error {
 	def := ComposeDef{
-		Network:       true,
-		NetworkName:   p.testnet.Name,
-		NetworkCIDR:   p.testnet.IP.String(),
-		BindAll:       false,
-		Nodes:         p.testnet.Nodes,
-		OmniEVMs:      p.testnet.OmniEVMs,
-		Anvils:        p.testnet.AnvilChains,
-		Relayer:       true,
-		Prometheus:    p.testnet.Prometheus,
-		Monitor:       true,
-		OmniTag:       p.omniTag,
-		OmniLogFormat: log.FormatConsole, // Local docker compose always use console log format.
+		Network:     true,
+		NetworkName: p.testnet.Name,
+		NetworkCIDR: p.testnet.IP.String(),
+		BindAll:     false,
+		Nodes:       p.testnet.Nodes,
+		OmniEVMs:    p.testnet.OmniEVMs,
+		Anvils:      p.testnet.AnvilChains,
+		Relayer:     true,
+		Prometheus:  p.testnet.Prometheus,
+		Monitor:     true,
+		OmniTag:     p.omniTag,
 	}
 
 	bz, err := GenerateComposeFile(def)
@@ -154,11 +153,10 @@ type ComposeDef struct {
 	OmniEVMs []types.OmniEVM
 	Anvils   []types.AnvilChain
 
-	Monitor       bool
-	OmniTag       string
-	Relayer       bool
-	Prometheus    bool
-	OmniLogFormat string
+	Monitor    bool
+	OmniTag    string
+	Relayer    bool
+	Prometheus bool
 }
 
 func (ComposeDef) GethTag() string {

--- a/e2e/docker/testdata/TestComposeTemplate_image_tag_7d1ae53.golden
+++ b/e2e/docker/testdata/TestComposeTemplate_image_tag_7d1ae53.golden
@@ -20,8 +20,6 @@ services:
     - 26656
     - 8584:26657
     - 6060
-    environment:
-    - HALO_LOG_FORMAT=console
     volumes:
     - ./node0:/halo
     depends_on:
@@ -123,8 +121,6 @@ services:
     container_name: relayer
     image: omniops/relayer:7d1ae53
     restart: unless-stopped # Restart on crash to mitigate startup race issues
-    environment:
-    - RELAYER_LOG_FORMAT=console
     volumes:
       - ./relayer:/relayer
     networks:
@@ -137,8 +133,6 @@ services:
     container_name: monitor
     image: omniops/monitor:7d1ae53
     restart: unless-stopped # Restart on crash to mitigate startup race issues
-    environment:
-      - LOG_FORMAT=console
     volumes:
       - ./monitor:/monitor
     networks:

--- a/e2e/docker/testdata/TestComposeTemplate_image_tag_main.golden
+++ b/e2e/docker/testdata/TestComposeTemplate_image_tag_main.golden
@@ -20,8 +20,6 @@ services:
     - 26656
     - 8584:26657
     - 6060
-    environment:
-    - HALO_LOG_FORMAT=console
     volumes:
     - ./node0:/halo
     depends_on:
@@ -123,8 +121,6 @@ services:
     container_name: relayer
     image: omniops/relayer:main
     restart: unless-stopped # Restart on crash to mitigate startup race issues
-    environment:
-    - RELAYER_LOG_FORMAT=console
     volumes:
       - ./relayer:/relayer
     networks:
@@ -137,8 +133,6 @@ services:
     container_name: monitor
     image: omniops/monitor:main
     restart: unless-stopped # Restart on crash to mitigate startup race issues
-    environment:
-      - LOG_FORMAT=console
     volumes:
       - ./monitor:/monitor
     networks:

--- a/e2e/vmcompose/provider.go
+++ b/e2e/vmcompose/provider.go
@@ -75,18 +75,17 @@ func (p *Provider) Setup() error {
 		}
 
 		def := docker.ComposeDef{
-			Network:       false,
-			BindAll:       true,
-			NetworkName:   p.Testnet.Name,
-			NetworkCIDR:   p.Testnet.IP.String(),
-			Nodes:         nodes,
-			OmniEVMs:      omniEVMs,
-			Anvils:        anvilChains,
-			Relayer:       services["relayer"],
-			Monitor:       services["monitor"],
-			Prometheus:    p.Testnet.Prometheus,
-			OmniTag:       p.omniTag,
-			OmniLogFormat: log.FormatLogfmt, // VM compose always use logfmt log format.
+			Network:     false,
+			BindAll:     true,
+			NetworkName: p.Testnet.Name,
+			NetworkCIDR: p.Testnet.IP.String(),
+			Nodes:       nodes,
+			OmniEVMs:    omniEVMs,
+			Anvils:      anvilChains,
+			Relayer:     services["relayer"],
+			Monitor:     services["monitor"],
+			Prometheus:  p.Testnet.Prometheus,
+			OmniTag:     p.omniTag,
 		}
 		compose, err := docker.GenerateComposeFile(def)
 		if err != nil {

--- a/e2e/vmcompose/testdata/TestSetup_127_0_0_1_compose.yaml.golden
+++ b/e2e/vmcompose/testdata/TestSetup_127_0_0_1_compose.yaml.golden
@@ -16,8 +16,6 @@ services:
     - 26656:26656
     - 26657:26657
     - 6060
-    environment:
-    - HALO_LOG_FORMAT=logfmt
     volumes:
     - ./validator01:/halo
     depends_on:

--- a/e2e/vmcompose/testdata/TestSetup_127_0_0_2_compose.yaml.golden
+++ b/e2e/vmcompose/testdata/TestSetup_127_0_0_2_compose.yaml.golden
@@ -16,8 +16,6 @@ services:
     - 26656:26656
     - 26657:26657
     - 6060
-    environment:
-    - HALO_LOG_FORMAT=logfmt
     volumes:
     - ./validator02:/halo
     depends_on:

--- a/e2e/vmcompose/testdata/TestSetup_127_0_0_3_compose.yaml.golden
+++ b/e2e/vmcompose/testdata/TestSetup_127_0_0_3_compose.yaml.golden
@@ -36,8 +36,6 @@ services:
     container_name: relayer
     image: omniops/relayer:7d1ae53
     restart: unless-stopped # Restart on crash to mitigate startup race issues
-    environment:
-    - RELAYER_LOG_FORMAT=logfmt
     volumes:
       - ./relayer:/relayer
     networks:

--- a/e2e/vmcompose/testdata/TestSetup_127_0_0_4_compose.yaml.golden
+++ b/e2e/vmcompose/testdata/TestSetup_127_0_0_4_compose.yaml.golden
@@ -16,8 +16,6 @@ services:
     - 26656:26656
     - 26657:26657
     - 6060
-    environment:
-    - HALO_LOG_FORMAT=logfmt
     volumes:
     - ./seed01:/halo
     depends_on:

--- a/e2e/vmcompose/testdata/TestSetup_127_0_0_5_compose.yaml.golden
+++ b/e2e/vmcompose/testdata/TestSetup_127_0_0_5_compose.yaml.golden
@@ -16,8 +16,6 @@ services:
     - 26656:26656
     - 26657:26657
     - 6060
-    environment:
-    - HALO_LOG_FORMAT=logfmt
     volumes:
     - ./fullnode01:/halo
     depends_on:


### PR DESCRIPTION
Solve the problem of monitor service on staging have console logs. This is due to misconfiguration. Solve it by defining log config in one place, not two.

task: none