### PR TITLE
ci(e2e): fix default seed nodes

### DIFF
--- a/e2e/types/manifest.go
+++ b/e2e/types/manifest.go
@@ -75,6 +75,18 @@ type Manifest struct {
 	Keys map[string]map[key.Type]string `toml:"keys"`
 }
 
+// Seeds returns a map of seed nodes by name.
+func (m Manifest) Seeds() map[string]bool {
+	resp := make(map[string]bool)
+	for name, node := range m.Nodes {
+		if Mode(node.Mode) == ModeSeed {
+			resp[name] = true
+		}
+	}
+
+	return resp
+}
+
 // OmniEVMs returns a map of omni evm instances names by <IsArchive> to deploy.
 // If only a single Omni EVM is to be deployed, the name is "omni_evm".
 // Otherwise, the names are "<node>_evm".


### PR DESCRIPTION
Adds all nodes with mode "seed" as p2p seed nodes by default. Also remove them persisted peers list.

task: none