### PR TITLE
ci(e2e): change geth to fullsync

### DIFF
--- a/e2e/app/geth.toml.tmpl
+++ b/e2e/app/geth.toml.tmpl
@@ -1,6 +1,6 @@
 [Eth]
 NetworkId = {{ .ChainID }}
-SyncMode = {{ if .IsArchive }}"full"{{else}}"snap"{{end}}
+SyncMode = "full"
 NoPruning = {{ .IsArchive }}
 
 [Eth.Miner]


### PR DESCRIPTION
Geth doesn't seem to support "full sync" when being used as fullnode engineAPI.

task: none