### PR TITLE
fix(metrics): fix geth metrics not increasing

### DIFF
--- a/e2e/docker/compose.yaml.tmpl
+++ b/e2e/docker/compose.yaml.tmpl
@@ -84,6 +84,7 @@ services:
       - --config=/geth/config.toml
       # Flags not available via config.toml
       - --nat=extip:{{ .AdvertisedIP }}
+      - --metrics
       - --pprof
       - --pprof.addr=0.0.0.0
       {{ if .IsArchive }}- --gcmode=archive{{ end }}

--- a/e2e/docker/testdata/TestComposeTemplate_image_tag_7d1ae53.golden
+++ b/e2e/docker/testdata/TestComposeTemplate_image_tag_7d1ae53.golden
@@ -93,6 +93,7 @@ services:
       - --config=/geth/config.toml
       # Flags not available via config.toml
       - --nat=extip:10.186.73.0
+      - --metrics
       - --pprof
       - --pprof.addr=0.0.0.0
       

--- a/e2e/docker/testdata/TestComposeTemplate_image_tag_main.golden
+++ b/e2e/docker/testdata/TestComposeTemplate_image_tag_main.golden
@@ -93,6 +93,7 @@ services:
       - --config=/geth/config.toml
       # Flags not available via config.toml
       - --nat=extip:10.186.73.0
+      - --metrics
       - --pprof
       - --pprof.addr=0.0.0.0
       

--- a/e2e/vmcompose/testdata/TestSetup_127_0_0_1_compose.yaml.golden
+++ b/e2e/vmcompose/testdata/TestSetup_127_0_0_1_compose.yaml.golden
@@ -48,6 +48,7 @@ services:
       - --config=/geth/config.toml
       # Flags not available via config.toml
       - --nat=extip:<nil>
+      - --metrics
       - --pprof
       - --pprof.addr=0.0.0.0
       

--- a/e2e/vmcompose/testdata/TestSetup_127_0_0_2_compose.yaml.golden
+++ b/e2e/vmcompose/testdata/TestSetup_127_0_0_2_compose.yaml.golden
@@ -48,6 +48,7 @@ services:
       - --config=/geth/config.toml
       # Flags not available via config.toml
       - --nat=extip:<nil>
+      - --metrics
       - --pprof
       - --pprof.addr=0.0.0.0
       

--- a/e2e/vmcompose/testdata/TestSetup_127_0_0_4_compose.yaml.golden
+++ b/e2e/vmcompose/testdata/TestSetup_127_0_0_4_compose.yaml.golden
@@ -48,6 +48,7 @@ services:
       - --config=/geth/config.toml
       # Flags not available via config.toml
       - --nat=extip:<nil>
+      - --metrics
       - --pprof
       - --pprof.addr=0.0.0.0
       

--- a/e2e/vmcompose/testdata/TestSetup_127_0_0_5_compose.yaml.golden
+++ b/e2e/vmcompose/testdata/TestSetup_127_0_0_5_compose.yaml.golden
@@ -48,6 +48,7 @@ services:
       - --config=/geth/config.toml
       # Flags not available via config.toml
       - --nat=extip:<nil>
+      - --metrics
       - --pprof
       - --pprof.addr=0.0.0.0
       


### PR DESCRIPTION
The geth metrics were exported but not increasing. Adding `--metrics` flag fixes that.

task: none
