### PR TITLE
ci(e2e): fix geth nodekey and metrics

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -199,28 +199,28 @@
         "filename": "e2e/app/setup.go",
         "hashed_secret": "7be029054a936fcb1827abd24388a53136be7b64",
         "is_verified": false,
-        "line_number": 134
+        "line_number": 135
       },
       {
         "type": "Secret Keyword",
         "filename": "e2e/app/setup.go",
         "hashed_secret": "55abc9109d5ea8a77be16bf3c76b4b199b524b12",
         "is_verified": false,
-        "line_number": 398
+        "line_number": 399
       },
       {
         "type": "Secret Keyword",
         "filename": "e2e/app/setup.go",
         "hashed_secret": "da57af224108e98e24d1e2a86221121990fa6478",
         "is_verified": false,
-        "line_number": 423
+        "line_number": 424
       },
       {
         "type": "Secret Keyword",
         "filename": "e2e/app/setup.go",
         "hashed_secret": "b11b6052ab454c167964c5b836faf0053a711b90",
         "is_verified": false,
-        "line_number": 458
+        "line_number": 459
       }
     ],
     "e2e/app/static/geth-keystore.json": [
@@ -830,5 +830,5 @@
       }
     ]
   },
-  "generated_at": "2024-04-01T14:59:24Z"
+  "generated_at": "2024-04-02T16:33:36Z"
 }

--- a/e2e/app/geth.toml.tmpl
+++ b/e2e/app/geth.toml.tmpl
@@ -4,8 +4,10 @@ SyncMode = "full"
 NoPruning = {{ .IsArchive }}
 
 [Eth.Miner]
-# Recommit defines the time interval for miner to re-create mining work. Required for fast block times.
-Recommit = 500000000 # 500ms
+# Geth has slow block building times, but we need fast times.
+# Decrease recommit to minimum (1s) and newPayloadTimeout to 500ms so blocks are built in less than 1s.
+Recommit = 1000000000 # 1s
+NewPayloadTimeout = 500000000 # 500ms
 
 [Node]
 DataDir = "/geth"

--- a/e2e/app/setup.go
+++ b/e2e/app/setup.go
@@ -3,6 +3,7 @@ package app
 import (
 	"bytes"
 	"context"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"log/slog"
@@ -360,9 +361,9 @@ func writeOmniEVMConfig(testnet types.Testnet) error {
 	gethConfigFiles := func(evm types.OmniEVM) map[string][]byte {
 		return map[string][]byte{
 			"genesis.json":      gethGenesisBz,
-			"keystore/keystore": gethKeystore, // TODO(corver): Remove this, it isn't used.
-			"geth_password.txt": []byte(""),   // Empty password
-			"geth/nodekey":      ethcrypto.FromECDSA(evm.NodeKey),
+			"keystore/keystore": gethKeystore,                                                 // TODO(corver): Remove this, it isn't used.
+			"geth_password.txt": []byte(""),                                                   // Empty password
+			"geth/nodekey":      []byte(hex.EncodeToString(ethcrypto.FromECDSA(evm.NodeKey))), // Nodekey is hex encoded
 			"geth/jwtsecret":    []byte(evm.JWTSecret),
 		}
 	}

--- a/e2e/app/testdata/TestWriteGethConfigTOML.golden
+++ b/e2e/app/testdata/TestWriteGethConfigTOML.golden
@@ -4,8 +4,10 @@ SyncMode = "full"
 NoPruning = true
 
 [Eth.Miner]
-# Recommit defines the time interval for miner to re-create mining work. Required for fast block times.
-Recommit = 500000000 # 500ms
+# Geth has slow block building times, but we need fast times.
+# Decrease recommit to minimum (1s) and newPayloadTimeout to 500ms so blocks are built in less than 1s.
+Recommit = 1000000000 # 1s
+NewPayloadTimeout = 500000000 # 500ms
 
 [Node]
 DataDir = "/geth"

--- a/e2e/docker/compose.yaml.tmpl
+++ b/e2e/docker/compose.yaml.tmpl
@@ -86,6 +86,7 @@ services:
       - --nat=extip:{{ .AdvertisedIP }}
       - --pprof
       - --pprof.addr=0.0.0.0
+      - --metrics
       {{ if .IsArchive }}- --gcmode=archive{{ end }}
     ports:
       - {{ if $.BindAll }}8551:{{end}}8551

--- a/e2e/docker/testdata/TestComposeTemplate_image_tag_7d1ae53.golden
+++ b/e2e/docker/testdata/TestComposeTemplate_image_tag_7d1ae53.golden
@@ -95,6 +95,7 @@ services:
       - --nat=extip:10.186.73.0
       - --pprof
       - --pprof.addr=0.0.0.0
+      - --metrics
       
     ports:
       - 8551

--- a/e2e/docker/testdata/TestComposeTemplate_image_tag_main.golden
+++ b/e2e/docker/testdata/TestComposeTemplate_image_tag_main.golden
@@ -95,6 +95,7 @@ services:
       - --nat=extip:10.186.73.0
       - --pprof
       - --pprof.addr=0.0.0.0
+      - --metrics
       
     ports:
       - 8551

--- a/e2e/vmcompose/testdata/TestSetup_127_0_0_1_compose.yaml.golden
+++ b/e2e/vmcompose/testdata/TestSetup_127_0_0_1_compose.yaml.golden
@@ -50,6 +50,7 @@ services:
       - --nat=extip:<nil>
       - --pprof
       - --pprof.addr=0.0.0.0
+      - --metrics
       
     ports:
       - 8551:8551

--- a/e2e/vmcompose/testdata/TestSetup_127_0_0_2_compose.yaml.golden
+++ b/e2e/vmcompose/testdata/TestSetup_127_0_0_2_compose.yaml.golden
@@ -50,6 +50,7 @@ services:
       - --nat=extip:<nil>
       - --pprof
       - --pprof.addr=0.0.0.0
+      - --metrics
       
     ports:
       - 8551:8551

--- a/e2e/vmcompose/testdata/TestSetup_127_0_0_4_compose.yaml.golden
+++ b/e2e/vmcompose/testdata/TestSetup_127_0_0_4_compose.yaml.golden
@@ -50,6 +50,7 @@ services:
       - --nat=extip:<nil>
       - --pprof
       - --pprof.addr=0.0.0.0
+      - --metrics
       
     ports:
       - 8551:8551

--- a/e2e/vmcompose/testdata/TestSetup_127_0_0_5_compose.yaml.golden
+++ b/e2e/vmcompose/testdata/TestSetup_127_0_0_5_compose.yaml.golden
@@ -50,6 +50,7 @@ services:
       - --nat=extip:<nil>
       - --pprof
       - --pprof.addr=0.0.0.0
+      - --metrics
       
     ports:
       - 8551:8551


### PR DESCRIPTION
Geth nodekey files are hex encoded (not just bytes).
Geth require --metrics flag to actually populate metrics.

task: none