### PR TITLE
feat(relayer): reset worker cursors on error

### DIFF
--- a/relayer/app/state.go
+++ b/relayer/app/state.go
@@ -33,6 +33,16 @@ func (s *State) GetHeight(dstID, srcID uint64) uint64 {
 	return s.cursors[dstID][srcID]
 }
 
+// Clear deletes all destination chain cursors.
+func (s *State) Clear(dstID uint64) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	delete(s.cursors, dstID)
+
+	return s.saveUnsafe()
+}
+
 // Persist saves the given height for the given chainID.
 func (s *State) Persist(dstID, srcID, height uint64) error {
 	s.mu.Lock()

--- a/relayer/app/state_internal_test.go
+++ b/relayer/app/state_internal_test.go
@@ -28,11 +28,27 @@ func TestPersistState(t *testing.T) {
 		}
 	}
 
-	loadedState, ok, err := LoadCursors(path)
-	require.NoError(t, err)
-	require.True(t, ok)
-	require.NotNil(t, loadedState)
-	require.True(t, mapsEqual(expected, loadedState.cursors))
+	load := func(t *testing.T) *State {
+		t.Helper()
+		loadedState, ok, err := LoadCursors(path)
+		require.NoError(t, err)
+		require.True(t, ok)
+		require.NotNil(t, loadedState)
+
+		return loadedState
+	}
+
+	require.True(t, mapsEqual(expected, load(t).cursors))
+
+	// Clear each destination
+	for dstChainID := range expected {
+		require.NoError(t, ps.Clear(dstChainID))
+		require.Empty(t, ps.cursors[dstChainID])
+		require.Empty(t, load(t).cursors[dstChainID])
+	}
+
+	require.Empty(t, ps.cursors)
+	require.Empty(t, load(t).cursors)
 }
 
 func mapsEqual(map1, map2 map[uint64]map[uint64]uint64) bool {

--- a/relayer/app/worker.go
+++ b/relayer/app/worker.go
@@ -58,9 +58,12 @@ func (w *Worker) Run(ctx context.Context) {
 			return
 		}
 
-		// TODO(corver): Clear worker persisted state on error, so it bootstraps from on-chain state.
-
 		log.Error(ctx, "Worker failed, resetting", err)
+
+		if err := w.state.Clear(w.destChain.ID); err != nil {
+			log.Error(ctx, "Failed to clear worker state", err)
+		}
+
 		workerResets.WithLabelValues(w.destChain.Name).Inc()
 		backoff()
 	}


### PR DESCRIPTION
Reset worker cursors on error. This mitigates the current bug where on-disk cursors are updated even if submissions fail.

task: none