### PR TITLE
ci(e2e): harden upgrade command

### DIFF
--- a/e2e/vmcompose/provider.go
+++ b/e2e/vmcompose/provider.go
@@ -175,6 +175,7 @@ func (p *Provider) Upgrade(ctx context.Context) error {
 		startCmd := fmt.Sprintf("cd /omni && "+
 			"sudo mv %s %s/docker-compose.yaml && "+
 			"cd %s && "+
+			"sudo docker compose down && "+
 			"sudo docker compose up -d",
 			composeFile, p.Testnet.Name, p.Testnet.Name)
 


### PR DESCRIPTION
Upgrading by simply `docker compose up -d` sometimes fails due to race conditions with init container and on-disk locks.

Best do `down` before `up -d`

task: none