### PR TITLE
feat(e2e): add network versions

### DIFF
--- a/e2e/app/avs.go
+++ b/e2e/app/avs.go
@@ -50,7 +50,19 @@ func deployAVSWithExport(ctx context.Context, def Definition, deployInfo types.D
 		return err
 	}
 
-	deployInfo.Set(chain.ID, types.ContractOmniAVS, addr, receipt.BlockNumber.Uint64())
+	// If receipt is nil, the avs has already been deployed, in which case we
+	// don't know the deploy height. This is fine for the AVS contract - we only
+	// need deploy heights for Portal contracts.
+	//
+	// It may be worth refactoring DeployInfos to allow for explicitly nil deploy heights.
+	// Or, do not track AVS in e2e run deploy info - it does not look like it is used.
+
+	blockNumber := uint64(0)
+	if receipt != nil {
+		blockNumber = receipt.BlockNumber.Uint64()
+	}
+
+	deployInfo.Set(chain.ID, types.ContractOmniAVS, addr, blockNumber)
 
 	logAVSDeployment(ctx, chain.Name, addr, receipt)
 

--- a/lib/contracts/addrs.go
+++ b/lib/contracts/addrs.go
@@ -7,8 +7,6 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
-
-	"github.com/google/uuid"
 )
 
 const (
@@ -253,7 +251,8 @@ func ProxyAdminSalt(network netconf.ID) string {
 }
 
 func PortalSalt(network netconf.ID) string {
-	return salt(network, "portal")
+	// only portal salts are versioned
+	return salt(network, "portal-"+network.Version())
 }
 
 func AVSSalt(network netconf.ID) string {
@@ -264,17 +263,10 @@ func AVSSalt(network netconf.ID) string {
 // Utils.
 //
 
-//nolint:gochecknoglobals // Static ID
-var runid = uuid.New().String()
-
 // salt generates a salt for a contract deployment. For ephemeral networks,
 // the salt includes a random per-run suffix. For persistent networks, the
 // sale is static.
 func salt(network netconf.ID, contract string) string {
-	if network.IsEphemeral() {
-		return string(network) + "-" + contract + "-" + runid
-	}
-
 	return string(network) + "-" + contract
 }
 

--- a/lib/netconf/network.go
+++ b/lib/netconf/network.go
@@ -32,6 +32,10 @@ func (i ID) String() string {
 	return string(i)
 }
 
+func (i ID) Version() string {
+	return i.Static().Version
+}
+
 const (
 	// Simnet is a simulated network for very simple testing of individual binaries.
 	// It is a single binary with mocked clients (no networking).


### PR DESCRIPTION
Add network versions.

Ephermeral networks have random versions. Persistent networks have explicit verions. Portal deployment salts include network version.


task: none
