### PR TITLE
feat(halo/app): add support for eigenlayer generated operator keys

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -332,6 +332,15 @@
         "line_number": 13
       }
     ],
+    "halo/app/privval_internal_test.go": [
+      {
+        "type": "Secret Keyword",
+        "filename": "halo/app/privval_internal_test.go",
+        "hashed_secret": "ea88c33fcfbffa7a2629897bb74346b2dbd250d6",
+        "is_verified": false,
+        "line_number": 116
+      }
+    ],
     "halo/attest/voter/voter.go": [
       {
         "type": "Secret Keyword",
@@ -862,5 +871,5 @@
       }
     ]
   },
-  "generated_at": "2024-04-04T13:04:24Z"
+  "generated_at": "2024-04-04T13:57:28Z"
 }

--- a/halo/app/privkey.go
+++ b/halo/app/privkey.go
@@ -1,0 +1,109 @@
+package app
+
+import (
+	"os"
+
+	"github.com/omni-network/omni/lib/errors"
+	"github.com/omni-network/omni/lib/k1util"
+
+	"github.com/cometbft/cometbft/crypto"
+	cmtjson "github.com/cometbft/cometbft/libs/json"
+	"github.com/cometbft/cometbft/privval"
+
+	"github.com/ethereum/go-ethereum/accounts/keystore"
+)
+
+// loadPrivVal returns a privval.FilePV by loading either a CometBFT priv validator key or an Ethereum keystore file.
+func loadPrivVal(cfg Config) (*privval.FilePV, error) {
+	cmtFile := cfg.Comet.PrivValidatorKeyFile()
+	cmtExists := exists(cmtFile)
+	keystoreFile, keystoreExists, err := cfg.KeystoreFile()
+	if err != nil {
+		return nil, err
+	}
+
+	if !cmtExists && !keystoreExists {
+		return nil, errors.New("neither a cometBFT priv validator key nor an eigenlayer operator key file exists", "comet_file", cmtFile, "eigen_file", cfg.KeystoreGlob())
+	} else if cmtExists && keystoreExists {
+		return nil, errors.New("both a cometBFT priv validator key and an eigenlayer operator key file exist", "comet_file", cmtFile, "eigen_file", keystoreFile)
+	}
+
+	var key crypto.PrivKey
+	if keystoreExists {
+		key, err = loadEthKeystore(keystoreFile, cfg.EigenKeyPassword)
+	} else {
+		key, err = loadCometFilePV(cmtFile)
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	state, err := loadCometPVState(cfg.Comet.PrivValidatorStateFile())
+	if err != nil {
+		return nil, err
+	}
+
+	// Create a new privval.FilePV with the loaded key and state.
+	// This is a workaround for the fact that there is no other way
+	// to set FilePVLastSignState filePath field.
+	resp := privval.NewFilePV(key, "", cfg.Comet.PrivValidatorStateFile())
+	resp.LastSignState.Step = state.Step
+	resp.LastSignState.Round = state.Round
+	resp.LastSignState.Height = state.Height
+	resp.LastSignState.Signature = state.Signature
+	resp.LastSignState.SignBytes = state.SignBytes
+
+	return resp, nil
+}
+
+// loadEthKeystore loads an Ethereum keystore file and returns the private key.
+func loadEthKeystore(keystoreFile string, password string) (crypto.PrivKey, error) {
+	bz, err := os.ReadFile(keystoreFile)
+	if err != nil {
+		return nil, errors.Wrap(err, "read keystore file", "path", keystoreFile)
+	}
+
+	key, err := keystore.DecryptKey(bz, password)
+	if err != nil {
+		return nil, errors.Wrap(err, "decrypt keystore file", "path", keystoreFile)
+	}
+
+	return k1util.StdPrivKeyToComet(key.PrivateKey)
+}
+
+// loadCometFilePV loads a CometBFT privval file and returns the private key.
+func loadCometFilePV(file string) (crypto.PrivKey, error) {
+	bz, err := os.ReadFile(file)
+	if err != nil {
+		return nil, errors.Wrap(err, "read comet privval", "path", file)
+	}
+
+	var pvKey privval.FilePVKey
+	err = cmtjson.Unmarshal(bz, &pvKey)
+	if err != nil {
+		return nil, errors.Wrap(err, "unmarshal comet privval", "path", file)
+	}
+
+	return pvKey.PrivKey, nil
+}
+
+// loadCometPVState loads a CometBFT privval state file.
+func loadCometPVState(file string) (privval.FilePVLastSignState, error) {
+	bz, err := os.ReadFile(file)
+	if err != nil {
+		return privval.FilePVLastSignState{}, errors.Wrap(err, "read comet privval state", "path", file)
+	}
+
+	var state privval.FilePVLastSignState
+	err = cmtjson.Unmarshal(bz, &state)
+	if err != nil {
+		return privval.FilePVLastSignState{}, errors.Wrap(err, "unmarshal comet privval state", "path", file)
+	}
+
+	return state, nil
+}
+
+func exists(file string) bool {
+	_, err := os.Stat(file)
+	return !os.IsNotExist(err)
+}

--- a/halo/app/privval_internal_test.go
+++ b/halo/app/privval_internal_test.go
@@ -1,0 +1,140 @@
+package app
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	halocfg "github.com/omni-network/omni/halo/config"
+	"github.com/omni-network/omni/lib/k1util"
+	"github.com/omni-network/omni/lib/tutil"
+
+	cmtconfig "github.com/cometbft/cometbft/config"
+	"github.com/cometbft/cometbft/privval"
+	cmtproto "github.com/cometbft/cometbft/proto/tendermint/types"
+
+	"github.com/ethereum/go-ethereum/crypto"
+
+	eigenecdsa "github.com/Layr-Labs/eigensdk-go/crypto/ecdsa"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLoadPrivVal(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		ethKeystore  bool
+		cmtPrivval   bool
+		cmtPrivState bool
+		err          bool
+	}{
+		{
+			name:         "eth keystore and state",
+			ethKeystore:  true,
+			cmtPrivval:   false,
+			cmtPrivState: true,
+		},
+		{
+			name:         "comet privval and state",
+			ethKeystore:  false,
+			cmtPrivval:   true,
+			cmtPrivState: true,
+		},
+		{
+			name:         "no files",
+			ethKeystore:  false,
+			cmtPrivval:   false,
+			cmtPrivState: false,
+			err:          true,
+		},
+		{
+			name:         "all",
+			ethKeystore:  true,
+			cmtPrivval:   true,
+			cmtPrivState: true,
+			err:          true,
+		},
+		{
+			name:         "eth keystore only",
+			ethKeystore:  true,
+			cmtPrivval:   false,
+			cmtPrivState: false,
+			err:          true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			homeDir := t.TempDir()
+
+			// Define the file paths
+			ethKeystoreFile := filepath.Join(homeDir, "config", "test.ecdsa.key.json")
+			ethKeystorePassword := tutil.RandomHash().Hex()
+			cmtPrivvalFile := filepath.Join(homeDir, "config", "priv_validator_key.json")
+			cmtPrivStateFile := filepath.Join(homeDir, "data", "priv_validator_state.json")
+
+			// Ensure the config and data directories exist
+			require.NoError(t, os.Mkdir(filepath.Dir(ethKeystoreFile), 0755))
+			require.NoError(t, os.Mkdir(filepath.Dir(cmtPrivStateFile), 0755))
+
+			// Generate the expected private key
+			privKey, err := crypto.GenerateKey()
+			require.NoError(t, err)
+
+			// Write the ethereum keystore file
+			if tt.ethKeystore {
+				err = eigenecdsa.WriteKey(ethKeystoreFile, privKey, ethKeystorePassword)
+				require.NoError(t, err)
+			}
+
+			// Convert the private key to a comet private key
+			cmtPrivKey, err := k1util.StdPrivKeyToComet(privKey)
+			require.NoError(t, err)
+
+			// Write the comet privval file (with non-zero state)
+			key := privval.NewFilePV(cmtPrivKey, cmtPrivvalFile, cmtPrivStateFile)
+			err = key.SignVote("chain", &cmtproto.Vote{
+				Type: cmtproto.PrecommitType,
+			})
+			require.NoError(t, err)
+			key.Save()
+
+			// Remove the files if they are not needed
+			if !tt.cmtPrivval {
+				require.NoError(t, os.Remove(cmtPrivvalFile))
+			}
+			if !tt.cmtPrivState {
+				require.NoError(t, os.Remove(cmtPrivStateFile))
+			}
+
+			// Setup the config
+			cfg := Config{
+				Config: halocfg.Config{
+					HomeDir:          homeDir,
+					EigenKeyPassword: ethKeystorePassword,
+				},
+				Comet: cmtconfig.Config{
+					BaseConfig: cmtconfig.BaseConfig{
+						RootDir:            homeDir,
+						PrivValidatorKey:   "config/priv_validator_key.json",
+						PrivValidatorState: "data/priv_validator_state.json",
+					},
+				},
+			}
+
+			// Run the test
+			pv, err := loadPrivVal(cfg)
+
+			// Assert the results
+			if tt.err {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				require.NotNil(t, pv)
+				require.True(t, pv.Key.PrivKey.Equals(cmtPrivKey))
+			}
+		})
+	}
+}

--- a/halo/app/start.go
+++ b/halo/app/start.go
@@ -86,8 +86,10 @@ func Start(ctx context.Context, cfg Config) (func(context.Context) error, error)
 		return nil, errors.Wrap(err, "enable cosmos-sdk telemetry")
 	}
 
-	// Load private validator key and state from disk (this hard exits on any error).
-	privVal := privval.LoadFilePV(cfg.Comet.PrivValidatorKeyFile(), cfg.Comet.PrivValidatorStateFile())
+	privVal, err := loadPrivVal(cfg)
+	if err != nil {
+		return nil, errors.Wrap(err, "load validator key")
+	}
 
 	db, err := dbm.NewDB("application", cfg.BackendType(), cfg.DataDir())
 	if err != nil {

--- a/halo/cmd/flags.go
+++ b/halo/cmd/flags.go
@@ -17,6 +17,7 @@ func bindRunFlags(flags *pflag.FlagSet, cfg *halocfg.Config) {
 	flags.StringVar(&cfg.PruningOption, "pruning", cfg.PruningOption, "Pruning strategy (default|nothing|everything)")
 	flags.DurationVar(&cfg.EVMBuildDelay, "evm-build-delay", cfg.EVMBuildDelay, "Minimum delay between triggering and fetching a EVM payload build")
 	flags.BoolVar(&cfg.EVMBuildOptimistic, "evm-build-optimistic", cfg.EVMBuildOptimistic, "Enables optimistic building of EVM payloads on previous block finalize")
+	flags.StringVar(&cfg.EigenKeyPassword, "eigenlayer-key-password", cfg.EigenKeyPassword, "Eigenlayer generated operator key password. Not required if CombetBFT priv_validator_key.json is used")
 }
 
 func bindInitFlags(flags *pflag.FlagSet, cfg *InitConfig) {

--- a/halo/cmd/init.go
+++ b/halo/cmd/init.go
@@ -155,12 +155,13 @@ func InitFiles(ctx context.Context, initCfg InitConfig) error {
 	}
 
 	// Setup comet private validator
+	// TODO(corver): Handle the eigenlayer keystore case.
 	var pv *privval.FilePV
 	privValKeyFile := comet.PrivValidatorKeyFile()
 	privValStateFile := comet.PrivValidatorStateFile()
 	if cmtos.FileExists(privValKeyFile) {
 		pv = privval.LoadFilePV(privValKeyFile, privValStateFile) // This hard exits on any error.
-		log.Info(ctx, "Found private validator",
+		log.Info(ctx, "Found cometBFT private validator",
 			"key_file", privValKeyFile,
 			"state_file", privValStateFile,
 		)

--- a/halo/cmd/testdata/TestCLIReference_run.golden
+++ b/halo/cmd/testdata/TestCLIReference_run.golden
@@ -4,16 +4,17 @@ Usage:
   halo run [flags]
 
 Flags:
-      --app-db-backend string       The type of database for application and snapshots databases (default "goleveldb")
-      --engine-jwt-file string      The path to the Engine API JWT file
-      --evm-build-delay duration    Minimum delay between triggering and fetching a EVM payload build (default 600ms)
-      --evm-build-optimistic        Enables optimistic building of EVM payloads on previous block finalize (default true)
-  -h, --help                        help for run
-      --home string                 The application home directory containing config and data (default "./halo")
-      --log-color string            Log color (only applicable to console format); auto, force, disable (default "auto")
-      --log-format string           Log format; console, json (default "console")
-      --log-level string            Log level; debug, info, warn, error (default "info")
-      --min-retain-blocks uint      Minimum block height offset during ABCI commit to prune CometBFT blocks
-      --pruning string              Pruning strategy (default|nothing|everything) (default "nothing")
-      --snapshot-interval uint      State sync snapshot interval (default 1000)
-      --snapshot-keep-recent uint   State sync snapshot to keep (default 2)
+      --app-db-backend string            The type of database for application and snapshots databases (default "goleveldb")
+      --eigenlayer-key-password string   Eigenlayer generated operator key password. Not required if CombetBFT priv_validator_key.json is used
+      --engine-jwt-file string           The path to the Engine API JWT file
+      --evm-build-delay duration         Minimum delay between triggering and fetching a EVM payload build (default 600ms)
+      --evm-build-optimistic             Enables optimistic building of EVM payloads on previous block finalize (default true)
+  -h, --help                             help for run
+      --home string                      The application home directory containing config and data (default "./halo")
+      --log-color string                 Log color (only applicable to console format); auto, force, disable (default "auto")
+      --log-format string                Log format; console, json (default "console")
+      --log-level string                 Log level; debug, info, warn, error (default "info")
+      --min-retain-blocks uint           Minimum block height offset during ABCI commit to prune CometBFT blocks
+      --pruning string                   Pruning strategy (default|nothing|everything) (default "nothing")
+      --snapshot-interval uint           State sync snapshot interval (default 1000)
+      --snapshot-keep-recent uint        State sync snapshot to keep (default 2)

--- a/halo/cmd/testdata/TestRunCmd_defaults.golden
+++ b/halo/cmd/testdata/TestRunCmd_defaults.golden
@@ -1,5 +1,6 @@
 {
  "HomeDir": "./halo",
+ "EigenKeyPassword": "",
  "EngineJWTFile": "",
  "SnapshotInterval": 1000,
  "SnapshotKeepRecent": 2,

--- a/halo/cmd/testdata/TestRunCmd_flags.golden
+++ b/halo/cmd/testdata/TestRunCmd_flags.golden
@@ -1,5 +1,6 @@
 {
  "HomeDir": "foo",
+ "EigenKeyPassword": "",
  "EngineJWTFile": "bar",
  "SnapshotInterval": 1000,
  "SnapshotKeepRecent": 2,

--- a/halo/cmd/testdata/TestRunCmd_json_files.golden
+++ b/halo/cmd/testdata/TestRunCmd_json_files.golden
@@ -1,5 +1,6 @@
 {
  "HomeDir": "testinput/input2",
+ "EigenKeyPassword": "123456",
  "EngineJWTFile": "jwt.json",
  "SnapshotInterval": 123,
  "SnapshotKeepRecent": 2,

--- a/halo/cmd/testdata/TestRunCmd_toml_files.golden
+++ b/halo/cmd/testdata/TestRunCmd_toml_files.golden
@@ -1,5 +1,6 @@
 {
  "HomeDir": "testinput/input1",
+ "EigenKeyPassword": "",
  "EngineJWTFile": "jwt.toml",
  "SnapshotInterval": 999,
  "SnapshotKeepRecent": 2,

--- a/halo/cmd/testinput/input2/config/halo.json
+++ b/halo/cmd/testinput/input2/config/halo.json
@@ -1,4 +1,5 @@
 {
+"eigenlayer-key-password": "123456",
 "engine-jwt-file": "jwt.json",
 "snapshot-interval": 123,
 "state-persist-interval": 12

--- a/halo/config/config.go
+++ b/halo/config/config.go
@@ -25,6 +25,7 @@ const (
 	snapshotDataDir = "snapshots"
 	networkFile     = "network.json"
 	voterStateFile  = "voter_state.json"
+	keystoreGlob    = "*.ecdsa.key.json" // From https://github.com/Layr-Labs/eigenlayer-cli/blob/master/pkg/operator/keys/create.go#L165
 
 	DefaultHomeDir            = "./halo" // Defaults to "halo" in current directory
 	defaultSnapshotInterval   = 1000     // Roughly once an hour (given 3s blocks)
@@ -41,6 +42,7 @@ const (
 func DefaultConfig() Config {
 	return Config{
 		HomeDir:            DefaultHomeDir,
+		EigenKeyPassword:   "", // No default
 		EngineJWTFile:      "", // No default
 		SnapshotInterval:   defaultSnapshotInterval,
 		SnapshotKeepRecent: defaultSnapshotKeepRecent,
@@ -55,6 +57,7 @@ func DefaultConfig() Config {
 // Config defines all halo specific config.
 type Config struct {
 	HomeDir            string
+	EigenKeyPassword   string
 	EngineJWTFile      string
 	SnapshotInterval   uint64 // See cosmossdk.io/store/snapshots/types/options.go
 	SnapshotKeepRecent uint64 // See cosmossdk.io/store/snapshots/types/options.go
@@ -90,6 +93,18 @@ func (c Config) SnapshotDir() string {
 	return filepath.Join(c.DataDir(), snapshotDataDir)
 }
 
+// KeystoreGlob returns the glob pattern for the eigenlayer-format ethereum keystore.
+func (c Config) KeystoreGlob() string {
+	return filepath.Join(c.HomeDir, configDir, keystoreGlob)
+}
+
+// KeystoreFile returns the path to the eigenlayer-format ethereum keystore file and true if it exists.
+// It returns false if the file does not exist.
+// It returns an error if multiple files are found.
+func (c Config) KeystoreFile() (string, bool, error) {
+	return statGlobSingle(c.KeystoreGlob())
+}
+
 //go:embed config.toml.tmpl
 var tomlTemplate []byte
 
@@ -121,4 +136,22 @@ func WriteConfigTOML(cfg Config, logCfg log.Config) error {
 	}
 
 	return nil
+}
+
+// statGlobSingle returns the single file path for the given glob pattern and true if it exists.
+// It returns false if no matching files are found.
+// It returns an error if multiple files are found.
+func statGlobSingle(pattern string) (string, bool, error) {
+	matches, err := filepath.Glob(pattern)
+	if err != nil {
+		return "", false, errors.Wrap(err, "bad glob pattern", "pattern", pattern)
+	}
+
+	if len(matches) == 0 {
+		return "", false, nil
+	} else if len(matches) > 1 {
+		return "", true, errors.New("multiple files found for glob pattern", "pattern", pattern, "matches", matches)
+	}
+
+	return matches[0], true, nil
 }

--- a/halo/config/config.toml.tmpl
+++ b/halo/config/config.toml.tmpl
@@ -12,6 +12,9 @@ version = "{{ .Version }}"
 # Omni chain execution client JWT file used for authentication.
 engine-jwt-file = "{{ .EngineJWTFile }}"
 
+# Eigenlayer generated operator private key password. The key itself should be stored in: <home_dir>/config/*.ecdsa.key.json.
+eigenlayer-key-password = "{{ .EigenKeyPassword }}"
+
 # SnapshotInterval specifies the height interval at which halo
 # will take state sync snapshots. Defaults to 1000 (roughly once an hour), setting this to
 # 0 disables state snapshots.

--- a/halo/config/testdata/default_halo.toml
+++ b/halo/config/testdata/default_halo.toml
@@ -12,6 +12,9 @@ version = "v0.1.2"
 # Omni chain execution client JWT file used for authentication.
 engine-jwt-file = ""
 
+# Eigenlayer generated operator private key password. The key itself should be stored in: <home_dir>/config/*.ecdsa.key.json.
+eigenlayer-key-password = ""
+
 # SnapshotInterval specifies the height interval at which halo
 # will take state sync snapshots. Defaults to 1000 (roughly once an hour), setting this to
 # 0 disables state snapshots.

--- a/lib/k1util/k1util.go
+++ b/lib/k1util/k1util.go
@@ -7,6 +7,7 @@ import (
 	"github.com/omni-network/omni/lib/errors"
 
 	"github.com/cometbft/cometbft/crypto"
+	k1 "github.com/cometbft/cometbft/crypto/secp256k1"
 	cryptopb "github.com/cometbft/cometbft/proto/tendermint/crypto"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -77,6 +78,15 @@ func PubKeyToAddress(pubkey crypto.PubKey) (common.Address, error) {
 	}
 
 	return ethcrypto.PubkeyToAddress(*ethPubKey), nil
+}
+
+func StdPrivKeyToComet(privkey *stdecdsa.PrivateKey) (crypto.PrivKey, error) {
+	bz := ethcrypto.FromECDSA(privkey)
+	if len(bz) != privKeyLen {
+		return nil, errors.New("invalid private key length")
+	}
+
+	return k1.PrivKey(bz), nil
 }
 
 func StdPrivKeyFromComet(privkey crypto.PrivKey) (*stdecdsa.PrivateKey, error) {


### PR DESCRIPTION
Add support for eigenlayer-generated operator private keys. 

Notes:
 - Keys should be stored in: `<home>/config/*.ecdsa.key.json`
 - Password must be provided as a flag: `--eigenlayer-key-password`
 - cometBFT key must be removed `config/priv_validator_key.json`

task: none
