### PR TITLE
fix(e2e): allow explorer db connection upgrade

### DIFF
--- a/e2e/app/run.go
+++ b/e2e/app/run.go
@@ -231,8 +231,8 @@ func E2ETest(ctx context.Context, def Definition, cfg E2ETestConfig, secrets age
 
 // Upgrade generates all local artifacts, but only copies the docker-compose file to the VMs.
 // It them calls docker-compose up.
-func Upgrade(ctx context.Context, def Definition) error {
-	if err := Setup(ctx, def, agent.Secrets{}, false, ""); err != nil {
+func Upgrade(ctx context.Context, def Definition, cfg DeployConfig) error {
+	if err := Setup(ctx, def, agent.Secrets{}, false, cfg.ExplorerDB); err != nil {
 		return err
 	}
 

--- a/e2e/cmd/cmd.go
+++ b/e2e/cmd/cmd.go
@@ -145,13 +145,19 @@ func newTestCmd(def *app.Definition) *cobra.Command {
 }
 
 func newUpgradeCmd(def *app.Definition) *cobra.Command {
-	return &cobra.Command{
+	cfg := app.DefaultDeployConfig()
+
+	cmd := &cobra.Command{
 		Use:   "upgrade",
 		Short: "Upgrades docker containers of a previously preserved network",
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			return app.Upgrade(cmd.Context(), *def)
+			return app.Upgrade(cmd.Context(), *def, cfg)
 		},
 	}
+
+	bindDeployFlags(cmd.Flags(), &cfg)
+
+	return cmd
 }
 
 func newAVSDeployCmd(def *app.Definition) *cobra.Command {


### PR DESCRIPTION
Allow upgrades of the explorer DB connection.

task: none