### PR TITLE
fix(halo/attest): only propose valid votes

### DIFF
--- a/halo/app/prouter.go
+++ b/halo/app/prouter.go
@@ -65,6 +65,6 @@ func makeProcessProposalHandler(app *App) sdk.ProcessProposalHandler {
 }
 
 func handleErr(ctx context.Context, err error) (*abci.ResponseProcessProposal, error) {
-	log.Warn(ctx, "Rejecting failed process proposal", err)
+	log.Error(ctx, "Rejecting failed process proposal", err)
 	return &abci.ResponseProcessProposal{Status: abci.ResponseProcessProposal_REJECT}, nil
 }

--- a/halo/attest/voter/voter.go
+++ b/halo/attest/voter/voter.go
@@ -156,7 +156,7 @@ func (a *Voter) runOnce(ctx context.Context, chainID uint64) error {
 			if err != nil {
 				return errors.Wrap(err, "window compare")
 			} else if cmp < 0 {
-				return errors.New("behind vote window (too slow)")
+				return errors.New("behind vote window (too slow)", "height", block.BlockHeight)
 			} // Being ahead is not a problem, since we buffer on disk.
 
 			if err := a.Vote(block, first); err != nil {


### PR DESCRIPTION
Only proposed votes in vote window. This solves an issue identified on staging where out-of-window votes were proposed which causes the chain to stall.

Block N:
- vote Window is: [6,10] (latest approved att=8)
- so a validator votes: v1:[6] which is in the vote window
- but when block N is processed, att 9 and 10 is approved.

Block N+1:
- vote Window is: [8,12] (latest approved att=10)
- but the block proposal now includes v1:[6] (vote from previous block)
- which is outside the vote window
- so the proposal gets rejected.

Solution:
- proposer should filter valid votes.
- Previously, it simply includes all votes it has, even though some might now be invalid.

task: none