### PR TITLE
fix(halo/attest): flip window compare boolean

### DIFF
--- a/halo/attest/keeper/keeper.go
+++ b/halo/attest/keeper/keeper.go
@@ -639,14 +639,13 @@ func isApproved(sigs []*Signature, valset ValSet) ([]*Signature, bool) {
 	return toDelete, sum > valset.TotalPower()*2/3
 }
 
-func windowCompare(voteWindow uint64, header *types.BlockHeader, latest uint64) int {
-	x := header.Height
-	mid := latest
-	delta := voteWindow
+// windowCompare returns -1 if x < mid-voteWindow, 1 if x > mid+voteWindow, else 0.
+func windowCompare(voteWindow uint64, midHeader *types.BlockHeader, x uint64) int {
+	mid := midHeader.Height
 
-	if x < uintSub(mid, delta) {
+	if x < uintSub(mid, voteWindow) {
 		return -1
-	} else if x > mid+delta {
+	} else if x > mid+voteWindow {
 		return 1
 	}
 

--- a/halo/attest/keeper/keeper_internal_test.go
+++ b/halo/attest/keeper/keeper_internal_test.go
@@ -1,5 +1,12 @@
 package keeper
 
+import (
+	"fmt"
+	"testing"
+
+	"github.com/omni-network/omni/halo/attest/types"
+)
+
 // AttestTable returns the attestations ORM table.
 func (k *Keeper) AttestTable() AttestationTable {
 	return k.attTable
@@ -8,4 +15,41 @@ func (k *Keeper) AttestTable() AttestationTable {
 // SignatureTable returns the attestations ORM table.
 func (k *Keeper) SignatureTable() SignatureTable {
 	return k.sigTable
+}
+
+func TestWindowCompose(t *testing.T) {
+	t.Parallel()
+	const window = 64
+	const mid = 32
+	const bigMid = 256
+
+	const in = 0
+	const above = 1
+	const below = -1
+
+	tests := []struct {
+		Mid      uint64
+		Target   uint64
+		Expected int
+	}{
+		{mid, mid, in},
+		{mid, mid + 1, in},
+		{mid, mid - 1, in},
+		{mid, mid + window, in},
+		{mid, 0, in},
+		{mid, mid + window + 1, above},
+		{mid, mid + window + window, above},
+		{bigMid, bigMid - window - 1, below},
+		{bigMid, bigMid - window - window, below},
+	}
+
+	for i, tt := range tests {
+		t.Run(fmt.Sprintf("mid_%d_target_%d", tt.Mid, tt.Target), func(t *testing.T) {
+			t.Parallel()
+			got := windowCompare(window, &types.BlockHeader{Height: tt.Mid}, tt.Target)
+			if got != tt.Expected {
+				t.Errorf("Test %d: Expected %d, got %d", i, tt.Expected, got)
+			}
+		})
+	}
 }


### PR DESCRIPTION
Window compare has a bug resulting in inverted responses.

task: none
