### PR TITLE
ci(e2e): fix instance equal

### DIFF
--- a/e2e/types/infra.go
+++ b/e2e/types/infra.go
@@ -37,6 +37,7 @@ func (d InfrastructureData) ServicesByInstance(data e2e.InstanceData) map[string
 	return resp
 }
 
+// instancesEqual returns true if the two instances are equal, as identified by IPs.
 func instancesEqual(a, b e2e.InstanceData) bool {
-	return a.IPAddress.Equal(b.IPAddress) && a.ExtIPAddress.Equal(b.ExtIPAddress) && a.Port == b.Port
+	return a.IPAddress.Equal(b.IPAddress) && a.ExtIPAddress.Equal(b.ExtIPAddress)
 }


### PR DESCRIPTION
Fix comparing e2e infra instances by only using IPs. Since ports are only defined for the one set, not the other.

task: none