### PR TITLE
fix(lib/cchain): fix consensus xblock timestamp

### DIFF
--- a/lib/cchain/provider/provider_test.go
+++ b/lib/cchain/provider/provider_test.go
@@ -54,7 +54,7 @@ func TestProvider(t *testing.T) {
 	}
 }
 
-// testFetcher implements FetchFunc.
+// testFetcher implements fetchFunc.
 // It first returns errs errors.
 // Then it returns 0,1,2,3,4,5... attestations up to max.
 type testFetcher struct {

--- a/lib/cchain/provider/testdata/TestXBlock.golden
+++ b/lib/cchain/provider/testdata/TestXBlock.golden
@@ -15,5 +15,5 @@
   }
  ],
  "Receipts": null,
- "Timestamp": "0001-01-01T00:00:00Z"
+ "Timestamp": "2024-04-05T10:13:47Z"
 }

--- a/lib/cchain/provider/xblock_internal_test.go
+++ b/lib/cchain/provider/xblock_internal_test.go
@@ -3,9 +3,13 @@ package provider
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/omni-network/omni/lib/cchain"
 	"github.com/omni-network/omni/lib/tutil"
+
+	ctypes "github.com/cometbft/cometbft/rpc/core/types"
+	"github.com/cometbft/cometbft/types"
 
 	fuzz "github.com/google/gofuzz"
 	"github.com/stretchr/testify/require"
@@ -29,18 +33,30 @@ func TestXBlock(t *testing.T) {
 	var height uint64
 	f.Fuzz(&height)
 
-	valFunc := func(ctx context.Context, h uint64, _ bool) ([]cchain.Validator, uint64, bool, error) {
+	timestamp := time.Unix(1712312027, 0).UTC()
+
+	valFunc := func(ctx context.Context, h uint64, _ bool) (valSetResponse, bool, error) {
 		require.EqualValues(t, height, h)
 		var resp []cchain.Validator
 		f.Fuzz(&resp)
 
-		return resp, height, true, nil
+		return valSetResponse{
+			ValSetID:   height,
+			Validators: resp,
+		}, true, nil
 	}
 	chainFunc := func(ctx context.Context) (uint64, error) {
 		return 77, nil
 	}
+	headerFunc := func(ctx context.Context, h *int64) (*ctypes.ResultHeader, error) {
+		return &ctypes.ResultHeader{
+			Header: &types.Header{
+				Time: timestamp,
+			},
+		}, nil
+	}
 
-	prov := Provider{valset: valFunc, chainID: chainFunc}
+	prov := Provider{valset: valFunc, chainID: chainFunc, header: headerFunc}
 
 	block, ok, err := prov.XBlock(context.Background(), height, false)
 	require.NoError(t, err)


### PR DESCRIPTION
Use the validator set created height to fetch the block header to use its timestamp.

Use height 1 instead of genesis since we can't fetch its timestamp.

task: none
