### PR TITLE
fix(halo/valsync): populate activated height in query

### DIFF
--- a/halo/valsync/keeper/query.go
+++ b/halo/valsync/keeper/query.go
@@ -126,8 +126,9 @@ func (k Keeper) ValidatorSet(ctx context.Context, req *types.ValidatorSetRequest
 	}
 
 	return &types.ValidatorSetResponse{
-		Id:            vatset.GetId(),
-		CreatedHeight: vatset.GetCreatedHeight(),
-		Validators:    vals,
+		Id:              vatset.GetId(),
+		CreatedHeight:   vatset.GetCreatedHeight(),
+		ActivatedHeight: vatset.GetActivatedHeight(),
+		Validators:      vals,
 	}, nil
 }


### PR DESCRIPTION
When querying validator set by id, we didn't populate activated height. This fixes it and adds a test.

task: none