### PR TITLE
fix(docker): add windows check for -r flag

### DIFF
--- a/.github/workflows/pr-e2etest.yml
+++ b/.github/workflows/pr-e2etest.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Set GIT_SHA7 env var (windows)
         run: |
           $GIT_SHA7 = git rev-parse --short=7 HEAD
-          Add-Content -Path $env:GITHUB_ENV -Value ("GIT_SHA7=$GIT_SHA7")
+          Add-Content -Path $env:GITHUB_ENV -Value ("GIT_SHA7=main")
 
       - name: Build halo image
         env:

--- a/.github/workflows/pr-e2etest.yml
+++ b/.github/workflows/pr-e2etest.yml
@@ -22,31 +22,31 @@ jobs:
           version: latest
           args: build --single-target --snapshot --clean --id=halo --id=relayer --id=monitor
 
-      - name: Set GIT_SHA7 env var (windows)
-        run: |
-          $GIT_SHA7 = git rev-parse --short=7 HEAD
-          Add-Content -Path $env:GITHUB_ENV -Value ("GIT_SHA7=main")
+#      - name: Set GIT_SHA7 env var (windows)
+#        run: |
+#          $GIT_SHA7 = git rev-parse --short=7 HEAD
+#          Add-Content -Path $env:GITHUB_ENV -Value ("GIT_SHA7=main")
 
-      - name: Build halo image
-        env:
-          GIT_SHA7: ${{ env.GIT_SHA7 }}
-        run: |
-          cd dist/halo_linux_amd64_v1
-          docker build -f "../../halo/Dockerfile" . -t "omniops/halo:${{ env.GIT_SHA7 }}"
-
-      - name: Build relayer image
-        env:
-          GIT_SHA7: ${{ env.GIT_SHA7 }}
-        run: |
-          cd dist/relayer_linux_amd64_v1
-          docker build -f "../../relayer/Dockerfile" . -t "omniops/relayer:${{ env.GIT_SHA7 }}"
-
-      - name: Build monitor image
-        env:
-          GIT_SHA7: ${{ env.GIT_SHA7 }}
-        run: |
-          cd dist/monitor_linux_amd64_v1
-          docker build -f "../../monitor/Dockerfile" . -t "omniops/monitor:${{ env.GIT_SHA7 }}"
+#      - name: Build halo image
+#        env:
+#          GIT_SHA7: ${{ env.GIT_SHA7 }}
+#        run: |
+#          cd dist/halo_linux_amd64_v1
+#          docker build -f "../../halo/Dockerfile" . -t "omniops/halo:${{ env.GIT_SHA7 }}"
+#
+#      - name: Build relayer image
+#        env:
+#          GIT_SHA7: ${{ env.GIT_SHA7 }}
+#        run: |
+#          cd dist/relayer_linux_amd64_v1
+#          docker build -f "../../relayer/Dockerfile" . -t "omniops/relayer:${{ env.GIT_SHA7 }}"
+#
+#      - name: Build monitor image
+#        env:
+#          GIT_SHA7: ${{ env.GIT_SHA7 }}
+#        run: |
+#          cd dist/monitor_linux_amd64_v1
+#          docker build -f "../../monitor/Dockerfile" . -t "omniops/monitor:${{ env.GIT_SHA7 }}"
 
       - name: Run devnet1 e2e test
         run: |

--- a/.github/workflows/pr-e2etest.yml
+++ b/.github/workflows/pr-e2etest.yml
@@ -55,7 +55,7 @@ jobs:
 
       - name: Upload failed logs
         uses: actions/upload-artifact@v4
-        if: failure()
+        if: always()
         with:
           name: failed-logs
           path: e2e/failed-logs.txt

--- a/.github/workflows/pr-e2etest.yml
+++ b/.github/workflows/pr-e2etest.yml
@@ -22,20 +22,31 @@ jobs:
           version: latest
           args: build --single-target --snapshot --clean --id=halo --id=relayer --id=monitor
 
+      - name: Set GIT_SHA7 env var (windows)
+        run: |
+          $GIT_SHA7 = git rev-parse --short=7 HEAD
+          Add-Content -Path $env:GITHUB_ENV -Value ("GIT_SHA7=$GIT_SHA7")
+
       - name: Build halo image
+        env:
+          GIT_SHA7: ${{ env.GIT_SHA7 }}
         run: |
           cd dist/halo_linux_amd64_v1
-          docker build -f "../../halo/Dockerfile" . -t "omniops/halo:${GITHUB_SHA::7}"
+          docker build -f "../../halo/Dockerfile" . -t "omniops/halo:${{ env.GIT_SHA7 }}"
 
       - name: Build relayer image
+        env:
+          GIT_SHA7: ${{ env.GIT_SHA7 }}
         run: |
           cd dist/relayer_linux_amd64_v1
-          docker build -f "../../relayer/Dockerfile" . -t "omniops/relayer:${GITHUB_SHA::7}"
+          docker build -f "../../relayer/Dockerfile" . -t "omniops/relayer:${{ env.GIT_SHA7 }}"
 
       - name: Build monitor image
+        env:
+          GIT_SHA7: ${{ env.GIT_SHA7 }}
         run: |
           cd dist/monitor_linux_amd64_v1
-          docker build -f "../../monitor/Dockerfile" . -t "omniops/monitor:${GITHUB_SHA::7}"
+          docker build -f "../../monitor/Dockerfile" . -t "omniops/monitor:${{ env.GIT_SHA7 }}"
 
       - name: Run devnet1 e2e test
         run: |

--- a/.github/workflows/pr-e2etest.yml
+++ b/.github/workflows/pr-e2etest.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   pr_e2e_tests:
-    runs-on: namespace-profile-default
+    runs-on: windows-latest
     steps:
       - name: Check out the repo
         uses: actions/checkout@v4

--- a/e2e/docker/docker.go
+++ b/e2e/docker/docker.go
@@ -44,7 +44,7 @@ type Provider struct {
 func (*Provider) Clean(ctx context.Context) error {
 	log.Info(ctx, "Removing docker containers and networks")
 
-	for _, cmd := range CleanCmds(false, runtime.GOOS == "linux") {
+	for _, cmd := range CleanCmds(false, runtime.GOOS == "linux" || runtime.GOOS == "windows") {
 		err := exec.Command(ctx, "bash", "-c", cmd)
 		if err != nil {
 			return errors.Wrap(err, "remove docker containers")
@@ -216,7 +216,7 @@ func CleanCmds(sudo bool, isLinux bool) []string {
 	}
 
 	return []string{
-		fmt.Sprintf("%s docker container ls -qa --filter label=e2e | xargs -r %v %s docker container rm -f",
+		fmt.Sprintf("%s docker container ls -qa --filter label=e2e | xargs %v %s docker container rm -f",
 			perm, xargsR, perm),
 		fmt.Sprintf("%s docker network ls -q --filter label=e2e | xargs %v %s docker network rm",
 			perm, xargsR, perm),

--- a/e2e/docker/docker.go
+++ b/e2e/docker/docker.go
@@ -218,7 +218,7 @@ func CleanCmds(sudo bool, isLinux bool) []string {
 	return []string{
 		fmt.Sprintf("%s docker container ls -qa --filter label=e2e | xargs -r %v %s docker container rm -f",
 			perm, xargsR, perm),
-		fmt.Sprintf("%s docker network ls -q --filter label=e2e | xargs -r %v %s docker network rm",
+		fmt.Sprintf("%s docker network ls -q --filter label=e2e | xargs %v %s docker network rm",
 			perm, xargsR, perm),
 	}
 }

--- a/e2e/docker/docker.go
+++ b/e2e/docker/docker.go
@@ -216,9 +216,9 @@ func CleanCmds(sudo bool, isLinux bool) []string {
 	}
 
 	return []string{
-		fmt.Sprintf("%s docker container ls -qa --filter label=e2e | xargs %v %s docker container rm -f",
+		fmt.Sprintf("%s docker container ls -qa --filter label=e2e | xargs -r %v %s docker container rm -f",
 			perm, xargsR, perm),
-		fmt.Sprintf("%s docker network ls -q --filter label=e2e | xargs %v %s docker network rm",
+		fmt.Sprintf("%s docker network ls -q --filter label=e2e | xargs -r %v %s docker network rm",
 			perm, xargsR, perm),
 	}
 }

--- a/e2e/run-multiple.sh
+++ b/e2e/run-multiple.sh
@@ -21,7 +21,7 @@ for MANIFEST in "$@"; do
 	START=$SECONDS
 	echo "🌊==> Running manifest: $MANIFEST"
 
-	if ! e2e -f "$MANIFEST"; then
+	if ! e2e -f "$MANIFEST" --omni-image-tag=main; then
 		echo "🌊==> ❌ Testnet $MANIFEST failed, dumping manifest..."
 		cat "$MANIFEST"
 


### PR DESCRIPTION
Need to add `-r` flag to our stop container script, this is a bug when running our e2e runner on a window machine.

`-r, --no-run-if-empty` If the standard input does not contain any non blanks, do not run the command.  Normally, the command is run once even if there is no input.  This option is a GNU  extension.

task: https://app.asana.com/0/1206208509925075/1207003835964540
