### PR TITLE
fix(lib/log): fix cosmos log source and stack

### DIFF
--- a/halo/app/cmtlog.go
+++ b/halo/app/cmtlog.go
@@ -41,7 +41,7 @@ func newCmtLogger(ctx context.Context, levelStr string) (cmtlog.Logger, error) {
 	}
 
 	return cmtLogger{
-		ctx:   ctx,
+		ctx:   log.WithSkip(ctx, 4), // Skip this logger.
 		level: level,
 	}, nil
 }

--- a/halo/app/sdklog.go
+++ b/halo/app/sdklog.go
@@ -28,7 +28,7 @@ type sdkLogger struct {
 
 func newSDKLogger(ctx context.Context) sdkLogger {
 	return sdkLogger{
-		ctx: ctx,
+		ctx: log.WithSkip(ctx, 4), // Skip this logger.
 	}
 }
 


### PR DESCRIPTION
Fixes CosmosSDK and CometBFT logs `source` by skipping the custom wrapper loggers. Also simplify stacktrace logic by just taking inner most stack which fixes issue of cosmosSDK errors missing stack traces. 

task: none