### PR TITLE
ci(e2e): support multiple public chain rpcs

### DIFF
--- a/e2e/app/create3.go
+++ b/e2e/app/create3.go
@@ -62,7 +62,7 @@ func deployPrivateCreate3(ctx context.Context, def Definition) error {
 
 func deployPublicCreate3(ctx context.Context, def Definition) error {
 	for _, c := range def.Testnet.PublicChains {
-		_, _, err := deployCreate3(ctx, def, c.Chain.ID)
+		_, _, err := deployCreate3(ctx, def, c.Chain().ID)
 		if err != nil {
 			return errors.Wrap(err, "deploy create3")
 		}

--- a/e2e/app/definition.go
+++ b/e2e/app/definition.go
@@ -38,7 +38,7 @@ type DefinitionConfig struct {
 	RelayerKeyFile string
 	FireAPIKey     string
 	FireKeyPath    string
-	RPCOverrides   map[string]string
+	RPCOverrides   map[string]string // map[chainName]rpcURL1,rpcURL2,...
 
 	InfraDataFile string // Not required for docker provider
 	OmniImgTag    string // OmniImgTag is the docker image tag used for halo and relayer.
@@ -424,10 +424,7 @@ func publicChains(manifest types.Manifest, cfg DefinitionConfig) ([]types.Public
 			addr = types.PublicRPCByName(name)
 		}
 
-		publics = append(publics, types.PublicChain{
-			Chain:      chain,
-			RPCAddress: addr,
-		})
+		publics = append(publics, types.NewPublicChain(chain, strings.Split(addr, ",")))
 	}
 
 	return publics, nil
@@ -440,15 +437,15 @@ func internalNetwork(testnet types.Testnet, deployInfo map[types.EVMChain]netman
 	// Add all public chains
 	for _, public := range testnet.PublicChains {
 		pc := netconf.Chain{
-			ID:                public.Chain.ID,
-			Name:              public.Chain.Name,
-			RPCURL:            public.RPCAddress,
-			PortalAddress:     deployInfo[public.Chain].PortalAddress,
-			DeployHeight:      deployInfo[public.Chain].DeployHeight,
-			BlockPeriod:       public.Chain.BlockPeriod,
-			FinalizationStrat: public.Chain.FinalizationStrat,
-			IsEthereum:        public.Chain.IsAVSTarget,
-			AVSContractAddr:   public.Chain.AVSContractAddress,
+			ID:                public.Chain().ID,
+			Name:              public.Chain().Name,
+			RPCURL:            public.NextRPCAddress(),
+			PortalAddress:     deployInfo[public.Chain()].PortalAddress,
+			DeployHeight:      deployInfo[public.Chain()].DeployHeight,
+			BlockPeriod:       public.Chain().BlockPeriod,
+			FinalizationStrat: public.Chain().FinalizationStrat,
+			IsEthereum:        public.Chain().IsAVSTarget,
+			AVSContractAddr:   public.Chain().AVSContractAddress,
 		}
 
 		chains = append(chains, pc)
@@ -511,14 +508,14 @@ func externalNetwork(testnet types.Testnet, deployInfo map[types.EVMChain]netman
 	// Add all public chains
 	for _, public := range testnet.PublicChains {
 		chains = append(chains, netconf.Chain{
-			ID:                public.Chain.ID,
-			Name:              public.Chain.Name,
-			RPCURL:            public.RPCAddress,
-			PortalAddress:     deployInfo[public.Chain].PortalAddress,
-			DeployHeight:      deployInfo[public.Chain].DeployHeight,
-			BlockPeriod:       public.Chain.BlockPeriod,
-			FinalizationStrat: public.Chain.FinalizationStrat,
-			IsEthereum:        public.Chain.IsAVSTarget,
+			ID:                public.Chain().ID,
+			Name:              public.Chain().Name,
+			RPCURL:            public.NextRPCAddress(),
+			PortalAddress:     deployInfo[public.Chain()].PortalAddress,
+			DeployHeight:      deployInfo[public.Chain()].DeployHeight,
+			BlockPeriod:       public.Chain().BlockPeriod,
+			FinalizationStrat: public.Chain().FinalizationStrat,
+			IsEthereum:        public.Chain().IsAVSTarget,
 		})
 	}
 

--- a/e2e/app/proxyadmin.go
+++ b/e2e/app/proxyadmin.go
@@ -28,7 +28,7 @@ func deployPrivateProxyAdmin(ctx context.Context, def Definition) error {
 
 func deployPublicProxyAdmin(ctx context.Context, def Definition) error {
 	for _, c := range def.Testnet.PublicChains {
-		if err := deployProxyAdmin(ctx, def, c.Chain.ID); err != nil {
+		if err := deployProxyAdmin(ctx, def, c.Chain().ID); err != nil {
 			return errors.Wrap(err, "deploy proxy admin")
 		}
 	}

--- a/e2e/cmd/flags.go
+++ b/e2e/cmd/flags.go
@@ -20,7 +20,7 @@ func bindDefFlags(flags *pflag.FlagSet, cfg *app.DefinitionConfig) {
 	flags.StringVar(&cfg.FireKeyPath, "fireblocks-key-path", cfg.FireKeyPath, "FireBlocks RSA private key path")
 	flags.StringVar(&cfg.OmniImgTag, "omni-image-tag", cfg.OmniImgTag, "Omni docker images tag (halo, relayer). Defaults to working dir git commit.")
 	flags.StringVar(&cfg.ExplorerDBConn, "explorer-db-conn", cfg.ExplorerDBConn, "Indexer database connection url")
-	flags.StringToStringVar(&cfg.RPCOverrides, "rpc-overrides", cfg.RPCOverrides, "Pubilc chain rpc overrides: '<chain1>=<url1>'")
+	flags.StringToStringVar(&cfg.RPCOverrides, "rpc-overrides", cfg.RPCOverrides, "Public chain rpc overrides: '<chain1>=<url1>,<url2>'")
 }
 
 func bindE2EFlags(flags *pflag.FlagSet, cfg *app.E2ETestConfig) {

--- a/e2e/netman/manager.go
+++ b/e2e/netman/manager.go
@@ -99,8 +99,8 @@ func NewManager(testnet types.Testnet, backends ethbackend.Backends, relayerKeyF
 	}
 	// Add all public chains
 	for _, public := range testnet.PublicChains {
-		portals[public.Chain.ID] = Portal{
-			Chain: public.Chain,
+		portals[public.Chain().ID] = Portal{
+			Chain: public.Chain(),
 			// Public chain deploy height and address will be updated by DeployPublicPortals.
 		}
 	}

--- a/e2e/types/testnet_test.go
+++ b/e2e/types/testnet_test.go
@@ -1,0 +1,19 @@
+package types_test
+
+import (
+	"testing"
+
+	"github.com/omni-network/omni/e2e/types"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestNextRPCAddress(t *testing.T) {
+	t.Parallel()
+	c := types.NewPublicChain(types.EVMChain{}, []string{"1 ", " 2", "3"})
+
+	require.Equal(t, "1", c.NextRPCAddress())
+	require.Equal(t, "2", c.NextRPCAddress())
+	require.Equal(t, "3", c.NextRPCAddress())
+	require.Equal(t, "1", c.NextRPCAddress())
+}

--- a/lib/ethclient/ethbackend/backends.go
+++ b/lib/ethclient/ethbackend/backends.go
@@ -62,12 +62,12 @@ func NewFireBackends(ctx context.Context, testnet types.Testnet, fireCl firebloc
 
 	// Configure public EVM Backends
 	for _, chain := range testnet.PublicChains {
-		ethCl, err := ethclient.Dial(chain.Chain.Name, chain.RPCAddress)
+		ethCl, err := ethclient.Dial(chain.Chain().Name, chain.NextRPCAddress())
 		if err != nil {
 			return Backends{}, errors.Wrap(err, "dial")
 		}
 
-		inner[chain.Chain.ID], err = NewFireBackend(ctx, chain.Chain.Name, chain.Chain.ID, chain.Chain.BlockPeriod, ethCl, fireCl)
+		inner[chain.Chain().ID], err = NewFireBackend(ctx, chain.Chain().Name, chain.Chain().ID, chain.Chain().BlockPeriod, ethCl, fireCl)
 		if err != nil {
 			return Backends{}, errors.Wrap(err, "new public Backend")
 		}
@@ -136,12 +136,12 @@ func NewBackends(testnet types.Testnet, deployKeyFile string) (Backends, error) 
 		if publicDeployKey == nil {
 			return Backends{}, errors.New("public deploy key required")
 		}
-		ethCl, err := ethclient.Dial(chain.Chain.Name, chain.RPCAddress)
+		ethCl, err := ethclient.Dial(chain.Chain().Name, chain.NextRPCAddress())
 		if err != nil {
 			return Backends{}, errors.Wrap(err, "dial")
 		}
 
-		inner[chain.Chain.ID], err = NewBackend(chain.Chain.Name, chain.Chain.ID, chain.Chain.BlockPeriod, ethCl, publicDeployKey)
+		inner[chain.Chain().ID], err = NewBackend(chain.Chain().Name, chain.Chain().ID, chain.Chain().BlockPeriod, ethCl, publicDeployKey)
 		if err != nil {
 			return Backends{}, errors.Wrap(err, "new public Backend")
 		}


### PR DESCRIPTION
Add support for multiple `--rpc-overrides=chain_a=url1,url2`. This is spread round robin over all users.

task: none