### PR TITLE
ci(e2e): use random started halo address

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -238,7 +238,7 @@
         "filename": "e2e/app/setup.go",
         "hashed_secret": "b11b6052ab454c167964c5b836faf0053a711b90",
         "is_verified": false,
-        "line_number": 412
+        "line_number": 411
       }
     ],
     "e2e/manifests/staging.toml": [
@@ -839,5 +839,5 @@
       }
     ]
   },
-  "generated_at": "2024-04-05T09:20:33Z"
+  "generated_at": "2024-04-08T07:01:48Z"
 }

--- a/e2e/app/setup.go
+++ b/e2e/app/setup.go
@@ -376,8 +376,7 @@ func writeRelayerConfig(def Definition, logCfg log.Config) error {
 	ralayCfg := relayapp.DefaultConfig()
 	ralayCfg.PrivateKey = privKeyFile
 	ralayCfg.NetworkFile = networkFile
-
-	ralayCfg.HaloURL = random(def.Testnet.Nodes).AddressRPC()
+	ralayCfg.HaloURL = def.Testnet.RandomHaloAddr()
 
 	if err := relayapp.WriteConfigTOML(ralayCfg, logCfg, filepath.Join(confRoot, configFile)); err != nil {
 		return errors.Wrap(err, "write relayer config")

--- a/e2e/types/testnet.go
+++ b/e2e/types/testnet.go
@@ -16,6 +16,8 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/p2p/enode"
+
+	"math/rand/v2"
 )
 
 // Testnet wraps e2e.Testnet with additional omni-specific fields.
@@ -29,6 +31,25 @@ type Testnet struct {
 	Explorer       bool
 	ExplorerMockDB bool
 	ExplorerDBConn string
+}
+
+// RandomHaloAddr returns a random halo address for cprovider and cometBFT rpc clients.
+// It uses the internal IP address of a random node that isn't delayed or a seed.
+func (t Testnet) RandomHaloAddr() string {
+	var eligible []string
+	for _, node := range t.Nodes {
+		if node.StartAt != 0 || node.Mode == ModeSeed {
+			continue // Skip delayed nodes or seed nodes
+		}
+
+		eligible = append(eligible, node.AddressRPC())
+	}
+
+	if len(eligible) == 0 {
+		return ""
+	}
+
+	return eligible[rand.IntN(len(eligible))]
 }
 
 func (t Testnet) AVSChain() (EVMChain, error) {


### PR DESCRIPTION
Fix flapping e2e test that used validator04 for relayer halo url which is only started at the end of the e2e test.

Instead, use a random halo address only from nodes that are started immediately.

task: none