### PR TITLE
fix(lib/cchain): revert timesstamp regression

### DIFF
--- a/lib/cchain/provider/testdata/TestXBlock.golden
+++ b/lib/cchain/provider/testdata/TestXBlock.golden
@@ -15,5 +15,5 @@
   }
  ],
  "Receipts": null,
- "Timestamp": "2024-04-05T10:13:47Z"
+ "Timestamp": "0001-01-01T00:00:00Z"
 }

--- a/lib/cchain/provider/xblock.go
+++ b/lib/cchain/provider/xblock.go
@@ -25,20 +25,6 @@ func (p Provider) XBlock(ctx context.Context, height uint64, latest bool) (xchai
 		return xchain.Block{}, false, nil
 	}
 
-	// Use the created height to fetch the header to use as the timestamp.
-	h := int64(resp.CreatedHeight)
-	if h == 0 {
-		// Can't fetch header for genesis, workaround is to use height 1 for now.
-		// This isn't critical, since timestamp is only used for display purposes.
-		h = 1
-	}
-	header, err := p.header(ctx, &h)
-	if err != nil {
-		return xchain.Block{}, false, errors.Wrap(err, "get header")
-	} else if header.Header == nil {
-		return xchain.Block{}, false, errors.New("created height header is nil")
-	}
-
 	chainID, err := p.chainID(ctx)
 	if err != nil {
 		return xchain.Block{}, false, errors.Wrap(err, "get chain ID")
@@ -69,7 +55,6 @@ func (p Provider) XBlock(ctx context.Context, height uint64, latest bool) (xchai
 			},
 			Data: data,
 		}},
-		Timestamp: header.Header.Time,
 	}, true, nil
 }
 


### PR DESCRIPTION
Removes the timestap field from consensus xblocks. It uses normal consensus cblock timestamp, but those blocks are pruned differently than xblocks data which causes conflicts.

XBlocks need their own timestamps. Until then, they will have zero timestamps.

task: none