### PR TITLE
ci(e2e): refactor eoa keys

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -76,10 +76,6 @@
       "path": "detect_secrets.filters.allowlist.is_line_allowlisted"
     },
     {
-      "path": "detect_secrets.filters.common.is_baseline_file",
-      "filename": ".secrets.baseline"
-    },
-    {
       "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
       "min_level": 2
     },
@@ -201,14 +197,14 @@
         "filename": "e2e/app/run.go",
         "hashed_secret": "7c1a7493a09f09e4669f6b1f03719a2262e7b323",
         "is_verified": false,
-        "line_number": 22
+        "line_number": 21
       },
       {
         "type": "Secret Keyword",
         "filename": "e2e/app/run.go",
         "hashed_secret": "fe86558143c0bd528f649a153bdc32b8fa90301c",
         "is_verified": false,
-        "line_number": 143
+        "line_number": 134
       }
     ],
     "e2e/app/setup.go": [
@@ -217,28 +213,28 @@
         "filename": "e2e/app/setup.go",
         "hashed_secret": "7be029054a936fcb1827abd24388a53136be7b64",
         "is_verified": false,
-        "line_number": 138
+        "line_number": 139
       },
       {
         "type": "Secret Keyword",
         "filename": "e2e/app/setup.go",
         "hashed_secret": "55abc9109d5ea8a77be16bf3c76b4b199b524b12",
         "is_verified": false,
-        "line_number": 352
+        "line_number": 353
       },
       {
         "type": "Secret Keyword",
         "filename": "e2e/app/setup.go",
         "hashed_secret": "da57af224108e98e24d1e2a86221121990fa6478",
         "is_verified": false,
-        "line_number": 377
+        "line_number": 382
       },
       {
         "type": "Secret Keyword",
         "filename": "e2e/app/setup.go",
         "hashed_secret": "b11b6052ab454c167964c5b836faf0053a711b90",
         "is_verified": false,
-        "line_number": 411
+        "line_number": 426
       }
     ],
     "e2e/manifests/staging.toml": [
@@ -322,114 +318,121 @@
       {
         "type": "Hex High Entropy String",
         "filename": "halo/genutil/evm/testdata/TestMakeGenesis.golden",
-        "hashed_secret": "08b650e252263f24012a9f28567c240a20c2f946",
+        "hashed_secret": "c913e86771bd6427da35bcad86caf9408ea230e3",
         "is_verified": false,
-        "line_number": 61
+        "line_number": 57
       },
       {
         "type": "Hex High Entropy String",
         "filename": "halo/genutil/evm/testdata/TestMakeGenesis.golden",
-        "hashed_secret": "bba31aa004481de49b494ec166f33686c717bc26",
+        "hashed_secret": "08b650e252263f24012a9f28567c240a20c2f946",
         "is_verified": false,
         "line_number": 64
       },
       {
         "type": "Hex High Entropy String",
         "filename": "halo/genutil/evm/testdata/TestMakeGenesis.golden",
-        "hashed_secret": "28ef15964c4850182b1fef49fc55950919db756f",
+        "hashed_secret": "bba31aa004481de49b494ec166f33686c717bc26",
         "is_verified": false,
         "line_number": 67
       },
       {
         "type": "Hex High Entropy String",
         "filename": "halo/genutil/evm/testdata/TestMakeGenesis.golden",
-        "hashed_secret": "72cd5d2bd88432c9ed5d75d51479070e70ec089e",
+        "hashed_secret": "28ef15964c4850182b1fef49fc55950919db756f",
         "is_verified": false,
         "line_number": 70
       },
       {
         "type": "Hex High Entropy String",
         "filename": "halo/genutil/evm/testdata/TestMakeGenesis.golden",
-        "hashed_secret": "3f0335f2af6f7b386ef0d32f094fbe826e7e3fa7",
+        "hashed_secret": "72cd5d2bd88432c9ed5d75d51479070e70ec089e",
         "is_verified": false,
         "line_number": 73
       },
       {
         "type": "Hex High Entropy String",
         "filename": "halo/genutil/evm/testdata/TestMakeGenesis.golden",
-        "hashed_secret": "87c4dc1a812364b8db6093f7ed72aced0c07630a",
+        "hashed_secret": "3f0335f2af6f7b386ef0d32f094fbe826e7e3fa7",
         "is_verified": false,
         "line_number": 76
       },
       {
         "type": "Hex High Entropy String",
         "filename": "halo/genutil/evm/testdata/TestMakeGenesis.golden",
-        "hashed_secret": "c52cffacab1f07ba79bbc61c32ff164fff8f9f8b",
+        "hashed_secret": "87c4dc1a812364b8db6093f7ed72aced0c07630a",
         "is_verified": false,
         "line_number": 79
       },
       {
         "type": "Hex High Entropy String",
         "filename": "halo/genutil/evm/testdata/TestMakeGenesis.golden",
-        "hashed_secret": "471394320cd7526cb50202735fd4156e9fac18bf",
+        "hashed_secret": "c52cffacab1f07ba79bbc61c32ff164fff8f9f8b",
         "is_verified": false,
         "line_number": 82
       },
       {
         "type": "Hex High Entropy String",
         "filename": "halo/genutil/evm/testdata/TestMakeGenesis.golden",
-        "hashed_secret": "0b88203fde5908bb7273ca44a7f685f977bde2ca",
+        "hashed_secret": "471394320cd7526cb50202735fd4156e9fac18bf",
         "is_verified": false,
         "line_number": 85
       },
       {
         "type": "Hex High Entropy String",
         "filename": "halo/genutil/evm/testdata/TestMakeGenesis.golden",
-        "hashed_secret": "9d06254807267e518daa2dc5629b8e298d391966",
+        "hashed_secret": "0b88203fde5908bb7273ca44a7f685f977bde2ca",
         "is_verified": false,
         "line_number": 88
       },
       {
         "type": "Hex High Entropy String",
         "filename": "halo/genutil/evm/testdata/TestMakeGenesis.golden",
-        "hashed_secret": "a79365b8364bf8a43643be2ac6dc1ecbc56f6d6a",
+        "hashed_secret": "9d06254807267e518daa2dc5629b8e298d391966",
         "is_verified": false,
         "line_number": 91
       },
       {
         "type": "Hex High Entropy String",
         "filename": "halo/genutil/evm/testdata/TestMakeGenesis.golden",
-        "hashed_secret": "aac432f7e35804ebe62d41d9f42657ce89479caf",
+        "hashed_secret": "a79365b8364bf8a43643be2ac6dc1ecbc56f6d6a",
         "is_verified": false,
         "line_number": 94
       },
       {
         "type": "Hex High Entropy String",
         "filename": "halo/genutil/evm/testdata/TestMakeGenesis.golden",
-        "hashed_secret": "616a05c8bcf93ed6f3c8f20ef3d41d6d0dc0418b",
+        "hashed_secret": "aac432f7e35804ebe62d41d9f42657ce89479caf",
         "is_verified": false,
         "line_number": 97
       },
       {
         "type": "Hex High Entropy String",
         "filename": "halo/genutil/evm/testdata/TestMakeGenesis.golden",
-        "hashed_secret": "ac3758d662cbdd3b3067756b1979a60d0e654a19",
+        "hashed_secret": "616a05c8bcf93ed6f3c8f20ef3d41d6d0dc0418b",
         "is_verified": false,
         "line_number": 100
       },
       {
         "type": "Hex High Entropy String",
         "filename": "halo/genutil/evm/testdata/TestMakeGenesis.golden",
-        "hashed_secret": "6372edf1c92d4dceccf1d6be9090746e24782003",
+        "hashed_secret": "ac3758d662cbdd3b3067756b1979a60d0e654a19",
         "is_verified": false,
         "line_number": 103
       },
       {
         "type": "Hex High Entropy String",
         "filename": "halo/genutil/evm/testdata/TestMakeGenesis.golden",
-        "hashed_secret": "b90fd3ae85361750377898f2a212638dfa6fd26b",
+        "hashed_secret": "6372edf1c92d4dceccf1d6be9090746e24782003",
         "is_verified": false,
         "line_number": 106
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "halo/genutil/evm/testdata/TestMakeGenesis.golden",
+        "hashed_secret": "b90fd3ae85361750377898f2a212638dfa6fd26b",
+        "is_verified": false,
+        "line_number": 109
       }
     ],
     "halo/genutil/testdata/TestMakeGenesis.golden": [
@@ -627,6 +630,15 @@
         "hashed_secret": "1f7e4e9473c8c12828910d0dfaca31b116f0bfe7",
         "is_verified": false,
         "line_number": 9
+      }
+    ],
+    "monitor/app/config.go": [
+      {
+        "type": "Secret Keyword",
+        "filename": "monitor/app/config.go",
+        "hashed_secret": "dd5585979d1148541e6e229e04a835ea89da0286",
+        "is_verified": false,
+        "line_number": 27
       }
     ],
     "relayer/app/config.go": [
@@ -839,5 +851,5 @@
       }
     ]
   },
-  "generated_at": "2024-04-08T07:01:48Z"
+  "generated_at": "2024-04-08T15:37:42Z"
 }

--- a/e2e/app/avs.go
+++ b/e2e/app/avs.go
@@ -3,17 +3,13 @@ package app
 import (
 	"context"
 
-	"github.com/omni-network/omni/e2e/types"
 	"github.com/omni-network/omni/lib/contracts/avs"
 	"github.com/omni-network/omni/lib/errors"
 	"github.com/omni-network/omni/lib/log"
-
-	"github.com/ethereum/go-ethereum/common"
-	ethtypes "github.com/ethereum/go-ethereum/core/types"
 )
 
-// AVSDeploy deploys the Omni AVS contracts.
-func AVSDeploy(ctx context.Context, def Definition) error {
+// DeployAVSAndCreate3 deploys a create3 contract and the Omni AVS contract.
+func DeployAVSAndCreate3(ctx context.Context, def Definition) error {
 	chain, err := def.Testnet.AVSChain()
 	if err != nil {
 		return errors.Wrap(err, "avs chain")
@@ -28,65 +24,30 @@ func AVSDeploy(ctx context.Context, def Definition) error {
 
 	log.Info(ctx, "Deploying via create3 factory", "chain", chain.Name, "addr", factory.Hex())
 
-	avs, receipt, err := deployAVS(ctx, def, chain.ID)
-	if err != nil {
-		return err
-	}
-
-	logAVSDeployment(ctx, chain.Name, avs, receipt)
-
-	return nil
+	return deployAVS(ctx, def)
 }
 
-// deployAVSWithExport deploys the Omni AVS contracts and exports the deployment information.
-func deployAVSWithExport(ctx context.Context, def Definition, deployInfo types.DeployInfos) error {
+func deployAVS(ctx context.Context, def Definition) error {
 	chain, err := def.Testnet.AVSChain()
 	if err != nil {
 		return errors.Wrap(err, "avs chain")
 	}
 
-	addr, receipt, err := deployAVS(ctx, def, chain.ID)
+	backend, err := def.Backends().Backend(chain.ID)
 	if err != nil {
-		return err
-	}
-
-	// If receipt is nil, the avs has already been deployed, in which case we
-	// don't know the deploy height. This is fine for the AVS contract - we only
-	// need deploy heights for Portal contracts.
-	//
-	// It may be worth refactoring DeployInfos to allow for explicitly nil deploy heights.
-	// Or, do not track AVS in e2e run deploy info - it does not look like it is used.
-
-	blockNumber := uint64(0)
-	if receipt != nil {
-		blockNumber = receipt.BlockNumber.Uint64()
-	}
-
-	deployInfo.Set(chain.ID, types.ContractOmniAVS, addr, blockNumber)
-
-	logAVSDeployment(ctx, chain.Name, addr, receipt)
-
-	return nil
-}
-
-func deployAVS(ctx context.Context, def Definition, chainID uint64) (common.Address, *ethtypes.Receipt, error) {
-	backend, err := def.Backends().Backend(chainID)
-	if err != nil {
-		return common.Address{}, nil, errors.Wrap(err, "backend")
+		return errors.Wrap(err, "backend")
 	}
 
 	addr, receipt, err := avs.DeployIfNeeded(ctx, def.Testnet.Network, backend)
 	if err != nil {
-		return common.Address{}, nil, errors.Wrap(err, "deploy")
+		return errors.Wrap(err, "deploy")
 	}
 
-	return addr, receipt, nil
-}
-
-func logAVSDeployment(ctx context.Context, chain string, addr common.Address, receipt *ethtypes.Receipt) {
 	if receipt == nil {
-		log.Info(ctx, "AVS contract already deployed", "chain", chain, "addr", addr.Hex())
+		log.Info(ctx, "AVS contract already deployed", "chain", chain.Name, "addr", addr.Hex())
 	} else {
-		log.Info(ctx, "AVS contract deployed", "chain", chain, "addr", addr.Hex(), "block", receipt.BlockNumber)
+		log.Info(ctx, "AVS contract deployed", "chain", chain.Name, "addr", addr.Hex(), "block", receipt.BlockNumber)
 	}
+
+	return nil
 }

--- a/e2e/app/eoa/eoa.go
+++ b/e2e/app/eoa/eoa.go
@@ -1,0 +1,90 @@
+// Package eoa defines well-known (non-fireblocks) eoa private keys used in an omni network.
+package eoa
+
+import (
+	"context"
+	"crypto/ecdsa"
+
+	"github.com/omni-network/omni/e2e/app/key"
+	"github.com/omni-network/omni/lib/anvil"
+	"github.com/omni-network/omni/lib/errors"
+	"github.com/omni-network/omni/lib/netconf"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/crypto"
+)
+
+type Type string
+
+const (
+	TypeRelayer Type = "relayer"
+	TypeMonitor Type = "monitor"
+)
+
+func (t Type) Verify() error {
+	if t != TypeRelayer && t != TypeMonitor {
+		return errors.New("invalid type", "type", t)
+	}
+
+	return nil
+}
+
+var (
+	devnetKeys = map[Type]*ecdsa.PrivateKey{
+		TypeRelayer: anvil.DevPrivateKey5(),
+		TypeMonitor: anvil.DevPrivateKey6(),
+	}
+)
+
+var secureAddrs = map[netconf.ID]map[Type]common.Address{
+	netconf.Staging: {
+		TypeRelayer: common.HexToAddress("0xfE921e06Ed0a22c035b4aCFF0A5D3a434A330c96"),
+		TypeMonitor: common.HexToAddress("0x0De553555Fa19d787Af4273B18bDB77282D618c4"),
+	},
+	netconf.Testnet: {
+		TypeRelayer: common.HexToAddress("0x01654f55E4F5E2f2ff8080702676F1984CBf7d8a"),
+		TypeMonitor: common.HexToAddress("0x12Dc870b3F5b7f810c3d1e489e32a64d4E25AaCA"),
+	},
+}
+
+// MustAddress returns the address for the EOA identified by the network and type.
+func MustAddress(network netconf.ID, typ Type) common.Address {
+	resp, _ := Address(network, typ)
+	return resp
+}
+
+// Address returns the address for the EOA identified by the network and type.
+func Address(network netconf.ID, typ Type) (common.Address, bool) {
+	if network == netconf.Devnet {
+		return crypto.PubkeyToAddress(devnetKeys[typ].PublicKey), true
+	}
+
+	resp, ok := secureAddrs[network][typ]
+
+	return resp, ok
+}
+
+// PrivateKey returns the private key for the EOA identified by the network and type.
+func PrivateKey(ctx context.Context, network netconf.ID, typ Type) (*ecdsa.PrivateKey, error) {
+	if network == netconf.Devnet {
+		return devnetKeys[typ], nil
+	}
+
+	// TODO(corver): Remove this workaround once the new testnet relayer key is funded.
+	// For now we keep on using the same staging key for testnet.
+	if network == netconf.Testnet && typ == TypeRelayer {
+		network = netconf.Staging
+	}
+
+	addr, ok := secureAddrs[network][typ]
+	if !ok {
+		return nil, errors.New("eoa key not defined", "network", network, "type", typ)
+	}
+
+	k, err := key.Download(ctx, network, string(typ), key.EOA, addr.Hex())
+	if err != nil {
+		return nil, errors.Wrap(err, "download key")
+	}
+
+	return k.ECDSA()
+}

--- a/e2e/app/fund.go
+++ b/e2e/app/fund.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"math/big"
 
+	"github.com/omni-network/omni/e2e/app/eoa"
 	"github.com/omni-network/omni/lib/anvil"
 	"github.com/omni-network/omni/lib/contracts"
 	"github.com/omni-network/omni/lib/errors"
@@ -42,6 +43,8 @@ func accountsToFund(network netconf.ID) []common.Address {
 			contracts.StagingProxyAdminOwner(),
 			contracts.StagingPortalAdmin(),
 			contracts.StagingAVSAdmin(),
+			eoa.MustAddress(netconf.Staging, eoa.TypeRelayer),
+			eoa.MustAddress(netconf.Staging, eoa.TypeMonitor),
 		}
 	case netconf.Devnet:
 		return []common.Address{
@@ -51,6 +54,8 @@ func accountsToFund(network netconf.ID) []common.Address {
 			contracts.DevnetProxyAdminOwner(),
 			contracts.DevnetPortalAdmin(),
 			contracts.DevnetAVSAdmin(),
+			eoa.MustAddress(netconf.Devnet, eoa.TypeRelayer),
+			eoa.MustAddress(netconf.Devnet, eoa.TypeMonitor),
 		}
 	default:
 		return []common.Address{}

--- a/e2e/app/key/key.go
+++ b/e2e/app/key/key.go
@@ -20,6 +20,7 @@ const (
 	Validator    Type = "validator"
 	P2PConsensus Type = "p2p_consensus"
 	P2PExecution Type = "p2p_execution"
+	EOA          Type = "eoa"
 )
 
 func (t Type) Verify() error {
@@ -27,7 +28,7 @@ func (t Type) Verify() error {
 		return errors.New("empty key type")
 	}
 	switch t {
-	case Validator, P2PConsensus, P2PExecution:
+	case Validator, P2PConsensus, P2PExecution, EOA:
 		return nil
 	default:
 		return errors.New("invalid key type")
@@ -82,7 +83,7 @@ func (k Key) ECDSA() (*ecdsa.PrivateKey, error) {
 // It panics since it assumes that the type is valid.
 func Generate(typ Type) Key {
 	switch typ {
-	case Validator, P2PExecution:
+	case Validator, P2PExecution, EOA:
 		return Key{
 			PrivKey: k1.GenPrivKey(),
 		}
@@ -99,7 +100,7 @@ func Generate(typ Type) Key {
 // FromBytes parses the given bytes into th eprovided key type.
 func FromBytes(typ Type, b []byte) (Key, error) {
 	switch typ {
-	case Validator, P2PExecution:
+	case Validator, P2PExecution, EOA:
 		if len(b) != k1.PrivKeySize {
 			return Key{}, errors.New("invalid key size")
 		}

--- a/e2e/app/key/key_internal_test.go
+++ b/e2e/app/key/key_internal_test.go
@@ -10,10 +10,10 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func DeleteSecretForT(ctx context.Context, t *testing.T, network netconf.ID, node string, typ Type, addr string) {
+func DeleteSecretForT(ctx context.Context, t *testing.T, network netconf.ID, name string, typ Type, addr string) {
 	t.Helper()
-	name := secretName(network, node, typ, addr)
+	secret := secretName(network, name, typ, addr)
 
-	out, err := exec.CommandContext(ctx, "gcloud", "secrets", "delete", name, "--quiet").CombinedOutput()
+	out, err := exec.CommandContext(ctx, "gcloud", "secrets", "delete", secret, "--quiet").CombinedOutput()
 	require.NoError(t, err, string(out))
 }

--- a/e2e/app/key/key_test.go
+++ b/e2e/app/key/key_test.go
@@ -16,7 +16,7 @@ import (
 
 func TestKeys(t *testing.T) {
 	t.Parallel()
-	for _, typ := range []key.Type{key.Validator, key.P2PConsensus, key.P2PExecution} {
+	for _, typ := range []key.Type{key.Validator, key.P2PConsensus, key.P2PExecution, key.EOA} {
 		t.Run(typ.String(), func(t *testing.T) {
 			t.Parallel()
 
@@ -36,7 +36,7 @@ func TestKeys(t *testing.T) {
 
 			ecdsaKey, err := key1.ECDSA()
 			switch typ {
-			case key.Validator, key.P2PExecution:
+			case key.Validator, key.P2PExecution, key.EOA:
 				require.NoError(t, err)
 				addrC := crypto.PubkeyToAddress(ecdsaKey.PublicKey)
 				require.Equal(t, addrA, addrC.Hex())
@@ -63,24 +63,24 @@ func TestIntegration(t *testing.T) {
 
 			ctx := context.Background()
 			network := netconf.Simnet
-			node := "deleteme"
+			name := "deleteme"
 
 			k, err := key.UploadNew(ctx, key.UploadConfig{
-				Network:  network,
-				NodeName: node,
-				Type:     typ,
+				Network: network,
+				Name:    name,
+				Type:    typ,
 			})
 			require.NoError(t, err)
 
 			addr, err := k.Addr()
 			require.NoError(t, err)
 
-			k2, err := key.Download(ctx, network, node, typ, addr)
+			k2, err := key.Download(ctx, network, name, typ, addr)
 			tutil.RequireNoError(t, err)
 
 			require.True(t, k.Equals(k2.PrivKey))
 
-			key.DeleteSecretForT(ctx, t, network, node, typ, addr)
+			key.DeleteSecretForT(ctx, t, network, name, typ, addr)
 		})
 	}
 }

--- a/e2e/app/key/upload.go
+++ b/e2e/app/key/upload.go
@@ -10,9 +10,9 @@ import (
 
 // UploadConfig is the configuration for uploading a key.
 type UploadConfig struct {
-	Network  netconf.ID
-	NodeName string
-	Type     Type
+	Network netconf.ID
+	Name    string
+	Type    Type
 }
 
 // UploadNew generates a new key and uploads it to the gcp secret manager.
@@ -33,21 +33,21 @@ func UploadNew(ctx context.Context, cfg UploadConfig) (Key, error) {
 
 	// TODO(corver): Delete or overwrite existing key with matching labels.
 
-	name := secretName(cfg.Network, cfg.NodeName, cfg.Type, addr)
-	if err := createGCPSecret(ctx, name, k.Bytes(), nil); err != nil {
+	secret := secretName(cfg.Network, cfg.Name, cfg.Type, addr)
+	if err := createGCPSecret(ctx, secret, k.Bytes(), nil); err != nil {
 		return Key{}, errors.Wrap(err, "upload key")
 	}
 
-	log.Info(ctx, "🔐 Key uploaded: "+name, "address", addr, "type", cfg.Type, "network", cfg.Network, "node", cfg.NodeName)
+	log.Info(ctx, "🔐 Key uploaded: "+secret, "address", addr, "type", cfg.Type, "network", cfg.Network, "secret", cfg.Name)
 
 	return k, nil
 }
 
 // Download retrieves a key from the gcp secret manager.
-func Download(ctx context.Context, network netconf.ID, node string, typ Type, addr string) (Key, error) {
-	bz, err := getGCPSecret(ctx, secretName(network, node, typ, addr))
+func Download(ctx context.Context, network netconf.ID, name string, typ Type, addr string) (Key, error) {
+	bz, err := getGCPSecret(ctx, secretName(network, name, typ, addr))
 	if err != nil {
-		return Key{}, errors.Wrap(err, "download key", "network", network, "node", node, "type", typ, "addr", addr)
+		return Key{}, errors.Wrap(err, "download key", "network", network, "name", name, "type", typ, "addr", addr)
 	}
 
 	k, err := FromBytes(typ, bz)
@@ -66,6 +66,6 @@ func Download(ctx context.Context, network netconf.ID, node string, typ Type, ad
 }
 
 // secretName returns the name of the secret in the gcp secret manager.
-func secretName(network netconf.ID, node string, typ Type, addr string) string {
-	return network.String() + "-" + node + "-" + typ.String() + "-" + addr
+func secretName(network netconf.ID, name string, typ Type, addr string) string {
+	return network.String() + "-" + name + "-" + typ.String() + "-" + addr
 }

--- a/e2e/app/monitor.go
+++ b/e2e/app/monitor.go
@@ -17,7 +17,7 @@ import (
 )
 
 func LogMetrics(ctx context.Context, def Definition) error {
-	extNetwork := externalNetwork(def.Testnet, def.Netman().DeployInfo())
+	extNetwork := externalNetwork(def)
 
 	// Pick a random node to monitor.
 
@@ -40,7 +40,7 @@ func StartMonitoringReceipts(ctx context.Context, def Definition) func() error {
 		return func() error { return errors.Wrap(err, "getting client") }
 	}
 
-	network := externalNetwork(def.Testnet, def.Netman().DeployInfo())
+	network := externalNetwork(def)
 	cProvider := cprovider.NewABCIProvider(client, network.ChainNamesByIDs())
 	xProvider := xprovider.New(network, def.Backends().RPCClients(), cProvider)
 	cChainID := def.Testnet.Network.Static().OmniConsensusChainIDUint64()

--- a/e2e/app/test.go
+++ b/e2e/app/test.go
@@ -5,7 +5,6 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/omni-network/omni/e2e/types"
 	"github.com/omni-network/omni/lib/errors"
 	"github.com/omni-network/omni/lib/log"
 	"github.com/omni-network/omni/lib/netconf"
@@ -14,9 +13,9 @@ import (
 )
 
 // Test runs test cases under tests/.
-func Test(ctx context.Context, def Definition, deployInfo types.DeployInfos, verbose bool) error {
+func Test(ctx context.Context, def Definition, verbose bool) error {
 	log.Info(ctx, "Running tests in ./test/...")
-	extNetwork := externalNetwork(def.Testnet, def.Netman().DeployInfo())
+	extNetwork := externalNetwork(def)
 
 	networkDir, err := os.MkdirTemp("", "omni-e2e")
 	if err != nil {
@@ -57,7 +56,7 @@ func Test(ctx context.Context, def Definition, deployInfo types.DeployInfos, ver
 	}
 
 	deployInfoFile := filepath.Join(networkDir, "deployinfo.json")
-	if err := deployInfo.Save(deployInfoFile); err != nil {
+	if err := def.DeployInfos().Save(deployInfoFile); err != nil {
 		return errors.Wrap(err, "saving deployinfo")
 	}
 	if err = os.Setenv("E2E_DEPLOY_INFO", deployInfoFile); err != nil {

--- a/e2e/app/valupdates.go
+++ b/e2e/app/valupdates.go
@@ -33,7 +33,7 @@ func FundValidatorsForTesting(ctx context.Context, def Definition) error {
 
 	log.Info(ctx, "Funding validators for testing")
 
-	network := externalNetwork(def.Testnet, def.Netman().DeployInfo())
+	network := externalNetwork(def)
 	omniEVM, _ := network.OmniEVMChain()
 	funder := def.Netman().Operator()
 	_, fundBackend, err := def.Backends().BindOpts(ctx, omniEVM.ID, funder)
@@ -103,7 +103,7 @@ func StartValidatorUpdates(ctx context.Context, def Definition) func() error {
 		})
 
 		// Create a backend to trigger deposits from
-		network := externalNetwork(def.Testnet, def.Netman().DeployInfo())
+		network := externalNetwork(def)
 		omniEVM, _ := network.OmniEVMChain()
 		ethCl, err := ethclient.Dial(omniEVM.Name, omniEVM.RPCURL)
 		if err != nil {

--- a/e2e/cmd/flags.go
+++ b/e2e/cmd/flags.go
@@ -11,11 +11,12 @@ import (
 )
 
 func bindDefFlags(flags *pflag.FlagSet, cfg *app.DefinitionConfig) {
+	var void string
 	flags.StringVarP(&cfg.ManifestFile, "manifest-file", "f", cfg.ManifestFile, "path to manifest file")
 	flags.StringVar(&cfg.InfraProvider, "infra", cfg.InfraProvider, "infrastructure provider: docker, vmcompose")
 	flags.StringVar(&cfg.InfraDataFile, "infra-file", cfg.InfraDataFile, "infrastructure data file (not required for docker provider)")
 	flags.StringVar(&cfg.DeployKeyFile, "deploy-key", cfg.DeployKeyFile, "path to deploy private key file")
-	flags.StringVar(&cfg.RelayerKeyFile, "relayer-key", cfg.RelayerKeyFile, "path to relayer private key file")
+	flags.StringVar(&void, "relayer-key", "", "DEPRECATED. Not used") // TODO(corver): Remove once ops repo updated.
 	flags.StringVar(&cfg.FireAPIKey, "fireblocks-api-key", cfg.FireAPIKey, "FireBlocks api key")
 	flags.StringVar(&cfg.FireKeyPath, "fireblocks-key-path", cfg.FireKeyPath, "FireBlocks RSA private key path")
 	flags.StringVar(&cfg.OmniImgTag, "omni-image-tag", cfg.OmniImgTag, "Omni docker images tag (halo, relayer). Defaults to working dir git commit.")
@@ -44,9 +45,9 @@ func bindCreate3DeployFlags(flags *pflag.FlagSet, cfg *app.Create3DeployConfig) 
 }
 
 func bindKeyCreateFlags(cmd *cobra.Command, cfg *key.UploadConfig) {
-	cmd.Flags().StringVar(&cfg.NodeName, "node", cfg.NodeName, "node name")
-	cmd.Flags().StringVar((*string)(&cfg.Type), "type", string(cfg.Type), "key type: validator, p2p_execution, p2p_consensus")
+	cmd.Flags().StringVar(&cfg.Name, "name", cfg.Name, "key name: either node name or eoa account type")
+	cmd.Flags().StringVar((*string)(&cfg.Type), "type", string(cfg.Type), "key type: validator, p2p_execution, p2p_consensus, eoa")
 
-	_ = cmd.MarkFlagRequired("node")
+	_ = cmd.MarkFlagRequired("name")
 	_ = cmd.MarkFlagRequired("type")
 }

--- a/e2e/netman/manager.go
+++ b/e2e/netman/manager.go
@@ -2,8 +2,6 @@ package netman
 
 import (
 	"context"
-	"crypto/ecdsa"
-	"math/big"
 
 	"github.com/omni-network/omni/contracts/bindings"
 	"github.com/omni-network/omni/e2e/types"
@@ -14,20 +12,12 @@ import (
 	"github.com/omni-network/omni/lib/forkjoin"
 	"github.com/omni-network/omni/lib/log"
 	"github.com/omni-network/omni/lib/netconf"
-	"github.com/omni-network/omni/lib/txmgr"
 
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/crypto"
-	"github.com/ethereum/go-ethereum/params"
 )
 
 //nolint:gochecknoglobals // Static mapping.
 var (
-	// this must be different than netman.Operator(), otherwise the txmgr nonce
-	// get's out of sync, because the relayer TXMgr and the operator TXMgr are running
-	// in separate services.
-	privateRelayerKey = anvil.DevPrivateKey5()
-
 	// fbDev is the address of the fireblocks "dev" account.
 	fbDev = common.HexToAddress("0x7a6cF389082dc698285474976d7C75CAdE08ab7e")
 )
@@ -47,14 +37,11 @@ type Manager interface {
 	// Portals returns the deployed portals from both public and private chains.
 	Portals() map[uint64]Portal
 
-	// RelayerKey returns the relayer private key hex.
-	RelayerKey() *ecdsa.PrivateKey
-
 	// Operator returns the address of the account that operates the network.
 	Operator() common.Address
 }
 
-func NewManager(testnet types.Testnet, backends ethbackend.Backends, relayerKeyFile string) (Manager, error) {
+func NewManager(testnet types.Testnet, backends ethbackend.Backends) (Manager, error) {
 	if testnet.OnlyMonitor {
 		if testnet.Network != netconf.Testnet {
 			return nil, errors.New("the AVS contract is currently only deployed to testnet")
@@ -99,53 +86,41 @@ func NewManager(testnet types.Testnet, backends ethbackend.Backends, relayerKeyF
 	}
 	// Add all public chains
 	for _, public := range testnet.PublicChains {
+		// Public chain deploy height and address may be statically populated.
+		staticDeploy, _ := testnet.Network.Static().PortalDeployment(public.Chain().ID)
 		portals[public.Chain().ID] = Portal{
 			Chain: public.Chain(),
-			// Public chain deploy height and address will be updated by DeployPublicPortals.
+			DeployInfo: DeployInfo{
+				PortalAddress: staticDeploy.Address,
+				DeployHeight:  staticDeploy.DeployHeight,
+			},
 		}
 	}
 
 	switch testnet.Network {
 	case netconf.Devnet:
-		if relayerKeyFile != "" {
-			return nil, errors.New("relayer keys not supported in devnet")
-		}
-
 		return &manager{
 			portals:     portals,
 			omniChainID: netconf.Devnet.Static().OmniExecutionChainID,
-			relayerKey:  privateRelayerKey,
 			backends:    backends,
 			network:     netconf.Devnet,
 			operator:    anvil.DevAccount4(),
 		}, nil
 	case netconf.Staging:
-		relayerKey, err := crypto.LoadECDSA(relayerKeyFile)
-		if err != nil {
-			return nil, errors.Wrap(err, "read relayer key file", "path", relayerKeyFile)
-		}
-
 		return &manager{
 			portals:     portals,
 			omniChainID: netconf.Staging.Static().OmniExecutionChainID,
-			relayerKey:  relayerKey,
 			backends:    backends,
 			network:     netconf.Staging,
 			operator:    fbDev,
 		}, nil
 	case netconf.Testnet:
-		relayerKey, err := crypto.LoadECDSA(relayerKeyFile)
-		if err != nil {
-			return nil, errors.Wrap(err, "read relayer key file", "path", relayerKeyFile)
-		}
-
 		return &manager{
 			portals:     portals,
 			omniChainID: netconf.Testnet.Static().OmniExecutionChainID,
 			backends:    backends,
 			network:     netconf.Testnet,
 			operator:    fbDev,
-			relayerKey:  relayerKey,
 		}, nil
 	default:
 		return nil, errors.New("unknown network", "network", network)
@@ -170,7 +145,6 @@ var _ Manager = (*manager)(nil)
 type manager struct {
 	portals     map[uint64]Portal // Note that this is mutable, Portals are updated by Deploy*Portals.
 	omniChainID uint64
-	relayerKey  *ecdsa.PrivateKey
 	backends    ethbackend.Backends
 	network     netconf.ID
 	operator    common.Address
@@ -187,10 +161,6 @@ func (m *manager) DeployInfo() map[types.EVMChain]DeployInfo {
 
 func (m *manager) DeployPublicPortals(ctx context.Context, valSetID uint64, validators []bindings.Validator,
 ) error {
-	if m.relayerKey == nil {
-		return errors.New("relayer key is nil")
-	}
-
 	// Log provided key balances for public chains (just FYI).
 	for _, portal := range m.portals {
 		if !portal.Chain.IsPublic {
@@ -203,11 +173,6 @@ func (m *manager) DeployPublicPortals(ctx context.Context, valSetID uint64, vali
 		}
 
 		if err := logBalance(ctx, backend, portal.Chain.Name, txOpts.From, "operator_key"); err != nil {
-			return err
-		}
-
-		relayerAddr := crypto.PubkeyToAddress(m.relayerKey.PublicKey)
-		if err := logBalance(ctx, backend, portal.Chain.Name, relayerAddr, "relayer_key"); err != nil {
 			return err
 		}
 	}
@@ -325,62 +290,15 @@ func (m *manager) DeployPrivatePortals(ctx context.Context, valSetID uint64, val
 		m.portals[res.Input.Chain.ID] = portal
 	}
 
-	return m.fundPrivateRelayer(ctx)
+	return nil
 }
 
 func (m *manager) Portals() map[uint64]Portal {
 	return m.portals
 }
 
-func (m *manager) RelayerKey() *ecdsa.PrivateKey {
-	return m.relayerKey
-}
-
 func (m *manager) Operator() common.Address {
 	return m.operator
-}
-
-func (m *manager) fundPrivateRelayer(ctx context.Context) error {
-	if privateRelayerKey.Equal(m.relayerKey) {
-		return nil // No need to fund relayer if key is private.
-	}
-
-	relayerAddr := crypto.PubkeyToAddress(m.relayerKey.PublicKey)
-
-	for _, portal := range m.portals {
-		if portal.Chain.IsPublic {
-			continue // We use relayer key for public chain, it should already be funded.
-		}
-
-		backend, err := m.backends.Backend(portal.Chain.ID)
-		if err != nil {
-			return errors.Wrap(err, "backend", "chain", portal.Chain.Name)
-		}
-
-		pctx := log.WithCtx(ctx, "chain", portal.Chain.Name)
-
-		bal, err := backend.BalanceAt(pctx, m.operator, nil)
-		if err != nil {
-			return err
-		}
-		b, _ := bal.Float64()
-
-		log.Info(pctx, "Funding relayer operator balance", "balance", b/params.Ether, "operator", m.operator.Hex())
-		// TODO(corver): Remove this debug log
-
-		tx, _, err := backend.Send(pctx, m.operator, txmgr.TxCandidate{
-			To:       &relayerAddr,
-			GasLimit: 100_000,                                                    // 100k is fine,
-			Value:    new(big.Int).Mul(big.NewInt(10), big.NewInt(params.Ether)), // 10 ETH
-		})
-		if err != nil {
-			return errors.Wrap(err, "send ether")
-		} else if _, err := backend.WaitMined(ctx, tx); err != nil {
-			return errors.Wrap(err, "wait mined")
-		}
-	}
-
-	return nil
 }
 
 // deployIfNeeded deploys a portal if it is not already deployed.
@@ -400,7 +318,7 @@ func (m *manager) deployIfNeeded(ctx context.Context, chain types.EVMChain, back
 		return common.Address{}, 0, errors.Wrap(err, "is deployed", "chain", chain)
 	}
 
-	hasStatic := m.network.Static().HasPortalDeployment(chain.ID)
+	staticDeploy, hasStatic := m.network.Static().PortalDeployment(chain.ID)
 
 	// for ephemeral networks, require that the portal is not already deployed
 	if isDeployed && m.network.IsEphemeral() {
@@ -419,8 +337,7 @@ func (m *manager) deployIfNeeded(ctx context.Context, chain types.EVMChain, back
 
 	// if the static deployment is set, return it
 	if hasStatic {
-		dep := m.network.Static().PortalDeployment(chain.ID)
-		return dep.Address, dep.DeployHeight, nil
+		return staticDeploy.Address, staticDeploy.DeployHeight, nil
 	}
 
 	// at this point, we need to deploy the portal

--- a/e2e/types/chain.go
+++ b/e2e/types/chain.go
@@ -4,7 +4,6 @@ import (
 	"time"
 
 	"github.com/omni-network/omni/lib/chainids"
-	"github.com/omni-network/omni/lib/contracts"
 	"github.com/omni-network/omni/lib/errors"
 	"github.com/omni-network/omni/lib/netconf"
 )
@@ -19,12 +18,11 @@ var (
 	}
 
 	chainHolesky = EVMChain{
-		Name:               "holesky",
-		ID:                 chainids.Holesky,
-		IsPublic:           true,
-		BlockPeriod:        12 * time.Second,
-		FinalizationStrat:  netconf.StratFinalized,
-		AVSContractAddress: contracts.TestnetAVS(),
+		Name:              "holesky",
+		ID:                chainids.Holesky,
+		IsPublic:          true,
+		BlockPeriod:       12 * time.Second,
+		FinalizationStrat: netconf.StratFinalized,
 	}
 
 	chainArbSepolia = EVMChain{

--- a/e2e/types/testnet.go
+++ b/e2e/types/testnet.go
@@ -13,7 +13,6 @@ import (
 
 	e2e "github.com/cometbft/cometbft/test/e2e/pkg"
 
-	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/p2p/enode"
 
@@ -87,13 +86,12 @@ func (t Testnet) HasOmniEVM() bool {
 
 // EVMChain represents a EVM chain in a omni network.
 type EVMChain struct {
-	Name               string // Chain Nam.
-	ID                 uint64 // Chain ID
-	IsPublic           bool
-	IsAVSTarget        bool
-	BlockPeriod        time.Duration
-	FinalizationStrat  netconf.FinalizationStrat
-	AVSContractAddress common.Address
+	Name              string // Chain Name
+	ID                uint64 // Chain ID
+	IsPublic          bool
+	IsAVSTarget       bool
+	BlockPeriod       time.Duration
+	FinalizationStrat netconf.FinalizationStrat
 }
 
 // OmniEVM represents a omni evm instance in a omni network. Similar to e2e.Node for halo instances.

--- a/halo/app/start_test.go
+++ b/halo/app/start_test.go
@@ -13,6 +13,7 @@ import (
 	cprovider "github.com/omni-network/omni/lib/cchain/provider"
 	"github.com/omni-network/omni/lib/log"
 	"github.com/omni-network/omni/lib/netconf"
+	"github.com/omni-network/omni/lib/tutil"
 	"github.com/omni-network/omni/lib/xchain"
 
 	rpchttp "github.com/cometbft/cometbft/rpc/client/http"
@@ -128,7 +129,7 @@ func setupSimnet(t *testing.T) haloapp.Config {
 		Network: netconf.Simnet,
 		Cosmos:  true,
 	})
-	require.NoError(t, err)
+	tutil.RequireNoError(t, err)
 
 	// CometBFT doesn't shutdown cleanly. It leaves goroutines running that write to disk.
 	// The test sometimes fails with: TempDir RemoveAll cleanup: unlinkat ... directory not empty

--- a/halo/cmd/init.go
+++ b/halo/cmd/init.go
@@ -21,6 +21,8 @@ import (
 	"github.com/cometbft/cometbft/privval"
 	"github.com/cometbft/cometbft/types"
 
+	"github.com/ethereum/go-ethereum/common"
+
 	"github.com/spf13/cobra"
 )
 
@@ -188,15 +190,18 @@ func InitFiles(ctx context.Context, initCfg InitConfig) error {
 	if cmtos.FileExists(networkFile) {
 		log.Info(ctx, "Found network config", "path", networkFile)
 	} else if initCfg.Network == netconf.Simnet {
+		dummyAddr := common.HexToAddress("0x000000000000000000000000000000000000dead")
+
 		// Create a simnet (single binary with mocked clients).
 		network := netconf.Network{
 			ID: initCfg.Network,
 			Chains: []netconf.Chain{
 				{
-					ID:          initCfg.Network.Static().OmniExecutionChainID,
-					Name:        "omni_evm",
-					IsOmniEVM:   true,
-					BlockPeriod: time.Millisecond * 500, // Speed up block times for testing
+					ID:            initCfg.Network.Static().OmniExecutionChainID,
+					Name:          "omni_evm",
+					IsOmniEVM:     true,
+					BlockPeriod:   time.Millisecond * 500, // Speed up block times for testing
+					PortalAddress: dummyAddr,
 				},
 				{
 					ID:              initCfg.Network.Static().OmniConsensusChainIDUint64(),
@@ -204,18 +209,21 @@ func InitFiles(ctx context.Context, initCfg InitConfig) error {
 					IsOmniConsensus: true,
 					DeployHeight:    1,                      // Validator sets start at height 1, not 0.
 					BlockPeriod:     time.Millisecond * 500, // Speed up block times for testing
+					PortalAddress:   dummyAddr,
 				},
 				{
-					ID:         100, // todo(Lazar): make it dynamic. this is coming from lib/xchain/provider/mock.go
-					Name:       "chain_a",
-					IsOmniEVM:  false,
-					IsEthereum: false,
+					ID:            100, // todo(Lazar): make it dynamic. this is coming from lib/xchain/provider/mock.go
+					Name:          "chain_a",
+					IsOmniEVM:     false,
+					IsEthereum:    false,
+					PortalAddress: dummyAddr,
 				},
 				{
-					ID:         200, // todo(Lazar): make it dynamic. this is coming from lib/xchain/provider/mock.go
-					Name:       "chain_b",
-					IsOmniEVM:  false,
-					IsEthereum: false,
+					ID:            200, // todo(Lazar): make it dynamic. this is coming from lib/xchain/provider/mock.go
+					Name:          "chain_b",
+					IsOmniEVM:     false,
+					IsEthereum:    false,
+					PortalAddress: dummyAddr,
 				},
 			},
 		}

--- a/halo/genutil/evm/evm.go
+++ b/halo/genutil/evm/evm.go
@@ -3,7 +3,9 @@ package evm
 import (
 	"math/big"
 
+	"github.com/omni-network/omni/e2e/app/eoa"
 	"github.com/omni-network/omni/halo/genutil/evm/predeploys"
+	"github.com/omni-network/omni/lib/anvil"
 	"github.com/omni-network/omni/lib/errors"
 	"github.com/omni-network/omni/lib/netconf"
 
@@ -93,16 +95,20 @@ func precompilesAlloc() types.GenesisAlloc {
 func stagingPrefundAlloc() types.GenesisAlloc {
 	return types.GenesisAlloc{
 		// anvil pre-funded accounts
-		common.HexToAddress("0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266"): {Balance: eth1m},
-		common.HexToAddress("0x70997970C51812dc3A010C7d01b50e0d17dc79C8"): {Balance: eth1m},
-		common.HexToAddress("0x3C44CdDdB6a900fa2b585dd299e03d12FA4293BC"): {Balance: eth1m},
-		common.HexToAddress("0x90F79bf6EB2c4f870365E785982E1f101E93b906"): {Balance: eth1m},
-		common.HexToAddress("0x15d34AAf54267DB7D7c367839AAf71A00a2C6A65"): {Balance: eth1m},
-		common.HexToAddress("0x9965507D1a55bcC2695C58ba16FB37d819B0A4dc"): {Balance: eth1m},
-		common.HexToAddress("0x976EA74026E726554dB657fA54763abd0C3a0aa9"): {Balance: eth1m},
-		common.HexToAddress("0x14dC79964da2C08b23698B3D3cc7Ca32193d9955"): {Balance: eth1m},
-		common.HexToAddress("0x23618e81E3f5cdF7f54C3d65f7FBc0aBf5B21E8f"): {Balance: eth1m},
-		common.HexToAddress("0xa0Ee7A142d267C1f36714E4a8F75612F20a79720"): {Balance: eth1m},
+		anvil.DevAccount0(): {Balance: eth1m},
+		anvil.DevAccount1(): {Balance: eth1m},
+		anvil.DevAccount2(): {Balance: eth1m},
+		anvil.DevAccount3(): {Balance: eth1m},
+		anvil.DevAccount4(): {Balance: eth1m},
+		anvil.DevAccount5(): {Balance: eth1m},
+		anvil.DevAccount6(): {Balance: eth1m},
+		anvil.DevAccount7(): {Balance: eth1m},
+		anvil.DevAccount8(): {Balance: eth1m},
+		anvil.DevAccount9(): {Balance: eth1m},
+
+		// Relayer and Monitor EOAs
+		eoa.MustAddress(netconf.Staging, eoa.TypeMonitor): {Balance: eth1m},
+		eoa.MustAddress(netconf.Staging, eoa.TypeRelayer): {Balance: eth1m},
 
 		// team ops accounts
 		common.HexToAddress("0xfE921e06Ed0a22c035b4aCFF0A5D3a434A330c96"): {Balance: eth1m}, // dev relayer (local)

--- a/lib/netconf/netconf.go
+++ b/lib/netconf/netconf.go
@@ -177,6 +177,15 @@ func Load(path string) (Network, error) {
 
 // Save saves the network configuration to the given path.
 func Save(network Network, path string) error {
+	for _, chain := range network.Chains {
+		if chain.IsOmniConsensus {
+			continue
+		}
+		if chain.PortalAddress == (common.Address{}) {
+			return errors.New("empty portal address", "chain", chain.Name)
+		}
+	}
+
 	bz, err := json.MarshalIndent(network, "", "  ")
 	if err != nil {
 		return errors.Wrap(err, "marshal network config file")
@@ -194,13 +203,13 @@ type chainJSON struct {
 	Name              string            `json:"name"`
 	RPCURL            string            `json:"rpcurl"`
 	AuthRPCURL        string            `json:"auth_rpcurl,omitempty"`
-	PortalAddress     string            `json:"portal_address,omitempty"`
+	PortalAddress     string            `json:"portal_address"`
 	DeployHeight      uint64            `json:"deploy_height"`
 	IsOmniEVM         bool              `json:"is_omni_evm,omitempty"`
 	IsOmniConsensus   bool              `json:"is_omni_consensus,omitempty"`
 	IsEthereum        bool              `json:"is_ethereum,omitempty"`
 	BlockPeriod       string            `json:"block_period"`
-	FinalizationStrat FinalizationStrat `json:"finalization_start,omitempty"`
+	FinalizationStrat FinalizationStrat `json:"finalization_start"`
 	AVSContractAddr   string            `json:"avs_contract_address,omitempty"`
 }
 

--- a/lib/netconf/static.go
+++ b/lib/netconf/static.go
@@ -42,27 +42,16 @@ func (s Static) OmniConsensusChainIDUint64() uint64 {
 	return consensusIDOffset + s.OmniExecutionChainID
 }
 
-// PortalDeployments returns the portal deployment for the given chainID.
+// PortalDeployment returns the portal deployment for the given chainID.
 // If there is none, it returns an empty deployment.
-func (Static) PortalDeployment(chainID uint64) Deployment {
-	for _, d := range statics[Testnet].Portals {
+func (s Static) PortalDeployment(chainID uint64) (Deployment, bool) {
+	for _, d := range s.Portals {
 		if d.ChainID == chainID {
-			return d
+			return d, true
 		}
 	}
 
-	return Deployment{}
-}
-
-// HasPortalDeployment returns true if there is a portal deployment for the given chainID.
-func (Static) HasPortalDeployment(chainID uint64) bool {
-	for _, d := range statics[Testnet].Portals {
-		if d.ChainID == chainID {
-			return true
-		}
-	}
-
-	return false
+	return Deployment{}, false
 }
 
 // Use random runid for version in ephemeral networks.

--- a/monitor/app/app.go
+++ b/monitor/app/app.go
@@ -39,6 +39,10 @@ func Run(ctx context.Context, cfg Config) error {
 		return errors.Wrap(err, "start load generator")
 	}
 
+	if err := startAVSSync(ctx, cfg, network); err != nil {
+		return errors.Wrap(err, "start AVS sync")
+	}
+
 	select {
 	case <-ctx.Done():
 		log.Info(ctx, "Shutdown detected, stopping...")

--- a/monitor/app/avssync.go
+++ b/monitor/app/avssync.go
@@ -1,0 +1,97 @@
+package monitor
+
+import (
+	"context"
+	"time"
+
+	"github.com/omni-network/omni/contracts/bindings"
+	"github.com/omni-network/omni/lib/errors"
+	"github.com/omni-network/omni/lib/ethclient"
+	"github.com/omni-network/omni/lib/ethclient/ethbackend"
+	"github.com/omni-network/omni/lib/log"
+	"github.com/omni-network/omni/lib/netconf"
+
+	"github.com/ethereum/go-ethereum/common"
+	ethcrypto "github.com/ethereum/go-ethereum/crypto"
+)
+
+// startAVSSync starts a forever-loop that calls `OmniAVS.SyncWithOmni` once per day.
+// This results in a xmsg from the AVS contract to the OmniRestaking contract with the latest Eigen delegations.
+func startAVSSync(ctx context.Context, cfg Config, network netconf.Network) error {
+	privateKey, err := ethcrypto.LoadECDSA(cfg.PrivateKey)
+	if err != nil {
+		return errors.Wrap(err, "failed to load private key")
+	}
+
+	ethL1, ok := network.EthereumChain()
+	if !ok {
+		log.Warn(ctx, "Not syncing avs since no ethereum chain defined", nil)
+		return nil
+	} else if ethL1.AVSContractAddr == (common.Address{}) {
+		log.Warn(ctx, "Not syncing avs since AVSContractAddr empty", nil)
+		return nil
+	}
+
+	ethCl, err := ethclient.Dial(ethL1.Name, ethL1.RPCURL)
+	if err != nil {
+		return errors.Wrap(err, "dial ethereum chain")
+	}
+
+	backend, err := ethbackend.NewBackend(ethL1.Name, ethL1.ID, ethL1.BlockPeriod, ethCl)
+	if err != nil {
+		return err
+	}
+
+	from, err := backend.AddAccount(privateKey)
+	if err != nil {
+		return err
+	}
+
+	omniAVS, err := bindings.NewOmniAVS(ethL1.AVSContractAddr, backend)
+	if err != nil {
+		return errors.Wrap(err, "new omni portal")
+	}
+
+	go syncAVSForever(ctx, omniAVS, backend, from)
+
+	return nil
+}
+
+func syncAVSForever(ctx context.Context, omniAVS *bindings.OmniAVS, backend *ethbackend.Backend, from common.Address) {
+	timer := time.NewTimer(time.Hour)
+	defer timer.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+		case <-timer.C:
+			err := syncAVSOnce(ctx, omniAVS, backend, from)
+			if err != nil {
+				log.Warn(ctx, "Syncing avs failed (will retry)", err)
+				timer.Reset(time.Hour)
+			} else {
+				timer.Reset(time.Hour * 24)
+			}
+		}
+	}
+}
+
+func syncAVSOnce(ctx context.Context, omniAVS *bindings.OmniAVS, backend *ethbackend.Backend, from common.Address) error {
+	txOpts, err := backend.BindOpts(ctx, from)
+	if err != nil {
+		return err
+	}
+
+	tx, err := omniAVS.SyncWithOmni(txOpts)
+	if err != nil {
+		return errors.Wrap(err, "sync with omni")
+	}
+
+	if _, err := backend.WaitMined(ctx, tx); err != nil {
+		return errors.Wrap(err, "wait mined")
+	}
+
+	log.Info(ctx, "Successfully synced AVS with omni")
+
+	return nil
+}

--- a/monitor/app/config.go
+++ b/monitor/app/config.go
@@ -17,12 +17,14 @@ import (
 type Config struct {
 	NetworkFile    string
 	MonitoringAddr string
+	PrivateKey     string
 
 	LoadGen loadgen.Config
 }
 
 func DefaultConfig() Config {
 	return Config{
+		PrivateKey:     "monitor.key",
 		NetworkFile:    "network.json",
 		MonitoringAddr: ":26660",
 	}

--- a/monitor/app/config.toml.tpl
+++ b/monitor/app/config.toml.tpl
@@ -9,6 +9,9 @@ version = "{{ .Version}}"
 ###                         Monitor Options                         ###
 #######################################################################
 
+# Path to the ethereum private key used to sign avs omni sync transactions.
+private-key = "{{ .PrivateKey }}"
+
 # The path to the Omni network configuration file.
 network-file = "{{ .NetworkFile }}"
 

--- a/monitor/app/testdata/default_monitor.toml
+++ b/monitor/app/testdata/default_monitor.toml
@@ -9,6 +9,9 @@ version = "v0.1.2"
 ###                         Monitor Options                         ###
 #######################################################################
 
+# Path to the ethereum private key used to sign avs omni sync transactions.
+private-key = "monitor.key"
+
 # The path to the Omni network configuration file.
 network-file = "network.json"
 

--- a/monitor/cmd/flags.go
+++ b/monitor/cmd/flags.go
@@ -8,6 +8,7 @@ import (
 )
 
 func bindRunFlags(flags *pflag.FlagSet, cfg *monitor.Config) {
+	flags.StringVar(&cfg.PrivateKey, "private-key", cfg.PrivateKey, "The path to the private key e.g path/private.key")
 	flags.StringVar(&cfg.NetworkFile, "network-file", cfg.NetworkFile, "The path to the network file e.g path/network.json")
 	flags.StringVar(&cfg.MonitoringAddr, "monitoring-addr", cfg.MonitoringAddr, "The address to bind the monitoring server")
 }


### PR DESCRIPTION
Introduces GCP based EOA keys:
 - Add a eoa key to monitor service
 - Use it to call `omniAVM.SyncToOmni` once per day.
 - Remove relayer-key flag from e2e app and from netman.
 - Move it and monitor key to `eoa` package.
 - Use GCP based keys (or anvil key for devnet)
 - Add eoa keys to devnet and staging genesis.
 - Fund eoa keys for anvil.
 - Remove deployInfo froms Deploy results
 - Move it to app.Definition, where it uses deterministic netman and avs contract addrs.

task: none