### PR TITLE
chore(lib/contracts): use legacy tx for create3 proxy admin deployments

### DIFF
--- a/lib/contracts/proxyadmin/deploy.go
+++ b/lib/contracts/proxyadmin/deploy.go
@@ -187,6 +187,15 @@ func deploy(ctx context.Context, cfg DeploymentConfig, backend *ethbackend.Backe
 		return common.Address{}, nil, errors.Wrap(err, "pack init code")
 	}
 
+	// Suggest gas price - thise forces bindings to use legacy txns.
+	// Some chains (i.e. arbitrum) struggle with proper dynamic tx gas
+	// estimation for create3 deployments. Using legacy txns is a workaround.
+	gasPrice, err := backend.SuggestGasPrice(ctx)
+	if err != nil {
+		return common.Address{}, nil, errors.Wrap(err, "suggest gas price")
+	}
+	txOpts.GasPrice = gasPrice
+
 	tx, err := factory.Deploy(txOpts, salt, initCode)
 	if err != nil {
 		return common.Address{}, nil, errors.Wrap(err, "deploy proxy admin")


### PR DESCRIPTION
Use legacy txns for create3 proxy admin deployment. 

task: none