### PR TITLE
ci(e2e): use proper testnet relayer key

### DIFF
--- a/e2e/app/eoa/eoa.go
+++ b/e2e/app/eoa/eoa.go
@@ -70,12 +70,6 @@ func PrivateKey(ctx context.Context, network netconf.ID, typ Type) (*ecdsa.Priva
 		return devnetKeys[typ], nil
 	}
 
-	// TODO(corver): Remove this workaround once the new testnet relayer key is funded.
-	// For now we keep on using the same staging key for testnet.
-	if network == netconf.Testnet && typ == TypeRelayer {
-		network = netconf.Staging
-	}
-
 	addr, ok := secureAddrs[network][typ]
 	if !ok {
 		return nil, errors.New("eoa key not defined", "network", network, "type", typ)

--- a/lib/txmgr/txmgr.go
+++ b/lib/txmgr/txmgr.go
@@ -351,8 +351,6 @@ func (m *simple) sendTx(ctx context.Context, tx *types.Transaction) (*types.Rece
 // publishTx publishes the transaction to the transaction pool. If it receives any underpriced errors
 // it will bump the fees and retry.
 // Returns the latest fee bumped tx, and a boolean indicating whether the tx was sent or not.
-//
-
 func (m *simple) publishTx(ctx context.Context, tx *types.Transaction, sendState *SendState,
 	bumpFeesImmediately bool) (*types.Transaction, bool) {
 	for {


### PR DESCRIPTION
Testnet EOAs have been manually funded. Use them.

task: none