### PR TITLE
ci(e2e): improve upgrade command

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -76,6 +76,10 @@
       "path": "detect_secrets.filters.allowlist.is_line_allowlisted"
     },
     {
+      "path": "detect_secrets.filters.common.is_baseline_file",
+      "filename": ".secrets.baseline"
+    },
+    {
       "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
       "min_level": 2
     },
@@ -197,14 +201,14 @@
         "filename": "e2e/app/run.go",
         "hashed_secret": "7c1a7493a09f09e4669f6b1f03719a2262e7b323",
         "is_verified": false,
-        "line_number": 21
+        "line_number": 22
       },
       {
         "type": "Secret Keyword",
         "filename": "e2e/app/run.go",
         "hashed_secret": "fe86558143c0bd528f649a153bdc32b8fa90301c",
         "is_verified": false,
-        "line_number": 134
+        "line_number": 135
       }
     ],
     "e2e/app/setup.go": [
@@ -851,5 +855,5 @@
       }
     ]
   },
-  "generated_at": "2024-04-08T15:37:42Z"
+  "generated_at": "2024-04-09T09:56:45Z"
 }

--- a/e2e/app/run.go
+++ b/e2e/app/run.go
@@ -6,6 +6,7 @@ import (
 	"github.com/omni-network/omni/contracts/bindings"
 	"github.com/omni-network/omni/e2e/app/agent"
 	"github.com/omni-network/omni/e2e/netman/pingpong"
+	"github.com/omni-network/omni/e2e/types"
 	"github.com/omni-network/omni/lib/errors"
 	"github.com/omni-network/omni/lib/k1util"
 	"github.com/omni-network/omni/lib/log"
@@ -222,12 +223,12 @@ func E2ETest(ctx context.Context, def Definition, cfg E2ETestConfig, secrets age
 
 // Upgrade generates all local artifacts, but only copies the docker-compose file to the VMs.
 // It them calls docker-compose up.
-func Upgrade(ctx context.Context, def Definition, cfg DeployConfig) error {
+func Upgrade(ctx context.Context, def Definition, cfg DeployConfig, upgradeCfg types.UpgradeConfig) error {
 	if err := Setup(ctx, def, agent.Secrets{}, false, cfg.ExplorerDB); err != nil {
 		return err
 	}
 
-	return def.Infra.Upgrade(ctx)
+	return def.Infra.Upgrade(ctx, upgradeCfg)
 }
 
 // toPortalValidators returns the provided validator set as a lice of portal validators.

--- a/e2e/cmd/cmd.go
+++ b/e2e/cmd/cmd.go
@@ -8,6 +8,7 @@ import (
 	"github.com/omni-network/omni/e2e/app/agent"
 	"github.com/omni-network/omni/e2e/app/eoa"
 	"github.com/omni-network/omni/e2e/app/key"
+	"github.com/omni-network/omni/e2e/types"
 	libcmd "github.com/omni-network/omni/lib/cmd"
 	"github.com/omni-network/omni/lib/errors"
 	"github.com/omni-network/omni/lib/log"
@@ -146,16 +147,18 @@ func newTestCmd(def *app.Definition) *cobra.Command {
 
 func newUpgradeCmd(def *app.Definition) *cobra.Command {
 	cfg := app.DefaultDeployConfig()
+	upgradeCfg := types.DefaultUpgradeConfig()
 
 	cmd := &cobra.Command{
 		Use:   "upgrade",
 		Short: "Upgrades docker containers of a previously preserved network",
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			return app.Upgrade(cmd.Context(), *def, cfg)
+			return app.Upgrade(cmd.Context(), *def, cfg, upgradeCfg)
 		},
 	}
 
 	bindDeployFlags(cmd.Flags(), &cfg)
+	bindUpgradeFlags(cmd.Flags(), &upgradeCfg)
 
 	return cmd
 }

--- a/e2e/cmd/flags.go
+++ b/e2e/cmd/flags.go
@@ -5,6 +5,7 @@ import (
 	"github.com/omni-network/omni/e2e/app"
 	"github.com/omni-network/omni/e2e/app/agent"
 	"github.com/omni-network/omni/e2e/app/key"
+	"github.com/omni-network/omni/e2e/types"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
@@ -38,6 +39,10 @@ func bindDeployFlags(flags *pflag.FlagSet, cfg *app.DeployConfig) {
 	bindPromFlags(flags, &cfg.AgentSecrets)
 	flags.Uint64Var(&cfg.PingPongN, "ping-pong", cfg.PingPongN, "Number of ping pongs messages to send. 0 disables it")
 	flags.StringVar(&cfg.ExplorerDB, "explorer-db", cfg.ExplorerDB, "Explorer DB connection string")
+}
+
+func bindUpgradeFlags(flags *pflag.FlagSet, cfg *types.UpgradeConfig) {
+	flags.StringVar(&cfg.ServiceRegexp, "services", cfg.ServiceRegexp, "Regexp applied to services per VM. Any match results in the VM being upgraded (all services on that VM are upgraded, not only matching services)")
 }
 
 func bindCreate3DeployFlags(flags *pflag.FlagSet, cfg *app.Create3DeployConfig) {

--- a/e2e/docker/docker.go
+++ b/e2e/docker/docker.go
@@ -102,7 +102,7 @@ func (p *Provider) Setup() error {
 	return nil
 }
 
-func (*Provider) Upgrade(_ context.Context) error {
+func (*Provider) Upgrade(context.Context, types.UpgradeConfig) error {
 	return errors.New("upgrade not supported for docker provider")
 }
 

--- a/e2e/types/infra.go
+++ b/e2e/types/infra.go
@@ -7,10 +7,20 @@ import (
 	"github.com/cometbft/cometbft/test/e2e/pkg/infra"
 )
 
+func DefaultUpgradeConfig() UpgradeConfig {
+	return UpgradeConfig{
+		ServiceRegexp: ".*",
+	}
+}
+
+type UpgradeConfig struct {
+	ServiceRegexp string
+}
+
 type InfraProvider interface {
 	infra.Provider
 
-	Upgrade(ctx context.Context) error
+	Upgrade(ctx context.Context, cfg UpgradeConfig) error
 
 	// Clean deletes all containers, networks, and data on disk.
 	Clean(ctx context.Context) error

--- a/e2e/vmcompose/provider.go
+++ b/e2e/vmcompose/provider.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"sync"
 
@@ -16,6 +17,8 @@ import (
 	"github.com/omni-network/omni/lib/log"
 
 	e2e "github.com/cometbft/cometbft/test/e2e/pkg"
+
+	"golang.org/x/sync/errgroup"
 )
 
 const ProviderName = "vmcompose"
@@ -125,7 +128,7 @@ func (p *Provider) Setup() error {
 }
 
 // Upgrade copies some of the local e2e generated artifacts to the VMs and starts the docker-compose services.
-func (p *Provider) Upgrade(ctx context.Context) error {
+func (p *Provider) Upgrade(ctx context.Context, cfg types.UpgradeConfig) error {
 	log.Info(ctx, "Upgrading docker-compose on VMs", "image", p.Testnet.UpgradeVersion)
 
 	var filePaths []string
@@ -133,68 +136,103 @@ func (p *Provider) Upgrade(ctx context.Context) error {
 		filePaths = append(filePaths, filepath.Join(p.Testnet.Dir, dir, file))
 	}
 
-	// TODO(corver): Also upgrade long-lived keys if changed
-	// - validator: ensure privval_state.json and voter_state.json doesn't complain
-
 	// Include halo config
 	for _, node := range p.Testnet.Nodes {
 		addFile(node.Name, "config/halo.toml")
 		addFile(node.Name, "config/config.toml")
 		addFile(node.Name, "config/network.json")
 		addFile(node.Name, "config/jwtsecret")
+		addFile(node.Name, "config/priv_validator_key.json")
+		addFile(node.Name, "config/node_key.json")
 	}
 
 	// Include geth config
 	for _, omniEVM := range p.Testnet.OmniEVMs {
 		addFile(omniEVM.InstanceName, "config.toml")
 		addFile(omniEVM.InstanceName, "geth/jwtsecret")
+		addFile(omniEVM.InstanceName, "geth/nodekey")
 	}
 
 	// Also relayer and monitor
 	addFile("relayer", "relayer.toml")
 	addFile("relayer", "network.json")
+	addFile("relayer", "privatekey")
 	addFile("monitor", "monitor.toml")
 	addFile("monitor", "network.json")
+	addFile("monitor", "privatekey")
+
 	// TODO(corver): Add explorer stuff
 
 	addFile("prometheus", "prometheus.yml")
 
+	// Upgrade VMs in parallel
+	eg, ctx := errgroup.WithContext(ctx)
+
 	for vmName, instance := range p.Data.VMs {
-		log.Debug(ctx, "Upgrading docker-compose", "vm", vmName)
-
-		for _, filePath := range filePaths {
-			if err := copyFileToVM(ctx, vmName, filePath); err != nil {
-				return errors.Wrap(err, "copy file", "vm", vmName, "file", filePath)
+		eg.Go(func() error {
+			if !matchAny(cfg, p.Data.ServicesByInstance(instance)) {
+				log.Debug(ctx, "Skipping vm upgrade, no matching services", "vm", vmName, "regexp", cfg.ServiceRegexp)
+				return nil
 			}
-		}
+			log.Debug(ctx, "Upgrading docker-compose", "vm", vmName)
 
-		composeFile := vmComposeFile(instance.IPAddress.String())
-		if err := copyFileToVM(ctx, vmName, filepath.Join(p.Testnet.Dir, composeFile)); err != nil {
-			return errors.Wrap(err, "copy compose", "vm", vmName)
-		}
-
-		// Figure out whether we need to call "docker compose down" before "docker compose up"
-		var maybeDown string
-		if services := p.Data.ServicesByInstance(instance); containsEVM(services) {
-			if containsAnvil(services) {
-				return errors.New("cannot upgrade VM with both omni_evm and anvil containers since omni_evm needs downing and anvil cannot be restarted", "vm", vmName)
+			for _, filePath := range filePaths {
+				if err := copyFileToVM(ctx, vmName, filePath); err != nil {
+					return errors.Wrap(err, "copy file", "vm", vmName, "file", filePath)
+				}
 			}
-			maybeDown = "sudo docker compose down && "
-		}
 
-		startCmd := fmt.Sprintf("cd /omni && "+
-			"sudo mv %s %s/docker-compose.yaml && "+
-			"cd %s && "+
-			maybeDown+
-			"sudo docker compose up -d",
-			composeFile, p.Testnet.Name, p.Testnet.Name)
+			composeFile := vmComposeFile(instance.IPAddress.String())
+			if err := copyFileToVM(ctx, vmName, filepath.Join(p.Testnet.Dir, composeFile)); err != nil {
+				return errors.Wrap(err, "copy compose", "vm", vmName)
+			}
 
-		if err := execOnVM(ctx, vmName, startCmd); err != nil {
-			return errors.Wrap(err, "compose up", "vm", vmName)
-		}
+			// Figure out whether we need to call "docker compose down" before "docker compose up"
+			var maybeDown string
+			if services := p.Data.ServicesByInstance(instance); containsEVM(services) {
+				if containsAnvil(services) {
+					return errors.New("cannot upgrade VM with both omni_evm and anvil containers since omni_evm needs downing and anvil cannot be restarted", "vm", vmName)
+				}
+				maybeDown = "sudo docker compose down && "
+			}
+
+			startCmd := fmt.Sprintf("cd /omni && "+
+				"sudo mv %s %s/docker-compose.yaml && "+
+				"cd %s && "+
+				maybeDown+
+				"sudo docker compose up -d",
+				composeFile, p.Testnet.Name, p.Testnet.Name)
+
+			if err := execOnVM(ctx, vmName, startCmd); err != nil {
+				return errors.Wrap(err, "compose up", "vm", vmName)
+			}
+
+			return nil
+		})
+	}
+
+	if err := eg.Wait(); err != nil {
+		return errors.Wrap(err, "wait errgroup")
 	}
 
 	return nil
+}
+
+// matchAny returns true if the pattern matches any of the services in the services map.
+// An empty pattern returns true, matching anything.
+func matchAny(cfg types.UpgradeConfig, services map[string]bool) bool {
+	if cfg.ServiceRegexp == "" {
+		return true
+	}
+
+	for service := range services {
+		matched, _ := regexp.MatchString(cfg.ServiceRegexp, service)
+		if matched {
+			return true
+		}
+	}
+
+	return false
 }
 
 func (p *Provider) StartNodes(ctx context.Context, _ ...*e2e.Node) error {


### PR DESCRIPTION
Improve upgrade command:
- Add support for "partial upgrades" where only VMs with matching serviceRexexp is upgraded.
- Upgrade VMs in parallel.
- Also upgrade keys

task: none