### PR TITLE
ci(e2e): fix upgrade copied files

### DIFF
--- a/e2e/app/agent/prometheus.yml.tmpl
+++ b/e2e/app/agent/prometheus.yml.tmpl
@@ -14,7 +14,7 @@ remote_write:
         regex: '(.+):(\d+)'
         target_label: container
         replacement: '${1}'
-{{end }}
+{{ end }}
 
 scrape_configs:
 {{- range .ScrapeConfigs }}

--- a/e2e/app/run.go
+++ b/e2e/app/run.go
@@ -224,7 +224,7 @@ func E2ETest(ctx context.Context, def Definition, cfg E2ETestConfig, secrets age
 // Upgrade generates all local artifacts, but only copies the docker-compose file to the VMs.
 // It them calls docker-compose up.
 func Upgrade(ctx context.Context, def Definition, cfg DeployConfig, upgradeCfg types.UpgradeConfig) error {
-	if err := Setup(ctx, def, agent.Secrets{}, false, cfg.ExplorerDB); err != nil {
+	if err := Setup(ctx, def, cfg.AgentSecrets, false, cfg.ExplorerDB); err != nil {
 		return err
 	}
 

--- a/lib/netconf/static.go
+++ b/lib/netconf/static.go
@@ -121,8 +121,3 @@ func ConsensusChainIDStr2Uint64(id string) (uint64, error) {
 
 	return resp, nil
 }
-
-// Version returns the version for the given network.
-func Version(network ID) string {
-	return statics[network].Version
-}


### PR DESCRIPTION
Copy files to correct path on remove VM. Only copy applicable services. Wire agent secrets.

task: none