### PR TITLE
chore(explorer/db): removing flag for explorer db

### DIFF
--- a/e2e/docker/compose.yaml.tmpl
+++ b/e2e/docker/compose.yaml.tmpl
@@ -189,7 +189,7 @@ services:
     restart: unless-stopped
     networks:
       {{ $.NetworkName }}:
-        {{ if $.Network }}ipv4_address: 10.186.73.206{{ end }}
+        {{ if $.Network }}ipv4_address: 10.186.73.205{{ end }}
 {{ end }}
 
 {{- if .Prometheus }}

--- a/e2e/docker/docker.go
+++ b/e2e/docker/docker.go
@@ -244,7 +244,7 @@ func additionalServices(testnet types.Testnet) []string {
 		resp = append(resp, "explorer_graphql")
 	}
 
-	if testnet.ExplorerMockDB {
+	if testnet.Network.IsEphemeral() {
 		resp = append(resp, "explorer_db")
 	}
 

--- a/e2e/docker/testdata/TestComposeTemplate_empheral_network.golden
+++ b/e2e/docker/testdata/TestComposeTemplate_empheral_network.golden
@@ -188,7 +188,7 @@ services:
     restart: unless-stopped
     networks:
       test:
-        ipv4_address: 10.186.73.206
+        ipv4_address: 10.186.73.205
 
   prometheus:
     labels:

--- a/e2e/manifests/devnet2.toml
+++ b/e2e/manifests/devnet2.toml
@@ -6,7 +6,6 @@ avs_target = "mock_l1"
 multi_omni_evms = true
 prometheus = true
 explorer=true
-explorer_mock_db=true
 
 [node.validator01]
 [node.validator02]


### PR DESCRIPTION
With the flag removed we'd create the container but not start it, the check to start it also should be `network.IsEphemeral`

task: none