### PR TITLE
ci(e2e): add explorer metrics

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -76,10 +76,6 @@
       "path": "detect_secrets.filters.allowlist.is_line_allowlisted"
     },
     {
-      "path": "detect_secrets.filters.common.is_baseline_file",
-      "filename": ".secrets.baseline"
-    },
-    {
       "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
       "min_level": 2
     },
@@ -160,21 +156,21 @@
         "filename": "e2e/app/agent/prometheus_internal_test.go",
         "hashed_secret": "7cb6efb98ba5972a9b5090dc2e517fe14d12cb04",
         "is_verified": false,
-        "line_number": 42
+        "line_number": 40
       },
       {
         "type": "Secret Keyword",
         "filename": "e2e/app/agent/prometheus_internal_test.go",
         "hashed_secret": "5ffe533b830f08a0326348a9160afafc8ada44db",
         "is_verified": false,
-        "line_number": 54
+        "line_number": 51
       },
       {
         "type": "Secret Keyword",
         "filename": "e2e/app/agent/prometheus_internal_test.go",
         "hashed_secret": "858b02bf93798fdd02736ef7ec278319018d1272",
         "is_verified": false,
-        "line_number": 103
+        "line_number": 98
       }
     ],
     "e2e/app/geth/testdata/TestWriteConfigTOML_archive.golden": [
@@ -331,112 +327,112 @@
         "filename": "halo/genutil/evm/testdata/TestMakeGenesis.golden",
         "hashed_secret": "08b650e252263f24012a9f28567c240a20c2f946",
         "is_verified": false,
-        "line_number": 64
+        "line_number": 14401
       },
       {
         "type": "Hex High Entropy String",
         "filename": "halo/genutil/evm/testdata/TestMakeGenesis.golden",
         "hashed_secret": "bba31aa004481de49b494ec166f33686c717bc26",
         "is_verified": false,
-        "line_number": 67
+        "line_number": 14404
       },
       {
         "type": "Hex High Entropy String",
         "filename": "halo/genutil/evm/testdata/TestMakeGenesis.golden",
         "hashed_secret": "28ef15964c4850182b1fef49fc55950919db756f",
         "is_verified": false,
-        "line_number": 70
+        "line_number": 14407
       },
       {
         "type": "Hex High Entropy String",
         "filename": "halo/genutil/evm/testdata/TestMakeGenesis.golden",
         "hashed_secret": "72cd5d2bd88432c9ed5d75d51479070e70ec089e",
         "is_verified": false,
-        "line_number": 73
+        "line_number": 14410
       },
       {
         "type": "Hex High Entropy String",
         "filename": "halo/genutil/evm/testdata/TestMakeGenesis.golden",
         "hashed_secret": "3f0335f2af6f7b386ef0d32f094fbe826e7e3fa7",
         "is_verified": false,
-        "line_number": 76
+        "line_number": 14413
       },
       {
         "type": "Hex High Entropy String",
         "filename": "halo/genutil/evm/testdata/TestMakeGenesis.golden",
         "hashed_secret": "87c4dc1a812364b8db6093f7ed72aced0c07630a",
         "is_verified": false,
-        "line_number": 79
+        "line_number": 14416
       },
       {
         "type": "Hex High Entropy String",
         "filename": "halo/genutil/evm/testdata/TestMakeGenesis.golden",
         "hashed_secret": "c52cffacab1f07ba79bbc61c32ff164fff8f9f8b",
         "is_verified": false,
-        "line_number": 82
+        "line_number": 14419
       },
       {
         "type": "Hex High Entropy String",
         "filename": "halo/genutil/evm/testdata/TestMakeGenesis.golden",
         "hashed_secret": "471394320cd7526cb50202735fd4156e9fac18bf",
         "is_verified": false,
-        "line_number": 85
+        "line_number": 14422
       },
       {
         "type": "Hex High Entropy String",
         "filename": "halo/genutil/evm/testdata/TestMakeGenesis.golden",
         "hashed_secret": "0b88203fde5908bb7273ca44a7f685f977bde2ca",
         "is_verified": false,
-        "line_number": 88
+        "line_number": 14425
       },
       {
         "type": "Hex High Entropy String",
         "filename": "halo/genutil/evm/testdata/TestMakeGenesis.golden",
         "hashed_secret": "9d06254807267e518daa2dc5629b8e298d391966",
         "is_verified": false,
-        "line_number": 91
+        "line_number": 14428
       },
       {
         "type": "Hex High Entropy String",
         "filename": "halo/genutil/evm/testdata/TestMakeGenesis.golden",
         "hashed_secret": "a79365b8364bf8a43643be2ac6dc1ecbc56f6d6a",
         "is_verified": false,
-        "line_number": 94
+        "line_number": 14431
       },
       {
         "type": "Hex High Entropy String",
         "filename": "halo/genutil/evm/testdata/TestMakeGenesis.golden",
         "hashed_secret": "aac432f7e35804ebe62d41d9f42657ce89479caf",
         "is_verified": false,
-        "line_number": 97
+        "line_number": 14434
       },
       {
         "type": "Hex High Entropy String",
         "filename": "halo/genutil/evm/testdata/TestMakeGenesis.golden",
         "hashed_secret": "616a05c8bcf93ed6f3c8f20ef3d41d6d0dc0418b",
         "is_verified": false,
-        "line_number": 100
+        "line_number": 14437
       },
       {
         "type": "Hex High Entropy String",
         "filename": "halo/genutil/evm/testdata/TestMakeGenesis.golden",
         "hashed_secret": "ac3758d662cbdd3b3067756b1979a60d0e654a19",
         "is_verified": false,
-        "line_number": 103
+        "line_number": 14440
       },
       {
         "type": "Hex High Entropy String",
         "filename": "halo/genutil/evm/testdata/TestMakeGenesis.golden",
         "hashed_secret": "6372edf1c92d4dceccf1d6be9090746e24782003",
         "is_verified": false,
-        "line_number": 106
+        "line_number": 14443
       },
       {
         "type": "Hex High Entropy String",
         "filename": "halo/genutil/evm/testdata/TestMakeGenesis.golden",
         "hashed_secret": "b90fd3ae85361750377898f2a212638dfa6fd26b",
         "is_verified": false,
-        "line_number": 109
+        "line_number": 14446
       }
     ],
     "halo/genutil/testdata/TestMakeGenesis.golden": [
@@ -855,5 +851,5 @@
       }
     ]
   },
-  "generated_at": "2024-04-10T08:27:38Z"
+  "generated_at": "2024-04-10T11:57:04Z"
 }

--- a/e2e/app/agent/prometheus_internal_test.go
+++ b/e2e/app/agent/prometheus_internal_test.go
@@ -24,8 +24,7 @@ func TestPromGen(t *testing.T) {
 		newNodes     []string
 		geths        []string
 		newGeths     []string
-		newRelayer   bool
-		newMonitor   bool
+		newServices  []string
 		hostname     string
 		agentSecrets bool
 	}{
@@ -37,8 +36,7 @@ func TestPromGen(t *testing.T) {
 			newNodes:     []string{"validator01"},
 			geths:        []string{"omni_evm"},
 			newGeths:     []string{"omni_evm"},
-			newRelayer:   false,
-			newMonitor:   false,
+			newServices:  nil,
 			agentSecrets: false,
 		},
 		{
@@ -49,8 +47,7 @@ func TestPromGen(t *testing.T) {
 			newNodes:     []string{"fullnode04"},
 			geths:        []string{"validator01_evm", "validator02_evm", "validator03_evm"},
 			newGeths:     []string{"fullnode04_evm"},
-			newRelayer:   true,
-			newMonitor:   false,
+			newServices:  []string{"relayer", "explorer_indexer"},
 			agentSecrets: true,
 		},
 		{
@@ -59,8 +56,7 @@ func TestPromGen(t *testing.T) {
 			nodes:        []string{"validator01", "validator02"},
 			hostname:     "localhost",
 			newNodes:     []string{"validator01"},
-			newMonitor:   true,
-			newRelayer:   false,
+			newServices:  []string{"monitor"},
 			agentSecrets: false,
 		},
 		{
@@ -69,8 +65,7 @@ func TestPromGen(t *testing.T) {
 			nodes:        []string{"validator01", "validator02", "fullnode03"},
 			hostname:     "vm",
 			newNodes:     []string{"fullnode04"},
-			newMonitor:   true,
-			newRelayer:   true,
+			newServices:  []string{"relayer", "monitor"},
 			agentSecrets: true,
 		},
 	}
@@ -110,7 +105,12 @@ func TestPromGen(t *testing.T) {
 			cfg1, err := genPromConfig(ctx, testnet, agentSecrets, test.hostname)
 			require.NoError(t, err)
 
-			cfg2 := ConfigForHost(cfg1, test.hostname+"-2", test.newNodes, test.newGeths, test.newRelayer, test.newMonitor)
+			services := make(map[string]bool)
+			for _, newService := range test.newServices {
+				services[newService] = true
+			}
+
+			cfg2 := ConfigForHost(cfg1, test.hostname+"-2", test.newNodes, test.newGeths, services)
 
 			t.Run("gen", func(t *testing.T) {
 				t.Parallel()

--- a/e2e/app/agent/testdata/TestPromGen_manifest1_gen.golden
+++ b/e2e/app/agent/testdata/TestPromGen_manifest1_gen.golden
@@ -3,14 +3,6 @@ global:
   evaluation_interval: 30s # Evaluate rules every 30 seconds.
 
 scrape_configs:
-  - job_name: "relayer"
-    metrics_path: "/metrics"
-    static_configs:
-      - targets: [relayer:26660] # relayer targets
-        labels:
-          network: 'manifest1-localhost'
-          host: 'localhost'
-
   - job_name: "halo"
     metrics_path: "/metrics"
     static_configs:
@@ -27,10 +19,34 @@ scrape_configs:
           network: 'manifest1-localhost'
           host: 'localhost'
 
+  - job_name: "relayer"
+    metrics_path: "/metrics"
+    static_configs:
+      - targets: [relayer:26660] # relayer targets
+        labels:
+          network: 'manifest1-localhost'
+          host: 'localhost'
+
   - job_name: "monitor"
     metrics_path: "/metrics"
     static_configs:
       - targets: [monitor:26660] # monitor targets
+        labels:
+          network: 'manifest1-localhost'
+          host: 'localhost'
+
+  - job_name: "explorer_indexer"
+    metrics_path: "/metrics"
+    static_configs:
+      - targets: [explorer_indexer:26660] # explorer_indexer targets
+        labels:
+          network: 'manifest1-localhost'
+          host: 'localhost'
+
+  - job_name: "explorer_graphql"
+    metrics_path: "/metrics"
+    static_configs:
+      - targets: [explorer_graphql:26660] # explorer_graphql targets
         labels:
           network: 'manifest1-localhost'
           host: 'localhost'

--- a/e2e/app/agent/testdata/TestPromGen_manifest1_update.golden
+++ b/e2e/app/agent/testdata/TestPromGen_manifest1_update.golden
@@ -3,14 +3,6 @@ global:
   evaluation_interval: 30s # Evaluate rules every 30 seconds.
 
 scrape_configs:
-  - job_name: "relayer"
-    metrics_path: "/metrics"
-    static_configs:
-      - targets: [] # relayer targets
-        labels:
-          network: 'manifest1-localhost'
-          host: 'localhost-2'
-
   - job_name: "halo"
     metrics_path: "/metrics"
     static_configs:
@@ -27,10 +19,34 @@ scrape_configs:
           network: 'manifest1-localhost'
           host: 'localhost-2'
 
+  - job_name: "relayer"
+    metrics_path: "/metrics"
+    static_configs:
+      - targets: [] # relayer targets
+        labels:
+          network: 'manifest1-localhost'
+          host: 'localhost-2'
+
   - job_name: "monitor"
     metrics_path: "/metrics"
     static_configs:
       - targets: [] # monitor targets
+        labels:
+          network: 'manifest1-localhost'
+          host: 'localhost-2'
+
+  - job_name: "explorer_indexer"
+    metrics_path: "/metrics"
+    static_configs:
+      - targets: [] # explorer_indexer targets
+        labels:
+          network: 'manifest1-localhost'
+          host: 'localhost-2'
+
+  - job_name: "explorer_graphql"
+    metrics_path: "/metrics"
+    static_configs:
+      - targets: [] # explorer_graphql targets
         labels:
           network: 'manifest1-localhost'
           host: 'localhost-2'

--- a/e2e/app/agent/testdata/TestPromGen_manifest2_gen.golden
+++ b/e2e/app/agent/testdata/TestPromGen_manifest2_gen.golden
@@ -15,14 +15,6 @@ remote_write:
 
 
 scrape_configs:
-  - job_name: "relayer"
-    metrics_path: "/metrics"
-    static_configs:
-      - targets: [relayer:26660] # relayer targets
-        labels:
-          network: 'staging'
-          host: 'vm'
-
   - job_name: "halo"
     metrics_path: "/metrics"
     static_configs:
@@ -39,10 +31,34 @@ scrape_configs:
           network: 'staging'
           host: 'vm'
 
+  - job_name: "relayer"
+    metrics_path: "/metrics"
+    static_configs:
+      - targets: [relayer:26660] # relayer targets
+        labels:
+          network: 'staging'
+          host: 'vm'
+
   - job_name: "monitor"
     metrics_path: "/metrics"
     static_configs:
       - targets: [monitor:26660] # monitor targets
+        labels:
+          network: 'staging'
+          host: 'vm'
+
+  - job_name: "explorer_indexer"
+    metrics_path: "/metrics"
+    static_configs:
+      - targets: [explorer_indexer:26660] # explorer_indexer targets
+        labels:
+          network: 'staging'
+          host: 'vm'
+
+  - job_name: "explorer_graphql"
+    metrics_path: "/metrics"
+    static_configs:
+      - targets: [explorer_graphql:26660] # explorer_graphql targets
         labels:
           network: 'staging'
           host: 'vm'

--- a/e2e/app/agent/testdata/TestPromGen_manifest2_update.golden
+++ b/e2e/app/agent/testdata/TestPromGen_manifest2_update.golden
@@ -15,14 +15,6 @@ remote_write:
 
 
 scrape_configs:
-  - job_name: "relayer"
-    metrics_path: "/metrics"
-    static_configs:
-      - targets: [relayer:26660] # relayer targets
-        labels:
-          network: 'staging'
-          host: 'vm-2'
-
   - job_name: "halo"
     metrics_path: "/metrics"
     static_configs:
@@ -39,10 +31,34 @@ scrape_configs:
           network: 'staging'
           host: 'vm-2'
 
+  - job_name: "relayer"
+    metrics_path: "/metrics"
+    static_configs:
+      - targets: [relayer:26660] # relayer targets
+        labels:
+          network: 'staging'
+          host: 'vm-2'
+
   - job_name: "monitor"
     metrics_path: "/metrics"
     static_configs:
       - targets: [] # monitor targets
+        labels:
+          network: 'staging'
+          host: 'vm-2'
+
+  - job_name: "explorer_indexer"
+    metrics_path: "/metrics"
+    static_configs:
+      - targets: [explorer_indexer:26660] # explorer_indexer targets
+        labels:
+          network: 'staging'
+          host: 'vm-2'
+
+  - job_name: "explorer_graphql"
+    metrics_path: "/metrics"
+    static_configs:
+      - targets: [] # explorer_graphql targets
         labels:
           network: 'staging'
           host: 'vm-2'

--- a/e2e/app/agent/testdata/TestPromGen_manifest3_gen.golden
+++ b/e2e/app/agent/testdata/TestPromGen_manifest3_gen.golden
@@ -3,14 +3,6 @@ global:
   evaluation_interval: 30s # Evaluate rules every 30 seconds.
 
 scrape_configs:
-  - job_name: "relayer"
-    metrics_path: "/metrics"
-    static_configs:
-      - targets: [relayer:26660] # relayer targets
-        labels:
-          network: 'manifest3-localhost'
-          host: 'localhost'
-
   - job_name: "halo"
     metrics_path: "/metrics"
     static_configs:
@@ -27,10 +19,34 @@ scrape_configs:
           network: 'manifest3-localhost'
           host: 'localhost'
 
+  - job_name: "relayer"
+    metrics_path: "/metrics"
+    static_configs:
+      - targets: [relayer:26660] # relayer targets
+        labels:
+          network: 'manifest3-localhost'
+          host: 'localhost'
+
   - job_name: "monitor"
     metrics_path: "/metrics"
     static_configs:
       - targets: [monitor:26660] # monitor targets
+        labels:
+          network: 'manifest3-localhost'
+          host: 'localhost'
+
+  - job_name: "explorer_indexer"
+    metrics_path: "/metrics"
+    static_configs:
+      - targets: [explorer_indexer:26660] # explorer_indexer targets
+        labels:
+          network: 'manifest3-localhost'
+          host: 'localhost'
+
+  - job_name: "explorer_graphql"
+    metrics_path: "/metrics"
+    static_configs:
+      - targets: [explorer_graphql:26660] # explorer_graphql targets
         labels:
           network: 'manifest3-localhost'
           host: 'localhost'

--- a/e2e/app/agent/testdata/TestPromGen_manifest3_update.golden
+++ b/e2e/app/agent/testdata/TestPromGen_manifest3_update.golden
@@ -3,14 +3,6 @@ global:
   evaluation_interval: 30s # Evaluate rules every 30 seconds.
 
 scrape_configs:
-  - job_name: "relayer"
-    metrics_path: "/metrics"
-    static_configs:
-      - targets: [] # relayer targets
-        labels:
-          network: 'manifest3-localhost'
-          host: 'localhost-2'
-
   - job_name: "halo"
     metrics_path: "/metrics"
     static_configs:
@@ -27,10 +19,34 @@ scrape_configs:
           network: 'manifest3-localhost'
           host: 'localhost-2'
 
+  - job_name: "relayer"
+    metrics_path: "/metrics"
+    static_configs:
+      - targets: [] # relayer targets
+        labels:
+          network: 'manifest3-localhost'
+          host: 'localhost-2'
+
   - job_name: "monitor"
     metrics_path: "/metrics"
     static_configs:
       - targets: [monitor:26660] # monitor targets
+        labels:
+          network: 'manifest3-localhost'
+          host: 'localhost-2'
+
+  - job_name: "explorer_indexer"
+    metrics_path: "/metrics"
+    static_configs:
+      - targets: [] # explorer_indexer targets
+        labels:
+          network: 'manifest3-localhost'
+          host: 'localhost-2'
+
+  - job_name: "explorer_graphql"
+    metrics_path: "/metrics"
+    static_configs:
+      - targets: [] # explorer_graphql targets
         labels:
           network: 'manifest3-localhost'
           host: 'localhost-2'

--- a/e2e/app/agent/testdata/TestPromGen_manifest4_gen.golden
+++ b/e2e/app/agent/testdata/TestPromGen_manifest4_gen.golden
@@ -15,14 +15,6 @@ remote_write:
 
 
 scrape_configs:
-  - job_name: "relayer"
-    metrics_path: "/metrics"
-    static_configs:
-      - targets: [relayer:26660] # relayer targets
-        labels:
-          network: 'staging'
-          host: 'vm'
-
   - job_name: "halo"
     metrics_path: "/metrics"
     static_configs:
@@ -39,10 +31,34 @@ scrape_configs:
           network: 'staging'
           host: 'vm'
 
+  - job_name: "relayer"
+    metrics_path: "/metrics"
+    static_configs:
+      - targets: [relayer:26660] # relayer targets
+        labels:
+          network: 'staging'
+          host: 'vm'
+
   - job_name: "monitor"
     metrics_path: "/metrics"
     static_configs:
       - targets: [monitor:26660] # monitor targets
+        labels:
+          network: 'staging'
+          host: 'vm'
+
+  - job_name: "explorer_indexer"
+    metrics_path: "/metrics"
+    static_configs:
+      - targets: [explorer_indexer:26660] # explorer_indexer targets
+        labels:
+          network: 'staging'
+          host: 'vm'
+
+  - job_name: "explorer_graphql"
+    metrics_path: "/metrics"
+    static_configs:
+      - targets: [explorer_graphql:26660] # explorer_graphql targets
         labels:
           network: 'staging'
           host: 'vm'

--- a/e2e/app/agent/testdata/TestPromGen_manifest4_update.golden
+++ b/e2e/app/agent/testdata/TestPromGen_manifest4_update.golden
@@ -15,14 +15,6 @@ remote_write:
 
 
 scrape_configs:
-  - job_name: "relayer"
-    metrics_path: "/metrics"
-    static_configs:
-      - targets: [relayer:26660] # relayer targets
-        labels:
-          network: 'staging'
-          host: 'vm-2'
-
   - job_name: "halo"
     metrics_path: "/metrics"
     static_configs:
@@ -39,10 +31,34 @@ scrape_configs:
           network: 'staging'
           host: 'vm-2'
 
+  - job_name: "relayer"
+    metrics_path: "/metrics"
+    static_configs:
+      - targets: [relayer:26660] # relayer targets
+        labels:
+          network: 'staging'
+          host: 'vm-2'
+
   - job_name: "monitor"
     metrics_path: "/metrics"
     static_configs:
       - targets: [monitor:26660] # monitor targets
+        labels:
+          network: 'staging'
+          host: 'vm-2'
+
+  - job_name: "explorer_indexer"
+    metrics_path: "/metrics"
+    static_configs:
+      - targets: [] # explorer_indexer targets
+        labels:
+          network: 'staging'
+          host: 'vm-2'
+
+  - job_name: "explorer_graphql"
+    metrics_path: "/metrics"
+    static_configs:
+      - targets: [] # explorer_graphql targets
         labels:
           network: 'staging'
           host: 'vm-2'

--- a/e2e/vmcompose/provider.go
+++ b/e2e/vmcompose/provider.go
@@ -117,7 +117,7 @@ func (p *Provider) Setup() error {
 		}
 
 		hostname := vmIP // TODO(corver): Add hostnames to infra instances.
-		agentCfg = agent.ConfigForHost(agentCfg, hostname, halos, geths, services["relayer"], services["monitor"])
+		agentCfg = agent.ConfigForHost(agentCfg, hostname, halos, geths, services)
 		err = os.WriteFile(filepath.Join(p.Testnet.Dir, vmAgentFile(vmIP)), agentCfg, 0o644)
 		if err != nil {
 			return errors.Wrap(err, "write compose file")

--- a/explorer/graphql/app/app.go
+++ b/explorer/graphql/app/app.go
@@ -12,6 +12,7 @@ import (
 	"github.com/omni-network/omni/lib/errors"
 	"github.com/omni-network/omni/lib/log"
 
+	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/rs/cors"
 	"golang.org/x/sync/errgroup"
 )
@@ -76,6 +77,9 @@ func Run(ctx context.Context, cfg Config) error {
 
 		return nil
 	})
+	eg.Go(func() error {
+		return serveMonitoring(cfg.MonitoringAddr)
+	})
 
 	if err := eg.Wait(); errors.Is(err, http.ErrServerClosed) {
 		return nil // No error on shutdown.
@@ -84,4 +88,20 @@ func Run(ctx context.Context, cfg Config) error {
 	}
 
 	return nil
+}
+
+// serveMonitoring serves the monitoring API.
+func serveMonitoring(address string) error {
+	mux := http.NewServeMux()
+	mux.Handle("/metrics", promhttp.Handler())
+
+	srv := &http.Server{
+		Addr:              address,
+		ReadHeaderTimeout: 5 * time.Second,
+		IdleTimeout:       5 * time.Second,
+		WriteTimeout:      5 * time.Second,
+		Handler:           mux,
+	}
+
+	return errors.Wrap(srv.ListenAndServe(), "serve monitoring")
 }

--- a/explorer/graphql/app/config.go
+++ b/explorer/graphql/app/config.go
@@ -20,11 +20,14 @@ const (
 type Config struct {
 	ListenAddress  string
 	ExplorerDBConn string
+	MonitoringAddr string
 }
 
 func DefaultConfig() Config {
 	return Config{
-		ListenAddress: defaultListenAddr,
+		ListenAddress:  defaultListenAddr,
+		ExplorerDBConn: "",
+		MonitoringAddr: ":26660",
 	}
 }
 

--- a/explorer/graphql/cmd/cmd.go
+++ b/explorer/graphql/cmd/cmd.go
@@ -42,4 +42,5 @@ func New() *cobra.Command {
 func bindGraphQLFlags(flags *pflag.FlagSet, cfg *app.Config) {
 	flags.StringVar(&cfg.ExplorerDBConn, "explorer-db-conn", cfg.ExplorerDBConn, "URL to the database")
 	flags.StringVar(&cfg.ListenAddress, "listen-addr", cfg.ListenAddress, "Address to listen on")
+	flags.StringVar(&cfg.MonitoringAddr, "monitoring-addr", cfg.MonitoringAddr, "The address to bind the monitoring server")
 }

--- a/explorer/indexer/app/config.go
+++ b/explorer/indexer/app/config.go
@@ -20,11 +20,14 @@ const (
 type Config struct {
 	NetworkFile    string
 	ExplorerDBConn string
+	MonitoringAddr string
 }
 
 func DefaultConfig() Config {
 	return Config{
-		NetworkFile: defaultNetworkFile,
+		NetworkFile:    defaultNetworkFile,
+		ExplorerDBConn: "",
+		MonitoringAddr: ":26660",
 	}
 }
 

--- a/explorer/indexer/cmd/cmd.go
+++ b/explorer/indexer/cmd/cmd.go
@@ -43,4 +43,5 @@ func New() *cobra.Command {
 func bindIndexerFlags(flags *pflag.FlagSet, cfg *app.Config) {
 	flags.StringVar(&cfg.NetworkFile, "network-file", cfg.NetworkFile, "The path to the network file e.g path/network.json")
 	flags.StringVar(&cfg.ExplorerDBConn, "explorer-db-conn", cfg.ExplorerDBConn, "URL to the database")
+	flags.StringVar(&cfg.MonitoringAddr, "monitoring-addr", cfg.MonitoringAddr, "The address to bind the monitoring server")
 }


### PR DESCRIPTION
Add prometheus metrics API to explorer-indexer/graphql. Also configure them with agent.

task: none