### PR TITLE
ci(e2e): increase parallel pingpongs

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -201,14 +201,14 @@
         "filename": "e2e/app/run.go",
         "hashed_secret": "7c1a7493a09f09e4669f6b1f03719a2262e7b323",
         "is_verified": false,
-        "line_number": 22
+        "line_number": 26
       },
       {
         "type": "Secret Keyword",
         "filename": "e2e/app/run.go",
         "hashed_secret": "fe86558143c0bd528f649a153bdc32b8fa90301c",
         "is_verified": false,
-        "line_number": 135
+        "line_number": 142
       }
     ],
     "e2e/app/setup.go": [
@@ -855,5 +855,5 @@
       }
     ]
   },
-  "generated_at": "2024-04-09T20:58:42Z"
+  "generated_at": "2024-04-10T08:27:38Z"
 }

--- a/e2e/netman/pingpong/pingpong.go
+++ b/e2e/netman/pingpong/pingpong.go
@@ -18,6 +18,8 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	ethtypes "github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/params"
+
+	"golang.org/x/sync/errgroup"
 )
 
 // XDapp defines the deployed pingpong contract xdapp.
@@ -148,8 +150,10 @@ func (d *XDapp) fund(ctx context.Context) error {
 	return nil
 }
 
-func (d *XDapp) StartAllEdges(ctx context.Context, count uint64) error {
+// StartAllEdges starts <parallel> ping pongs for all edges, each doing <count> hops.
+func (d *XDapp) StartAllEdges(ctx context.Context, parallel, count uint64) error {
 	log.Info(ctx, "Starting ping pong contracts")
+	eg, ctx := errgroup.WithContext(ctx)
 	for _, edge := range d.edges {
 		from := d.contracts[edge.From]
 		to := d.contracts[edge.To]
@@ -157,6 +161,7 @@ func (d *XDapp) StartAllEdges(ctx context.Context, count uint64) error {
 		log.Debug(ctx, "Starting ping pong contract",
 			"from", from.Chain.Name,
 			"to", to.Chain.Name,
+			"parallel", parallel,
 			"count", count,
 		)
 
@@ -165,21 +170,31 @@ func (d *XDapp) StartAllEdges(ctx context.Context, count uint64) error {
 			return err
 		}
 
-		tx, err := from.PingPong.Start(txOpts, to.Chain.ID, to.Address, count)
-		if err != nil {
-			return errors.Wrap(err, "start ping pong", "from", from.Chain.Name, "to", to.Chain.Name)
-		}
+		for i := uint64(0); i < parallel; i++ {
+			eg.Go(func() error {
+				tx, err := from.PingPong.Start(txOpts, to.Chain.ID, to.Address, count)
+				if err != nil {
+					return errors.Wrap(err, "start ping pong", "from", from.Chain.Name, "to", to.Chain.Name)
+				}
 
-		if _, err := bind.WaitMined(ctx, backend, tx); err != nil {
-			return errors.Wrap(err, "wait mined", "chain", from.Chain.Name, "tx", tx.Hash())
+				if _, err := bind.WaitMined(ctx, backend, tx); err != nil {
+					return errors.Wrap(err, "wait mined", "chain", from.Chain.Name, "tx", tx.Hash())
+				}
+
+				return nil
+			})
 		}
+	}
+
+	if err := eg.Wait(); err != nil {
+		return errors.Wrap(err, "wait parallel start")
 	}
 
 	return nil
 }
 
-// WaitDone waits for all ping pongs to be done.
-// Note this doesn't work on anvil since it doesn't support subscriptions.
+// WaitDone waits for all edges to complete the hops of a single ping pong.
+// Note this doesn't wait for all parallel ping pongs to complete, it only waits for one of P.
 func (d *XDapp) WaitDone(ctx context.Context) error {
 	log.Info(ctx, "Waiting for ping pongs to complete")
 	ctx, cancel := context.WithTimeout(ctx, time.Minute)

--- a/lib/ethclient/ethbackend/backend.go
+++ b/lib/ethclient/ethbackend/backend.go
@@ -198,7 +198,7 @@ func (b *Backend) BindOpts(ctx context.Context, from common.Address) (*bind.Tran
 
 			return resp, nil
 		},
-		Context: log.WithCtx(ctx, "dest_chain", b.chainName, "from_addr", from.Hex()[6]),
+		Context: log.WithCtx(ctx, "dest_chain", b.chainName, "from_addr", from.Hex()[:10]),
 	}, nil
 }
 


### PR DESCRIPTION
Increase the number of parallel pingpongs to test multiple xmsgs per block.

task: none