### PR TITLE
chore(halo/attest): add vote and latency metrics

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -114,6 +114,7 @@ issues:
     - "flag-parameter" # Relax revive, flag parameters are ok if used sparingly.
     - "G306: Expect WriteFile permissions to be 0600 or less" # We write a lot of files that need to be editable.
     - "exported: type name will be used as module.Module" # Cosmos style
+    - "defer: prefer not to defer chains of function calls" # We use this for defer latency()()
 
     # Loop variable issues have been fixed in Go 1.22, so can be ignored
     - "G601: Implicit memory aliasing in for loop"

--- a/halo/attest/keeper/keeper_test.go
+++ b/halo/attest/keeper/keeper_test.go
@@ -209,6 +209,7 @@ func TestKeeper_Approve(t *testing.T) {
 	valset2_3 := newValSet(9, val2, val3)
 
 	defaultExpectations := func(_ sdk.Context, m mocks) {
+		m.namer.EXPECT().ChainName(gomock.Any()).AnyTimes().Return("")
 		m.voter.EXPECT().TrimBehind(gomock.Any()).Times(1).Return(0)
 		m.valProvider.EXPECT().ActiveSetByHeight(gomock.Any(), uint64(0)).
 			Return(valset1_2_3, nil).

--- a/halo/attest/keeper/metrics.go
+++ b/halo/attest/keeper/metrics.go
@@ -1,6 +1,8 @@
 package keeper
 
 import (
+	"time"
+
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 )
@@ -12,4 +14,35 @@ var (
 		Name:      "approved_height",
 		Help:      "The height of latest approved attestation per source chain",
 	}, []string{"chain"})
+
+	votesProposed = promauto.NewHistogramVec(prometheus.HistogramOpts{
+		Namespace: "halo",
+		Subsystem: "attest",
+		Name:      "proposed_votes",
+		Help:      "The number of votes proposed per block per source chain",
+		Buckets:   []float64{1, 2, 5, 10, 25, 50, 100, 250, 500, 1000},
+	}, []string{"chain"})
+
+	votesExtended = promauto.NewHistogramVec(prometheus.HistogramOpts{
+		Namespace: "halo",
+		Subsystem: "attest",
+		Name:      "extended_votes",
+		Help:      "The number of votes included by a validator per block per source chain",
+		Buckets:   []float64{1, 2, 5, 10, 25, 50, 100, 250, 500, 1000},
+	}, []string{"chain"})
+
+	dbLatency = promauto.NewHistogramVec(prometheus.HistogramOpts{
+		Namespace: "halo",
+		Subsystem: "attest",
+		Name:      "db_latency_seconds",
+		Help:      "Latency (in seconds) for each db function call (both internal and external)",
+		Buckets:   []float64{.001, .002, .005, .01, .025, .05, .1},
+	}, []string{"method"})
 )
+
+func latency(method string) func() {
+	t0 := time.Now()
+	return func() {
+		dbLatency.WithLabelValues(method).Observe(time.Since(t0).Seconds())
+	}
+}

--- a/halo/attest/voter/voter.go
+++ b/halo/attest/voter/voter.go
@@ -161,7 +161,7 @@ func (a *Voter) runOnce(ctx context.Context, chainID uint64) error {
 			} else if cmp < 0 {
 				return errors.New("behind vote window (too slow)", "vote_height", block.BlockHeight)
 			} else if cmp > 0 {
-				backoff := expbackoff.New(ctx, expbackoff.WithPeriodicConfig(time.Minute))
+				backoff := expbackoff.New(ctx, expbackoff.WithPeriodicConfig(time.Second*5))
 				for a.AvailableCount() > maxAvailable {
 					log.Warn(ctx, "Voting paused, latest approved attestation is too far behind (stuck?)", nil, "vote_height", block.BlockHeight)
 					backoff()

--- a/lib/cchain/provider/abci.go
+++ b/lib/cchain/provider/abci.go
@@ -1,4 +1,3 @@
-//nolint:revive // Defer chains is best for latency metrics.
 package provider
 
 import (

--- a/lib/ethclient/engineclient.go
+++ b/lib/ethclient/engineclient.go
@@ -1,4 +1,3 @@
-//nolint:revive // Defer chain is better in this case.
 package ethclient
 
 import (

--- a/lib/ethclient/ethclient.go
+++ b/lib/ethclient/ethclient.go
@@ -92,7 +92,7 @@ func (w Wrapper) Address() string {
 // HeaderByType returns the block header for the given head type.
 func (w Wrapper) HeaderByType(ctx context.Context, typ HeadType) (*types.Header, error) {
 	const endpoint = "header_by_type"
-	defer latency(w.chain, endpoint)() //nolint:revive // Defer chain is fine here.
+	defer latency(w.chain, endpoint)()
 
 	var header *types.Header
 	err := w.cl.Client().CallContext(
@@ -113,7 +113,7 @@ func (w Wrapper) HeaderByType(ctx context.Context, typ HeadType) (*types.Header,
 // PeerCount returns the number of p2p peers as reported by the net_peerCount method.
 func (w Wrapper) PeerCount(ctx context.Context) (uint64, error) {
 	const endpoint = "peer_count"
-	defer latency(w.chain, endpoint)() //nolint:revive // Defer chain is fine here.
+	defer latency(w.chain, endpoint)()
 
 	resp, err := w.cl.PeerCount(ctx)
 	if err != nil {


### PR DESCRIPTION
Add metrics to attest keeper to debug slow votes:
- votes extended per block (by validators) (per source chain)
- votes proposed per block
- db method latencies

task: none