### PR TITLE
chore(halo/voter): increase disk buffer

### DIFF
--- a/halo/attest/voter/voter.go
+++ b/halo/attest/voter/voter.go
@@ -26,7 +26,7 @@ import (
 
 const (
 	prodBackoff  = time.Second
-	maxAvailable = 1000
+	maxAvailable = 10_000
 )
 
 var _ types.Voter = (*Voter)(nil)


### PR DESCRIPTION
Increases voter disk buffer from 1k to 10k. 1k isn't much, since we can include up to 256 votes per block, so 10k allows buffering 40 blocks which is better than 4.

task: none
