### PR TITLE
chore(halo/voter): add proposed metric per block

### DIFF
--- a/halo/attest/voter/metrics.go
+++ b/halo/attest/voter/metrics.go
@@ -42,6 +42,22 @@ var (
 		Help:      "Current number of proposed votes per source chain. Alert if growing.",
 	}, []string{"chain"})
 
+	proposedPerBlock = promauto.NewHistogram(prometheus.HistogramOpts{
+		Namespace: "halo",
+		Subsystem: "voter",
+		Name:      "proposed_per_block",
+		Help:      "Number of proposed votes per block.",
+		Buckets:   []float64{1, 2, 5, 10, 25, 50, 100, 250, 500, 1000},
+	})
+
+	committedPerBlock = promauto.NewHistogram(prometheus.HistogramOpts{
+		Namespace: "halo",
+		Subsystem: "voter",
+		Name:      "committed_per_block",
+		Help:      "Number of committed votes per block.",
+		Buckets:   []float64{1, 2, 5, 10, 25, 50, 100, 250, 500, 1000},
+	})
+
 	trimTotal = promauto.NewCounterVec(prometheus.CounterOpts{
 		Namespace: "halo",
 		Subsystem: "voter",

--- a/halo/attest/voter/voter.go
+++ b/halo/attest/voter/voter.go
@@ -247,6 +247,8 @@ func (a *Voter) GetAvailable() []*types.Vote {
 
 // SetProposed sets the votes as proposed.
 func (a *Voter) SetProposed(headers []*types.BlockHeader) error {
+	proposedPerBlock.Observe(float64(len(headers)))
+
 	if len(headers) == 0 {
 		return nil
 	}
@@ -274,6 +276,8 @@ func (a *Voter) SetProposed(headers []*types.BlockHeader) error {
 
 // SetCommitted sets the votes as committed. Persisting the result to disk.
 func (a *Voter) SetCommitted(headers []*types.BlockHeader) error {
+	committedPerBlock.Observe(float64(len(headers)))
+
 	if len(headers) == 0 {
 		return nil
 	}


### PR DESCRIPTION
Adds a metric for "number of committed/proposed votes" per block per validator. This will help identify if votes are not actually moved from "available" to "proposed" and "proposed" to "committed".

task: none