### PR TITLE
chore(lib/stream): add callback latencies

### DIFF
--- a/lib/cchain/provider/metrics.go
+++ b/lib/cchain/provider/metrics.go
@@ -29,6 +29,14 @@ var (
 		Help:      "Latest streamed xblock height per worker per source chain. Alert if not growing.",
 	}, []string{"worker", "chain"})
 
+	callbackLatency = promauto.NewHistogramVec(prometheus.HistogramOpts{
+		Namespace: "lib",
+		Subsystem: "cprovider",
+		Name:      "callback_latency_seconds",
+		Help:      "Callback latency in seconds per worker per source chain. Alert if growing.",
+		Buckets:   []float64{.001, .002, .005, .01, .025, .05, .1, .25, .5, 1, 2.5},
+	}, []string{"worker", "chain"})
+
 	queryLatency = promauto.NewHistogramVec(prometheus.HistogramOpts{
 		Namespace: "lib",
 		Subsystem: "cprovider",

--- a/lib/cchain/provider/provider.go
+++ b/lib/cchain/provider/provider.go
@@ -4,6 +4,7 @@ package provider
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/omni-network/omni/lib/cchain"
 	"github.com/omni-network/omni/lib/errors"
@@ -102,6 +103,9 @@ func (p Provider) Subscribe(in context.Context, srcChainID uint64, height uint64
 		},
 		SetStreamHeight: func(h uint64) {
 			streamHeight.WithLabelValues(workerName, srcChain).Set(float64(h))
+		},
+		SetCallbackLatency: func(d time.Duration) {
+			callbackLatency.WithLabelValues(workerName, srcChain).Observe(d.Seconds())
 		},
 	}
 

--- a/lib/xchain/provider/metrics.go
+++ b/lib/xchain/provider/metrics.go
@@ -26,4 +26,12 @@ var (
 		Name:      "stream_height",
 		Help:      "Latest streamed xblock height per source chain. Alert if not growing.",
 	}, []string{"chain"})
+
+	callbackLatency = promauto.NewHistogramVec(prometheus.HistogramOpts{
+		Namespace: "lib",
+		Subsystem: "xprovider",
+		Name:      "callback_latency_seconds",
+		Help:      "Callback latency in seconds per source chain. Alert if growing.",
+		Buckets:   []float64{.001, .002, .005, .01, .025, .05, .1, .25, .5, 1, 2.5},
+	}, []string{"chain"})
 )

--- a/lib/xchain/provider/provider.go
+++ b/lib/xchain/provider/provider.go
@@ -6,6 +6,7 @@ package provider
 
 import (
 	"context"
+	"time"
 
 	"github.com/omni-network/omni/lib/cchain"
 	"github.com/omni-network/omni/lib/errors"
@@ -125,6 +126,9 @@ func (p *Provider) stream(
 		},
 		SetStreamHeight: func(h uint64) {
 			streamHeight.WithLabelValues(chain.Name).Set(float64(h))
+		},
+		SetCallbackLatency: func(d time.Duration) {
+			callbackLatency.WithLabelValues(chain.Name).Observe(d.Seconds())
 		},
 	}
 


### PR DESCRIPTION
Adds callback latencies to both xprovider and cprovider. 

This aims to help identify vote bottlenecks. But should be useful in general.

task: none