### PR TITLE
fix(e2e): allow all incoming cors

### DIFF
--- a/e2e/app/geth/config.go
+++ b/e2e/app/geth/config.go
@@ -121,6 +121,7 @@ func MakeGethConfig(conf Config) FullConfig {
 	cfg.Node.HTTPVirtualHosts = []string{"*"}
 	cfg.Node.AuthVirtualHosts = []string{"*"}
 	cfg.Node.WSOrigins = []string{"*"}
+	cfg.Node.HTTPCors = []string{"*"}
 
 	return cfg
 }

--- a/e2e/app/geth/testdata/TestWriteConfigTOML_archive.golden
+++ b/e2e/app/geth/testdata/TestWriteConfigTOML_archive.golden
@@ -60,6 +60,7 @@ DataDir = "/geth"
 IPCPath = "/geth/geth.ipc"
 HTTPHost = "0.0.0.0"
 HTTPPort = 8545
+HTTPCors = ["*"]
 HTTPVirtualHosts = ["*"]
 HTTPModules = ["net", "web3", "eth"]
 AuthAddr = "0.0.0.0"

--- a/e2e/app/geth/testdata/TestWriteConfigTOML_full.golden
+++ b/e2e/app/geth/testdata/TestWriteConfigTOML_full.golden
@@ -60,6 +60,7 @@ DataDir = "/geth"
 IPCPath = "/geth/geth.ipc"
 HTTPHost = "0.0.0.0"
 HTTPPort = 8545
+HTTPCors = ["*"]
 HTTPVirtualHosts = ["*"]
 HTTPModules = ["net", "web3", "eth"]
 AuthAddr = "0.0.0.0"


### PR DESCRIPTION
Adds an all-allow to `MakeGethConfig()` for the Cross-Origin Resource Sharing header to send to requesting browser clients. 

Allows requests to be served to any browser client without CORS errors. 

task: none
