### PR TITLE
feat(relayer): split submissions by estimating gas model

### DIFF
--- a/lib/txmgr/metrics.go
+++ b/lib/txmgr/metrics.go
@@ -32,6 +32,6 @@ var (
 		Subsystem: "txmgr",
 		Name:      "tx_gas_used",
 		Help:      "Gas used by transactions",
-		Buckets:   []float64{10000, 25000, 50000, 100000, 250000, 500000, 1000000},
+		Buckets:   prometheus.ExponentialBuckets(21_000, 10_000_000, 8),
 	}, []string{"chain"})
 )

--- a/relayer/app/creator.go
+++ b/relayer/app/creator.go
@@ -1,9 +1,28 @@
 package relayer
 
 import (
+	"slices"
+
 	"github.com/omni-network/omni/lib/errors"
 	"github.com/omni-network/omni/lib/xchain"
 )
+
+const (
+	subGasBase         uint64 = 500_000
+	subGasXmsgOverhead uint64 = 100_000
+	subGasMax          uint64 = 10_000_000 // Many chains has block gas limit of 30M, so we limit ourselves to 1/3 of that.
+)
+
+// estimateGas returns the estimated max gas usage of a submissions using a naive model:
+// - <gasBase> + sum(xmsg.DestGasLimit + <gasXmsgOverhead>).
+func estimateGas(msgs []xchain.Msg) uint64 {
+	resp := subGasBase
+	for _, msg := range msgs {
+		resp += msg.DestGasLimit + subGasXmsgOverhead
+	}
+
+	return resp
+}
 
 // CreateSubmissions splits the update into multiple submissions that are each small enough (wrt calldata and gas)
 // to be submitted on-chain.
@@ -43,8 +62,22 @@ func CreateSubmissions(up StreamUpdate) ([]xchain.Submission, error) {
 
 // groupMsgsByCost split the messages into groups that are each small enough (wrt calldata and gas)
 // to be submitted on-chain.
-//
-// TODO(corver): For now, we only create a single group per update.
 func groupMsgsByCost(msgs []xchain.Msg) [][]xchain.Msg {
-	return [][]xchain.Msg{msgs}
+	var resp [][]xchain.Msg
+
+	var current []xchain.Msg
+	for _, msg := range msgs {
+		// If adding the msg to the current batch will cross max limit, then
+		// complete the batch by adding it to the response and starting a new empty current batch.
+		if estimateGas(append(slices.Clone(current), msg)) > subGasMax {
+			resp = append(resp, current)
+			current = nil
+		}
+
+		// Add the message to the current batch
+		current = append(current, msg)
+	}
+
+	// Add current batch to response and return
+	return append(resp, current)
 }

--- a/relayer/app/creator_internal_test.go
+++ b/relayer/app/creator_internal_test.go
@@ -1,0 +1,88 @@
+package relayer
+
+import (
+	"testing"
+
+	"github.com/omni-network/omni/lib/xchain"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestEstimateGas(t *testing.T) {
+	t.Parallel()
+
+	// Constants defined in contracts/src/protocol/OmniPortalConstants.sol
+	const msgGasLimitMin uint64 = 21_000
+	const msgGasLimitMax uint64 = 5_000_000
+
+	tests := []struct {
+		name     string
+		msgGas   []uint64
+		expected []uint64
+	}{
+		{
+			name:     "empty",
+			msgGas:   nil,
+			expected: uints(subGasBase),
+		},
+		{
+			name:     "one min",
+			msgGas:   uints(msgGasLimitMin),
+			expected: uints(subGasBase + subGasXmsgOverhead + msgGasLimitMin),
+		},
+		{
+			name:     "one max",
+			msgGas:   uints(msgGasLimitMax),
+			expected: uints(subGasBase + subGasXmsgOverhead + msgGasLimitMax),
+		},
+		{
+			name:   "two min",
+			msgGas: uints(msgGasLimitMin, msgGasLimitMin),
+			expected: uints(
+				subGasBase + ((subGasXmsgOverhead + msgGasLimitMin) * 2),
+			),
+		},
+		{
+			name:   "two max",
+			msgGas: uints(msgGasLimitMax, msgGasLimitMax),
+			expected: uints(
+				subGasBase+subGasXmsgOverhead+msgGasLimitMax,
+				subGasBase+subGasXmsgOverhead+msgGasLimitMax,
+			),
+		},
+		{
+			name:   "many",
+			msgGas: uints(msgGasLimitMin, msgGasLimitMax, msgGasLimitMin, msgGasLimitMax, msgGasLimitMin, msgGasLimitMax),
+			expected: uints(
+				subGasBase+(subGasXmsgOverhead+msgGasLimitMax)+(subGasXmsgOverhead+msgGasLimitMin)*2,
+				subGasBase+(subGasXmsgOverhead+msgGasLimitMax)+(subGasXmsgOverhead+msgGasLimitMin)*1,
+				subGasBase+(subGasXmsgOverhead+msgGasLimitMax)+(subGasXmsgOverhead+msgGasLimitMin)*0,
+			),
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			var xmsgs []xchain.Msg
+			for _, gas := range test.msgGas {
+				xmsgs = append(xmsgs, xchain.Msg{DestGasLimit: gas})
+			}
+
+			groups := groupMsgsByCost(xmsgs)
+
+			require.Len(t, groups, len(test.expected))
+			for i, group := range groups {
+				require.Equal(t, int(test.expected[i]), int(estimateGas(group)))
+
+				// Ensure we never cross the max
+				require.LessOrEqual(t, int(estimateGas(group)), int(subGasMax))
+			}
+		})
+	}
+}
+
+func uints(ii ...uint64) []uint64 {
+	return ii
+}

--- a/relayer/app/metrics.go
+++ b/relayer/app/metrics.go
@@ -48,6 +48,14 @@ var (
 		Help:      "The total number of reverted (unsuccessful) submissions to destination chain from a specific source chain",
 	}, []string{"src_chain", "dst_chain"})
 
+	gasEstimated = promauto.NewHistogramVec(prometheus.HistogramOpts{
+		Namespace: "relayer",
+		Subsystem: "worker",
+		Name:      "estimated_gas",
+		Help:      "Estimated max gas usage by submissions by destination chain",
+		Buckets:   prometheus.ExponentialBuckets(21_000, 10_000_000, 8),
+	}, []string{"dst_chain"})
+
 	emitCursor = promauto.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: "relayer",
 		Subsystem: "monitor",


### PR DESCRIPTION
Implement a simple model for estimating submission gas. Use it to split streamUpdates into multiple submissions.

task: none