### PR TITLE
fix(halo/voter): fix trimming issues

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -76,6 +76,10 @@
       "path": "detect_secrets.filters.allowlist.is_line_allowlisted"
     },
     {
+      "path": "detect_secrets.filters.common.is_baseline_file",
+      "filename": ".secrets.baseline"
+    },
+    {
       "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
       "min_level": 2
     },
@@ -347,7 +351,7 @@
         "filename": "halo/attest/voter/voter.go",
         "hashed_secret": "9dd83331ff39a93b5b457a8b6b8835f7086a7d6c",
         "is_verified": false,
-        "line_number": 81
+        "line_number": 82
       }
     ],
     "halo/genutil/evm/testdata/TestMakeGenesis.golden": [
@@ -887,5 +891,5 @@
       }
     ]
   },
-  "generated_at": "2024-04-11T11:51:11Z"
+  "generated_at": "2024-04-12T12:39:18Z"
 }

--- a/halo/attest/voter/voter_internal_test.go
+++ b/halo/attest/voter/voter_internal_test.go
@@ -25,3 +25,8 @@ func LoadVoterForT(t *testing.T, privKey crypto.PrivKey, path string, provider x
 
 	return v
 }
+
+// LatestByChain returns the latest vote by chain for testing purposes only.
+func (v *Voter) LatestByChain(chainID uint64) (*types.Vote, bool) {
+	return v.latestByChain(chainID)
+}

--- a/halo/attest/voter/voter_test.go
+++ b/halo/attest/voter/voter_test.go
@@ -137,6 +137,9 @@ func TestVoteWindow(t *testing.T) {
 	w.Available(t, chain1, 2, true)
 	w.Available(t, chain1, 3, true)
 
+	// Propose 1
+	w.Propose(t, chain1, 1)
+
 	// Trim behind 3 (deletes 1 and 2)
 	l := w.v.TrimBehind(map[uint64]uint64{chain1: 3})
 	require.EqualValues(t, 2, l)
@@ -152,6 +155,11 @@ func TestVoteWindow(t *testing.T) {
 	w.Available(t, chain1, 1, false)
 	w.Available(t, chain1, 2, false)
 	w.Available(t, chain1, 3, false)
+
+	// Ensure latest by chain not trimmed.
+	latest, ok := w.v.LatestByChain(chain1)
+	require.True(t, ok)
+	require.EqualValues(t, 3, latest.BlockHeader.Height)
 }
 
 func TestVoter(t *testing.T) {
@@ -254,10 +262,11 @@ func TestVoter(t *testing.T) {
 	var stateJSON map[string]any
 	require.NoError(t, json.Unmarshal(bz, &stateJSON))
 
-	require.Len(t, stateJSON, 3)
+	require.Len(t, stateJSON, 4)
 	require.Empty(t, stateJSON["available"])
 	require.Empty(t, stateJSON["proposed"])
 	require.Len(t, stateJSON["committed"], 2) // One per chain
+	require.Len(t, stateJSON["latest"], 2)    // One per chain
 
 	v.AddErr(t, 1, 3)
 	v.AddErr(t, 1, 2)

--- a/halo/comet/comet.go
+++ b/halo/comet/comet.go
@@ -5,11 +5,15 @@ import (
 
 	"github.com/omni-network/omni/lib/errors"
 	"github.com/omni-network/omni/lib/k1util"
+	"github.com/omni-network/omni/lib/tracer"
 
 	rpcclient "github.com/cometbft/cometbft/rpc/client"
 	cmttypes "github.com/cometbft/cometbft/types"
 
 	"github.com/ethereum/go-ethereum/common"
+
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
 )
 
 const perPageConst = 100
@@ -37,6 +41,9 @@ type adapter struct {
 // IsValidator returns true if the given address is a validator at the latest height.
 // It is best-effort, so returns false on any error.
 func (a adapter) IsValidator(ctx context.Context, valAddress common.Address) bool {
+	ctx, span := tracer.Start(ctx, "comet/is_validator")
+	defer span.End()
+
 	status, err := a.cl.Status(ctx)
 	if err != nil || status.SyncInfo.CatchingUp {
 		return false // Best effort
@@ -64,6 +71,9 @@ func (a adapter) IsValidator(ctx context.Context, valAddress common.Address) boo
 // Validators returns the cometBFT validators at the given height or false if not
 // available (probably due to snapshot sync after height).
 func (a adapter) Validators(ctx context.Context, height int64) (*cmttypes.ValidatorSet, bool, error) {
+	ctx, span := tracer.Start(ctx, "comet/validators", trace.WithAttributes(attribute.Int64("height", height)))
+	defer span.End()
+
 	perPage := perPageConst // Can't take a pointer to a const directly.
 
 	var vals []*cmttypes.Validator


### PR DESCRIPTION
Fixes two issues in vote:
 - TrimBehind didn't trim proposed votes. It should since we shouldn't vote for them again.
 - TrimBehind interfered with the "ensure sequential votes" logic resulting in false positives. Rather keep explicit "latest vote" in state.

task: none