### PR TITLE
chore(halo/voter): remove halo queries

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -351,7 +351,7 @@
         "filename": "halo/attest/voter/voter.go",
         "hashed_secret": "9dd83331ff39a93b5b457a8b6b8835f7086a7d6c",
         "is_verified": false,
-        "line_number": 82
+        "line_number": 85
       }
     ],
     "halo/genutil/evm/testdata/TestMakeGenesis.golden": [
@@ -891,5 +891,5 @@
       }
     ]
   },
-  "generated_at": "2024-04-12T12:39:18Z"
+  "generated_at": "2024-04-15T11:50:56Z"
 }

--- a/halo/app/app.go
+++ b/halo/app/app.go
@@ -57,7 +57,7 @@ type App struct {
 	ConsensusParamsKeeper consensuskeeper.Keeper
 	EVMEngKeeper          *evmengkeeper.Keeper
 	AttestKeeper          *attestkeeper.Keeper
-	ValSyncKeeper         valsynckeeper.Keeper
+	ValSyncKeeper         *valsynckeeper.Keeper
 }
 
 // newApp returns a reference to an initialized App.
@@ -160,6 +160,7 @@ func (a App) SetCometAPI(api comet.API) {
 func (a App) SetVoter(voter atypes.Voter) {
 	a.AttestKeeper.SetVoter(voter)
 	a.EVMEngKeeper.SetAddressProvider(voter)
+	a.ValSyncKeeper.SetSubscriber(voter)
 }
 
 var (

--- a/halo/attest/testutil/mock_interfaces.go
+++ b/halo/attest/testutil/mock_interfaces.go
@@ -13,11 +13,12 @@ import (
 	context "context"
 	reflect "reflect"
 
+	types "github.com/cometbft/cometbft/abci/types"
 	crypto "github.com/cometbft/cometbft/proto/tendermint/crypto"
-	types "github.com/cosmos/cosmos-sdk/types"
+	types0 "github.com/cosmos/cosmos-sdk/types"
 	common "github.com/ethereum/go-ethereum/common"
-	types0 "github.com/omni-network/omni/halo/attest/types"
-	types1 "github.com/omni-network/omni/halo/valsync/types"
+	types1 "github.com/omni-network/omni/halo/attest/types"
+	types2 "github.com/omni-network/omni/halo/valsync/types"
 	gomock "go.uber.org/mock/gomock"
 )
 
@@ -45,7 +46,7 @@ func (m *MockStakingKeeper) EXPECT() *MockStakingKeeperMockRecorder {
 }
 
 // GetPubKeyByConsAddr mocks base method.
-func (m *MockStakingKeeper) GetPubKeyByConsAddr(arg0 context.Context, arg1 types.ConsAddress) (crypto.PublicKey, error) {
+func (m *MockStakingKeeper) GetPubKeyByConsAddr(arg0 context.Context, arg1 types0.ConsAddress) (crypto.PublicKey, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetPubKeyByConsAddr", arg0, arg1)
 	ret0, _ := ret[0].(crypto.PublicKey)
@@ -83,10 +84,10 @@ func (m *MockVoter) EXPECT() *MockVoterMockRecorder {
 }
 
 // GetAvailable mocks base method.
-func (m *MockVoter) GetAvailable() []*types0.Vote {
+func (m *MockVoter) GetAvailable() []*types1.Vote {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetAvailable")
-	ret0, _ := ret[0].([]*types0.Vote)
+	ret0, _ := ret[0].([]*types1.Vote)
 	return ret0
 }
 
@@ -111,7 +112,7 @@ func (mr *MockVoterMockRecorder) LocalAddress() *gomock.Call {
 }
 
 // SetCommitted mocks base method.
-func (m *MockVoter) SetCommitted(headers []*types0.BlockHeader) error {
+func (m *MockVoter) SetCommitted(headers []*types1.BlockHeader) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SetCommitted", headers)
 	ret0, _ := ret[0].(error)
@@ -125,7 +126,7 @@ func (mr *MockVoterMockRecorder) SetCommitted(headers any) *gomock.Call {
 }
 
 // SetProposed mocks base method.
-func (m *MockVoter) SetProposed(headers []*types0.BlockHeader) error {
+func (m *MockVoter) SetProposed(headers []*types1.BlockHeader) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SetProposed", headers)
 	ret0, _ := ret[0].(error)
@@ -139,17 +140,29 @@ func (mr *MockVoterMockRecorder) SetProposed(headers any) *gomock.Call {
 }
 
 // TrimBehind mocks base method.
-func (m *MockVoter) TrimBehind(edgesByChain map[uint64]uint64) int {
+func (m *MockVoter) TrimBehind(minsByChain map[uint64]uint64) int {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "TrimBehind", edgesByChain)
+	ret := m.ctrl.Call(m, "TrimBehind", minsByChain)
 	ret0, _ := ret[0].(int)
 	return ret0
 }
 
 // TrimBehind indicates an expected call of TrimBehind.
-func (mr *MockVoterMockRecorder) TrimBehind(edgesByChain any) *gomock.Call {
+func (mr *MockVoterMockRecorder) TrimBehind(minsByChain any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TrimBehind", reflect.TypeOf((*MockVoter)(nil).TrimBehind), edgesByChain)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TrimBehind", reflect.TypeOf((*MockVoter)(nil).TrimBehind), minsByChain)
+}
+
+// UpdateValidators mocks base method.
+func (m *MockVoter) UpdateValidators(valset []types.ValidatorUpdate) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "UpdateValidators", valset)
+}
+
+// UpdateValidators indicates an expected call of UpdateValidators.
+func (mr *MockVoterMockRecorder) UpdateValidators(valset any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateValidators", reflect.TypeOf((*MockVoter)(nil).UpdateValidators), valset)
 }
 
 // MockValProvider is a mock of ValProvider interface.
@@ -176,10 +189,10 @@ func (m *MockValProvider) EXPECT() *MockValProviderMockRecorder {
 }
 
 // ActiveSetByHeight mocks base method.
-func (m *MockValProvider) ActiveSetByHeight(ctx context.Context, height uint64) (*types1.ValidatorSetResponse, error) {
+func (m *MockValProvider) ActiveSetByHeight(ctx context.Context, height uint64) (*types2.ValidatorSetResponse, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ActiveSetByHeight", ctx, height)
-	ret0, _ := ret[0].(*types1.ValidatorSetResponse)
+	ret0, _ := ret[0].(*types2.ValidatorSetResponse)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/halo/attest/types/interface.go
+++ b/halo/attest/types/interface.go
@@ -3,6 +3,8 @@ package types
 import (
 	"context"
 
+	abci "github.com/cometbft/cometbft/abci/types"
+
 	"github.com/ethereum/go-ethereum/common"
 )
 
@@ -33,20 +35,18 @@ type Voter interface {
 	// LocalAddress returns the local validator's ethereum address.
 	LocalAddress() common.Address
 
-	// TrimBehind deletes all available votes that are behind the vote window edges (map[chainID]edge) since
+	// TrimBehind deletes all available votes that are behind the vote window minimums (map[chainID]minimum) since
 	// they will never be committed. It returns the number that was deleted.
-	TrimBehind(edgesByChain map[uint64]uint64) int
+	TrimBehind(minsByChain map[uint64]uint64) int
+
+	// UpdateValidators sets the latest validator set when passed to cometBFT.
+	// This is used to calculate whether the voter is in-or-out of the validator set.
+	UpdateValidators(valset []abci.ValidatorUpdate)
 }
 
 // VoterDeps abstracts the Voter's internal cosmosSDK dependencies; basically the attest keeper.
 // They have a circular dependency.
 type VoterDeps interface {
-	// IsValidator returns true if the given address is a validator on the given chain at the time of calling.
-	IsValidator(ctx context.Context, address common.Address) bool
-	// WindowCompare returns wether the given attestation block header is behind (-1), or in (0), or ahead (1)
-	// of the current vote window. The vote window is a configured number of blocks around the latest approved
-	// attestation for the provided chain.
-	WindowCompare(ctx context.Context, chainID uint64, height uint64) (int, error)
 	// LatestAttestationHeight returns the latest approved attestation height for the given chain.
 	LatestAttestationHeight(ctx context.Context, chainID uint64) (uint64, bool, error)
 }

--- a/halo/attest/voter/voter_internal_test.go
+++ b/halo/attest/voter/voter_internal_test.go
@@ -1,8 +1,8 @@
 package voter
 
 import (
+	"context"
 	"testing"
-	"time"
 
 	"github.com/omni-network/omni/halo/attest/types"
 	"github.com/omni-network/omni/lib/xchain"
@@ -15,13 +15,13 @@ import (
 // LoadVoterForT is a helper function to load a voter for testing.
 // It sets the backoff period to 1ms.
 func LoadVoterForT(t *testing.T, privKey crypto.PrivKey, path string, provider xchain.Provider,
-	deps types.VoterDeps, chains map[uint64]string,
+	deps types.VoterDeps, chains map[uint64]string, backoff func(),
 ) *Voter {
 	t.Helper()
 	v, err := LoadVoter(privKey, path, provider, deps, chains)
 	require.NoError(t, err)
 
-	v.backoffPeriod = time.Millisecond
+	v.backoffFunc = func(ctx context.Context) func() { return backoff }
 
 	return v
 }

--- a/halo/attest/voter/voter_test.go
+++ b/halo/attest/voter/voter_test.go
@@ -11,11 +11,11 @@ import (
 
 	"github.com/omni-network/omni/halo/attest/types"
 	"github.com/omni-network/omni/halo/attest/voter"
+	"github.com/omni-network/omni/lib/k1util"
 	"github.com/omni-network/omni/lib/xchain"
 
+	abci "github.com/cometbft/cometbft/abci/types"
 	k1 "github.com/cometbft/cometbft/crypto/secp256k1"
-
-	"github.com/ethereum/go-ethereum/common"
 
 	fuzz "github.com/google/gofuzz"
 	"github.com/stretchr/testify/require"
@@ -31,6 +31,8 @@ func TestRunner(t *testing.T) {
 	require.NoError(t, err)
 
 	pk := k1.GenPrivKey()
+	require.NoError(t, err)
+
 	const (
 		chain1     = 1
 		isVal      = true
@@ -40,13 +42,14 @@ func TestRunner(t *testing.T) {
 	)
 
 	prov := make(stubProvider)
-	deps := &mockDeps{isValChan: make(chan bool)}
-	v := voter.LoadVoterForT(t, pk, path, prov, deps, map[uint64]string{chain1: ""})
+	backoff := new(testBackOff)
+	deps := &mockDeps{}
+	v := voter.LoadVoterForT(t, pk, path, prov, deps, map[uint64]string{chain1: ""}, backoff.BackOff)
 
 	// callback is a helper function that calls the callback and asserts the error.
-	callback := func(t *testing.T, sub sub, deps *mockDeps, height uint64, isVal, ok bool) {
+	callback := func(t *testing.T, sub sub, height uint64, isVal, ok bool) {
 		t.Helper()
-		go func() { deps.isValChan <- isVal }() // IsValidator should be called first.
+		setIsVal(t, v, pk, isVal)
 		err := sub.callback(ctx, xchain.Block{
 			BlockHeader: xchain.BlockHeader{
 				SourceChainID: chain1,
@@ -65,39 +68,41 @@ func TestRunner(t *testing.T) {
 	// Start
 	v.Start(ctx)
 
-	// Assert it restarts a few time, checking IsValidator
-	deps.isValChan <- isNotVal
-	deps.isValChan <- isNotVal
+	// Assert it restarts a few (3) times, while not validator
+	require.Eventually(t, func() bool {
+		return backoff.Count() > 3
+	}, time.Second, time.Millisecond)
 
 	// Enable IsValidator, this will start a subscription
-	deps.isValChan <- isVal
+	setIsVal(t, v, pk, true)
 
 	sub := <-prov // Get the subscription
 	require.EqualValues(t, chain1, sub.chainID)
 	require.EqualValues(t, 0, sub.height)
 
-	callback(t, sub, deps, 0, isVal, returnsOk) // Callback block 0 (in window)
-	callback(t, sub, deps, 1, isVal, returnsOk) // Callback block 1 (after window)
+	callback(t, sub, 0, isVal, returnsOk) // Callback block 0 (in window)
+	callback(t, sub, 1, isVal, returnsOk) // Callback block 1 (after window)
 
-	deps.SetWindow(3)                            // Set window to 3
-	callback(t, sub, deps, 2, isVal, returnsErr) // Callback block 2 (before window) (triggers reset of worker)
+	v.TrimBehind(map[uint64]uint64{chain1: 3}) // Set window to 3
+	callback(t, sub, 2, isVal, returnsErr)     // Callback block 2 (before window) (triggers reset of worker)
 
 	// Assert it reset
-	deps.isValChan <- isVal
 	sub = <-prov // Get the new subscription
 	require.EqualValues(t, chain1, sub.chainID)
 	require.EqualValues(t, 2, sub.height) // Assert it starts from 2 this time
 
-	deps.SetWindow(2)                           // Set window to 2
-	callback(t, sub, deps, 2, isVal, returnsOk) // Callback block 2
+	v.TrimBehind(map[uint64]uint64{chain1: 2}) // Set window to 2
+	callback(t, sub, 2, isVal, returnsOk)      // Callback block 2
 
-	callback(t, sub, deps, 3, isNotVal, returnsErr) // Callback block 3, but not validator anymore (triggers reset of worker)
+	callback(t, sub, 3, isNotVal, returnsErr) // Callback block 3, but not validator anymore (triggers reset of worker)
+
+	// Enable IsValidator again
+	setIsVal(t, v, pk, true)
 
 	// Assert it reset
 	const newHeight = 99
 	deps.SetHeight(newHeight) // Set a new latest attestation height
-	deps.isValChan <- isVal
-	sub = <-prov // Get the new subscription
+	sub = <-prov              // Get the new subscription
 	require.EqualValues(t, chain1, sub.chainID)
 	require.EqualValues(t, newHeight+1, sub.height) // Assert it starts from newHeight+1 this time
 
@@ -117,10 +122,12 @@ func TestVoteWindow(t *testing.T) {
 	pk := k1.GenPrivKey()
 	const chain1 = 1
 
+	backoff := new(testBackOff)
 	prov := make(stubProvider)
-	deps := &mockDeps{isVal: true}
-	v := voter.LoadVoterForT(t, pk, path, prov, deps, map[uint64]string{chain1: ""})
+	deps := &mockDeps{}
+	v := voter.LoadVoterForT(t, pk, path, prov, deps, map[uint64]string{chain1: ""}, backoff.BackOff)
 	require.NoError(t, err)
+	setIsVal(t, v, pk, true)
 
 	v.Start(ctx)
 	expectSubscriptions(t, prov, chain1, 0)
@@ -183,14 +190,16 @@ func TestVoter(t *testing.T) {
 	reloadVoter := func(t *testing.T, from1, from2 uint64) *wrappedVoter {
 		t.Helper()
 		p := make(stubProvider)
-		a := voter.LoadVoterForT(t, pk, path, p, stubDeps{}, map[uint64]string{chain1: "", chain2: "", chain3: ""})
+		backoff := new(testBackOff)
+		v := voter.LoadVoterForT(t, pk, path, p, stubDeps{}, map[uint64]string{chain1: "", chain2: "", chain3: ""}, backoff.BackOff)
 		require.NoError(t, err)
+		setIsVal(t, v, pk, true)
 
 		cancel()
 		var ctx context.Context
 		ctx, cancel = context.WithCancel(context.Background())
 
-		a.Start(ctx)
+		v.Start(ctx)
 
 		expectSubscriptions(t, p,
 			chain1, from1,
@@ -198,7 +207,7 @@ func TestVoter(t *testing.T) {
 			chain3, 0,
 		)
 
-		return &wrappedVoter{v: a, f: fuzzer}
+		return &wrappedVoter{v: v, f: fuzzer}
 	}
 
 	v := reloadVoter(t, 0, 0)
@@ -376,53 +385,14 @@ func (w *wrappedVoter) AddErr(t *testing.T, chainID, height uint64) {
 }
 
 type mockDeps struct {
-	mu        sync.Mutex
-	isValChan chan bool // If non-nil, each IsValidator call will read from this.
-	isVal     bool      // Else IsValidator will return this.
-	window    uint64
-	height    uint64
-}
-
-func (m *mockDeps) SetIsValidator(is bool) {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-	m.isVal = is
-}
-
-func (m *mockDeps) SetWindow(w uint64) {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-	m.window = w
+	mu     sync.Mutex
+	height uint64
 }
 
 func (m *mockDeps) SetHeight(h uint64) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.height = h
-}
-
-func (m *mockDeps) IsValidator(context.Context, common.Address) bool {
-	if m.isValChan != nil {
-		return <-m.isValChan
-	}
-
-	m.mu.Lock()
-	defer m.mu.Unlock()
-
-	return m.isVal
-}
-
-func (m *mockDeps) WindowCompare(_ context.Context, _ uint64, height uint64) (int, error) {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-
-	if height < m.window {
-		return -1, nil
-	} else if height > m.window {
-		return 1, nil
-	}
-
-	return 0, nil
 }
 
 func (m *mockDeps) LatestAttestationHeight(context.Context, uint64) (uint64, bool, error) {
@@ -433,14 +403,6 @@ func (m *mockDeps) LatestAttestationHeight(context.Context, uint64) (uint64, boo
 }
 
 type stubDeps struct{}
-
-func (a stubDeps) IsValidator(context.Context, common.Address) bool {
-	return true
-}
-
-func (stubDeps) WindowCompare(context.Context, uint64, uint64) (int, error) {
-	return 0, nil
-}
 
 func (stubDeps) LatestAttestationHeight(context.Context, uint64) (uint64, bool, error) {
 	return 0, false, nil
@@ -483,4 +445,36 @@ func (stubProvider) GetSubmittedCursor(context.Context, uint64, uint64) (xchain.
 
 func (stubProvider) GetEmittedCursor(context.Context, uint64, uint64) (xchain.StreamCursor, bool, error) {
 	panic("unexpected")
+}
+
+type testBackOff struct {
+	mu      sync.Mutex
+	backoff int
+}
+
+func (b *testBackOff) Count() int {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	return b.backoff
+}
+
+func (b *testBackOff) BackOff() {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.backoff++
+}
+
+func setIsVal(t *testing.T, v *voter.Voter, pk k1.PrivKey, isVal bool) {
+	t.Helper()
+
+	cmtPubkey, err := k1util.PBPubKeyFromBytes(pk.PubKey().Bytes())
+	require.NoError(t, err)
+
+	power := int64(0)
+	if isVal {
+		power = 1
+	}
+
+	v.UpdateValidators([]abci.ValidatorUpdate{{PubKey: cmtPubkey, Power: power}})
 }

--- a/halo/valsync/keeper/common_internal_test.go
+++ b/halo/valsync/keeper/common_internal_test.go
@@ -17,13 +17,14 @@ import (
 )
 
 type mocks struct {
-	sKeeper *testutil.MockStakingKeeper
-	aKeeper *testutil.MockAttestKeeper
+	sKeeper    *testutil.MockStakingKeeper
+	aKeeper    *testutil.MockAttestKeeper
+	subscriber *testutil.MockSubscriber
 }
 
 type expectation func(sdk.Context, mocks)
 
-func setupKeeper(t *testing.T, expectations ...expectation) (Keeper, sdk.Context) {
+func setupKeeper(t *testing.T, expectations ...expectation) (*Keeper, sdk.Context) {
 	t.Helper()
 
 	key := storetypes.NewKVStoreKey(types.ModuleName)
@@ -36,8 +37,9 @@ func setupKeeper(t *testing.T, expectations ...expectation) (Keeper, sdk.Context
 	// gomock initialization
 	ctrl := gomock.NewController(t)
 	m := mocks{
-		sKeeper: testutil.NewMockStakingKeeper(ctrl),
-		aKeeper: testutil.NewMockAttestKeeper(ctrl),
+		sKeeper:    testutil.NewMockStakingKeeper(ctrl),
+		aKeeper:    testutil.NewMockAttestKeeper(ctrl),
+		subscriber: testutil.NewMockSubscriber(ctrl),
 	}
 
 	for _, exp := range expectations {
@@ -46,6 +48,7 @@ func setupKeeper(t *testing.T, expectations ...expectation) (Keeper, sdk.Context
 
 	k, err := NewKeeper(codec, storeSvc, m.sKeeper, m.aKeeper)
 	require.NoError(t, err, "new keeper")
+	k.SetSubscriber(m.subscriber)
 
 	return k, ctx
 }

--- a/halo/valsync/keeper/query_internal_test.go
+++ b/halo/valsync/keeper/query_internal_test.go
@@ -104,6 +104,8 @@ func approvedExpectation() expectation {
 			uint64(1), // Only query for 1 attestation.
 		).AnyTimes().
 			Return([]*types1.Attestation{{}}, nil)
+
+		m.subscriber.EXPECT().UpdateValidators(gomock.Any()).AnyTimes()
 	}
 }
 

--- a/halo/valsync/module/module.go
+++ b/halo/valsync/module/module.go
@@ -65,7 +65,7 @@ func (AppModuleBasic) RegisterGRPCGatewayRoutes(client.Context, *runtime.ServeMu
 type AppModule struct {
 	AppModuleBasic
 
-	keeper keeper.Keeper
+	keeper *keeper.Keeper
 }
 
 func (m AppModule) EndBlock(ctx context.Context) ([]abci.ValidatorUpdate, error) {
@@ -100,7 +100,7 @@ func (AppModuleBasic) ValidateGenesis(cdc codec.JSONCodec, _ client.TxEncodingCo
 
 func NewAppModule(
 	cdc codec.Codec,
-	keeper keeper.Keeper,
+	keeper *keeper.Keeper,
 ) AppModule {
 	return AppModule{
 		AppModuleBasic: NewAppModuleBasic(cdc),
@@ -146,7 +146,7 @@ type ModuleInputs struct {
 type ModuleOutputs struct {
 	depinject.Out
 
-	Keeper keeper.Keeper
+	Keeper *keeper.Keeper
 	Module appmodule.AppModule
 }
 

--- a/halo/valsync/testutil/expected_interfaces.go
+++ b/halo/valsync/testutil/expected_interfaces.go
@@ -12,3 +12,7 @@ type StakingKeeper interface {
 type AttestKeeper interface {
 	types.AttestKeeper
 }
+
+type Subscriber interface {
+	types.ValSetSubscriber
+}

--- a/halo/valsync/testutil/mock_interfaces.go
+++ b/halo/valsync/testutil/mock_interfaces.go
@@ -109,3 +109,38 @@ func (mr *MockAttestKeeperMockRecorder) ListAttestationsFrom(ctx, chainID, heigh
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListAttestationsFrom", reflect.TypeOf((*MockAttestKeeper)(nil).ListAttestationsFrom), ctx, chainID, height, max)
 }
+
+// MockSubscriber is a mock of Subscriber interface.
+type MockSubscriber struct {
+	ctrl     *gomock.Controller
+	recorder *MockSubscriberMockRecorder
+}
+
+// MockSubscriberMockRecorder is the mock recorder for MockSubscriber.
+type MockSubscriberMockRecorder struct {
+	mock *MockSubscriber
+}
+
+// NewMockSubscriber creates a new mock instance.
+func NewMockSubscriber(ctrl *gomock.Controller) *MockSubscriber {
+	mock := &MockSubscriber{ctrl: ctrl}
+	mock.recorder = &MockSubscriberMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockSubscriber) EXPECT() *MockSubscriberMockRecorder {
+	return m.recorder
+}
+
+// UpdateValidators mocks base method.
+func (m *MockSubscriber) UpdateValidators(arg0 []types.ValidatorUpdate) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "UpdateValidators", arg0)
+}
+
+// UpdateValidators indicates an expected call of UpdateValidators.
+func (mr *MockSubscriberMockRecorder) UpdateValidators(arg0 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateValidators", reflect.TypeOf((*MockSubscriber)(nil).UpdateValidators), arg0)
+}

--- a/halo/valsync/types/interfaces.go
+++ b/halo/valsync/types/interfaces.go
@@ -18,3 +18,7 @@ type StakingKeeper interface {
 	EndBlocker(ctx context.Context) ([]abci.ValidatorUpdate, error)
 	GetLastValidators(ctx context.Context) ([]stypes.Validator, error)
 }
+
+type ValSetSubscriber interface {
+	UpdateValidators(valset []abci.ValidatorUpdate)
+}

--- a/lib/k1util/k1util.go
+++ b/lib/k1util/k1util.go
@@ -125,6 +125,14 @@ func PubKeyToCosmos(pubkey crypto.PubKey) (cosmoscrypto.PubKey, error) {
 	}, nil
 }
 
+func PBPubKeyFromBytes(pubkey []byte) (cryptopb.PublicKey, error) {
+	if len(pubkey) != pubkeyCompressedLen {
+		return cryptopb.PublicKey{}, errors.New("invalid pubkey length", "length", len(pubkey))
+	}
+
+	return cryptopb.PublicKey{Sum: &cryptopb.PublicKey_Secp256K1{Secp256K1: pubkey}}, nil
+}
+
 // PubKeyPBToAddress returns the Ethereum address for the given k1 public key.
 func PubKeyPBToAddress(pubkey cryptopb.PublicKey) (common.Address, error) {
 	pubkeyBytes := pubkey.GetSecp256K1()


### PR DESCRIPTION
Removes the `windowCompare` and `IsValidator` queries from `voter.Deps` by avoiding queries all-together:
 - Use `voter.TrimBehind` to calculate `isInWindow`
 - Add a `UpdateValidators` function that is called by `valsync` keeper.

This remove all the queries completely so should increases vote speed significantly.

task: none
