### PR TITLE
fix(halo/evmengine): handle evm syncing

### DIFF
--- a/e2e/manifests/ci.toml
+++ b/e2e/manifests/ci.toml
@@ -2,6 +2,8 @@ network = "devnet"
 anvil_chains = ["mock_rollup", "mock_l1"]
 avs_target = "mock_l1"
 
+multi_omni_evms = true
+
 pingpong_n = 5 # Increased ping pong to span validator updates
 
 [node.validator01]

--- a/halo/evmengine/keeper/abci.go
+++ b/halo/evmengine/keeper/abci.go
@@ -95,6 +95,8 @@ func (k *Keeper) PrepareProposal(ctx sdk.Context, req *abci.RequestPreparePropos
 
 		payloadID = forkchoiceResp.PayloadID
 		triggeredAt = time.Now()
+	} else {
+		log.Debug(ctx, "Using optimistic payload", "height", height, "payload", payloadID.String())
 	}
 
 	// Wait the minimum build_delay for the payload to be available.

--- a/halo/evmengine/keeper/keeper_internal_test.go
+++ b/halo/evmengine/keeper/keeper_internal_test.go
@@ -116,7 +116,7 @@ func TestKeeper_isNextProposer(t *testing.T) {
 
 			cdc := getCodec(t)
 			txConfig := authtx.NewTxConfig(cdc, nil)
-			mockEngine, err := newMockEngineAPI()
+			mockEngine, err := newMockEngineAPI(0)
 			require.NoError(t, err)
 
 			cmtAPI := newMockCometAPI(t, tt.args.validatorsFunc)

--- a/halo/evmengine/keeper/proposal_server.go
+++ b/halo/evmengine/keeper/proposal_server.go
@@ -5,6 +5,10 @@ import (
 
 	"github.com/omni-network/omni/halo/evmengine/types"
 	"github.com/omni-network/omni/lib/errors"
+	"github.com/omni-network/omni/lib/expbackoff"
+	"github.com/omni-network/omni/lib/log"
+
+	"github.com/ethereum/go-ethereum/beacon/engine"
 
 	"github.com/cosmos/gogoproto/proto"
 )
@@ -18,7 +22,27 @@ type proposalServer struct {
 func (s proposalServer) ExecutionPayload(ctx context.Context, msg *types.MsgExecutionPayload,
 ) (*types.ExecutionPayloadResponse, error) {
 	// Push the payload to the EVM, ensuring it is valid.
-	payload, err := pushPayload(ctx, s.engineCl, msg)
+	var payload engine.ExecutableData
+	err := retryForever(ctx, func(ctx context.Context) (bool, error) {
+		pload, status, err := pushPayload(ctx, s.engineCl, msg)
+		if err != nil || isUnknown(status) {
+			// We need to retry forever on networking errors, but can't easily identify them, so retry all errors.
+			log.Warn(ctx, "Verifying proposal failed: push new payload to evm (will retry)", err,
+				"status", status.Status)
+
+			return false, nil // Retry
+		} else if invalid, err := isInvalid(status); invalid {
+			return false, errors.Wrap(err, "invalid payload, rejecting proposal") // Don't retry
+		} else if isSyncing(status) {
+			// If this is initial sync, we need to continue and set a target head to sync to, so don't retry.
+			log.Warn(ctx, "Can't properly verifying proposal: evm syncing", err,
+				"payload_height", pload.Number)
+		}
+
+		payload = pload
+
+		return true, nil // We are done, don't retry.
+	})
 	if err != nil {
 		return nil, err
 	}
@@ -57,4 +81,24 @@ func evmEventsEqual(a, b []*types.EVMEvent) error {
 	}
 
 	return nil
+}
+
+// backoffFunc aliased for testing.
+var backoffFunc = expbackoff.New
+
+func retryForever(ctx context.Context, fn func(ctx context.Context) (bool, error)) error {
+	backoff := backoffFunc(ctx)
+	for {
+		ok, err := fn(ctx)
+		if ctx.Err() != nil {
+			return errors.Wrap(ctx.Err(), "retry canceled")
+		} else if err != nil {
+			return err
+		} else if !ok {
+			backoff()
+			continue
+		}
+
+		return nil
+	}
 }

--- a/halo/evmengine/keeper/proposal_server_internal_test.go
+++ b/halo/evmengine/keeper/proposal_server_internal_test.go
@@ -1,12 +1,14 @@
 package keeper
 
 import (
+	"context"
 	"encoding/json"
 	"math/big"
 	"testing"
 	"time"
 
 	"github.com/omni-network/omni/halo/evmengine/types"
+	"github.com/omni-network/omni/lib/expbackoff"
 
 	"github.com/ethereum/go-ethereum/beacon/engine"
 	"github.com/ethereum/go-ethereum/common"
@@ -23,7 +25,7 @@ func Test_proposalServer_ExecutionPayload(t *testing.T) {
 	cdc := getCodec(t)
 	txConfig := authtx.NewTxConfig(cdc, nil)
 
-	mockEngine, err := newMockEngineAPI()
+	mockEngine, err := newMockEngineAPI(0)
 	require.NoError(t, err)
 
 	ctx, storeService := setupCtxStore(t, nil)
@@ -72,10 +74,10 @@ func Test_proposalServer_ExecutionPayload(t *testing.T) {
 
 	newPayload()
 	assertExecutionPayload()
+}
 
-	_, err = propSrv.ExecutionPayload(ctx, &types.MsgExecutionPayload{
-		Authority:        authtypes.NewModuleAddress(types.ModuleName).String(),
-		ExecutionPayload: []byte("invalid"),
-	})
-	require.Error(t, err)
+func fastBackoffForT() {
+	backoffFunc = func(context.Context, ...func(*expbackoff.Config)) func() {
+		return func() {}
+	}
 }


### PR DESCRIPTION
Handle evm syncing in evmengine.

When verifying proposals (ProcessProposal)
 - If payload invalid, reject proposal
 - if syncing, wait until not syncing
 - Other errors, retry 

When finalizing proposal (FinaliseBlock)
 - if payload invalid, error
 - if syncing, wait until not syncing
 - Other errors, retry

task: none