### PR TITLE
ci(e2e): debug validator insufficient balance

### DIFF
--- a/cli/cmd/devnet.go
+++ b/cli/cmd/devnet.go
@@ -278,15 +278,12 @@ func devnetFund(ctx context.Context, cfg devnetFundConfig) error {
 		return errors.Wrap(err, "wait mined")
 	}
 
-	b, err := backend.BalanceAt(ctx, addr, nil)
+	balance, err := backend.EtherBalanceAt(ctx, addr)
 	if err != nil {
 		return errors.Wrap(err, "get balance")
 	}
 
-	bf, _ := b.Float64()
-	bf /= params.Ether
-
-	log.Info(ctx, "Account funded", "address", cfg.Address, "balance", fmt.Sprintf("%.2f ETH", bf))
+	log.Info(ctx, "Account funded", "address", cfg.Address, "balance", fmt.Sprintf("%.2f ETH", balance))
 
 	return nil
 }

--- a/e2e/netman/helpers.go
+++ b/e2e/netman/helpers.go
@@ -9,23 +9,19 @@ import (
 	"github.com/omni-network/omni/lib/log"
 
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/params"
 )
 
 func logBalance(ctx context.Context, backend *ethbackend.Backend, chain string, addr common.Address, name string,
 ) error {
-	b, err := backend.BalanceAt(ctx, addr, nil)
+	balance, err := backend.EtherBalanceAt(ctx, addr)
 	if err != nil {
 		return errors.Wrap(err, "get balance")
 	}
 
-	bf, _ := b.Float64()
-	bf /= params.Ether
-
 	log.Info(ctx, "Provided public chain key balance",
 		"chain", chain,
 		"address", addr.Hex(),
-		"balance", fmt.Sprintf("%.2f", bf),
+		"balance", fmt.Sprintf("%.2f", balance),
 		"key_name", name,
 	)
 

--- a/e2e/netman/pingpong/pingpong.go
+++ b/e2e/netman/pingpong/pingpong.go
@@ -111,15 +111,12 @@ func (d *XDapp) LogBalances(ctx context.Context) error {
 			return err
 		}
 
-		b, err := backend.BalanceAt(ctx, contract.Address, nil)
+		balance, err := backend.EtherBalanceAt(ctx, contract.Address)
 		if err != nil {
 			return errors.Wrap(err, "balance at", "chain", contract.Chain.Name)
 		}
 
-		bf, _ := b.Float64()
-		bf /= params.Ether
-
-		log.Debug(ctx, "Ping pong balance", "chain", contract.Chain.Name, "balance", bf)
+		log.Debug(ctx, "Ping pong balance", "chain", contract.Chain.Name, "balance", balance)
 	}
 
 	return nil

--- a/lib/ethclient/ethclient.go
+++ b/lib/ethclient/ethclient.go
@@ -5,8 +5,10 @@ import (
 
 	"github.com/omni-network/omni/lib/errors"
 
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/ethclient"
+	"github.com/ethereum/go-ethereum/params"
 	"github.com/ethereum/go-ethereum/rpc"
 )
 
@@ -122,4 +124,18 @@ func (w Wrapper) PeerCount(ctx context.Context) (uint64, error) {
 	}
 
 	return resp, nil
+}
+
+// EtherBalanceAt returns the current balance in ether of the provided account.
+// Note this converts big.Int to float64 so IS NOT accurate.
+// Only use if accuracy is not required, i.e., for display/metrics purposes.
+func (w Wrapper) EtherBalanceAt(ctx context.Context, addr common.Address) (float64, error) {
+	b, err := w.BalanceAt(ctx, addr, nil)
+	if err != nil {
+		return 0, err
+	}
+
+	bf, _ := b.Float64()
+
+	return bf / params.Ether, nil
 }

--- a/lib/ethclient/ethclient_gen.go
+++ b/lib/ethclient/ethclient_gen.go
@@ -29,6 +29,7 @@ type Client interface {
 	ethereum.TransactionReader
 	ethereum.TransactionSender
 	HeaderByType(ctx context.Context, typ HeadType) (*types.Header, error)
+	EtherBalanceAt(ctx context.Context, addr common.Address) (float64, error)
 	PeerCount(ctx context.Context) (uint64, error)
 	Address() string
 	Close()

--- a/lib/ethclient/genwrap/genwrap.go
+++ b/lib/ethclient/genwrap/genwrap.go
@@ -45,6 +45,7 @@ type Client interface {
     {{range .Providers}} ethereum.{{.}}
     {{end -}}
 	HeaderByType(ctx context.Context, typ HeadType) (*types.Header, error)
+	EtherBalanceAt(ctx context.Context, addr common.Address) (float64, error)
     PeerCount(ctx context.Context) (uint64, error)
 	Address() string
 	Close()

--- a/lib/ethclient/mock/mock_interfaces.go
+++ b/lib/ethclient/mock/mock_interfaces.go
@@ -190,6 +190,21 @@ func (mr *MockClientMockRecorder) EstimateGas(ctx, call any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EstimateGas", reflect.TypeOf((*MockClient)(nil).EstimateGas), ctx, call)
 }
 
+// EtherBalanceAt mocks base method.
+func (m *MockClient) EtherBalanceAt(ctx context.Context, addr common.Address) (float64, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "EtherBalanceAt", ctx, addr)
+	ret0, _ := ret[0].(float64)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// EtherBalanceAt indicates an expected call of EtherBalanceAt.
+func (mr *MockClientMockRecorder) EtherBalanceAt(ctx, addr any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EtherBalanceAt", reflect.TypeOf((*MockClient)(nil).EtherBalanceAt), ctx, addr)
+}
+
 // FilterLogs mocks base method.
 func (m *MockClient) FilterLogs(ctx context.Context, q ethereum.FilterQuery) ([]types.Log, error) {
 	m.ctrl.T.Helper()

--- a/monitor/account/monitor.go
+++ b/monitor/account/monitor.go
@@ -8,8 +8,6 @@ import (
 	"github.com/omni-network/omni/lib/ethclient"
 	"github.com/omni-network/omni/lib/log"
 	"github.com/omni-network/omni/lib/netconf"
-
-	"github.com/ethereum/go-ethereum/params"
 )
 
 // startMonitoring starts the monitoring goroutines.
@@ -59,7 +57,7 @@ func monitorAccountForever(ctx context.Context, account account, chainName strin
 
 // monitorAccountOnce monitors account for the given chain.
 func monitorAccountOnce(ctx context.Context, account account, chainName string, client ethclient.Client) error {
-	balance, err := client.BalanceAt(ctx, account.addr, nil)
+	balance, err := client.EtherBalanceAt(ctx, account.addr)
 	if err != nil {
 		return errors.Wrap(err, "balance account")
 	}
@@ -69,10 +67,7 @@ func monitorAccountOnce(ctx context.Context, account account, chainName string, 
 		return errors.Wrap(err, "nonce account")
 	}
 
-	bf, _ := balance.Float64()
-	bf /= params.Ether
-
-	accountBalance.WithLabelValues(chainName, string(account.addressType)).Set(bf)
+	accountBalance.WithLabelValues(chainName, string(account.addressType)).Set(balance)
 	accountNonce.WithLabelValues(chainName, string(account.addressType)).Set(float64(nonce))
 
 	return nil

--- a/monitor/loadgen/stake.go
+++ b/monitor/loadgen/stake.go
@@ -12,7 +12,6 @@ import (
 	"github.com/omni-network/omni/lib/k1util"
 	"github.com/omni-network/omni/lib/log"
 
-	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/params"
 
@@ -50,7 +49,7 @@ func selfDelegateForever(ctx context.Context, contract *bindings.OmniStake, back
 func selfDelegateOnce(ctx context.Context, contract *bindings.OmniStake, backend *ethbackend.Backend, validator *ecdsa.PublicKey) error {
 	addr := crypto.PubkeyToAddress(*validator)
 
-	ethBalance, err := ethBalance(ctx, backend, addr)
+	ethBalance, err := backend.EtherBalanceAt(ctx, addr)
 	if err != nil {
 		return err
 	} else if ethBalance < 1 {
@@ -82,16 +81,4 @@ func selfDelegateOnce(ctx context.Context, contract *bindings.OmniStake, backend
 	)
 
 	return nil
-}
-
-// ethBalance returns the balance of an address in ether (1e18 wei).
-func ethBalance(ctx context.Context, backend *ethbackend.Backend, addr common.Address) (float64, error) {
-	bal, err := backend.BalanceAt(ctx, addr, nil)
-	if err != nil {
-		return 0, err
-	}
-
-	balF64, _ := bal.Float64()
-
-	return balF64 / params.Ether, nil
 }

--- a/relayer/app/monitor.go
+++ b/relayer/app/monitor.go
@@ -13,7 +13,6 @@ import (
 	"github.com/omni-network/omni/lib/xchain"
 
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/params"
 
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
@@ -200,7 +199,7 @@ func monitorAccountForever(ctx context.Context, addr common.Address, chainName s
 
 // monitorAccountOnce monitors the relayer account for the given chain.
 func monitorAccountOnce(ctx context.Context, addr common.Address, chainName string, client ethclient.Client) error {
-	balance, err := client.BalanceAt(ctx, addr, nil)
+	balance, err := client.EtherBalanceAt(ctx, addr)
 	if err != nil {
 		return errors.Wrap(err, "balance at")
 	}
@@ -210,9 +209,7 @@ func monitorAccountOnce(ctx context.Context, addr common.Address, chainName stri
 		return errors.Wrap(err, "nonce at")
 	}
 
-	bf, _ := balance.Float64()
-	bf /= params.Ether
-	accountBalance.WithLabelValues(chainName).Set(bf)
+	accountBalance.WithLabelValues(chainName).Set(balance)
 	accountNonce.WithLabelValues(chainName).Set(float64(nonce))
 
 	return nil


### PR DESCRIPTION
Adds validator balance to logs when funding validators. 

Also extract common `EtherBalanceAt` to reduce duplication.

task: none