### PR TITLE
ci(e2e): extend e2e timeouts

### DIFF
--- a/e2e/app/eoa/eoa.go
+++ b/e2e/app/eoa/eoa.go
@@ -40,18 +40,13 @@ func AllRoles() []Role {
 }
 
 func (r Role) Verify() error {
-	if r != RoleRelayer &&
-		r != RoleMonitor &&
-		r != RoleCreate3Deployer &&
-		r != RoleDeployer &&
-		r != RoleProxyAdminOwner &&
-		r != RoleFbDev &&
-		r != RolePortalAdmin &&
-		r != RoleAVSAdmin {
-		return errors.New("invalid role", "role", r)
+	for _, role := range AllRoles() {
+		if r == role {
+			return nil
+		}
 	}
 
-	return nil
+	return errors.New("invalid role", "role", r)
 }
 
 type Type string

--- a/e2e/app/wait.go
+++ b/e2e/app/wait.go
@@ -42,7 +42,7 @@ func waitingTime(nodes int, height int64) time.Duration {
 
 func WaitAllSubmissions(ctx context.Context, portals map[uint64]netman.Portal, minimum uint64) error {
 	log.Info(ctx, "Waiting for submissions on all destination chains")
-	ctx, cancel := context.WithTimeout(ctx, 2*time.Minute)
+	ctx, cancel := context.WithTimeout(ctx, 5*time.Minute)
 	defer cancel()
 
 	for _, dest := range portals {

--- a/e2e/netman/pingpong/pingpong.go
+++ b/e2e/netman/pingpong/pingpong.go
@@ -194,7 +194,7 @@ func (d *XDapp) StartAllEdges(ctx context.Context, parallel, count uint64) error
 // Note this doesn't wait for all parallel ping pongs to complete, it only waits for one of P.
 func (d *XDapp) WaitDone(ctx context.Context) error {
 	log.Info(ctx, "Waiting for ping pongs to complete")
-	ctx, cancel := context.WithTimeout(ctx, time.Minute)
+	ctx, cancel := context.WithTimeout(ctx, 5*time.Minute)
 	defer cancel()
 	for _, edge := range d.edges {
 		// Retry fetching done log until found or context is done

--- a/halo/cmd/cometconfig.go
+++ b/halo/cmd/cometconfig.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/omni-network/omni/lib/errors"
 	"github.com/omni-network/omni/lib/log"
@@ -38,6 +39,10 @@ func DefaultCometConfig(homeDir string) cfg.Config {
 	conf.SetRoot(conf.RootDir)
 	conf.LogLevel = "error"                            // Decrease default comet log level, it is super noisy.
 	conf.TxIndex = &cfg.TxIndexConfig{Indexer: "null"} // Disable tx indexing.
+
+	// Decrease statesync fetches and discovery
+	conf.StateSync.ChunkFetchers = 1
+	conf.StateSync.DiscoveryTime = time.Second * 10
 
 	return *conf
 }

--- a/halo/cmd/testdata/TestRunCmd_defaults.golden
+++ b/halo/cmd/testdata/TestRunCmd_defaults.golden
@@ -115,9 +115,9 @@
    "TrustPeriod": 604800000000000,
    "TrustHeight": 0,
    "TrustHash": "",
-   "DiscoveryTime": 15000000000,
+   "DiscoveryTime": 10000000000,
    "ChunkRequestTimeout": 10000000000,
-   "ChunkFetchers": 4
+   "ChunkFetchers": 1
   },
   "BlockSync": {
    "Version": "v0"

--- a/halo/cmd/testdata/TestRunCmd_flags.golden
+++ b/halo/cmd/testdata/TestRunCmd_flags.golden
@@ -115,9 +115,9 @@
    "TrustPeriod": 604800000000000,
    "TrustHeight": 0,
    "TrustHash": "",
-   "DiscoveryTime": 15000000000,
+   "DiscoveryTime": 10000000000,
    "ChunkRequestTimeout": 10000000000,
-   "ChunkFetchers": 4
+   "ChunkFetchers": 1
   },
   "BlockSync": {
    "Version": "v0"

--- a/halo/cmd/testdata/TestRunCmd_json_files.golden
+++ b/halo/cmd/testdata/TestRunCmd_json_files.golden
@@ -115,9 +115,9 @@
    "TrustPeriod": 604800000000000,
    "TrustHeight": 0,
    "TrustHash": "",
-   "DiscoveryTime": 15000000000,
+   "DiscoveryTime": 10000000000,
    "ChunkRequestTimeout": 10000000000,
-   "ChunkFetchers": 4
+   "ChunkFetchers": 1
   },
   "BlockSync": {
    "Version": "v0"

--- a/halo/cmd/testdata/TestRunCmd_toml_files.golden
+++ b/halo/cmd/testdata/TestRunCmd_toml_files.golden
@@ -115,9 +115,9 @@
    "TrustPeriod": 604800000000000,
    "TrustHeight": 0,
    "TrustHash": "",
-   "DiscoveryTime": 15000000000,
+   "DiscoveryTime": 10000000000,
    "ChunkRequestTimeout": 10000000000,
-   "ChunkFetchers": 4
+   "ChunkFetchers": 1
   },
   "BlockSync": {
    "Version": "v0"


### PR DESCRIPTION
ci.toml now runs 4 omni_evms instead of 1. This causes general slowdown on github runners causing timeouts so extend it.

Also:
 - Small optimisation wrt eoa role verify
 - Tune statesync to be more robust

task: none