### PR TITLE
fix(explorer/indexer): msg insert fix

### DIFF
--- a/explorer/indexer/app/db.go
+++ b/explorer/indexer/app/db.go
@@ -127,9 +127,9 @@ func insertMessages(ctx context.Context, tx *ent.Tx, block xchain.Block, dbBlock
 			SetStreamOffset(m.StreamOffset).
 			SetTxHash(m.TxHash[:]).
 			SetCreatedAt(time.Now()).
-			SetBlockHash(dbBlock.BlockHash).
-			SetBlockHeight(dbBlock.BlockHeight).
-			SetCreatedAt(dbBlock.CreatedAt).
+			SetBlockHash(block.BlockHash[:]).
+			SetBlockHeight(block.BlockHeight).
+			SetBlockTime(block.Timestamp).
 			Save(ctx)
 		if err != nil {
 			return errors.Wrap(err, "inserting message")

--- a/explorer/indexer/app/db_test.go
+++ b/explorer/indexer/app/db_test.go
@@ -186,6 +186,9 @@ func eval(t *testing.T, r results) {
 		var expectedMessageIDs []int
 		for _, m := range expectedMessages {
 			expectedMessageIDs = append(expectedMessageIDs, m.ID)
+			require.NotNil(t, m.BlockHash)
+			require.NotNil(t, m.BlockHeight)
+			require.NotNil(t, m.BlockTime)
 		}
 		actualMessageIDs := b.QueryMsgs().IDsX(context.Background())
 


### PR DESCRIPTION
Was inserting empty data from the wrong block reference.

task: none