### PR TITLE
chore(halo/attest): decrease genesis trim lag

### DIFF
--- a/halo/app/app_config.go
+++ b/halo/app/app_config.go
@@ -40,7 +40,7 @@ const (
 	// TODO(corver): Maybe move these to genesis itself.
 	genesisVoteWindow   = 64
 	genesisVoteExtLimit = 256
-	genesisTrimLag      = 1_000_000 // Delete application state after +-2 weeks (given period of 1.2s).
+	genesisTrimLag      = 72_000 // Delete attestations state after +-1 day (given a period of 1.2s).
 )
 
 // init initializes the Cosmos SDK configuration.

--- a/halo/evmengine/keeper/proposal_server_internal_test.go
+++ b/halo/evmengine/keeper/proposal_server_internal_test.go
@@ -77,6 +77,8 @@ func Test_proposalServer_ExecutionPayload(t *testing.T) {
 }
 
 func fastBackoffForT() {
+	backoffFuncMu.Lock()
+	defer backoffFuncMu.Unlock()
 	backoffFunc = func(context.Context, ...func(*expbackoff.Config)) func() {
 		return func() {}
 	}


### PR DESCRIPTION
Decrease attestation trim lag from 14 days to 1 day. This addresses our HUGE DB problem and should decrease the size by 10x.

task: none