### PR TITLE
chore(halo): decrease default prune options

### DIFF
--- a/halo/app/app_config.go
+++ b/halo/app/app_config.go
@@ -41,6 +41,9 @@ const (
 	genesisVoteWindow   = 64
 	genesisVoteExtLimit = 256
 	genesisTrimLag      = 72_000 // Delete attestations state after +-1 day (given a period of 1.2s).
+
+	defaultPruningKeep     = 72_000 // Keep 1 day's of application state by default (given period of 1.2s).
+	defaultPruningInterval = 300    // Prune every 5 minutes or so.
 )
 
 // init initializes the Cosmos SDK configuration.

--- a/halo/app/start.go
+++ b/halo/app/start.go
@@ -254,11 +254,18 @@ func makeBaseAppOpts(cfg Config) ([]func(*baseapp.BaseApp), error) {
 
 	snapshotOptions := snapshottypes.NewSnapshotOptions(cfg.SnapshotInterval, uint32(cfg.SnapshotKeepRecent))
 
+	pruneOpts := pruningtypes.NewPruningOptionsFromString(cfg.PruningOption)
+	if cfg.PruningOption == pruningtypes.PruningOptionDefault {
+		// Override the default cosmosSDK pruning values with much more aggressive defaults
+		// since historical state isn't very important for most use-cases.
+		pruneOpts = pruningtypes.NewCustomPruningOptions(defaultPruningKeep, defaultPruningInterval)
+	}
+
 	return []func(*baseapp.BaseApp){
 		// baseapp.SetOptimisticExecution(), // TODO(corver): Enable this.
 		baseapp.SetChainID(chainID),
 		baseapp.SetMinRetainBlocks(cfg.MinRetainBlocks),
-		baseapp.SetPruning(pruningtypes.NewPruningOptionsFromString(cfg.PruningOption)),
+		baseapp.SetPruning(pruneOpts),
 		baseapp.SetInterBlockCache(store.NewCommitKVStoreCacheManager()),
 		baseapp.SetSnapshot(snapshotStore, snapshotOptions),
 		baseapp.SetMempool(mempool.NoOpMempool{}),


### PR DESCRIPTION
Decrease the `default` prune option from 5 days to 1 day. This should also decrease disk usage by 5x. Normal users of halo don't need historical state in general. So 1 day should be fine as default.

task: none
