### PR TITLE
ci(e2e): fix flapping e2e test

### DIFF
--- a/e2e/app/definition.go
+++ b/e2e/app/definition.go
@@ -566,8 +566,8 @@ func externalNetwork(def Definition) netconf.Network {
 		}
 	}
 
-	// Connect to a random omni evm
-	omniEVM := random(def.Testnet.OmniEVMs)
+	// Connect to a proper omni_evm that isn't unavailable
+	omniEVM := def.Testnet.BroadcastOmniEVM()
 	omniEVMDepInfo := def.DeployInfos()[omniEVM.Chain.ID]
 	chains = append(chains, netconf.Chain{
 		ID:                omniEVM.Chain.ID,


### PR DESCRIPTION
Use a proposer `BroadcastEVM` when selecting EVM RPCs for external networks. Otherwise, validator04 is sometimes chosen which is down at the start of E2E and so cannot mine transactions.

task: none