### PR TITLE
refactor(halo): move authrpc field from netconf to halo flag

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -208,28 +208,28 @@
         "filename": "e2e/app/setup.go",
         "hashed_secret": "7be029054a936fcb1827abd24388a53136be7b64",
         "is_verified": false,
-        "line_number": 139
+        "line_number": 140
       },
       {
         "type": "Secret Keyword",
         "filename": "e2e/app/setup.go",
         "hashed_secret": "55abc9109d5ea8a77be16bf3c76b4b199b524b12",
         "is_verified": false,
-        "line_number": 362
+        "line_number": 364
       },
       {
         "type": "Secret Keyword",
         "filename": "e2e/app/setup.go",
         "hashed_secret": "da57af224108e98e24d1e2a86221121990fa6478",
         "is_verified": false,
-        "line_number": 391
+        "line_number": 393
       },
       {
         "type": "Secret Keyword",
         "filename": "e2e/app/setup.go",
         "hashed_secret": "b11b6052ab454c167964c5b836faf0053a711b90",
         "is_verified": false,
-        "line_number": 435
+        "line_number": 437
       }
     ],
     "e2e/manifests/staging.toml": [
@@ -882,5 +882,5 @@
       }
     ]
   },
-  "generated_at": "2024-04-18T12:32:13Z"
+  "generated_at": "2024-04-25T12:14:21Z"
 }

--- a/e2e/app/definition.go
+++ b/e2e/app/definition.go
@@ -361,17 +361,16 @@ func TestnetFromManifest(ctx context.Context, manifest types.Manifest, infd type
 		}
 
 		omniEVMS = append(omniEVMS, types.OmniEVM{
-			Chain:           types.OmniEVMByNetwork(manifest.Network),
-			InstanceName:    name,
-			AdvertisedIP:    advertisedIP,
-			ProxyPort:       inst.Port,
-			InternalRPC:     fmt.Sprintf("http://%s:8545", internalIP),
-			InternalAuthRPC: fmt.Sprintf("http://%s:8551", internalIP),
-			ExternalRPC:     fmt.Sprintf("http://%s:%d", inst.ExtIPAddress.String(), inst.Port),
-			NodeKey:         nodeKey,
-			Enode:           en,
-			IsArchive:       isArchive,
-			JWTSecret:       tutil.RandomHash().Hex(),
+			Chain:        types.OmniEVMByNetwork(manifest.Network),
+			InstanceName: name,
+			AdvertisedIP: advertisedIP,
+			ProxyPort:    inst.Port,
+			InternalRPC:  fmt.Sprintf("http://%s:8545", internalIP),
+			ExternalRPC:  fmt.Sprintf("http://%s:%d", inst.ExtIPAddress.String(), inst.Port),
+			NodeKey:      nodeKey,
+			Enode:        en,
+			IsArchive:    isArchive,
+			JWTSecret:    tutil.RandomHash().Hex(),
 		})
 	}
 
@@ -498,7 +497,6 @@ func internalNetwork(def Definition, evmPrefix string) netconf.Network {
 		ID:                omniEVM.Chain.ID,
 		Name:              omniEVM.Chain.Name,
 		RPCURL:            omniEVM.InternalRPC,
-		AuthRPCURL:        omniEVM.InternalAuthRPC,
 		BlockPeriod:       omniEVM.Chain.BlockPeriod,
 		FinalizationStrat: omniEVM.Chain.FinalizationStrat,
 		IsOmniEVM:         true,

--- a/e2e/types/testnet.go
+++ b/e2e/types/testnet.go
@@ -105,15 +105,14 @@ type EVMChain struct {
 
 // OmniEVM represents a omni evm instance in a omni network. Similar to e2e.Node for halo instances.
 type OmniEVM struct {
-	Chain           EVMChain // For netconf (all instances must have the same chain)
-	InstanceName    string   // For docker container name
-	AdvertisedIP    net.IP   // For setting up NAT on geth bootnode
-	ProxyPort       uint32   // For binding
-	InternalRPC     string   // For JSON-RPC queries from halo/relayer
-	InternalAuthRPC string   // For engine API queries from halo
-	ExternalRPC     string   // For JSON-RPC queries from e2e app.
-	IsArchive       bool     // Whether this instance is in archive mode
-	JWTSecret       string   // JWT secret for authentication
+	Chain        EVMChain // For netconf (all instances must have the same chain)
+	InstanceName string   // For docker container name
+	AdvertisedIP net.IP   // For setting up NAT on geth bootnode
+	ProxyPort    uint32   // For binding
+	InternalRPC  string   // For JSON-RPC queries from halo/relayer
+	ExternalRPC  string   // For JSON-RPC queries from e2e app.
+	IsArchive    bool     // Whether this instance is in archive mode
+	JWTSecret    string   // JWT secret for authentication
 
 	// P2P networking
 	NodeKey *ecdsa.PrivateKey // Private key

--- a/halo/app/start.go
+++ b/halo/app/start.go
@@ -81,6 +81,10 @@ func Run(ctx context.Context, cfg Config) error {
 func Start(ctx context.Context, cfg Config) (func(context.Context) error, error) {
 	log.Info(ctx, "Starting halo consensus client")
 
+	if err := cfg.Verify(); err != nil {
+		return nil, errors.Wrap(err, "verify halo config")
+	}
+
 	buildinfo.Instrument(ctx)
 
 	network, err := netconf.Load(cfg.NetworkFile())
@@ -306,12 +310,7 @@ func newEngineClient(ctx context.Context, cfg Config, network netconf.Network, p
 		return nil, errors.Wrap(err, "load engine JWT file")
 	}
 
-	omniChain, ok := network.OmniEVMChain()
-	if !ok {
-		return nil, errors.New("omni chain not found in network")
-	}
-
-	engineCl, err := ethclient.NewAuthClient(ctx, omniChain.AuthRPCURL, jwtBytes)
+	engineCl, err := ethclient.NewAuthClient(ctx, cfg.EngineEndpoint, jwtBytes)
 	if err != nil {
 		return nil, errors.Wrap(err, "create engine client")
 	}

--- a/halo/app/start_test.go
+++ b/halo/app/start_test.go
@@ -118,6 +118,8 @@ func setupSimnet(t *testing.T) haloapp.Config {
 	haloCfg.HomeDir = homeDir
 	haloCfg.BackendType = string(db.MemDBBackend)
 	haloCfg.EVMBuildDelay = time.Millisecond
+	haloCfg.EngineEndpoint = "dummy"
+	haloCfg.EngineJWTFile = "dummy"
 
 	cfg := haloapp.Config{
 		Config: haloCfg,

--- a/halo/cmd/cmd.go
+++ b/halo/cmd/cmd.go
@@ -53,7 +53,7 @@ func newRunCmd(name string, runFunc func(context.Context, app.Config) error) *co
 		},
 	}
 
-	bindRunFlags(cmd.Flags(), &haloCfg)
+	bindRunFlags(cmd, &haloCfg)
 	log.BindFlags(cmd.Flags(), &logCfg)
 
 	return cmd

--- a/halo/cmd/flags.go
+++ b/halo/cmd/flags.go
@@ -5,12 +5,16 @@ import (
 	libcmd "github.com/omni-network/omni/lib/cmd"
 	"github.com/omni-network/omni/lib/tracer"
 
+	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 )
 
-func bindRunFlags(flags *pflag.FlagSet, cfg *halocfg.Config) {
+func bindRunFlags(cmd *cobra.Command, cfg *halocfg.Config) {
+	flags := cmd.Flags()
+
 	libcmd.BindHomeFlag(flags, &cfg.HomeDir)
 	tracer.BindFlags(flags, &cfg.Tracer)
+	flags.StringVar(&cfg.EngineEndpoint, "engine-endpoint", cfg.EngineEndpoint, "An EVM execution client Engine API http endpoint")
 	flags.StringVar(&cfg.EngineJWTFile, "engine-jwt-file", cfg.EngineJWTFile, "The path to the Engine API JWT file")
 	flags.Uint64Var(&cfg.SnapshotInterval, "snapshot-interval", cfg.SnapshotInterval, "State sync snapshot interval")
 	flags.Uint64Var(&cfg.SnapshotKeepRecent, "snapshot-keep-recent", cfg.SnapshotKeepRecent, "State sync snapshot to keep")

--- a/halo/cmd/testdata/TestCLIReference_run.golden
+++ b/halo/cmd/testdata/TestCLIReference_run.golden
@@ -6,6 +6,7 @@ Usage:
 Flags:
       --app-db-backend string            The type of database for application and snapshots databases (default "goleveldb")
       --eigenlayer-key-password string   Eigenlayer generated operator key password. Not required if CombetBFT priv_validator_key.json is used
+      --engine-endpoint string           An EVM execution client Engine API http endpoint
       --engine-jwt-file string           The path to the Engine API JWT file
       --evm-build-delay duration         Minimum delay between triggering and fetching a EVM payload build (default 600ms)
       --evm-build-optimistic             Enables optimistic building of EVM payloads on previous block finalize (default true)

--- a/halo/cmd/testdata/TestRunCmd_defaults.golden
+++ b/halo/cmd/testdata/TestRunCmd_defaults.golden
@@ -2,6 +2,7 @@
  "HomeDir": "./halo",
  "EigenKeyPassword": "",
  "EngineJWTFile": "",
+ "EngineEndpoint": "",
  "SnapshotInterval": 1000,
  "SnapshotKeepRecent": 2,
  "BackendType": "goleveldb",

--- a/halo/cmd/testdata/TestRunCmd_flags.golden
+++ b/halo/cmd/testdata/TestRunCmd_flags.golden
@@ -2,6 +2,7 @@
  "HomeDir": "foo",
  "EigenKeyPassword": "",
  "EngineJWTFile": "bar",
+ "EngineEndpoint": "",
  "SnapshotInterval": 1000,
  "SnapshotKeepRecent": 2,
  "BackendType": "goleveldb",

--- a/halo/cmd/testdata/TestRunCmd_json_files.golden
+++ b/halo/cmd/testdata/TestRunCmd_json_files.golden
@@ -2,6 +2,7 @@
  "HomeDir": "testinput/input2",
  "EigenKeyPassword": "123456",
  "EngineJWTFile": "jwt.json",
+ "EngineEndpoint": "",
  "SnapshotInterval": 123,
  "SnapshotKeepRecent": 2,
  "BackendType": "goleveldb",

--- a/halo/cmd/testdata/TestRunCmd_toml_files.golden
+++ b/halo/cmd/testdata/TestRunCmd_toml_files.golden
@@ -2,6 +2,7 @@
  "HomeDir": "testinput/input1",
  "EigenKeyPassword": "",
  "EngineJWTFile": "jwt.toml",
+ "EngineEndpoint": "",
  "SnapshotInterval": 999,
  "SnapshotKeepRecent": 2,
  "BackendType": "goleveldb",

--- a/halo/config/config.go
+++ b/halo/config/config.go
@@ -43,8 +43,9 @@ const (
 func DefaultConfig() Config {
 	return Config{
 		HomeDir:            DefaultHomeDir,
-		EigenKeyPassword:   "", // No default
+		EngineEndpoint:     "", // No default
 		EngineJWTFile:      "", // No default
+		EigenKeyPassword:   "", // No default
 		SnapshotInterval:   defaultSnapshotInterval,
 		SnapshotKeepRecent: defaultSnapshotKeepRecent,
 		BackendType:        string(defaultDBBackend),
@@ -61,6 +62,7 @@ type Config struct {
 	HomeDir            string
 	EigenKeyPassword   string
 	EngineJWTFile      string
+	EngineEndpoint     string
 	SnapshotInterval   uint64 // See cosmossdk.io/store/snapshots/types/options.go
 	SnapshotKeepRecent uint64 // See cosmossdk.io/store/snapshots/types/options.go
 	BackendType        string // See cosmos-db/db.go
@@ -106,6 +108,16 @@ func (c Config) KeystoreGlob() string {
 // It returns an error if multiple files are found.
 func (c Config) KeystoreFile() (string, bool, error) {
 	return statGlobSingle(c.KeystoreGlob())
+}
+
+func (c Config) Verify() error {
+	if c.EngineEndpoint == "" {
+		return errors.New("flag --engine-endpoint is empty")
+	} else if c.EngineJWTFile == "" {
+		return errors.New("flag --engine-jwt-file is empty")
+	}
+
+	return nil
 }
 
 //go:embed config.toml.tmpl

--- a/halo/config/config.toml.tmpl
+++ b/halo/config/config.toml.tmpl
@@ -9,6 +9,9 @@ version = "{{ .Version }}"
 ###                          Halo Options                           ###
 #######################################################################
 
+# Omni chain execution client Engine API http endpoint.
+engine-endpoint = "{{ .EngineEndpoint }}"
+
 # Omni chain execution client JWT file used for authentication.
 engine-jwt-file = "{{ .EngineJWTFile }}"
 

--- a/halo/config/testdata/default_halo.toml
+++ b/halo/config/testdata/default_halo.toml
@@ -9,6 +9,9 @@ version = "v0.1.3"
 ###                          Halo Options                           ###
 #######################################################################
 
+# Omni chain execution client Engine API http endpoint.
+engine-endpoint = ""
+
 # Omni chain execution client JWT file used for authentication.
 engine-jwt-file = ""
 

--- a/lib/netconf/netconf.go
+++ b/lib/netconf/netconf.go
@@ -156,7 +156,6 @@ type Chain struct {
 	ID                uint64            // Chain ID asa per https://chainlist.org
 	Name              string            // Chain name as per https://chainlist.org
 	RPCURL            string            // RPC URL of the chain
-	AuthRPCURL        string            // RPC URL of the chain with JWT authentication enabled
 	PortalAddress     common.Address    // Address of the omni portal contract on the chain
 	DeployHeight      uint64            // Height that the portal contracts were deployed
 	IsOmniEVM         bool              // Whether this is the Omni EVM chain
@@ -209,7 +208,6 @@ type chainJSON struct {
 	ID                uint64            `json:"id"`
 	Name              string            `json:"name"`
 	RPCURL            string            `json:"rpcurl"`
-	AuthRPCURL        string            `json:"auth_rpcurl,omitempty"`
 	PortalAddress     string            `json:"portal_address"`
 	DeployHeight      uint64            `json:"deploy_height"`
 	IsOmniEVM         bool              `json:"is_omni_evm,omitempty"`
@@ -246,7 +244,6 @@ func (c *Chain) UnmarshalJSON(bz []byte) error {
 		ID:                cj.ID,
 		Name:              cj.Name,
 		RPCURL:            cj.RPCURL,
-		AuthRPCURL:        cj.AuthRPCURL,
 		PortalAddress:     portalAddr,
 		DeployHeight:      cj.DeployHeight,
 		IsOmniEVM:         cj.IsOmniEVM,
@@ -275,7 +272,6 @@ func (c Chain) MarshalJSON() ([]byte, error) {
 		ID:                c.ID,
 		Name:              c.Name,
 		RPCURL:            c.RPCURL,
-		AuthRPCURL:        c.AuthRPCURL,
 		PortalAddress:     portalAddr,
 		DeployHeight:      c.DeployHeight,
 		IsOmniEVM:         c.IsOmniEVM,

--- a/lib/netconf/testdata/TestSaveLoad.golden
+++ b/lib/netconf/testdata/TestSaveLoad.golden
@@ -5,38 +5,38 @@
    "id": 5828590068104375683,
    "name": "鎢屃裂À",
    "rpcurl": "飖Ǒp!ǪŰM旰綷罨袢捺悲ȅ-@",
-   "auth_rpcurl": "ʛ,^籿Ź濓\u003c鈡鶭ŁPyÌ",
-   "portal_address": "0x2ceFB439380e1E4066cDEFfEe9ec171d0F345D33",
-   "deploy_height": 5437755693941739170,
-   "is_omni_consensus": true,
-   "block_period": "2354805h17m7.671536598s",
-   "finalization_start": "鄏þƿ髈儱Ŀ蒫÷K鬣壈",
-   "avs_contract_address": "0xac7367A66A13087A9889EF3f0C9437545dF513a2"
-  },
-  {
-   "id": 13459205444906724476,
-   "name": "aǇ趴x瑻霳鸻ȉ",
-   "rpcurl": "+ËQLuVǭz瘯霡豐Ȭ-ƀh婉Ţ飦t",
-   "auth_rpcurl": "R涞!Ä\u003e漌Ǭ顼溹*",
-   "portal_address": "0x87F059AC134759D71E5AF9669ba97e342c6B656b",
-   "deploy_height": 10254432012947362948,
+   "portal_address": "0x78968D1662E46D908944a92A4B5AeFcD2c841eC7",
+   "deploy_height": 1900800649570732577,
    "is_omni_evm": true,
    "is_ethereum": true,
-   "block_period": "1392685h44m1.507918464s",
-   "finalization_start": "ʈ劉j蕓ư銩6ĳ憏歅%ɜ¤0Ȼ",
-   "avs_contract_address": "0x9365C528Deb1d9De9E7Fc8B0126586329CC669Cf"
+   "block_period": "-935053h4m54.403288883s",
+   "finalization_start": "IeYF墄[C_",
+   "avs_contract_address": "0x33a2818d7F2c5644D428EDbd78130cB999EdD378"
   },
   {
-   "id": 694998618745504662,
-   "name": "殪\"g踮螧喘夓麑Y·L继Ɂɯz剩Ʉ",
-   "rpcurl": "Ƒ»",
-   "auth_rpcurl": "3瓯洼籏Ħ*噷·oũ答Bc黰¢ơđ?ȵ",
-   "portal_address": "0x30D6c076C7d6A929AaAf991153a5915Eb2909435",
-   "deploy_height": 17022257212851920996,
+   "id": 4303487026632006283,
+   "name": "ɥmeCʊ 炄闌剾",
+   "rpcurl": "ʅȀʙĄĥ腲ʤaǇ趴",
+   "portal_address": "0x8cFD558406d45816570dA345A258a4F475f17fE5",
+   "deploy_height": 2939510796997021459,
+   "is_omni_consensus": true,
+   "is_ethereum": true,
+   "block_period": "-530658h29m31.733917296s",
+   "finalization_start": "",
+   "avs_contract_address": "0xd713BDeDf81e7675242619af19b8C358B31dAa3e"
+  },
+  {
+   "id": 12220965479361160785,
+   "name": "ɀÄf渂硹譯匬襧*|机Ȱ晸ʈ劉j",
+   "rpcurl": "ŻHĦɈ好ǎ+扰_",
+   "portal_address": "0x53aD16b7e98AA9375e2e4bC9922b44f63e11e13f",
+   "deploy_height": 5470582473102924320,
    "is_omni_evm": true,
-   "block_period": "-1600609h58m29.865376476s",
-   "finalization_start": "ą韥Üfǅ噊",
-   "avs_contract_address": "0xDcD190a024C9Fe6b853D4af6838F022787D34C00"
+   "is_omni_consensus": true,
+   "is_ethereum": true,
+   "block_period": "193055h10m18.745504662s",
+   "finalization_start": "殪\"g踮螧喘夓麑Y·L继Ɂɯz剩Ʉ",
+   "avs_contract_address": "0xa42E21C06dB26dA0ea24B0B3FDf951a5a40C0754"
   }
  ]
 }


### PR DESCRIPTION
First step in refactor netconf to use onchain registry.

Remove `Chain.AuthRPC` from netconf and move to a flag `--engine-endpoint` on halo.

task: none