### PR TITLE
refactor(lib/netconf): remove avs related fields

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -76,10 +76,6 @@
       "path": "detect_secrets.filters.allowlist.is_line_allowlisted"
     },
     {
-      "path": "detect_secrets.filters.common.is_baseline_file",
-      "filename": ".secrets.baseline"
-    },
-    {
       "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
       "min_level": 2
     },
@@ -174,14 +170,14 @@
         "filename": "e2e/app/definition.go",
         "hashed_secret": "6616ab7d49764018125fb7f010148dbb655e2c44",
         "is_verified": false,
-        "line_number": 64
+        "line_number": 63
       },
       {
         "type": "Basic Auth Credentials",
         "filename": "e2e/app/definition.go",
         "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
         "is_verified": false,
-        "line_number": 67
+        "line_number": 66
       }
     ],
     "e2e/app/geth/testdata/TestWriteConfigTOML_archive.golden": [
@@ -238,7 +234,7 @@
         "filename": "e2e/manifests/staging.toml",
         "hashed_secret": "f2400ac6800113efbeede5e2b7942549147600b3",
         "is_verified": false,
-        "line_number": 21
+        "line_number": 20
       }
     ],
     "e2e/manifests/testnet.toml": [
@@ -247,14 +243,14 @@
         "filename": "e2e/manifests/testnet.toml",
         "hashed_secret": "70c787f6b2cb3bfce2a249c364dda0fc70b2f6b1",
         "is_verified": false,
-        "line_number": 48
+        "line_number": 46
       },
       {
         "type": "Hex High Entropy String",
         "filename": "e2e/manifests/testnet.toml",
         "hashed_secret": "7d389016386dad7957488ad08e577a7f7fef8a26",
         "is_verified": false,
-        "line_number": 54
+        "line_number": 52
       }
     ],
     "explorer/Makefile": [
@@ -327,6 +323,1905 @@
         "line_number": 13
       }
     ],
+    "explorer/ui/app/assets/icons/config.json": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "explorer/ui/app/assets/icons/config.json",
+        "hashed_secret": "a230cd3dba690966f922d2f747bfb8e00c773ee9",
+        "is_verified": false,
+        "line_number": 11
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "explorer/ui/app/assets/icons/config.json",
+        "hashed_secret": "daaa8bd9aef3b2c07836f6eba50bbdc63e105443",
+        "is_verified": false,
+        "line_number": 25
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "explorer/ui/app/assets/icons/config.json",
+        "hashed_secret": "89dcacbb69601ab8892906d16bfe92c1ce01c031",
+        "is_verified": false,
+        "line_number": 39
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "explorer/ui/app/assets/icons/config.json",
+        "hashed_secret": "bf228cad75f067962e15c81c8970b5037ab256ed",
+        "is_verified": false,
+        "line_number": 53
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "explorer/ui/app/assets/icons/config.json",
+        "hashed_secret": "90d04de8d3407195ab11746f721e632cc6609a01",
+        "is_verified": false,
+        "line_number": 67
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "explorer/ui/app/assets/icons/config.json",
+        "hashed_secret": "575703c4d6500136e3d2242f78c0dee47c4cd510",
+        "is_verified": false,
+        "line_number": 81
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "explorer/ui/app/assets/icons/config.json",
+        "hashed_secret": "b939258afd50daa37d0e7071b60095e90e4e442b",
+        "is_verified": false,
+        "line_number": 95
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "explorer/ui/app/assets/icons/config.json",
+        "hashed_secret": "e65cb41cedbc697af145392058b17427b1309fac",
+        "is_verified": false,
+        "line_number": 109
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "explorer/ui/app/assets/icons/config.json",
+        "hashed_secret": "4f86fc543db144fc50a9d3949f293950b2a1a8ac",
+        "is_verified": false,
+        "line_number": 123
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "explorer/ui/app/assets/icons/config.json",
+        "hashed_secret": "570cc89ba8f2e68052dd923eb6f905cf17b05656",
+        "is_verified": false,
+        "line_number": 137
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "explorer/ui/app/assets/icons/config.json",
+        "hashed_secret": "74b9f41117c45c76232b31d427a9aebc278ab907",
+        "is_verified": false,
+        "line_number": 151
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "explorer/ui/app/assets/icons/config.json",
+        "hashed_secret": "181fd18bbf7e60c043389022a3075a0414cd46b7",
+        "is_verified": false,
+        "line_number": 165
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "explorer/ui/app/assets/icons/config.json",
+        "hashed_secret": "faedb4795a83f63aa0ca1dbee37860df2af5439a",
+        "is_verified": false,
+        "line_number": 179
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "explorer/ui/app/assets/icons/config.json",
+        "hashed_secret": "a67db802a89f6384388c99c087cd01a228e671a7",
+        "is_verified": false,
+        "line_number": 193
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "explorer/ui/app/assets/icons/config.json",
+        "hashed_secret": "fcff7642cc49e1bb5f267b57d957f3bc6eb6dd98",
+        "is_verified": false,
+        "line_number": 207
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "explorer/ui/app/assets/icons/config.json",
+        "hashed_secret": "e8d5a9d9555f1248f87086f6faf1beef4b50eddc",
+        "is_verified": false,
+        "line_number": 221
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "explorer/ui/app/assets/icons/config.json",
+        "hashed_secret": "96421d99547ab17034bbd1d1d4eaa48c4094e128",
+        "is_verified": false,
+        "line_number": 235
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "explorer/ui/app/assets/icons/config.json",
+        "hashed_secret": "ae277fbca8c50d2865e91a5b52fefb302f8c8e58",
+        "is_verified": false,
+        "line_number": 249
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "explorer/ui/app/assets/icons/config.json",
+        "hashed_secret": "7759b7118e7c75d7c580329cfc78c0129f12ede4",
+        "is_verified": false,
+        "line_number": 263
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "explorer/ui/app/assets/icons/config.json",
+        "hashed_secret": "f2df6c129a02265e64e07077a8d3fac3227c304e",
+        "is_verified": false,
+        "line_number": 277
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "explorer/ui/app/assets/icons/config.json",
+        "hashed_secret": "4cbe24cb053daf8588d58abdd35a845ccca7664b",
+        "is_verified": false,
+        "line_number": 291
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "explorer/ui/app/assets/icons/config.json",
+        "hashed_secret": "9080719bf2c78419637752dce0416af6febf07e9",
+        "is_verified": false,
+        "line_number": 305
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "explorer/ui/app/assets/icons/config.json",
+        "hashed_secret": "b1e4509380aaa4aa0d8a64d82986047ec98fcd2d",
+        "is_verified": false,
+        "line_number": 319
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "explorer/ui/app/assets/icons/config.json",
+        "hashed_secret": "ee4c3679e199d718d3bf7e1e2f9efda423ff8c2c",
+        "is_verified": false,
+        "line_number": 333
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "explorer/ui/app/assets/icons/config.json",
+        "hashed_secret": "e4d1d6660a8f95e6a5e0614a4bce459358ad9de6",
+        "is_verified": false,
+        "line_number": 347
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "explorer/ui/app/assets/icons/config.json",
+        "hashed_secret": "feb407074a56dabc24eab01b105aca2089d3fd4b",
+        "is_verified": false,
+        "line_number": 361
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "explorer/ui/app/assets/icons/config.json",
+        "hashed_secret": "cffe21658fcdd118fbeefa4800c266718342a68e",
+        "is_verified": false,
+        "line_number": 375
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "explorer/ui/app/assets/icons/config.json",
+        "hashed_secret": "c3724bbf26ae0afc46b8116394080b4c9b3e60fd",
+        "is_verified": false,
+        "line_number": 389
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "explorer/ui/app/assets/icons/config.json",
+        "hashed_secret": "d1e81d2bc5a8f5669c8515fa6d98cd4738e16b69",
+        "is_verified": false,
+        "line_number": 403
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "explorer/ui/app/assets/icons/config.json",
+        "hashed_secret": "6643f58f687015da8ed69917485237c50c901741",
+        "is_verified": false,
+        "line_number": 417
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "explorer/ui/app/assets/icons/config.json",
+        "hashed_secret": "6a9d2425019fa045818feab015a88e706eb01ff7",
+        "is_verified": false,
+        "line_number": 431
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "explorer/ui/app/assets/icons/config.json",
+        "hashed_secret": "298dcf518ecd3da9adf1864e322083f474abd027",
+        "is_verified": false,
+        "line_number": 445
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "explorer/ui/app/assets/icons/config.json",
+        "hashed_secret": "a6b5b76c8322f5feaa6c5b7c1d9dd3264b3a52ee",
+        "is_verified": false,
+        "line_number": 459
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "explorer/ui/app/assets/icons/config.json",
+        "hashed_secret": "611e99225423ee4e1ebc7b0d969c2a38f50415d9",
+        "is_verified": false,
+        "line_number": 473
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "explorer/ui/app/assets/icons/config.json",
+        "hashed_secret": "afdbfa515d74947ded39a7991fd3b7938463d936",
+        "is_verified": false,
+        "line_number": 487
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "explorer/ui/app/assets/icons/config.json",
+        "hashed_secret": "4cc1fb07d867fdf7d695ec7625ac564c0d13ae9a",
+        "is_verified": false,
+        "line_number": 501
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "explorer/ui/app/assets/icons/config.json",
+        "hashed_secret": "dbc5e7130c1c86a96e7213a97e4ff06ffdf325ec",
+        "is_verified": false,
+        "line_number": 515
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "explorer/ui/app/assets/icons/config.json",
+        "hashed_secret": "19400a8a82b6d1ec7544ef0054057e78d116bda3",
+        "is_verified": false,
+        "line_number": 529
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "explorer/ui/app/assets/icons/config.json",
+        "hashed_secret": "2b716efc03b1f5e4e55c085c2b043cf6fb069d86",
+        "is_verified": false,
+        "line_number": 543
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "explorer/ui/app/assets/icons/config.json",
+        "hashed_secret": "2820ac3f1eff79f3489b89cb95e13be1ee5d5e41",
+        "is_verified": false,
+        "line_number": 557
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "explorer/ui/app/assets/icons/config.json",
+        "hashed_secret": "108f0f728820e3a3b173a560e6a9b431ca2d3da5",
+        "is_verified": false,
+        "line_number": 571
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "explorer/ui/app/assets/icons/config.json",
+        "hashed_secret": "667f5b63fa34de578a26fd33f6fea6812c711051",
+        "is_verified": false,
+        "line_number": 585
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "explorer/ui/app/assets/icons/config.json",
+        "hashed_secret": "b874f8a4515a4e219bdd1c72ee312d1ab733b333",
+        "is_verified": false,
+        "line_number": 599
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "explorer/ui/app/assets/icons/config.json",
+        "hashed_secret": "42aa8feac89a9433d61b9f540397e515850c4c5f",
+        "is_verified": false,
+        "line_number": 613
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "explorer/ui/app/assets/icons/config.json",
+        "hashed_secret": "1cfb80dd83814c559fa0653f948c49bf282a739b",
+        "is_verified": false,
+        "line_number": 627
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "explorer/ui/app/assets/icons/config.json",
+        "hashed_secret": "159fab9be54d9f742aa43ec9a2791499a43c0a9b",
+        "is_verified": false,
+        "line_number": 641
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "explorer/ui/app/assets/icons/config.json",
+        "hashed_secret": "31bc72da55220c30390110c4bd4abb5dba5f7d56",
+        "is_verified": false,
+        "line_number": 655
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "explorer/ui/app/assets/icons/config.json",
+        "hashed_secret": "f8c667176419af4e89a5b1d062766f16cbe162e1",
+        "is_verified": false,
+        "line_number": 669
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "explorer/ui/app/assets/icons/config.json",
+        "hashed_secret": "e5a63827f2c3ebf0d9ebd0f5a75d9676596f89f0",
+        "is_verified": false,
+        "line_number": 683
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "explorer/ui/app/assets/icons/config.json",
+        "hashed_secret": "e31ad00ca83166910fd822358457a54ee2e1d4f4",
+        "is_verified": false,
+        "line_number": 697
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "explorer/ui/app/assets/icons/config.json",
+        "hashed_secret": "20f790e454c7df200c8a9457c841366da08335df",
+        "is_verified": false,
+        "line_number": 711
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "explorer/ui/app/assets/icons/config.json",
+        "hashed_secret": "8679a3d521fc594098b3f36f70f7f63e348c6515",
+        "is_verified": false,
+        "line_number": 725
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "explorer/ui/app/assets/icons/config.json",
+        "hashed_secret": "8c2d78165af267d4013c7ce41d07dea8d60bcda4",
+        "is_verified": false,
+        "line_number": 739
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "explorer/ui/app/assets/icons/config.json",
+        "hashed_secret": "cd20058b8e4ac99e3dd9f78dbf6c2da84f5f3339",
+        "is_verified": false,
+        "line_number": 753
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "explorer/ui/app/assets/icons/config.json",
+        "hashed_secret": "2db14d2caaad478033193bc2a936d43ae797cda4",
+        "is_verified": false,
+        "line_number": 767
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "explorer/ui/app/assets/icons/config.json",
+        "hashed_secret": "b0d5f71e871586a3eaf7534e4130427c116fd3e6",
+        "is_verified": false,
+        "line_number": 781
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "explorer/ui/app/assets/icons/config.json",
+        "hashed_secret": "1a4fec523528b74fefaffff50a065aa23a28395c",
+        "is_verified": false,
+        "line_number": 795
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "explorer/ui/app/assets/icons/config.json",
+        "hashed_secret": "3801055e585facbf50233f886b8cf9eabe6fe36f",
+        "is_verified": false,
+        "line_number": 809
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "explorer/ui/app/assets/icons/config.json",
+        "hashed_secret": "53284927c4fb6d2f9157377ea5536023afb0cd5a",
+        "is_verified": false,
+        "line_number": 823
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "explorer/ui/app/assets/icons/config.json",
+        "hashed_secret": "20e9f02122fb697dbf18931f2bcc5b8ddb1e68fd",
+        "is_verified": false,
+        "line_number": 837
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "explorer/ui/app/assets/icons/config.json",
+        "hashed_secret": "66eaa08886a05812935404163b79ee1a6b235867",
+        "is_verified": false,
+        "line_number": 851
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "explorer/ui/app/assets/icons/config.json",
+        "hashed_secret": "1551d7c3e8ab6f5efbfdc220d3aa13db24343a6b",
+        "is_verified": false,
+        "line_number": 865
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "explorer/ui/app/assets/icons/config.json",
+        "hashed_secret": "065eebcb480cadb7d120826a0350bbd06a3848f3",
+        "is_verified": false,
+        "line_number": 879
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "explorer/ui/app/assets/icons/config.json",
+        "hashed_secret": "4b8cdf1765f76ea01d9609780c4ed7287ad62fa1",
+        "is_verified": false,
+        "line_number": 893
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "explorer/ui/app/assets/icons/config.json",
+        "hashed_secret": "f8068e0447494e5afd383ef092560aa65a229c3b",
+        "is_verified": false,
+        "line_number": 907
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "explorer/ui/app/assets/icons/config.json",
+        "hashed_secret": "2b7edd243409affa9cb57a1451534430601120ab",
+        "is_verified": false,
+        "line_number": 921
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "explorer/ui/app/assets/icons/config.json",
+        "hashed_secret": "e427134680294a4b3ce66841fa19a8290df79fd8",
+        "is_verified": false,
+        "line_number": 935
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "explorer/ui/app/assets/icons/config.json",
+        "hashed_secret": "a5e5e5201ea0f289adead98d574f7bffbc7139d6",
+        "is_verified": false,
+        "line_number": 949
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "explorer/ui/app/assets/icons/config.json",
+        "hashed_secret": "faa7577dbb772e4e3b4e40593b39b049635daae2",
+        "is_verified": false,
+        "line_number": 963
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "explorer/ui/app/assets/icons/config.json",
+        "hashed_secret": "cbfbaf6ae2551cd44b4675a9d8de4d63d5d11ced",
+        "is_verified": false,
+        "line_number": 977
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "explorer/ui/app/assets/icons/config.json",
+        "hashed_secret": "d354b20453d6d015698925dc681f6c49aa458adb",
+        "is_verified": false,
+        "line_number": 991
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "explorer/ui/app/assets/icons/config.json",
+        "hashed_secret": "d72838cc90100701db88104fe9d06bd2af8a3d68",
+        "is_verified": false,
+        "line_number": 1005
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "explorer/ui/app/assets/icons/config.json",
+        "hashed_secret": "a63f1d2a50d42c915faef2937efb7d672491fa19",
+        "is_verified": false,
+        "line_number": 1019
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "explorer/ui/app/assets/icons/config.json",
+        "hashed_secret": "6006ff0c1aa7bcc1369dfaf82b3b168ec805e4c8",
+        "is_verified": false,
+        "line_number": 1033
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "explorer/ui/app/assets/icons/config.json",
+        "hashed_secret": "d833e4771af5baa156cb2e58345e4fe208f3ce68",
+        "is_verified": false,
+        "line_number": 1047
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "explorer/ui/app/assets/icons/config.json",
+        "hashed_secret": "8a922e44c18026bad07ca38f8eea0e4446810a2e",
+        "is_verified": false,
+        "line_number": 1061
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "explorer/ui/app/assets/icons/config.json",
+        "hashed_secret": "fb210d273856b380e79f5fc41a526f7c861eb30b",
+        "is_verified": false,
+        "line_number": 1075
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "explorer/ui/app/assets/icons/config.json",
+        "hashed_secret": "972164a1690d5ae19795d9a97ff70cf624e6f013",
+        "is_verified": false,
+        "line_number": 1089
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "explorer/ui/app/assets/icons/config.json",
+        "hashed_secret": "c1b767208455e28025a0b8040aa3c1428373b944",
+        "is_verified": false,
+        "line_number": 1103
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "explorer/ui/app/assets/icons/config.json",
+        "hashed_secret": "3363bbfbf1f412599d20dd9c1e1720a24c17e29d",
+        "is_verified": false,
+        "line_number": 1117
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "explorer/ui/app/assets/icons/config.json",
+        "hashed_secret": "c125d1c6c27e49756d11f85b24c855c454b9ead6",
+        "is_verified": false,
+        "line_number": 1131
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "explorer/ui/app/assets/icons/config.json",
+        "hashed_secret": "41c7ac72311454300f47bffd4f55fd3717776f14",
+        "is_verified": false,
+        "line_number": 1145
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "explorer/ui/app/assets/icons/config.json",
+        "hashed_secret": "03da234665bb3c7d8a25e585fd16d8d4e69de845",
+        "is_verified": false,
+        "line_number": 1159
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "explorer/ui/app/assets/icons/config.json",
+        "hashed_secret": "9ce8bf986d72a8e71fdaab76e0548fb97476a736",
+        "is_verified": false,
+        "line_number": 1173
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "explorer/ui/app/assets/icons/config.json",
+        "hashed_secret": "6ec14a524f40a047c4713c3069ffea237f4581ee",
+        "is_verified": false,
+        "line_number": 1187
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "explorer/ui/app/assets/icons/config.json",
+        "hashed_secret": "432a027ca40bface85a813f2fb6aeca90030a28b",
+        "is_verified": false,
+        "line_number": 1201
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "explorer/ui/app/assets/icons/config.json",
+        "hashed_secret": "2cb1f91f67ccca367e60b24a0e95601162d53d48",
+        "is_verified": false,
+        "line_number": 1215
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "explorer/ui/app/assets/icons/config.json",
+        "hashed_secret": "6f48ecdc5e9b7b457f50d81039566518a03bf092",
+        "is_verified": false,
+        "line_number": 1229
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "explorer/ui/app/assets/icons/config.json",
+        "hashed_secret": "b08ffc3570eabeb9ce750612e101f8239286cee2",
+        "is_verified": false,
+        "line_number": 1243
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "explorer/ui/app/assets/icons/config.json",
+        "hashed_secret": "a3ee0348d2dfaa4d316ac0d08fb748c10b3554b7",
+        "is_verified": false,
+        "line_number": 1257
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "explorer/ui/app/assets/icons/config.json",
+        "hashed_secret": "1f086d75f68ecb81facfdf93d5bada6832dada09",
+        "is_verified": false,
+        "line_number": 1271
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "explorer/ui/app/assets/icons/config.json",
+        "hashed_secret": "47b0c2e9d0fb166d0ed22a43f631898f6a3d0d8e",
+        "is_verified": false,
+        "line_number": 1285
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "explorer/ui/app/assets/icons/config.json",
+        "hashed_secret": "976c4d0a7da89afedb63fd972a6a3092d3b046a1",
+        "is_verified": false,
+        "line_number": 1299
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "explorer/ui/app/assets/icons/config.json",
+        "hashed_secret": "6aba1ae8f9b2136a5ab7143cb15312f890bcd3fe",
+        "is_verified": false,
+        "line_number": 1313
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "explorer/ui/app/assets/icons/config.json",
+        "hashed_secret": "2bcb20c36ad36a6ddf63ff71cf7d1a83dc1a1281",
+        "is_verified": false,
+        "line_number": 1327
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "explorer/ui/app/assets/icons/config.json",
+        "hashed_secret": "dc264348c435e8762a1d554f10d9b94a96fa1863",
+        "is_verified": false,
+        "line_number": 1341
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "explorer/ui/app/assets/icons/config.json",
+        "hashed_secret": "8f5f6e791d93dafe1d1c336982078a482202c761",
+        "is_verified": false,
+        "line_number": 1355
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "explorer/ui/app/assets/icons/config.json",
+        "hashed_secret": "6bae1f9c4f13e2dbbb0d43f9e57afa4c3c4e862f",
+        "is_verified": false,
+        "line_number": 1369
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "explorer/ui/app/assets/icons/config.json",
+        "hashed_secret": "3eb83b9f050c7a3cb71d89f7a10578fc89d73d7a",
+        "is_verified": false,
+        "line_number": 1383
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "explorer/ui/app/assets/icons/config.json",
+        "hashed_secret": "be6d07aeda64c175bf6affb9263d8155345de5b8",
+        "is_verified": false,
+        "line_number": 1397
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "explorer/ui/app/assets/icons/config.json",
+        "hashed_secret": "afbb895e212e652421ab82ecc9fd7b2184a44861",
+        "is_verified": false,
+        "line_number": 1411
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "explorer/ui/app/assets/icons/config.json",
+        "hashed_secret": "c75aa3e4083cfaee77a872b787b01f04b4de4d68",
+        "is_verified": false,
+        "line_number": 1425
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "explorer/ui/app/assets/icons/config.json",
+        "hashed_secret": "72781deb9dfc071d5c6252a4da465cdee6e5df4f",
+        "is_verified": false,
+        "line_number": 1439
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "explorer/ui/app/assets/icons/config.json",
+        "hashed_secret": "2fd62b296761f02f395161ab80aad4eb50d9a84b",
+        "is_verified": false,
+        "line_number": 1453
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "explorer/ui/app/assets/icons/config.json",
+        "hashed_secret": "54ea30b783075e4db1e27486058ad88e1a940ae5",
+        "is_verified": false,
+        "line_number": 1467
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "explorer/ui/app/assets/icons/config.json",
+        "hashed_secret": "743af2d3f0d54965677295905aaa61bf580a8181",
+        "is_verified": false,
+        "line_number": 1481
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "explorer/ui/app/assets/icons/config.json",
+        "hashed_secret": "e3b22c70cd94ca166a2208b1cf43406b95831a34",
+        "is_verified": false,
+        "line_number": 1495
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "explorer/ui/app/assets/icons/config.json",
+        "hashed_secret": "05a2b2ecca0cbe5438df4142b4a989203fa2e944",
+        "is_verified": false,
+        "line_number": 1509
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "explorer/ui/app/assets/icons/config.json",
+        "hashed_secret": "033549c126f8b78b693cc1d2ed62c378db1f39e9",
+        "is_verified": false,
+        "line_number": 1523
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "explorer/ui/app/assets/icons/config.json",
+        "hashed_secret": "fdef5d0723966866457f72895227534d520db7c5",
+        "is_verified": false,
+        "line_number": 1537
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "explorer/ui/app/assets/icons/config.json",
+        "hashed_secret": "a5892c97312e9d8b5d0dd7eb20cb0507ae361d17",
+        "is_verified": false,
+        "line_number": 1551
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "explorer/ui/app/assets/icons/config.json",
+        "hashed_secret": "dfa151e7f7e9e1bf6babadf23caf49e49c595035",
+        "is_verified": false,
+        "line_number": 1565
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "explorer/ui/app/assets/icons/config.json",
+        "hashed_secret": "9ba104f8f403db52c7326145ae4369d7d03314ae",
+        "is_verified": false,
+        "line_number": 1579
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "explorer/ui/app/assets/icons/config.json",
+        "hashed_secret": "c3477c4cb7d53bb129c7b88e91df4c204f3035df",
+        "is_verified": false,
+        "line_number": 1593
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "explorer/ui/app/assets/icons/config.json",
+        "hashed_secret": "771fe882faaa8701fff47319bcd219fb8fec3947",
+        "is_verified": false,
+        "line_number": 1607
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "explorer/ui/app/assets/icons/config.json",
+        "hashed_secret": "b74e1cc919203fecc61ae6888523e52f2ff4e93c",
+        "is_verified": false,
+        "line_number": 1621
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "explorer/ui/app/assets/icons/config.json",
+        "hashed_secret": "34c79e4e47fbfb297ec228499c3a42393deac887",
+        "is_verified": false,
+        "line_number": 1635
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "explorer/ui/app/assets/icons/config.json",
+        "hashed_secret": "8a2238ff69dc8463b809e3c4cf0e8948d2ced612",
+        "is_verified": false,
+        "line_number": 1649
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "explorer/ui/app/assets/icons/config.json",
+        "hashed_secret": "45fdf6c76718bb12169ba3770637eb638bfc5ffc",
+        "is_verified": false,
+        "line_number": 1663
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "explorer/ui/app/assets/icons/config.json",
+        "hashed_secret": "7d3955ced101465b312200f0fa6f4b668b176ca9",
+        "is_verified": false,
+        "line_number": 1677
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "explorer/ui/app/assets/icons/config.json",
+        "hashed_secret": "a0cfc3afab36caf4a7d303bdf386e10d3c5970a9",
+        "is_verified": false,
+        "line_number": 1691
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "explorer/ui/app/assets/icons/config.json",
+        "hashed_secret": "6f02928853968072a6e6a26adaa2d9b0837aab78",
+        "is_verified": false,
+        "line_number": 1705
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "explorer/ui/app/assets/icons/config.json",
+        "hashed_secret": "da5ed2cb0d7cf9343d8d2687012a82fd23beb214",
+        "is_verified": false,
+        "line_number": 1719
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "explorer/ui/app/assets/icons/config.json",
+        "hashed_secret": "1e557e47dc4086fa584978b315b5c1587fc085b2",
+        "is_verified": false,
+        "line_number": 1733
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "explorer/ui/app/assets/icons/config.json",
+        "hashed_secret": "c15006acd784d5a2533dffa90a78064e79039478",
+        "is_verified": false,
+        "line_number": 1747
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "explorer/ui/app/assets/icons/config.json",
+        "hashed_secret": "10f0da584375da02e73d1179b89b99e3ab293702",
+        "is_verified": false,
+        "line_number": 1761
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "explorer/ui/app/assets/icons/config.json",
+        "hashed_secret": "ec0a77c854474fdde89f82329e490bf384b1e577",
+        "is_verified": false,
+        "line_number": 1775
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "explorer/ui/app/assets/icons/config.json",
+        "hashed_secret": "b5b0261b0246d3b16a79788a2e69bd213b8e4809",
+        "is_verified": false,
+        "line_number": 1789
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "explorer/ui/app/assets/icons/config.json",
+        "hashed_secret": "e3a7c506c85de21bce8586ffbe5d6ecb56f3d8d3",
+        "is_verified": false,
+        "line_number": 1803
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "explorer/ui/app/assets/icons/config.json",
+        "hashed_secret": "58b5653d2e5fb0c7c3618039e68182dbe63e201a",
+        "is_verified": false,
+        "line_number": 1817
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "explorer/ui/app/assets/icons/config.json",
+        "hashed_secret": "4c9cde22a9b948e2d0258e0ad08588cf1a79f3d9",
+        "is_verified": false,
+        "line_number": 1831
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "explorer/ui/app/assets/icons/config.json",
+        "hashed_secret": "02721941a6e44b032b61cf806fe0eee518505cbb",
+        "is_verified": false,
+        "line_number": 1845
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "explorer/ui/app/assets/icons/config.json",
+        "hashed_secret": "c347ff2d6f71939bda6c30e1aab51d0fd8aaeef7",
+        "is_verified": false,
+        "line_number": 1859
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "explorer/ui/app/assets/icons/config.json",
+        "hashed_secret": "de24d4827e910706d2eb52ddd1e6821a79d626d8",
+        "is_verified": false,
+        "line_number": 1873
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "explorer/ui/app/assets/icons/config.json",
+        "hashed_secret": "9505ee84fa822553a9020483fc1d847ef9aca8b8",
+        "is_verified": false,
+        "line_number": 1887
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "explorer/ui/app/assets/icons/config.json",
+        "hashed_secret": "f042cd5e05599135cc16879dc722fa047770e541",
+        "is_verified": false,
+        "line_number": 1901
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "explorer/ui/app/assets/icons/config.json",
+        "hashed_secret": "a8ecf1449d560f929b92cb43f4df7d3d5c09da09",
+        "is_verified": false,
+        "line_number": 1915
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "explorer/ui/app/assets/icons/config.json",
+        "hashed_secret": "1040a099073a64930e12f91589a72d05dc7c7d4c",
+        "is_verified": false,
+        "line_number": 1929
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "explorer/ui/app/assets/icons/config.json",
+        "hashed_secret": "7da85e08c9188ef636fc9143a13f8d7f4148e05a",
+        "is_verified": false,
+        "line_number": 1943
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "explorer/ui/app/assets/icons/config.json",
+        "hashed_secret": "502abd1a807424a2ca088ae641dbd59fb2099039",
+        "is_verified": false,
+        "line_number": 1957
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "explorer/ui/app/assets/icons/config.json",
+        "hashed_secret": "62276859970a6a67bb181e0b9de9676d284beeb5",
+        "is_verified": false,
+        "line_number": 1971
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "explorer/ui/app/assets/icons/config.json",
+        "hashed_secret": "1c51eb1a0c8126ad9550bcc7a8e98556a8e3adf0",
+        "is_verified": false,
+        "line_number": 1985
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "explorer/ui/app/assets/icons/config.json",
+        "hashed_secret": "0b72f4a7d770429a6aefce3dc53674c245924087",
+        "is_verified": false,
+        "line_number": 1999
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "explorer/ui/app/assets/icons/config.json",
+        "hashed_secret": "afe5434ece87f90014cbe4ebe8ba4480b0415ce4",
+        "is_verified": false,
+        "line_number": 2013
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "explorer/ui/app/assets/icons/config.json",
+        "hashed_secret": "1230e93194042028ad9153489faf0f1576ba5cd2",
+        "is_verified": false,
+        "line_number": 2027
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "explorer/ui/app/assets/icons/config.json",
+        "hashed_secret": "2bcf23f587890f20392ac7d05e262e53fdbc4162",
+        "is_verified": false,
+        "line_number": 2041
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "explorer/ui/app/assets/icons/config.json",
+        "hashed_secret": "98c1d8cf1c3b9d6a47ef0e5cc27e86ee1188f9bf",
+        "is_verified": false,
+        "line_number": 2055
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "explorer/ui/app/assets/icons/config.json",
+        "hashed_secret": "f8f0f8c5cabceee576727bbe5e1168cfce72586b",
+        "is_verified": false,
+        "line_number": 2069
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "explorer/ui/app/assets/icons/config.json",
+        "hashed_secret": "2485db7d1276ab520f277e5a767118ea0e901814",
+        "is_verified": false,
+        "line_number": 2083
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "explorer/ui/app/assets/icons/config.json",
+        "hashed_secret": "f4a320667d2e39892cf8254a06ff9b6bb8d01cf0",
+        "is_verified": false,
+        "line_number": 2097
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "explorer/ui/app/assets/icons/config.json",
+        "hashed_secret": "1e3569864a9a22e84e27479d205fd98ec72fd68f",
+        "is_verified": false,
+        "line_number": 2111
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "explorer/ui/app/assets/icons/config.json",
+        "hashed_secret": "2709e82a9b1fff2d6410d8c3349e7ff8b781a53f",
+        "is_verified": false,
+        "line_number": 2125
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "explorer/ui/app/assets/icons/config.json",
+        "hashed_secret": "19b235b51b5b09d01c4c3ab66921b9c7c0165189",
+        "is_verified": false,
+        "line_number": 2139
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "explorer/ui/app/assets/icons/config.json",
+        "hashed_secret": "e471ce9a0180d81689f4b2a7676c7d404c1918e4",
+        "is_verified": false,
+        "line_number": 2153
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "explorer/ui/app/assets/icons/config.json",
+        "hashed_secret": "b28a27eff270a36053eaf5859865c6f8208dc4fe",
+        "is_verified": false,
+        "line_number": 2167
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "explorer/ui/app/assets/icons/config.json",
+        "hashed_secret": "8cd7d92fecef0a35d6648f9fbe37b2d20d3c0bb3",
+        "is_verified": false,
+        "line_number": 2181
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "explorer/ui/app/assets/icons/config.json",
+        "hashed_secret": "d2521b00fbbc256bc28d903b59c99619945b6d3d",
+        "is_verified": false,
+        "line_number": 2195
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "explorer/ui/app/assets/icons/config.json",
+        "hashed_secret": "fc4ecc6968d6cd7f27e53cac7b7910005b246bc9",
+        "is_verified": false,
+        "line_number": 2209
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "explorer/ui/app/assets/icons/config.json",
+        "hashed_secret": "f55b8ae16c3532c8eef2f85b11b3f8436041ded1",
+        "is_verified": false,
+        "line_number": 2223
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "explorer/ui/app/assets/icons/config.json",
+        "hashed_secret": "cd88bc7077ff5d8d69bf6051c611f41e6d74d110",
+        "is_verified": false,
+        "line_number": 2237
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "explorer/ui/app/assets/icons/config.json",
+        "hashed_secret": "f0a418687049a6829e34b2926023130e54c0f31c",
+        "is_verified": false,
+        "line_number": 2251
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "explorer/ui/app/assets/icons/config.json",
+        "hashed_secret": "8f73fa7089c7093bedf91c82c904695cc4656953",
+        "is_verified": false,
+        "line_number": 2265
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "explorer/ui/app/assets/icons/config.json",
+        "hashed_secret": "501e87e8b61ce10cda36649d07f3cd4aa5b9d481",
+        "is_verified": false,
+        "line_number": 2279
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "explorer/ui/app/assets/icons/config.json",
+        "hashed_secret": "d2481769ab861451d2cd613fdb45891d0c2ee9e1",
+        "is_verified": false,
+        "line_number": 2293
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "explorer/ui/app/assets/icons/config.json",
+        "hashed_secret": "d1df20c95ea7a0aaa57c1919b1aa08e2b29ffdc9",
+        "is_verified": false,
+        "line_number": 2307
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "explorer/ui/app/assets/icons/config.json",
+        "hashed_secret": "f975eae95894458e5ae18fea497f3719536f0d48",
+        "is_verified": false,
+        "line_number": 2321
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "explorer/ui/app/assets/icons/config.json",
+        "hashed_secret": "02a6629098b966220ce52d199b5e60a965489cb6",
+        "is_verified": false,
+        "line_number": 2335
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "explorer/ui/app/assets/icons/config.json",
+        "hashed_secret": "913f2af54dc08948bc55b08f61515be97ca611a0",
+        "is_verified": false,
+        "line_number": 2349
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "explorer/ui/app/assets/icons/config.json",
+        "hashed_secret": "dd4b918ab47f5ba7f6b6defebc5d177812f167a3",
+        "is_verified": false,
+        "line_number": 2363
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "explorer/ui/app/assets/icons/config.json",
+        "hashed_secret": "e6ff45a8c7d54b75bbfdde83072b5657e8721762",
+        "is_verified": false,
+        "line_number": 2377
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "explorer/ui/app/assets/icons/config.json",
+        "hashed_secret": "af74a332206f4a30bfea41c4b981859b2690af05",
+        "is_verified": false,
+        "line_number": 2391
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "explorer/ui/app/assets/icons/config.json",
+        "hashed_secret": "de9a29ecc4f8282990a5d705ce3d87f4cb4860dd",
+        "is_verified": false,
+        "line_number": 2405
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "explorer/ui/app/assets/icons/config.json",
+        "hashed_secret": "eba56b6d306c51e7f333c95e4853924408cdfd6a",
+        "is_verified": false,
+        "line_number": 2419
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "explorer/ui/app/assets/icons/config.json",
+        "hashed_secret": "c2f1c747a546b87a5ac45060e2d6bcf265667207",
+        "is_verified": false,
+        "line_number": 2433
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "explorer/ui/app/assets/icons/config.json",
+        "hashed_secret": "5627bfcedce38d08b49d275f9a90f6471343f19a",
+        "is_verified": false,
+        "line_number": 2447
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "explorer/ui/app/assets/icons/config.json",
+        "hashed_secret": "85065d2e92d204b50ef2415bd1dbf509e916b7c0",
+        "is_verified": false,
+        "line_number": 2461
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "explorer/ui/app/assets/icons/config.json",
+        "hashed_secret": "586fdd0cd012d1e3cd2698f08bee3e96f3574ba1",
+        "is_verified": false,
+        "line_number": 2475
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "explorer/ui/app/assets/icons/config.json",
+        "hashed_secret": "b77ff67d512be9775ba149554a83fe49c11f4f8b",
+        "is_verified": false,
+        "line_number": 2489
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "explorer/ui/app/assets/icons/config.json",
+        "hashed_secret": "379d2f3d130a3353cbd64344d967662e2e62efca",
+        "is_verified": false,
+        "line_number": 2503
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "explorer/ui/app/assets/icons/config.json",
+        "hashed_secret": "2f58e77cf6908faf3f7f57996ab6fb4c583f3c26",
+        "is_verified": false,
+        "line_number": 2517
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "explorer/ui/app/assets/icons/config.json",
+        "hashed_secret": "c3152ded6b5b18785a285491ff6433ee43437011",
+        "is_verified": false,
+        "line_number": 2531
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "explorer/ui/app/assets/icons/config.json",
+        "hashed_secret": "604151ee079fb08db7cd0dcee59a64378f542164",
+        "is_verified": false,
+        "line_number": 2545
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "explorer/ui/app/assets/icons/config.json",
+        "hashed_secret": "7ac44d4a838f2aa6f66525381ebb25e5ef6124e4",
+        "is_verified": false,
+        "line_number": 2559
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "explorer/ui/app/assets/icons/config.json",
+        "hashed_secret": "15144d4266489c2c6de92a1d4ef5cfcb26e34c9b",
+        "is_verified": false,
+        "line_number": 2573
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "explorer/ui/app/assets/icons/config.json",
+        "hashed_secret": "c90d2f26f96d3be5db4a1688b2519534beea0d8f",
+        "is_verified": false,
+        "line_number": 2587
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "explorer/ui/app/assets/icons/config.json",
+        "hashed_secret": "f37d5280cbd4afbb7f80e6bc59c593b13f0dc881",
+        "is_verified": false,
+        "line_number": 2601
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "explorer/ui/app/assets/icons/config.json",
+        "hashed_secret": "216709a9c56ecb14c3bdb4d948b81da1c178a25a",
+        "is_verified": false,
+        "line_number": 2615
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "explorer/ui/app/assets/icons/config.json",
+        "hashed_secret": "b9662843f6050cd2e27c9753d85df5e01f7aee7f",
+        "is_verified": false,
+        "line_number": 2629
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "explorer/ui/app/assets/icons/config.json",
+        "hashed_secret": "3fa3ae85bc1971efe8c0b528aa2d560a31dacb50",
+        "is_verified": false,
+        "line_number": 2643
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "explorer/ui/app/assets/icons/config.json",
+        "hashed_secret": "14c1d6151c19ea6c12713c4ba547bb716e524e88",
+        "is_verified": false,
+        "line_number": 2657
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "explorer/ui/app/assets/icons/config.json",
+        "hashed_secret": "0956a9866a979947be602866ffae8ee541fd210e",
+        "is_verified": false,
+        "line_number": 2671
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "explorer/ui/app/assets/icons/config.json",
+        "hashed_secret": "eb2feb0051f3aed9f0bbc9aa03ad197ac410fae6",
+        "is_verified": false,
+        "line_number": 2685
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "explorer/ui/app/assets/icons/config.json",
+        "hashed_secret": "6871739fefc27b61ae7e209c3d95984a38993b64",
+        "is_verified": false,
+        "line_number": 2699
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "explorer/ui/app/assets/icons/config.json",
+        "hashed_secret": "9eaad49c55fd2b3706dbf5e50e4b3afd1e3796f0",
+        "is_verified": false,
+        "line_number": 2713
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "explorer/ui/app/assets/icons/config.json",
+        "hashed_secret": "a62d5d695272d26d7690dd4aff74765aa286f7e1",
+        "is_verified": false,
+        "line_number": 2727
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "explorer/ui/app/assets/icons/config.json",
+        "hashed_secret": "4ae2948707117f46dc764436fd2356944e01914e",
+        "is_verified": false,
+        "line_number": 2741
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "explorer/ui/app/assets/icons/config.json",
+        "hashed_secret": "72751b06843453d1c2ab5299747ebe102073984b",
+        "is_verified": false,
+        "line_number": 2755
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "explorer/ui/app/assets/icons/config.json",
+        "hashed_secret": "ab56d3043ff1e8c5c2160508bfc944e4e7212d69",
+        "is_verified": false,
+        "line_number": 2769
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "explorer/ui/app/assets/icons/config.json",
+        "hashed_secret": "142f863649f00f801fbc456b3f6fe4b71872b774",
+        "is_verified": false,
+        "line_number": 2783
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "explorer/ui/app/assets/icons/config.json",
+        "hashed_secret": "7994361b74f472cb9c505a021dca3a848dac7c2b",
+        "is_verified": false,
+        "line_number": 2797
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "explorer/ui/app/assets/icons/config.json",
+        "hashed_secret": "40225c3a23696da940db57d2fb13daa3778ca583",
+        "is_verified": false,
+        "line_number": 2811
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "explorer/ui/app/assets/icons/config.json",
+        "hashed_secret": "7985a269731d81f54b16dcbad7d2b7946cd6c42f",
+        "is_verified": false,
+        "line_number": 2825
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "explorer/ui/app/assets/icons/config.json",
+        "hashed_secret": "fafa2a4fa9a6258f5cd92baafdc480568643f68b",
+        "is_verified": false,
+        "line_number": 2839
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "explorer/ui/app/assets/icons/config.json",
+        "hashed_secret": "7727422877d9753497e27eb265e819bb030d9a49",
+        "is_verified": false,
+        "line_number": 2853
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "explorer/ui/app/assets/icons/config.json",
+        "hashed_secret": "d95c40dacbac2f77a6f580d35a46c07bb8a4bb89",
+        "is_verified": false,
+        "line_number": 2867
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "explorer/ui/app/assets/icons/config.json",
+        "hashed_secret": "74b726ed466c997411dfb53f985929c577d729d5",
+        "is_verified": false,
+        "line_number": 2881
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "explorer/ui/app/assets/icons/config.json",
+        "hashed_secret": "b84f709ca34566c28800ac5cbf4eb728dddabe46",
+        "is_verified": false,
+        "line_number": 2895
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "explorer/ui/app/assets/icons/config.json",
+        "hashed_secret": "71bc158a905ed1016dbb052f5bb264da04c050c2",
+        "is_verified": false,
+        "line_number": 2909
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "explorer/ui/app/assets/icons/config.json",
+        "hashed_secret": "4efc274f1ca1e1080191dd34986177b3eb0ed7f3",
+        "is_verified": false,
+        "line_number": 2923
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "explorer/ui/app/assets/icons/config.json",
+        "hashed_secret": "c845bb9a0e9de88ad11cf4e88cb0297221e4099c",
+        "is_verified": false,
+        "line_number": 2937
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "explorer/ui/app/assets/icons/config.json",
+        "hashed_secret": "dc86bd50f6326ec8115e9ba566f6e4b471a3bc26",
+        "is_verified": false,
+        "line_number": 2951
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "explorer/ui/app/assets/icons/config.json",
+        "hashed_secret": "5de783f7db14269f0194f8b52dbdf43ae6454588",
+        "is_verified": false,
+        "line_number": 2965
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "explorer/ui/app/assets/icons/config.json",
+        "hashed_secret": "155f1f42d1e219f6993de1942626dff4c9dbd871",
+        "is_verified": false,
+        "line_number": 2979
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "explorer/ui/app/assets/icons/config.json",
+        "hashed_secret": "2ee7e76fd98d087337fa23fb5ef6a257b0746c62",
+        "is_verified": false,
+        "line_number": 2993
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "explorer/ui/app/assets/icons/config.json",
+        "hashed_secret": "cfebba173d1b3e5285458ea7df6f4430d0fcbef9",
+        "is_verified": false,
+        "line_number": 3007
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "explorer/ui/app/assets/icons/config.json",
+        "hashed_secret": "1d54eeb22b074cadea650656d99598795b4e1c7b",
+        "is_verified": false,
+        "line_number": 3021
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "explorer/ui/app/assets/icons/config.json",
+        "hashed_secret": "80d0b7dafeb1ffa655d18f86301b3b9dbbbfb60c",
+        "is_verified": false,
+        "line_number": 3035
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "explorer/ui/app/assets/icons/config.json",
+        "hashed_secret": "e324bb2da44f806629263e2cce63129cc09285aa",
+        "is_verified": false,
+        "line_number": 3049
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "explorer/ui/app/assets/icons/config.json",
+        "hashed_secret": "e70e2f84811b37e05d7c0dead91141d5361942d8",
+        "is_verified": false,
+        "line_number": 3063
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "explorer/ui/app/assets/icons/config.json",
+        "hashed_secret": "6bb8e5e8077f11664bda512583c7ffdf09d70b6a",
+        "is_verified": false,
+        "line_number": 3077
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "explorer/ui/app/assets/icons/config.json",
+        "hashed_secret": "1827b624fa596529a949458593589f35b8670094",
+        "is_verified": false,
+        "line_number": 3091
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "explorer/ui/app/assets/icons/config.json",
+        "hashed_secret": "ffbfb747a93f370819146d061c234ec67f69825d",
+        "is_verified": false,
+        "line_number": 3105
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "explorer/ui/app/assets/icons/config.json",
+        "hashed_secret": "b9759b509d8f86abb7f460a3aeb930955aee3aec",
+        "is_verified": false,
+        "line_number": 3119
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "explorer/ui/app/assets/icons/config.json",
+        "hashed_secret": "2346dfeaa944f1d2d31913ef43cbbf68944215b6",
+        "is_verified": false,
+        "line_number": 3133
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "explorer/ui/app/assets/icons/config.json",
+        "hashed_secret": "2b3cab0b9b3d7fc5ad41bfc52a66e913e6247e55",
+        "is_verified": false,
+        "line_number": 3147
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "explorer/ui/app/assets/icons/config.json",
+        "hashed_secret": "5ad4490e154095da07c2f68e66ac6988e2a3def4",
+        "is_verified": false,
+        "line_number": 3161
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "explorer/ui/app/assets/icons/config.json",
+        "hashed_secret": "6c9293a4b6342aa626a7620c15cdc4b28cf8c278",
+        "is_verified": false,
+        "line_number": 3175
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "explorer/ui/app/assets/icons/config.json",
+        "hashed_secret": "22374c90a0fd7624f4d98c4ca4bc875c9fb5c637",
+        "is_verified": false,
+        "line_number": 3189
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "explorer/ui/app/assets/icons/config.json",
+        "hashed_secret": "52e17efa41be5d44bc97b55d198adcbb92cb1611",
+        "is_verified": false,
+        "line_number": 3203
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "explorer/ui/app/assets/icons/config.json",
+        "hashed_secret": "9ca5d922ad4bd0451b2e11088b99f957a7283bf1",
+        "is_verified": false,
+        "line_number": 3217
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "explorer/ui/app/assets/icons/config.json",
+        "hashed_secret": "a3a219ae0406132ab8c350e89e463c44d4aede58",
+        "is_verified": false,
+        "line_number": 3231
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "explorer/ui/app/assets/icons/config.json",
+        "hashed_secret": "70c1e6e871a963c4c876b84e8246337f929b5a4f",
+        "is_verified": false,
+        "line_number": 3245
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "explorer/ui/app/assets/icons/config.json",
+        "hashed_secret": "c809b67e98b1e6fe88430b74fbe430861387aa94",
+        "is_verified": false,
+        "line_number": 3259
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "explorer/ui/app/assets/icons/config.json",
+        "hashed_secret": "7cf3b2959dc17ac526720c0924b408fed6d4b3d0",
+        "is_verified": false,
+        "line_number": 3273
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "explorer/ui/app/assets/icons/config.json",
+        "hashed_secret": "04551ce153077859a630542afb233f7920ec93d8",
+        "is_verified": false,
+        "line_number": 3287
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "explorer/ui/app/assets/icons/config.json",
+        "hashed_secret": "0c4a55f67693bf9eef2abfc163aa09d435bc847a",
+        "is_verified": false,
+        "line_number": 3301
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "explorer/ui/app/assets/icons/config.json",
+        "hashed_secret": "ae215d0f195a49adc28d9fca63c0ccaca8bea0e7",
+        "is_verified": false,
+        "line_number": 3315
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "explorer/ui/app/assets/icons/config.json",
+        "hashed_secret": "72908efb039ee293480b10fb8d24797178ff3b19",
+        "is_verified": false,
+        "line_number": 3329
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "explorer/ui/app/assets/icons/config.json",
+        "hashed_secret": "51a5defc2146a0a907e8b641d2dd63376c7221ca",
+        "is_verified": false,
+        "line_number": 3343
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "explorer/ui/app/assets/icons/config.json",
+        "hashed_secret": "bc8b82474d2fed35f159628ec9dbf2d065d68bc6",
+        "is_verified": false,
+        "line_number": 3357
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "explorer/ui/app/assets/icons/config.json",
+        "hashed_secret": "93271bdb2b49d25d39c51c2a371587827bbc17b8",
+        "is_verified": false,
+        "line_number": 3371
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "explorer/ui/app/assets/icons/config.json",
+        "hashed_secret": "9ebad5b117bec74b6698dd1c499ea303f5f5c241",
+        "is_verified": false,
+        "line_number": 3385
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "explorer/ui/app/assets/icons/config.json",
+        "hashed_secret": "dc5def4ce10f6dfac73d9b1a1583f5d8b2218b3b",
+        "is_verified": false,
+        "line_number": 3399
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "explorer/ui/app/assets/icons/config.json",
+        "hashed_secret": "bb40d1cab6d17a926e525222b337693cd0e7c82b",
+        "is_verified": false,
+        "line_number": 3413
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "explorer/ui/app/assets/icons/config.json",
+        "hashed_secret": "0701417262e0e49c5be374bc2a2c76e399000a53",
+        "is_verified": false,
+        "line_number": 3427
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "explorer/ui/app/assets/icons/config.json",
+        "hashed_secret": "dfb10ab9c7f70c73b409d17b290679377e16609d",
+        "is_verified": false,
+        "line_number": 3441
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "explorer/ui/app/assets/icons/config.json",
+        "hashed_secret": "c83cba5efc8a39b482d1cefcab0d1146ad292ca8",
+        "is_verified": false,
+        "line_number": 3455
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "explorer/ui/app/assets/icons/config.json",
+        "hashed_secret": "403b4c587e82713576526c349939e46c78f4c8fd",
+        "is_verified": false,
+        "line_number": 3469
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "explorer/ui/app/assets/icons/config.json",
+        "hashed_secret": "0beb08312e1545f4d784bbf4e08ff7165d767c44",
+        "is_verified": false,
+        "line_number": 3483
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "explorer/ui/app/assets/icons/config.json",
+        "hashed_secret": "a786fa4ca54f62412f8fdd18efa3f2e43fedf028",
+        "is_verified": false,
+        "line_number": 3497
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "explorer/ui/app/assets/icons/config.json",
+        "hashed_secret": "6ac3a5069a3713b5f1692d09c3d4cda19c9d5f7d",
+        "is_verified": false,
+        "line_number": 3511
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "explorer/ui/app/assets/icons/config.json",
+        "hashed_secret": "0b7b0363e4acf4ea209a4edfb6706ef31bec56d6",
+        "is_verified": false,
+        "line_number": 3525
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "explorer/ui/app/assets/icons/config.json",
+        "hashed_secret": "9e14fb26fcb054445209d4b1baea3e6477050792",
+        "is_verified": false,
+        "line_number": 3539
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "explorer/ui/app/assets/icons/config.json",
+        "hashed_secret": "7e40a5f77e5323c8adf69a3a2b3cb1a8759b11e7",
+        "is_verified": false,
+        "line_number": 3553
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "explorer/ui/app/assets/icons/config.json",
+        "hashed_secret": "ca047adeae71371db72dd3b1a135b490e2ca086f",
+        "is_verified": false,
+        "line_number": 3567
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "explorer/ui/app/assets/icons/config.json",
+        "hashed_secret": "4b649e40fd00e0dc036b4b8fb7736e0ce3a4a4f6",
+        "is_verified": false,
+        "line_number": 3581
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "explorer/ui/app/assets/icons/config.json",
+        "hashed_secret": "ca12bce88b9a5e2a7a7276a548b59ceb32b3cc01",
+        "is_verified": false,
+        "line_number": 3595
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "explorer/ui/app/assets/icons/config.json",
+        "hashed_secret": "fed0f16b454d450e1b8004841b22b56f52d79913",
+        "is_verified": false,
+        "line_number": 3609
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "explorer/ui/app/assets/icons/config.json",
+        "hashed_secret": "c4cd558d067122a72f7eb011a5eeeebdb9eda407",
+        "is_verified": false,
+        "line_number": 3623
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "explorer/ui/app/assets/icons/config.json",
+        "hashed_secret": "0daac3e3cc0e5a0e4beae1422454b539780cad5c",
+        "is_verified": false,
+        "line_number": 3637
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "explorer/ui/app/assets/icons/config.json",
+        "hashed_secret": "2114d31727af70b0e4717eccd49305c12fbb5822",
+        "is_verified": false,
+        "line_number": 3651
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "explorer/ui/app/assets/icons/config.json",
+        "hashed_secret": "80b80b8d15afa5ce07d4864df55c0eb74ce5f995",
+        "is_verified": false,
+        "line_number": 3665
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "explorer/ui/app/assets/icons/config.json",
+        "hashed_secret": "0916652588a2eb8415881eb67e91acbdbdc30107",
+        "is_verified": false,
+        "line_number": 3679
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "explorer/ui/app/assets/icons/config.json",
+        "hashed_secret": "c0eb17dde4896c14de712dda9f12ddc3398a0ef7",
+        "is_verified": false,
+        "line_number": 3693
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "explorer/ui/app/assets/icons/config.json",
+        "hashed_secret": "5803c4e599ef445c73bd261e6118b4f116e11b63",
+        "is_verified": false,
+        "line_number": 3707
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "explorer/ui/app/assets/icons/config.json",
+        "hashed_secret": "932680880c1bb62520243cf899fb9621a4e5587d",
+        "is_verified": false,
+        "line_number": 3721
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "explorer/ui/app/assets/icons/config.json",
+        "hashed_secret": "e913d667665398274ac25e6e2a39a3f1cb42a23c",
+        "is_verified": false,
+        "line_number": 3735
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "explorer/ui/app/assets/icons/config.json",
+        "hashed_secret": "40588dfb86270829b8d7ec6d85ad5dd00d0017fe",
+        "is_verified": false,
+        "line_number": 3749
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "explorer/ui/app/assets/icons/config.json",
+        "hashed_secret": "3429cdf2f3832ab62082f7d537ec94af19882aa4",
+        "is_verified": false,
+        "line_number": 3763
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "explorer/ui/app/assets/icons/config.json",
+        "hashed_secret": "35babba7f4ae9eedace2de90565e80bae48443af",
+        "is_verified": false,
+        "line_number": 3777
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "explorer/ui/app/assets/icons/config.json",
+        "hashed_secret": "ab1a9231b1b5b013a950ee2c8acb7927990a31e2",
+        "is_verified": false,
+        "line_number": 3791
+      }
+    ],
     "halo/app/privval_internal_test.go": [
       {
         "type": "Secret Keyword",
@@ -358,112 +2253,112 @@
         "filename": "halo/genutil/evm/testdata/TestMakeGenesis.golden",
         "hashed_secret": "08b650e252263f24012a9f28567c240a20c2f946",
         "is_verified": false,
-        "line_number": 14401
+        "line_number": 14413
       },
       {
         "type": "Hex High Entropy String",
         "filename": "halo/genutil/evm/testdata/TestMakeGenesis.golden",
         "hashed_secret": "bba31aa004481de49b494ec166f33686c717bc26",
         "is_verified": false,
-        "line_number": 14404
+        "line_number": 14416
       },
       {
         "type": "Hex High Entropy String",
         "filename": "halo/genutil/evm/testdata/TestMakeGenesis.golden",
         "hashed_secret": "28ef15964c4850182b1fef49fc55950919db756f",
         "is_verified": false,
-        "line_number": 14407
+        "line_number": 14419
       },
       {
         "type": "Hex High Entropy String",
         "filename": "halo/genutil/evm/testdata/TestMakeGenesis.golden",
         "hashed_secret": "72cd5d2bd88432c9ed5d75d51479070e70ec089e",
         "is_verified": false,
-        "line_number": 14410
+        "line_number": 14422
       },
       {
         "type": "Hex High Entropy String",
         "filename": "halo/genutil/evm/testdata/TestMakeGenesis.golden",
         "hashed_secret": "3f0335f2af6f7b386ef0d32f094fbe826e7e3fa7",
         "is_verified": false,
-        "line_number": 14413
+        "line_number": 14425
       },
       {
         "type": "Hex High Entropy String",
         "filename": "halo/genutil/evm/testdata/TestMakeGenesis.golden",
         "hashed_secret": "87c4dc1a812364b8db6093f7ed72aced0c07630a",
         "is_verified": false,
-        "line_number": 14416
+        "line_number": 14428
       },
       {
         "type": "Hex High Entropy String",
         "filename": "halo/genutil/evm/testdata/TestMakeGenesis.golden",
         "hashed_secret": "c52cffacab1f07ba79bbc61c32ff164fff8f9f8b",
         "is_verified": false,
-        "line_number": 14419
+        "line_number": 14431
       },
       {
         "type": "Hex High Entropy String",
         "filename": "halo/genutil/evm/testdata/TestMakeGenesis.golden",
         "hashed_secret": "471394320cd7526cb50202735fd4156e9fac18bf",
         "is_verified": false,
-        "line_number": 14422
+        "line_number": 14434
       },
       {
         "type": "Hex High Entropy String",
         "filename": "halo/genutil/evm/testdata/TestMakeGenesis.golden",
         "hashed_secret": "0b88203fde5908bb7273ca44a7f685f977bde2ca",
         "is_verified": false,
-        "line_number": 14425
+        "line_number": 14437
       },
       {
         "type": "Hex High Entropy String",
         "filename": "halo/genutil/evm/testdata/TestMakeGenesis.golden",
         "hashed_secret": "9d06254807267e518daa2dc5629b8e298d391966",
         "is_verified": false,
-        "line_number": 14428
+        "line_number": 14440
       },
       {
         "type": "Hex High Entropy String",
         "filename": "halo/genutil/evm/testdata/TestMakeGenesis.golden",
         "hashed_secret": "a79365b8364bf8a43643be2ac6dc1ecbc56f6d6a",
         "is_verified": false,
-        "line_number": 14431
+        "line_number": 14443
       },
       {
         "type": "Hex High Entropy String",
         "filename": "halo/genutil/evm/testdata/TestMakeGenesis.golden",
         "hashed_secret": "aac432f7e35804ebe62d41d9f42657ce89479caf",
         "is_verified": false,
-        "line_number": 14434
+        "line_number": 14446
       },
       {
         "type": "Hex High Entropy String",
         "filename": "halo/genutil/evm/testdata/TestMakeGenesis.golden",
         "hashed_secret": "616a05c8bcf93ed6f3c8f20ef3d41d6d0dc0418b",
         "is_verified": false,
-        "line_number": 14437
+        "line_number": 14449
       },
       {
         "type": "Hex High Entropy String",
         "filename": "halo/genutil/evm/testdata/TestMakeGenesis.golden",
         "hashed_secret": "ac3758d662cbdd3b3067756b1979a60d0e654a19",
         "is_verified": false,
-        "line_number": 14440
+        "line_number": 14452
       },
       {
         "type": "Hex High Entropy String",
         "filename": "halo/genutil/evm/testdata/TestMakeGenesis.golden",
         "hashed_secret": "6372edf1c92d4dceccf1d6be9090746e24782003",
         "is_verified": false,
-        "line_number": 14443
+        "line_number": 14455
       },
       {
         "type": "Hex High Entropy String",
         "filename": "halo/genutil/evm/testdata/TestMakeGenesis.golden",
         "hashed_secret": "b90fd3ae85361750377898f2a212638dfa6fd26b",
         "is_verified": false,
-        "line_number": 14446
+        "line_number": 14458
       }
     ],
     "halo/genutil/testdata/TestMakeGenesis.golden": [
@@ -882,5 +2777,5 @@
       }
     ]
   },
-  "generated_at": "2024-04-25T12:14:21Z"
+  "generated_at": "2024-04-25T15:25:33Z"
 }

--- a/e2e/app/avs.go
+++ b/e2e/app/avs.go
@@ -10,9 +10,9 @@ import (
 
 // DeployAVSAndCreate3 deploys a create3 contract and the Omni AVS contract.
 func DeployAVSAndCreate3(ctx context.Context, def Definition) error {
-	chain, err := def.Testnet.AVSChain()
-	if err != nil {
-		return errors.Wrap(err, "avs chain")
+	chain, ok := externalNetwork(def).EthereumChain()
+	if !ok {
+		return errors.New("no ethereum l1 chain")
 	}
 
 	factory, receipt, err := deployCreate3(ctx, def, chain.ID)
@@ -28,9 +28,9 @@ func DeployAVSAndCreate3(ctx context.Context, def Definition) error {
 }
 
 func deployAVS(ctx context.Context, def Definition) error {
-	chain, err := def.Testnet.AVSChain()
-	if err != nil {
-		return errors.Wrap(err, "avs chain")
+	chain, ok := externalNetwork(def).EthereumChain()
+	if !ok {
+		return errors.New("no ethereum l1 chain")
 	}
 
 	backend, err := def.Backends().Backend(chain.ID)

--- a/e2e/app/monitor.go
+++ b/e2e/app/monitor.go
@@ -114,7 +114,6 @@ func StartMonitoringReceipts(ctx context.Context, def Definition) func() error {
 }
 
 func MonitorCursors(ctx context.Context, portals map[uint64]netman.Portal, network netconf.Network) error {
-	network.EthereumChain()
 	for _, dest := range network.EVMChains() {
 		for _, src := range network.EVMChains() {
 			if src.ID == dest.ID {

--- a/e2e/manifests/ci.toml
+++ b/e2e/manifests/ci.toml
@@ -1,6 +1,5 @@
 network = "devnet"
 anvil_chains = ["mock_rollup", "mock_l1"]
-avs_target = "mock_l1"
 
 multi_omni_evms = true
 

--- a/e2e/manifests/devnet0.toml
+++ b/e2e/manifests/devnet0.toml
@@ -3,6 +3,5 @@
 
 network = "devnet"
 anvil_chains = ["mock_l1", "mock_rollup"]
-avs_target = "mock_l1"
 
 [node.validator01]

--- a/e2e/manifests/devnet1.toml
+++ b/e2e/manifests/devnet1.toml
@@ -1,7 +1,6 @@
 # Devnet1 is the simple multi-validator devnet. It contains 2 validators.
 network = "devnet"
 anvil_chains = ["mock_l1", "mock_rollup"]
-avs_target = "mock_l1"
 
 multi_omni_evms = true
 prometheus = true

--- a/e2e/manifests/devnet2.toml
+++ b/e2e/manifests/devnet2.toml
@@ -1,7 +1,6 @@
 # Devnet2 is the smallest devnet possible. It only a single validator with the explorer enabled.
 network = "devnet"
 anvil_chains = ["mock_l1", "mock_rollup"]
-avs_target = "mock_l1"
 
 multi_omni_evms = true
 prometheus = true

--- a/e2e/manifests/mainnet.toml
+++ b/e2e/manifests/mainnet.toml
@@ -1,6 +1,5 @@
 network = "mainnet"
 public_chains = ["ethereum"]
-avs_target    = "ethereum"
 
 only_monitor = true
 prometheus   = true

--- a/e2e/manifests/simple.toml
+++ b/e2e/manifests/simple.toml
@@ -1,6 +1,5 @@
 network = "devnet"
 anvil_chains = ["mock_rollup", "mock_l1"]
-avs_target = "mock_l1"
 
 [node.validator01]
 [node.validator02]

--- a/e2e/manifests/staging.toml
+++ b/e2e/manifests/staging.toml
@@ -1,7 +1,6 @@
 network = "staging"
 public_chains = ["op_sepolia"]
-anvil_chains = ["chain_a"]
-avs_target = "chain_a"
+anvil_chains = ["mock_l1"]
 multi_omni_evms = true
 prometheus = true
 explorer = true

--- a/e2e/manifests/testnet.toml
+++ b/e2e/manifests/testnet.toml
@@ -1,7 +1,5 @@
 network = "testnet"
-
 public_chains = ["holesky","op_sepolia","arb_sepolia"]
-avs_target = "holesky"
 
 multi_omni_evms = true
 prometheus = true

--- a/e2e/netman/pingpong/pingpong.go
+++ b/e2e/netman/pingpong/pingpong.go
@@ -98,12 +98,6 @@ func Deploy(ctx context.Context, netMgr netman.Manager, backends ethbackend.Back
 	return dapp, nil
 }
 
-func (d *XDapp) ExportDeployInfo(resp types.DeployInfos) {
-	for chainID, contract := range d.contracts {
-		resp.Set(chainID, types.ContractPingPong, contract.Address, contract.DeployHeight)
-	}
-}
-
 func (d *XDapp) LogBalances(ctx context.Context) error {
 	for _, contract := range d.contracts {
 		backend, err := d.backends.Backend(contract.Chain.ID)

--- a/e2e/types/deployinfo.go
+++ b/e2e/types/deployinfo.go
@@ -12,9 +12,7 @@ import (
 type ContractName string
 
 const (
-	ContractPortal   ContractName = "portal"
-	ContractOmniAVS  ContractName = "omni_avs"
-	ContractPingPong ContractName = "ping_pong"
+	ContractPortal ContractName = "portal"
 )
 
 // DeployInfos contains the addresses of deployed xdapps and contracts by chainID.

--- a/e2e/types/manifest.go
+++ b/e2e/types/manifest.go
@@ -59,10 +59,6 @@ type Manifest struct {
 	// PublicChains defines the public chains to connect to; arb_sepolia, etc.
 	PublicChains []string `toml:"public_chains"`
 
-	// AVSTarget identifies the chain to deploy the AVS contracts to.
-	// It must be one of the anvil or public chains.
-	AVSTarget string `toml:"avs_target"`
-
 	// MultiOmniEVMs defines whether to deploy one or multiple Omni EVMs.
 	MultiOmniEVMs bool `toml:"multi_omni_evms"`
 

--- a/e2e/types/testnet.go
+++ b/e2e/types/testnet.go
@@ -8,7 +8,6 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/omni-network/omni/lib/errors"
 	"github.com/omni-network/omni/lib/netconf"
 
 	e2e "github.com/cometbft/cometbft/test/e2e/pkg"
@@ -49,22 +48,6 @@ func (t Testnet) RandomHaloAddr() string {
 	return eligible[rand.IntN(len(eligible))]
 }
 
-func (t Testnet) AVSChain() (EVMChain, error) {
-	for _, c := range t.AnvilChains {
-		if c.Chain.IsAVSTarget {
-			return c.Chain, nil
-		}
-	}
-
-	for _, c := range t.PublicChains {
-		if c.chain.IsAVSTarget {
-			return c.chain, nil
-		}
-	}
-
-	return EVMChain{}, errors.New("avs target chain found")
-}
-
 // BroadcastOmniEVM returns a Omni EVM to use for e2e app tx broadcasts.
 // It prefers a validator nodes since we have an issue with mempool+p2p+startup where
 // txs get stuck in non-validator mempool immediately after startup if not connected to peers yet.
@@ -98,7 +81,6 @@ type EVMChain struct {
 	Name              string // Chain Name
 	ID                uint64 // Chain ID
 	IsPublic          bool
-	IsAVSTarget       bool
 	BlockPeriod       time.Duration
 	FinalizationStrat netconf.FinalizationStrat
 }

--- a/explorer/indexer/app/chain_test.go
+++ b/explorer/indexer/app/chain_test.go
@@ -38,7 +38,6 @@ func TestChain(t *testing.T) {
 				RPCURL:            "http://mock_l1:8545",
 				PortalAddress:     common.Address([]byte("0x268bb5F3d4301b591288390E76b97BE8E8B1Ca82")),
 				DeployHeight:      0,
-				IsEthereum:        true,
 				BlockPeriod:       time.Duration(1) * time.Second,
 				FinalizationStrat: "latest",
 			},

--- a/explorer/indexer/app/cursor_test.go
+++ b/explorer/indexer/app/cursor_test.go
@@ -34,7 +34,6 @@ func TestCursor(t *testing.T) {
 				RPCURL:            "http://mock_l1:8545",
 				PortalAddress:     common.Address([]byte("0x268bb5F3d4301b591288390E76b97BE8E8B1Ca82")),
 				DeployHeight:      0,
-				IsEthereum:        true,
 				BlockPeriod:       time.Duration(1) * time.Second,
 				FinalizationStrat: "latest",
 			},

--- a/halo/cmd/init.go
+++ b/halo/cmd/init.go
@@ -212,13 +212,11 @@ func InitFiles(ctx context.Context, initCfg InitConfig) error {
 				{
 					ID:            100, // todo(Lazar): make it dynamic. this is coming from lib/xchain/provider/mock.go
 					Name:          "chain_a",
-					IsEthereum:    false,
 					PortalAddress: dummyAddr,
 				},
 				{
 					ID:            200, // todo(Lazar): make it dynamic. this is coming from lib/xchain/provider/mock.go
 					Name:          "chain_b",
-					IsEthereum:    false,
 					PortalAddress: dummyAddr,
 				},
 			},

--- a/lib/netconf/testdata/TestSaveLoad.golden
+++ b/lib/netconf/testdata/TestSaveLoad.golden
@@ -7,32 +7,26 @@
    "rpcurl": "飖Ǒp!ǪŰM旰綷罨袢捺悲ȅ-@",
    "portal_address": "0x78968D1662E46D908944a92A4B5AeFcD2c841eC7",
    "deploy_height": 1900800649570732577,
-   "is_ethereum": true,
-   "block_period": "-1455003h26m2.384355226s",
-   "finalization_start": "讻IeYF墄[C",
-   "avs_contract_address": "0x5D33a2818D7F2C5644d428eDBd78130cb999edd3"
+   "block_period": "1076167h14m26.189473666s",
+   "finalization_start": "~轱:ŽƔA苩"
   },
   {
-   "id": 8800248523004128376,
-   "name": "ȖɥmeCʊ ",
-   "rpcurl": "暮斚嬆ʅȀʙĄĥ腲ʤaǇ",
-   "portal_address": "0x1D8Cfd558406d45816570dA345a258A4F475F17F",
-   "deploy_height": 14549873146773073637,
-   "is_ethereum": true,
-   "block_period": "-551784h5m2.213503634s",
-   "finalization_start": "飦tD6ɀk諮Ȃ遃ɸ",
-   "avs_contract_address": "0x242619aF19B8c358b31daA3E51Fa4C421666e082"
+   "id": 5259823216098853135,
+   "name": "_睿ȉǫ蹟",
+   "rpcurl": "Ę鄏þƿ髈儱Ŀ蒫÷K鬣壈gƢ",
+   "portal_address": "0x67a66a13087A9889Ef3f0C9437545Df513a27c88",
+   "deploy_height": 15899325485858621180,
+   "block_period": "-876125h54m39.968728898s",
+   "finalization_start": "x瑻霳鸻ȉĔȹ$Ievɥʈ"
   },
   {
-   "id": 2430368660124652522,
-   "name": "*|机Ȱ晸ʈ劉j蕓ư銩6ĳ憏",
-   "rpcurl": "+",
-   "portal_address": "0xD17a53Ad16B7E98aA9375E2e4BC9922B44F63E11",
-   "deploy_height": 4256679219153142497,
-   "is_ethereum": true,
-   "block_period": "90415h39m55.608582598s",
-   "finalization_start": "鷸ȳ琍殪\"g踮螧喘夓麑Y·L继Ɂ",
-   "avs_contract_address": "0x8363F8B4a42e21c06dB26dA0eA24B0b3FDf951A5"
+   "id": 10620786042408765326,
+   "name": "霡豐Ȭ-ƀh婉Ţ飦tD6ɀk諮Ȃ",
+   "rpcurl": "Ǭ顼溹*x唎蕍",
+   "portal_address": "0xac134759D71e5af9669Ba97e342c6B656b846810",
+   "deploy_height": 16039643194165739319,
+   "block_period": "-1311148h58m37.614876206s",
+   "finalization_start": "kÐŻHĦɈ好"
   }
  ]
 }

--- a/monitor/app/avssync.go
+++ b/monitor/app/avssync.go
@@ -27,8 +27,8 @@ func startAVSSync(ctx context.Context, cfg Config, network netconf.Network) erro
 	if !ok {
 		log.Warn(ctx, "Not syncing avs since no ethereum chain defined", nil)
 		return nil
-	} else if ethL1.AVSContractAddr == (common.Address{}) {
-		log.Warn(ctx, "Not syncing avs since AVSContractAddr empty", nil)
+	} else if network.ID.Static().AVSContractAddress == (common.Address{}) {
+		log.Warn(ctx, "Not syncing avs since netconf.AVSContractAddr empty", nil)
 		return nil
 	} else if ethL1.PortalAddress == (common.Address{}) {
 		log.Warn(ctx, "Not syncing avs since no l1 portal defined", nil)
@@ -53,7 +53,7 @@ func startAVSSync(ctx context.Context, cfg Config, network netconf.Network) erro
 		return err
 	}
 
-	omniAVS, err := bindings.NewOmniAVS(ethL1.AVSContractAddr, backend)
+	omniAVS, err := bindings.NewOmniAVS(network.ID.Static().AVSContractAddress, backend)
 	if err != nil {
 		return errors.Wrap(err, "new omni portal")
 	}


### PR DESCRIPTION
Next step ito on-chain netconf: Remove AVS related fields from network.json on disk.

> Note that `avs_target` is now implicitly mapped on chain ID/name: either `ethereum`, or `holesky` or `mock_l1`.

task: none