### PR TITLE
ci(e2e): clean network as late as possible

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -76,10 +76,6 @@
       "path": "detect_secrets.filters.allowlist.is_line_allowlisted"
     },
     {
-      "path": "detect_secrets.filters.common.is_baseline_file",
-      "filename": ".secrets.baseline"
-    },
-    {
       "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
       "min_level": 2
     },
@@ -224,28 +220,28 @@
         "filename": "e2e/app/setup.go",
         "hashed_secret": "7be029054a936fcb1827abd24388a53136be7b64",
         "is_verified": false,
-        "line_number": 149
+        "line_number": 153
       },
       {
         "type": "Secret Keyword",
         "filename": "e2e/app/setup.go",
         "hashed_secret": "55abc9109d5ea8a77be16bf3c76b4b199b524b12",
         "is_verified": false,
-        "line_number": 384
+        "line_number": 388
       },
       {
         "type": "Secret Keyword",
         "filename": "e2e/app/setup.go",
         "hashed_secret": "da57af224108e98e24d1e2a86221121990fa6478",
         "is_verified": false,
-        "line_number": 408
+        "line_number": 412
       },
       {
         "type": "Secret Keyword",
         "filename": "e2e/app/setup.go",
         "hashed_secret": "b11b6052ab454c167964c5b836faf0053a711b90",
         "is_verified": false,
-        "line_number": 448
+        "line_number": 452
       }
     ],
     "e2e/manifests/staging.toml": [
@@ -2797,5 +2793,5 @@
       }
     ]
   },
-  "generated_at": "2024-04-29T11:15:55Z"
+  "generated_at": "2024-04-29T11:24:35Z"
 }

--- a/cli/cmd/devnet.go
+++ b/cli/cmd/devnet.go
@@ -117,7 +117,11 @@ func cleanupDevnet(ctx context.Context) error {
 		return err
 	}
 
-	return app.Cleanup(ctx, def)
+	if err := app.CleanInfra(ctx, def); err != nil {
+		return err
+	}
+
+	return app.CleanupDir(ctx, def.Testnet.Dir)
 }
 
 func printDevnetInfo(ctx context.Context) error {

--- a/e2e/app/cleanup.go
+++ b/e2e/app/cleanup.go
@@ -13,17 +13,17 @@ import (
 	"github.com/cometbft/cometbft/test/e2e/pkg/infra/docker"
 )
 
-// Cleanup removes the infra containers and testnet directory.
-func Cleanup(ctx context.Context, def Definition) error {
+// CleanInfra stops and removes the infra containers.
+func CleanInfra(ctx context.Context, def Definition) error {
 	if err := def.Infra.Clean(ctx); err != nil {
 		return errors.Wrap(err, "cleaning infrastructure")
 	}
 
-	return cleanupDir(ctx, def.Testnet.Dir)
+	return nil
 }
 
-// cleanupDir cleans up a testnet directory.
-func cleanupDir(ctx context.Context, dir string) error {
+// CleanupDir cleans up a testnet directory.
+func CleanupDir(ctx context.Context, dir string) error {
 	if dir == "" {
 		return errors.New("no directory set")
 	}

--- a/e2e/app/setup.go
+++ b/e2e/app/setup.go
@@ -52,6 +52,10 @@ const (
 func Setup(ctx context.Context, def Definition, depCfg DeployConfig) error {
 	log.Info(ctx, "Setup testnet", "dir", def.Testnet.Dir)
 
+	if err := CleanupDir(ctx, def.Testnet.Dir); err != nil {
+		return err
+	}
+
 	if err := os.MkdirAll(def.Testnet.Dir, os.ModePerm); err != nil {
 		return errors.Wrap(err, "mkdir")
 	}

--- a/e2e/cmd/cmd.go
+++ b/e2e/cmd/cmd.go
@@ -131,7 +131,11 @@ func newCleanCmd(def *app.Definition) *cobra.Command {
 		Use:   "clean",
 		Short: "Cleans (deletes) previously preserved network infrastructure",
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			return app.Cleanup(cmd.Context(), *def)
+			if err := app.CleanInfra(cmd.Context(), *def); err != nil {
+				return err
+			}
+
+			return app.CleanupDir(cmd.Context(), def.Testnet.Dir)
 		},
 	}
 }


### PR DESCRIPTION
Only stop and delete existing network at the last possible moment before re-deploying the new network.

This decreases downtime incase the deploy fails. 

task: none