### PR TITLE
ci(e2e): fix vmcompose evm regex

### DIFF
--- a/e2e/vmcompose/data.go
+++ b/e2e/vmcompose/data.go
@@ -12,7 +12,7 @@ import (
 	e2e "github.com/cometbft/cometbft/test/e2e/pkg"
 )
 
-var evmRegx = regexp.MustCompile("(.*_evm|chain_.*)")
+var evmRegx = regexp.MustCompile("(.*_evm|chain_.*|mock_.*)")
 
 const (
 	evmPort  = 8545


### PR DESCRIPTION
Fix `vmcompose` evm regex to match `mock_l1`. 

task: none