### PR TITLE
refactor(lib/netconf): move rpc endpoints to flags

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -76,6 +76,10 @@
       "path": "detect_secrets.filters.allowlist.is_line_allowlisted"
     },
     {
+      "path": "detect_secrets.filters.common.is_baseline_file",
+      "filename": ".secrets.baseline"
+    },
+    {
       "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
       "min_level": 2
     },
@@ -170,14 +174,14 @@
         "filename": "e2e/app/definition.go",
         "hashed_secret": "6616ab7d49764018125fb7f010148dbb655e2c44",
         "is_verified": false,
-        "line_number": 63
+        "line_number": 66
       },
       {
         "type": "Basic Auth Credentials",
         "filename": "e2e/app/definition.go",
         "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
         "is_verified": false,
-        "line_number": 66
+        "line_number": 69
       }
     ],
     "e2e/app/geth/testdata/TestWriteConfigTOML_archive.golden": [
@@ -204,28 +208,28 @@
         "filename": "e2e/app/setup.go",
         "hashed_secret": "7be029054a936fcb1827abd24388a53136be7b64",
         "is_verified": false,
-        "line_number": 140
+        "line_number": 155
       },
       {
         "type": "Secret Keyword",
         "filename": "e2e/app/setup.go",
         "hashed_secret": "55abc9109d5ea8a77be16bf3c76b4b199b524b12",
         "is_verified": false,
-        "line_number": 364
+        "line_number": 391
       },
       {
         "type": "Secret Keyword",
         "filename": "e2e/app/setup.go",
         "hashed_secret": "da57af224108e98e24d1e2a86221121990fa6478",
         "is_verified": false,
-        "line_number": 393
+        "line_number": 420
       },
       {
         "type": "Secret Keyword",
         "filename": "e2e/app/setup.go",
         "hashed_secret": "b11b6052ab454c167964c5b836faf0053a711b90",
         "is_verified": false,
-        "line_number": 437
+        "line_number": 465
       }
     ],
     "e2e/manifests/staging.toml": [
@@ -311,7 +315,7 @@
         "filename": "explorer/indexer/app/config.go",
         "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
         "is_verified": false,
-        "line_number": 29
+        "line_number": 31
       }
     ],
     "explorer/indexer/app/testdata/default_explorer_indexer.toml": [
@@ -2564,7 +2568,7 @@
         "filename": "monitor/app/config.go",
         "hashed_secret": "dd5585979d1148541e6e229e04a835ea89da0286",
         "is_verified": false,
-        "line_number": 27
+        "line_number": 29
       }
     ],
     "relayer/app/config.go": [
@@ -2573,7 +2577,7 @@
         "filename": "relayer/app/config.go",
         "hashed_secret": "8cc9404ee4a70f25fb3bc043bfcbb4288f644bc3",
         "is_verified": false,
-        "line_number": 26
+        "line_number": 28
       }
     ],
     "scripts/gethdevnet/execution/genesis.json": [
@@ -2777,5 +2781,5 @@
       }
     ]
   },
-  "generated_at": "2024-04-25T15:25:33Z"
+  "generated_at": "2024-04-27T12:03:27Z"
 }

--- a/e2e/app/avs.go
+++ b/e2e/app/avs.go
@@ -10,7 +10,8 @@ import (
 
 // DeployAVSAndCreate3 deploys a create3 contract and the Omni AVS contract.
 func DeployAVSAndCreate3(ctx context.Context, def Definition) error {
-	chain, ok := externalNetwork(def).EthereumChain()
+	network, _ := externalNetwork(def)
+	chain, ok := network.EthereumChain()
 	if !ok {
 		return errors.New("no ethereum l1 chain")
 	}
@@ -28,7 +29,8 @@ func DeployAVSAndCreate3(ctx context.Context, def Definition) error {
 }
 
 func deployAVS(ctx context.Context, def Definition) error {
-	chain, ok := externalNetwork(def).EthereumChain()
+	network, _ := externalNetwork(def)
+	chain, ok := network.EthereumChain()
 	if !ok {
 		return errors.New("no ethereum l1 chain")
 	}

--- a/e2e/app/fund.go
+++ b/e2e/app/fund.go
@@ -55,7 +55,7 @@ func fundAccounts(ctx context.Context, def Definition) error {
 
 // FundEOAAccounts funds the EOAs that need funding to their target balance.
 func FundEOAAccounts(ctx context.Context, def Definition) error {
-	network := externalNetwork(def)
+	network, _ := externalNetwork(def)
 	accounts, ok := eoa.AllAccounts(network.ID)
 	if !ok {
 		return errors.New("no accounts found", "network", network.ID)

--- a/e2e/app/monitor.go
+++ b/e2e/app/monitor.go
@@ -17,10 +17,9 @@ import (
 )
 
 func LogMetrics(ctx context.Context, def Definition) error {
-	extNetwork := externalNetwork(def)
+	extNetwork, _ := externalNetwork(def)
 
 	// Pick a random node to monitor.
-
 	if err := MonitorCProvider(ctx, random(def.Testnet.Nodes), extNetwork); err != nil {
 		return errors.Wrap(err, "monitoring cchain provider")
 	}
@@ -40,7 +39,7 @@ func StartMonitoringReceipts(ctx context.Context, def Definition) func() error {
 		return func() error { return errors.Wrap(err, "getting client") }
 	}
 
-	network := externalNetwork(def)
+	network, _ := externalNetwork(def)
 	cProvider := cprovider.NewABCIProvider(client, def.Testnet.Network, network.ChainNamesByIDs())
 	xProvider := xprovider.New(network, def.Backends().RPCClients(), cProvider)
 	cChainID := def.Testnet.Network.Static().OmniConsensusChainIDUint64()

--- a/e2e/app/run.go
+++ b/e2e/app/run.go
@@ -262,10 +262,11 @@ func toPortalValidators(validators map[*e2e.Node]int64) ([]bindings.Validator, e
 }
 
 func logRPCs(ctx context.Context, def Definition) {
-	network := externalNetwork(def)
+	network, endpoints := externalNetwork(def)
 	for _, chain := range network.EVMChains() {
+		rpc, _ := endpoints.GetByNameOrID(chain.Name, chain.ID)
 		log.Info(ctx, "EVM Chain RPC available", "chain_id", chain.ID,
-			"chain_name", chain.Name, "url", chain.RPCURL)
+			"chain_name", chain.Name, "url", rpc)
 	}
 }
 

--- a/e2e/app/test.go
+++ b/e2e/app/test.go
@@ -2,6 +2,7 @@ package app
 
 import (
 	"context"
+	"encoding/json"
 	"os"
 	"path/filepath"
 
@@ -12,10 +13,20 @@ import (
 	"github.com/cometbft/cometbft/test/e2e/pkg/exec"
 )
 
+const (
+	EnvInfraType       = "INFRASTRUCTURE_TYPE"
+	EnvInfraFile       = "INFRASTRUCTURE_FILE"
+	EnvE2EManifest     = "E2E_MANIFEST"
+	EnvE2ENode         = "E2E_NODE"
+	EnvE2ENetwork      = "E2E_NETWORK"
+	EnvE2ERPCEndpoints = "E2E_RPC_ENDPOINTS"
+	EnvE2EDeployInfo   = "E2E_DEPLOY_INFO"
+)
+
 // Test runs test cases under tests/.
 func Test(ctx context.Context, def Definition, verbose bool) error {
 	log.Info(ctx, "Running tests in ./test/...")
-	extNetwork := externalNetwork(def)
+	extNetwork, endpoints := externalNetwork(def)
 
 	networkDir, err := os.MkdirTemp("", "omni-e2e")
 	if err != nil {
@@ -26,8 +37,17 @@ func Test(ctx context.Context, def Definition, verbose bool) error {
 		return errors.Wrap(err, "saving network")
 	}
 
-	if err = os.Setenv("E2E_NETWORK", networkFile); err != nil {
-		return errors.Wrap(err, "setting E2E_MANIFEST")
+	if err = os.Setenv(EnvE2ENetwork, networkFile); err != nil {
+		return errors.Wrap(err, "setting env var")
+	}
+
+	endpointsFile := filepath.Join(networkDir, "endpoints.json")
+	if endopintsBytes, err := json.Marshal(endpoints); err != nil {
+		return errors.Wrap(err, "marshaling endpoints")
+	} else if err := os.WriteFile(endpointsFile, endopintsBytes, 0644); err != nil {
+		return errors.Wrap(err, "writing endpoints")
+	} else if err = os.Setenv(EnvE2ERPCEndpoints, endpointsFile); err != nil {
+		return errors.Wrap(err, "setting env ar")
 	}
 
 	manifestFile, err := filepath.Abs(def.Testnet.File)
@@ -35,8 +55,8 @@ func Test(ctx context.Context, def Definition, verbose bool) error {
 		return errors.Wrap(err, "absolute manifest path")
 	}
 
-	if err = os.Setenv("E2E_MANIFEST", manifestFile); err != nil {
-		return errors.Wrap(err, "setting E2E_MANIFEST")
+	if err = os.Setenv(EnvE2EManifest, manifestFile); err != nil {
+		return errors.Wrap(err, "setting env var")
 	}
 
 	infd := def.Infra.GetInfrastructureData()
@@ -45,30 +65,32 @@ func Test(ctx context.Context, def Definition, verbose bool) error {
 		if err != nil {
 			return errors.Wrap(err, "absolute infrastructure path")
 		}
-		err = os.Setenv("INFRASTRUCTURE_FILE", infdPath)
+		err = os.Setenv(EnvInfraFile, infdPath)
 		if err != nil {
-			return errors.Wrap(err, "setting INFRASTRUCTURE_FILE")
+			return errors.Wrap(err, "setting env var")
 		}
 	}
 
-	if err = os.Setenv("INFRASTRUCTURE_TYPE", infd.Provider); err != nil {
-		return errors.Wrap(err, "setting INFRASTRUCTURE_TYPE")
+	if err = os.Setenv(EnvInfraType, infd.Provider); err != nil {
+		return errors.Wrap(err, "setting env var")
 	}
 
 	deployInfoFile := filepath.Join(networkDir, "deployinfo.json")
 	if err := def.DeployInfos().Save(deployInfoFile); err != nil {
 		return errors.Wrap(err, "saving deployinfo")
 	}
-	if err = os.Setenv("E2E_DEPLOY_INFO", deployInfoFile); err != nil {
+	if err = os.Setenv(EnvE2EDeployInfo, deployInfoFile); err != nil {
 		return errors.Wrap(err, "setting E2E_DEPLOY_INFO")
 	}
 
 	log.Debug(ctx, "Env files",
-		"E2E_NETWORK", networkFile,
-		"E2E_MANIFEST", manifestFile,
-		"INFRASTRUCTURE_TYPE", infd.Provider,
-		"INFRASTRUCTURE_FILE", infd.Path,
-		"E2E_DEPLOY_INFO", deployInfoFile)
+		EnvE2ENetwork, networkFile,
+		EnvE2EManifest, manifestFile,
+		EnvInfraType, infd.Provider,
+		EnvInfraFile, infd.Path,
+		EnvE2EDeployInfo, deployInfoFile,
+		EnvE2ERPCEndpoints, endpointsFile,
+	)
 
 	args := []string{"go", "test", "-timeout", "60s", "-count", "1"}
 	if verbose {

--- a/e2e/app/valupdates.go
+++ b/e2e/app/valupdates.go
@@ -34,7 +34,7 @@ func FundValidatorsForTesting(ctx context.Context, def Definition) error {
 
 	log.Info(ctx, "Funding validators for testing", "count", len(def.Testnet.Nodes))
 
-	network := externalNetwork(def)
+	network, _ := externalNetwork(def)
 	omniEVM, _ := network.OmniEVMChain()
 	funder := def.Netman().Operator()
 	_, fundBackend, err := def.Backends().BindOpts(ctx, omniEVM.ID, funder)
@@ -124,9 +124,14 @@ func StartValidatorUpdates(ctx context.Context, def Definition) func() error {
 		})
 
 		// Create a backend to trigger deposits from
-		network := externalNetwork(def)
+		network, endpoints := externalNetwork(def)
 		omniEVM, _ := network.OmniEVMChain()
-		ethCl, err := ethclient.Dial(omniEVM.Name, omniEVM.RPCURL)
+		rpc, err := endpoints.GetByNameOrID(omniEVM.Name, omniEVM.ID)
+		if err != nil {
+			returnErr(errors.Wrap(err, "get rpc"))
+			return
+		}
+		ethCl, err := ethclient.Dial(omniEVM.Name, rpc)
 		if err != nil {
 			returnErr(errors.Wrap(err, "dial"))
 			return

--- a/e2e/test/portal_registry_test.go
+++ b/e2e/test/portal_registry_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/omni-network/omni/halo/genutil/evm/predeploys"
 	"github.com/omni-network/omni/lib/ethclient"
 	"github.com/omni-network/omni/lib/netconf"
+	"github.com/omni-network/omni/lib/xchain"
 
 	"github.com/ethereum/go-ethereum/common"
 
@@ -15,13 +16,16 @@ import (
 
 func TestPortalRegistry(t *testing.T) {
 	t.Parallel()
-	testNetwork(t, func(t *testing.T, network netconf.Network) {
+	testNetwork(t, func(t *testing.T, network netconf.Network, endpoints xchain.RPCEndpoints) {
 		t.Helper()
 
 		omniEVM, ok := network.OmniEVMChain()
 		require.True(t, ok)
 
-		omniClient, err := ethclient.Dial(omniEVM.Name, omniEVM.RPCURL)
+		rpc, err := endpoints.GetByNameOrID(omniEVM.Name, omniEVM.ID)
+		require.NoError(t, err)
+
+		omniClient, err := ethclient.Dial(omniEVM.Name, rpc)
 		require.NoError(t, err)
 
 		// test that all portals are registered

--- a/e2e/types/testnet.go
+++ b/e2e/types/testnet.go
@@ -72,6 +72,25 @@ func (t Testnet) BroadcastOmniEVM() OmniEVM {
 	return t.OmniEVMs[0]
 }
 
+// BroadcastNode returns a halo node to use for RPC queries broadcasts.
+// It prefers a validator nodes since we have an issue with mempool+p2p+startup where
+// txs get stuck in non-validator mempool immediately after startup if not connected to peers yet.
+// Also avoid validators that are not started immediately.
+func (t Testnet) BroadcastNode() *e2e.Node {
+	for _, node := range t.Nodes {
+		if !strings.Contains(node.Name, "validator") {
+			continue
+		}
+		if node.StartAt > 0 {
+			continue
+		}
+
+		return node
+	}
+
+	return t.Nodes[0]
+}
+
 func (t Testnet) HasOmniEVM() bool {
 	return len(t.OmniEVMs) > 0
 }

--- a/explorer/indexer/app/chain_test.go
+++ b/explorer/indexer/app/chain_test.go
@@ -35,7 +35,6 @@ func TestChain(t *testing.T) {
 			chain: netconf.Chain{
 				ID:                100,
 				Name:              "mock_l1",
-				RPCURL:            "http://mock_l1:8545",
 				PortalAddress:     common.Address([]byte("0x268bb5F3d4301b591288390E76b97BE8E8B1Ca82")),
 				DeployHeight:      0,
 				BlockPeriod:       time.Duration(1) * time.Second,
@@ -51,7 +50,6 @@ func TestChain(t *testing.T) {
 			chain: netconf.Chain{
 				ID:                1016561,
 				Name:              "omni_consensus",
-				RPCURL:            "http://mock_arb:8545",
 				PortalAddress:     common.Address([]byte("0x268bb5F3d4301b591288390E76b97BE8E8B1Ca82")),
 				DeployHeight:      10687126,
 				BlockPeriod:       time.Duration(2) * time.Second,

--- a/explorer/indexer/app/config.go
+++ b/explorer/indexer/app/config.go
@@ -7,6 +7,7 @@ import (
 	"github.com/omni-network/omni/lib/buildinfo"
 	"github.com/omni-network/omni/lib/errors"
 	"github.com/omni-network/omni/lib/log"
+	"github.com/omni-network/omni/lib/xchain"
 
 	cmtos "github.com/cometbft/cometbft/libs/os"
 
@@ -18,6 +19,7 @@ const (
 )
 
 type Config struct {
+	RPCEndpoints   xchain.RPCEndpoints
 	NetworkFile    string
 	ExplorerDBConn string
 	MonitoringAddr string

--- a/explorer/indexer/app/config.toml.tmpl
+++ b/explorer/indexer/app/config.toml.tmpl
@@ -16,6 +16,23 @@ explorer-db-conn = "{{ .ExplorerDBConn }}"
 network-file = "{{ .NetworkFile }}"
 
 #######################################################################
+###                             X-Chain                             ###
+#######################################################################
+
+[xchain]
+
+# Cross-chain EVM RPC endpoints to use for voting; only required for validators. One per supported EVM is required.
+# It is strongly advised to operate fullnodes for each chain and NOT to use free public RPCs.
+[xchain.evm-rpc-endpoints]
+{{- if not .RPCEndpoints }}
+# ethereum = "http://my-ethreum-node:8545"
+# optimism = "https://my-op-node.com"
+{{ end -}}
+{{- range $key, $value := .RPCEndpoints }}
+{{ $key }} = "{{ $value }}"
+{{ end }}
+
+#######################################################################
 ###                         Logging Options                         ###
 #######################################################################
 

--- a/explorer/indexer/app/cursor_test.go
+++ b/explorer/indexer/app/cursor_test.go
@@ -31,7 +31,6 @@ func TestCursor(t *testing.T) {
 			chain: netconf.Chain{
 				ID:                100,
 				Name:              "mock_l1",
-				RPCURL:            "http://mock_l1:8545",
 				PortalAddress:     common.Address([]byte("0x268bb5F3d4301b591288390E76b97BE8E8B1Ca82")),
 				DeployHeight:      0,
 				BlockPeriod:       time.Duration(1) * time.Second,
@@ -44,7 +43,6 @@ func TestCursor(t *testing.T) {
 			chain: netconf.Chain{
 				ID:                1016561,
 				Name:              "omni_consensus",
-				RPCURL:            "http://mock_arb:8545",
 				PortalAddress:     common.Address([]byte("0x268bb5F3d4301b591288390E76b97BE8E8B1Ca82")),
 				DeployHeight:      10687126,
 				BlockPeriod:       time.Duration(2) * time.Second,

--- a/explorer/indexer/app/testdata/default_explorer_indexer.toml
+++ b/explorer/indexer/app/testdata/default_explorer_indexer.toml
@@ -16,6 +16,19 @@ explorer-db-conn = "postgres://omni:password@explorer_db:5432/omni_db"
 network-file = "network.json"
 
 #######################################################################
+###                             X-Chain                             ###
+#######################################################################
+
+[xchain]
+
+# Cross-chain EVM RPC endpoints to use for voting; only required for validators. One per supported EVM is required.
+# It is strongly advised to operate fullnodes for each chain and NOT to use free public RPCs.
+[xchain.evm-rpc-endpoints]
+# ethereum = "http://my-ethreum-node:8545"
+# optimism = "https://my-op-node.com"
+
+
+#######################################################################
 ###                         Logging Options                         ###
 #######################################################################
 

--- a/explorer/indexer/cmd/cmd.go
+++ b/explorer/indexer/cmd/cmd.go
@@ -5,6 +5,7 @@ import (
 	"github.com/omni-network/omni/explorer/indexer/app"
 	libcmd "github.com/omni-network/omni/lib/cmd"
 	"github.com/omni-network/omni/lib/log"
+	"github.com/omni-network/omni/lib/xchain"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
@@ -41,6 +42,7 @@ func New() *cobra.Command {
 }
 
 func bindIndexerFlags(flags *pflag.FlagSet, cfg *app.Config) {
+	xchain.BindFlags(flags, &cfg.RPCEndpoints)
 	flags.StringVar(&cfg.NetworkFile, "network-file", cfg.NetworkFile, "The path to the network file e.g path/network.json")
 	flags.StringVar(&cfg.ExplorerDBConn, "explorer-db-conn", cfg.ExplorerDBConn, "URL to the database")
 	flags.StringVar(&cfg.MonitoringAddr, "monitoring-addr", cfg.MonitoringAddr, "The address to bind the monitoring server")

--- a/halo/cmd/cmd_internal_test.go
+++ b/halo/cmd/cmd_internal_test.go
@@ -104,26 +104,41 @@ func TestCLIReference(t *testing.T) {
 	}
 }
 
+//go:generate go test . -run=TestTomlConfig -count=100
+
 func TestTomlConfig(t *testing.T) {
 	t.Parallel()
 	dir := t.TempDir()
 	var chars = []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ")
 
+	randomString := func() string {
+		var resp string
+		for i := 0; i < 1+rand.Intn(64); i++ {
+			resp += string(chars[rand.Intn(len(chars))])
+		}
+
+		return resp
+	}
+
 	// Create a fuzzer with small uint64s and ansi strings (toml struggles with large numbers and UTF8).
-	fuzzer := fuzz.New().Funcs(
+	fuzzer := fuzz.New().NumElements(1, 8).Funcs(
 		func(i *uint64, c fuzz.Continue) {
 			*i = uint64(rand.Intn(1_000_000))
 		},
 		func(s *string, c fuzz.Continue) {
-			for i := 0; i < rand.Intn(64); i++ {
-				*s += string(chars[rand.Intn(len(chars))])
-			}
+			*s = randomString()
 		},
 	)
 
 	var expect halocfg.Config
 	fuzzer.Fuzz(&expect)
 	expect.HomeDir = dir
+
+	// The Toml library converts map keys to lower case. So do this so expect==actual.
+	for k := range expect.RPCEndpoints {
+		expect.RPCEndpoints[strings.ToLower(randomString())] = randomString()
+		delete(expect.RPCEndpoints, k)
+	}
 
 	// Ensure the <home>/config directory exists.
 	require.NoError(t, os.Mkdir(filepath.Join(dir, "config"), 0o755))
@@ -133,7 +148,7 @@ func TestTomlConfig(t *testing.T) {
 
 	// Create a run command that asserts the config is as expected.
 	cmd := newRunCmd("run", func(_ context.Context, actual app.Config) error {
-		require.Equal(t, expect, actual.Config)
+		require.EqualValues(t, expect, actual.Config)
 
 		return nil
 	})
@@ -141,7 +156,7 @@ func TestTomlConfig(t *testing.T) {
 	// Create and execute a root command that runs the run command.
 	rootCmd := libcmd.NewRootCmd("halo", "", cmd)
 	rootCmd.SetArgs([]string{"run", "--home=" + dir})
-	require.NoError(t, rootCmd.Execute())
+	tutil.RequireNoError(t, rootCmd.Execute())
 }
 
 // slice is a convenience function for creating string slice literals.

--- a/halo/cmd/flags.go
+++ b/halo/cmd/flags.go
@@ -4,6 +4,7 @@ import (
 	halocfg "github.com/omni-network/omni/halo/config"
 	libcmd "github.com/omni-network/omni/lib/cmd"
 	"github.com/omni-network/omni/lib/tracer"
+	"github.com/omni-network/omni/lib/xchain"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
@@ -14,6 +15,7 @@ func bindRunFlags(cmd *cobra.Command, cfg *halocfg.Config) {
 
 	libcmd.BindHomeFlag(flags, &cfg.HomeDir)
 	tracer.BindFlags(flags, &cfg.Tracer)
+	xchain.BindFlags(flags, &cfg.RPCEndpoints)
 	flags.StringVar(&cfg.EngineEndpoint, "engine-endpoint", cfg.EngineEndpoint, "An EVM execution client Engine API http endpoint")
 	flags.StringVar(&cfg.EngineJWTFile, "engine-jwt-file", cfg.EngineJWTFile, "The path to the Engine API JWT file")
 	flags.Uint64Var(&cfg.SnapshotInterval, "snapshot-interval", cfg.SnapshotInterval, "State sync snapshot interval")

--- a/halo/cmd/init.go
+++ b/halo/cmd/init.go
@@ -13,6 +13,7 @@ import (
 	"github.com/omni-network/omni/lib/errors"
 	"github.com/omni-network/omni/lib/log"
 	"github.com/omni-network/omni/lib/netconf"
+	"github.com/omni-network/omni/lib/xchain"
 
 	cmtconfig "github.com/cometbft/cometbft/config"
 	k1 "github.com/cometbft/cometbft/crypto/secp256k1"
@@ -28,11 +29,12 @@ import (
 
 // InitConfig is the config for the init command.
 type InitConfig struct {
-	HomeDir string
-	Network netconf.ID
-	Force   bool
-	Clean   bool
-	Cosmos  bool
+	HomeDir      string
+	Network      netconf.ID
+	RCPEndpoints xchain.RPCEndpoints
+	Force        bool
+	Clean        bool
+	Cosmos       bool
 }
 
 // newInitCmd returns a new cobra command that initializes the files and folders required by halo.
@@ -114,6 +116,7 @@ func InitFiles(ctx context.Context, initCfg InitConfig) error {
 	comet := DefaultCometConfig(homeDir)
 	cfg := halocfg.DefaultConfig()
 	cfg.HomeDir = homeDir
+	cfg.RPCEndpoints = initCfg.RCPEndpoints
 
 	// Folders
 	folders := []struct {

--- a/halo/cmd/testdata/TestCLIReference_run.golden
+++ b/halo/cmd/testdata/TestCLIReference_run.golden
@@ -4,20 +4,21 @@ Usage:
   halo run [flags]
 
 Flags:
-      --app-db-backend string            The type of database for application and snapshots databases (default "goleveldb")
-      --eigenlayer-key-password string   Eigenlayer generated operator key password. Not required if CombetBFT priv_validator_key.json is used
-      --engine-endpoint string           An EVM execution client Engine API http endpoint
-      --engine-jwt-file string           The path to the Engine API JWT file
-      --evm-build-delay duration         Minimum delay between triggering and fetching a EVM payload build (default 600ms)
-      --evm-build-optimistic             Enables optimistic building of EVM payloads on previous block finalize (default true)
-  -h, --help                             help for run
-      --home string                      The application home directory containing config and data (default "./halo")
-      --log-color string                 Log color (only applicable to console format); auto, force, disable (default "auto")
-      --log-format string                Log format; console, json (default "console")
-      --log-level string                 Log level; debug, info, warn, error (default "info")
-      --min-retain-blocks uint           Minimum block height offset during ABCI commit to prune CometBFT blocks
-      --pruning string                   Pruning strategy (default|nothing|everything) (default "nothing")
-      --snapshot-interval uint           State sync snapshot interval (default 1000)
-      --snapshot-keep-recent uint        State sync snapshot to keep (default 2)
-      --tracing-endpoint string          Tracing OTLP endpoint
-      --tracing-headers string           Tracing OTLP headers
+      --app-db-backend string                     The type of database for application and snapshots databases (default "goleveldb")
+      --eigenlayer-key-password string            Eigenlayer generated operator key password. Not required if CombetBFT priv_validator_key.json is used
+      --engine-endpoint string                    An EVM execution client Engine API http endpoint
+      --engine-jwt-file string                    The path to the Engine API JWT file
+      --evm-build-delay duration                  Minimum delay between triggering and fetching a EVM payload build (default 600ms)
+      --evm-build-optimistic                      Enables optimistic building of EVM payloads on previous block finalize (default true)
+  -h, --help                                      help for run
+      --home string                               The application home directory containing config and data (default "./halo")
+      --log-color string                          Log color (only applicable to console format); auto, force, disable (default "auto")
+      --log-format string                         Log format; console, json (default "console")
+      --log-level string                          Log level; debug, info, warn, error (default "info")
+      --min-retain-blocks uint                    Minimum block height offset during ABCI commit to prune CometBFT blocks
+      --pruning string                            Pruning strategy (default|nothing|everything) (default "nothing")
+      --snapshot-interval uint                    State sync snapshot interval (default 1000)
+      --snapshot-keep-recent uint                 State sync snapshot to keep (default 2)
+      --tracing-endpoint string                   Tracing OTLP endpoint
+      --tracing-headers string                    Tracing OTLP headers
+      --xchain-evm-rpc-endpoints stringToString   Cross-chain EVM RPC endpoints. e.g. "ethereum=http://geth:8545,optimism=https://optimism.io" (default [])

--- a/halo/cmd/testdata/TestRunCmd_defaults.golden
+++ b/halo/cmd/testdata/TestRunCmd_defaults.golden
@@ -3,6 +3,7 @@
  "EigenKeyPassword": "",
  "EngineJWTFile": "",
  "EngineEndpoint": "",
+ "RPCEndpoints": null,
  "SnapshotInterval": 1000,
  "SnapshotKeepRecent": 2,
  "BackendType": "goleveldb",

--- a/halo/cmd/testdata/TestRunCmd_flags.golden
+++ b/halo/cmd/testdata/TestRunCmd_flags.golden
@@ -3,6 +3,7 @@
  "EigenKeyPassword": "",
  "EngineJWTFile": "bar",
  "EngineEndpoint": "",
+ "RPCEndpoints": null,
  "SnapshotInterval": 1000,
  "SnapshotKeepRecent": 2,
  "BackendType": "goleveldb",

--- a/halo/cmd/testdata/TestRunCmd_json_files.golden
+++ b/halo/cmd/testdata/TestRunCmd_json_files.golden
@@ -3,6 +3,7 @@
  "EigenKeyPassword": "123456",
  "EngineJWTFile": "jwt.json",
  "EngineEndpoint": "",
+ "RPCEndpoints": null,
  "SnapshotInterval": 123,
  "SnapshotKeepRecent": 2,
  "BackendType": "goleveldb",

--- a/halo/cmd/testdata/TestRunCmd_toml_files.golden
+++ b/halo/cmd/testdata/TestRunCmd_toml_files.golden
@@ -3,6 +3,10 @@
  "EigenKeyPassword": "",
  "EngineJWTFile": "jwt.toml",
  "EngineEndpoint": "",
+ "RPCEndpoints": {
+  "ethereum": "http://ethereum.rpc",
+  "optimism": "http://optimism.rpc"
+ },
  "SnapshotInterval": 999,
  "SnapshotKeepRecent": 2,
  "BackendType": "goleveldb",

--- a/halo/cmd/testinput/input1/config/halo.toml
+++ b/halo/cmd/testinput/input1/config/halo.toml
@@ -1,5 +1,7 @@
 engine-jwt-file="jwt.toml"
 
+
+
 snapshot-interval=999
 
 [state]
@@ -8,3 +10,8 @@ persist-interval=99
 [tracing]
 endpoint="http://tracing.com"
 headers="Authorization=Basic 123456"
+
+[xchain]
+[xchain.evm-rpc-endpoints]
+ethereum = "http://ethereum.rpc"
+optimism = "http://optimism.rpc"

--- a/halo/config/config.go
+++ b/halo/config/config.go
@@ -10,6 +10,7 @@ import (
 	"github.com/omni-network/omni/lib/errors"
 	"github.com/omni-network/omni/lib/log"
 	"github.com/omni-network/omni/lib/tracer"
+	"github.com/omni-network/omni/lib/xchain"
 
 	cmtos "github.com/cometbft/cometbft/libs/os"
 
@@ -63,6 +64,7 @@ type Config struct {
 	EigenKeyPassword   string
 	EngineJWTFile      string
 	EngineEndpoint     string
+	RPCEndpoints       xchain.RPCEndpoints
 	SnapshotInterval   uint64 // See cosmossdk.io/store/snapshots/types/options.go
 	SnapshotKeepRecent uint64 // See cosmossdk.io/store/snapshots/types/options.go
 	BackendType        string // See cosmos-db/db.go

--- a/halo/config/config.toml.tmpl
+++ b/halo/config/config.toml.tmpl
@@ -63,6 +63,22 @@ evm-build-delay = "{{.EVMBuildDelay}}"
 evm-build-optimistic = {{.EVMBuildOptimistic}}
 
 #######################################################################
+###                             X-Chain                             ###
+#######################################################################
+
+[xchain]
+
+# Cross-chain EVM RPC endpoints to use for voting; only required for validators. One per supported EVM is required.
+# It is strongly advised to operate fullnodes for each chain and NOT to use free public RPCs.
+[xchain.evm-rpc-endpoints]
+{{- if not .RPCEndpoints }}
+# ethereum = "http://my-ethreum-node:8545"
+# optimism = "https://my-op-node.com"
+{{ end -}}
+{{- range $key, $value := .RPCEndpoints }}
+{{ $key }} = "{{ $value }}"
+{{ end }}
+#######################################################################
 ###                         Logging Options                         ###
 #######################################################################
 

--- a/halo/config/config_test.go
+++ b/halo/config/config_test.go
@@ -20,6 +20,9 @@ func TestDefaultConfigReference(t *testing.T) {
 
 	cfg := halocfg.DefaultConfig()
 	cfg.HomeDir = tempDir
+	cfg.RPCEndpoints = map[string]string{
+		"ethereum": "http://127.0.0.1:8545",
+	}
 
 	require.NoError(t, os.MkdirAll(filepath.Join(tempDir, "config"), 0o755))
 	require.NoError(t, halocfg.WriteConfigTOML(cfg, log.DefaultConfig()))

--- a/halo/config/testdata/default_halo.toml
+++ b/halo/config/testdata/default_halo.toml
@@ -63,6 +63,17 @@ evm-build-delay = "600ms"
 evm-build-optimistic = true
 
 #######################################################################
+###                             X-Chain                             ###
+#######################################################################
+
+[xchain]
+
+# Cross-chain EVM RPC endpoints to use for voting; only required for validators. One per supported EVM is required.
+# It is strongly advised to operate fullnodes for each chain and NOT to use free public RPCs.
+[xchain.evm-rpc-endpoints]
+ethereum = "http://127.0.0.1:8545"
+
+#######################################################################
 ###                         Logging Options                         ###
 #######################################################################
 

--- a/lib/netconf/netconf.go
+++ b/lib/netconf/netconf.go
@@ -74,7 +74,7 @@ func (n Network) ChainNamesByIDs() map[uint64]string {
 // OmniEVMChain returns the Omni execution chain config or false if it does not exist.
 func (n Network) OmniEVMChain() (Chain, bool) {
 	for _, chain := range n.Chains {
-		if chain.ID == n.ID.Static().OmniExecutionChainID {
+		if IsOmniExecution(n.ID, chain.ID) {
 			return chain, true
 		}
 	}
@@ -166,9 +166,9 @@ const (
 // the Omni cross chain protocol. This is most supported Rollup EVMs, but
 // also the Omni EVM, and the Omni Consensus chain.
 type Chain struct {
-	ID                uint64            // Chain ID asa per https://chainlist.org
-	Name              string            // Chain name as per https://chainlist.org
-	RPCURL            string            // RPC URL of the chain
+	ID   uint64 // Chain ID asa per https://chainlist.org
+	Name string // Chain name as per https://chainlist.org
+	// RPCURL            string            // RPC URL of the chain
 	PortalAddress     common.Address    // Address of the omni portal contract on the chain
 	DeployHeight      uint64            // Height that the portal contracts were deployed
 	BlockPeriod       time.Duration     // Block period of the chain
@@ -243,7 +243,6 @@ func (c *Chain) UnmarshalJSON(bz []byte) error {
 	*c = Chain{
 		ID:                cj.ID,
 		Name:              cj.Name,
-		RPCURL:            cj.RPCURL,
 		PortalAddress:     portalAddr,
 		DeployHeight:      cj.DeployHeight,
 		BlockPeriod:       blockPeriod,
@@ -263,7 +262,6 @@ func (c Chain) MarshalJSON() ([]byte, error) {
 	cj := chainJSON{
 		ID:                c.ID,
 		Name:              c.Name,
-		RPCURL:            c.RPCURL,
 		PortalAddress:     portalAddr,
 		DeployHeight:      c.DeployHeight,
 		BlockPeriod:       c.BlockPeriod.String(),

--- a/lib/netconf/static.go
+++ b/lib/netconf/static.go
@@ -140,3 +140,8 @@ func ConsensusChainIDStr2Uint64(id string) (uint64, error) {
 func IsOmniConsensus(network ID, chainID uint64) bool {
 	return network.Static().OmniConsensusChainIDUint64() == chainID
 }
+
+// IsOmniExecution returns true if provided chainID is the omni execution chain for the network.
+func IsOmniExecution(network ID, chainID uint64) bool {
+	return network.Static().OmniExecutionChainID == chainID
+}

--- a/lib/netconf/testdata/TestSaveLoad.golden
+++ b/lib/netconf/testdata/TestSaveLoad.golden
@@ -4,29 +4,29 @@
   {
    "id": 5828590068104375683,
    "name": "鎢屃裂À",
-   "rpcurl": "飖Ǒp!ǪŰM旰綷罨袢捺悲ȅ-@",
-   "portal_address": "0x78968D1662E46D908944a92A4B5AeFcD2c841eC7",
-   "deploy_height": 1900800649570732577,
-   "block_period": "1076167h14m26.189473666s",
-   "finalization_start": "~轱:ŽƔA苩"
+   "rpcurl": "",
+   "portal_address": "0xBE68fD5c15c732b9cc7aFd4ff2dF2845935efd49",
+   "deploy_height": 15327675974124053897,
+   "block_period": "-631784h45m43.038248076s",
+   "finalization_start": "\u003c鈡鶭ŁPy"
   },
   {
-   "id": 5259823216098853135,
-   "name": "_睿ȉǫ蹟",
-   "rpcurl": "Ę鄏þƿ髈儱Ŀ蒫÷K鬣壈gƢ",
-   "portal_address": "0x67a66a13087A9889Ef3f0C9437545Df513a27c88",
-   "deploy_height": 15899325485858621180,
-   "block_period": "-876125h54m39.968728898s",
-   "finalization_start": "x瑻霳鸻ȉĔȹ$Ievɥʈ"
+   "id": 4817100730374455627,
+   "name": "笨Gń條ģ|2諱4",
+   "rpcurl": "",
+   "portal_address": "0xD9525b035FD958D23472fe9B73D671fDf5133f89",
+   "deploy_height": 5735187812301142556,
+   "block_period": "529387h35m15.403748486s",
+   "finalization_start": ""
   },
   {
-   "id": 10620786042408765326,
-   "name": "霡豐Ȭ-ƀh婉Ţ飦tD6ɀk諮Ȃ",
-   "rpcurl": "Ǭ顼溹*x唎蕍",
-   "portal_address": "0xac134759D71e5af9669Ba97e342c6B656b846810",
-   "deploy_height": 16039643194165739319,
-   "block_period": "-1311148h58m37.614876206s",
-   "finalization_start": "kÐŻHĦɈ好"
+   "id": 7511938291065765907,
+   "name": "Ƚ東潇澍ȣ1ȖɥmeCʊ 炄闌剾",
+   "rpcurl": "",
+   "portal_address": "0xD8e0a2E8ec0a504a40eB1b0024Aa07e7b004845f",
+   "deploy_height": 17987662841182572659,
+   "block_period": "-411979h10m35.702892746s",
+   "finalization_start": "z瘯霡豐Ȭ-"
   }
  ]
 }

--- a/lib/xchain/flags.go
+++ b/lib/xchain/flags.go
@@ -1,0 +1,26 @@
+package xchain
+
+import (
+	"strconv"
+
+	"github.com/omni-network/omni/lib/errors"
+
+	"github.com/spf13/pflag"
+)
+
+type RPCEndpoints map[string]string
+
+func (e RPCEndpoints) GetByNameOrID(name string, chainID uint64) (string, error) {
+	if val, ok := e[name]; ok {
+		return val, nil
+	} else if val, ok := e[strconv.FormatUint(chainID, 10)]; ok {
+		return val, nil
+	}
+
+	return "", errors.New("no rpc endpoint for chain", "chain_name", name, "chain_id", chainID)
+}
+
+// BindFlags binds the xchain evm rpc flag.
+func BindFlags(flags *pflag.FlagSet, endpoints *RPCEndpoints) {
+	flags.StringToStringVar((*map[string]string)(endpoints), "xchain-evm-rpc-endpoints", *endpoints, "Cross-chain EVM RPC endpoints. e.g. \"ethereum=http://geth:8545,optimism=https://optimism.io\"")
+}

--- a/monitor/account/account.go
+++ b/monitor/account/account.go
@@ -7,6 +7,7 @@ import (
 	"github.com/omni-network/omni/lib/errors"
 	"github.com/omni-network/omni/lib/ethclient"
 	"github.com/omni-network/omni/lib/netconf"
+	"github.com/omni-network/omni/lib/xchain"
 
 	"github.com/ethereum/go-ethereum/common"
 )
@@ -25,12 +26,16 @@ type account struct {
 }
 
 // Monitor starts monitoring account balances.
-func Monitor(ctx context.Context, network netconf.Network) error {
+func Monitor(ctx context.Context, network netconf.Network, endpoints xchain.RPCEndpoints) error {
 	rpcClientPerChain := make(map[uint64]ethclient.Client)
 	for _, chain := range network.EVMChains() {
-		c, err := ethclient.Dial(chain.Name, chain.RPCURL)
+		rpc, err := endpoints.GetByNameOrID(chain.Name, chain.ID)
 		if err != nil {
-			return errors.Wrap(err, "dial rpc", "chain_id", chain.ID, "rpc_url", chain.RPCURL)
+			return err
+		}
+		c, err := ethclient.Dial(chain.Name, rpc)
+		if err != nil {
+			return errors.Wrap(err, "dial rpc", "chain_id", chain.ID, "rpc_url", rpc)
 		}
 		rpcClientPerChain[chain.ID] = c
 	}

--- a/monitor/app/app.go
+++ b/monitor/app/app.go
@@ -27,11 +27,11 @@ func Run(ctx context.Context, cfg Config) error {
 		return err
 	}
 
-	if err := avs.Monitor(ctx, network); err != nil {
+	if err := avs.Monitor(ctx, network, cfg.RPCEndpoints); err != nil {
 		return errors.Wrap(err, "monitor AVS")
 	}
 
-	if err := account.Monitor(ctx, network); err != nil {
+	if err := account.Monitor(ctx, network, cfg.RPCEndpoints); err != nil {
 		return errors.Wrap(err, "monitor account balances")
 	}
 
@@ -74,7 +74,7 @@ func serveMonitoring(address string) <-chan error {
 }
 
 func startLoadGen(ctx context.Context, cfg Config, network netconf.Network) error {
-	if err := loadgen.Start(ctx, network, cfg.LoadGen); err != nil {
+	if err := loadgen.Start(ctx, network, cfg.RPCEndpoints, cfg.LoadGen); err != nil {
 		return errors.Wrap(err, "start load generator")
 	}
 

--- a/monitor/app/avssync.go
+++ b/monitor/app/avssync.go
@@ -38,7 +38,12 @@ func startAVSSync(ctx context.Context, cfg Config, network netconf.Network) erro
 		return nil
 	}
 
-	ethCl, err := ethclient.Dial(ethL1.Name, ethL1.RPCURL)
+	rpc, err := cfg.RPCEndpoints.GetByNameOrID(ethL1.Name, ethL1.ID)
+	if err != nil {
+		return err
+	}
+
+	ethCl, err := ethclient.Dial(ethL1.Name, rpc)
 	if err != nil {
 		return errors.Wrap(err, "dial ethereum chain")
 	}

--- a/monitor/app/config.go
+++ b/monitor/app/config.go
@@ -7,6 +7,7 @@ import (
 	"github.com/omni-network/omni/lib/buildinfo"
 	"github.com/omni-network/omni/lib/errors"
 	"github.com/omni-network/omni/lib/log"
+	"github.com/omni-network/omni/lib/xchain"
 	"github.com/omni-network/omni/monitor/loadgen"
 
 	cmtos "github.com/cometbft/cometbft/libs/os"
@@ -15,6 +16,7 @@ import (
 )
 
 type Config struct {
+	RPCEndpoints   xchain.RPCEndpoints
 	NetworkFile    string
 	MonitoringAddr string
 	PrivateKey     string

--- a/monitor/app/config.toml.tpl
+++ b/monitor/app/config.toml.tpl
@@ -19,6 +19,23 @@ network-file = "{{ .NetworkFile }}"
 monitoring-addr = "{{ .MonitoringAddr }}"
 
 #######################################################################
+###                             X-Chain                             ###
+#######################################################################
+
+[xchain]
+
+# Cross-chain EVM RPC endpoints to use for voting; only required for validators. One per supported EVM is required.
+# It is strongly advised to operate fullnodes for each chain and NOT to use free public RPCs.
+[xchain.evm-rpc-endpoints]
+{{- if not .RPCEndpoints }}
+# ethereum = "http://my-ethreum-node:8545"
+# optimism = "https://my-op-node.com"
+{{ end -}}
+{{- range $key, $value := .RPCEndpoints }}
+{{ $key }} = "{{ $value }}"
+{{ end }}
+
+#######################################################################
 ###                         Logging Options                         ###
 #######################################################################
 

--- a/monitor/app/testdata/default_monitor.toml
+++ b/monitor/app/testdata/default_monitor.toml
@@ -19,6 +19,19 @@ network-file = "network.json"
 monitoring-addr = ":26660"
 
 #######################################################################
+###                             X-Chain                             ###
+#######################################################################
+
+[xchain]
+
+# Cross-chain EVM RPC endpoints to use for voting; only required for validators. One per supported EVM is required.
+# It is strongly advised to operate fullnodes for each chain and NOT to use free public RPCs.
+[xchain.evm-rpc-endpoints]
+# ethereum = "http://my-ethreum-node:8545"
+# optimism = "https://my-op-node.com"
+
+
+#######################################################################
 ###                         Logging Options                         ###
 #######################################################################
 

--- a/monitor/avs/avs.go
+++ b/monitor/avs/avs.go
@@ -8,12 +8,13 @@ import (
 	"github.com/omni-network/omni/lib/ethclient"
 	"github.com/omni-network/omni/lib/log"
 	"github.com/omni-network/omni/lib/netconf"
+	"github.com/omni-network/omni/lib/xchain"
 
 	"github.com/ethereum/go-ethereum/common"
 )
 
 // Monitor starts monitoring the AVS contract.
-func Monitor(ctx context.Context, network netconf.Network) error {
+func Monitor(ctx context.Context, network netconf.Network, endpoints xchain.RPCEndpoints) error {
 	if network.ID != netconf.Testnet && network.ID != netconf.Mainnet {
 		// only monitor in Testned and Mainnet
 		return nil
@@ -24,11 +25,16 @@ func Monitor(ctx context.Context, network netconf.Network) error {
 		return errors.New("no avs chain found")
 	}
 
+	rpc, err := endpoints.GetByNameOrID(ch.Name, ch.ID)
+	if err != nil {
+		return err
+	}
+
 	log.Info(ctx, "Starting AVS monitor")
 
-	client, err := ethclient.Dial(ch.Name, ch.RPCURL)
+	client, err := ethclient.Dial(ch.Name, rpc)
 	if err != nil {
-		return errors.Wrap(err, "dialing", "chain", ch.Name)
+		return errors.Wrap(err, "dialing", "chain", ch.Name, "rpc", rpc)
 	}
 
 	avs, err := newAVS(client, network.ID.Static().AVSContractAddress)

--- a/monitor/cmd/flags.go
+++ b/monitor/cmd/flags.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"github.com/omni-network/omni/lib/xchain"
 	monitor "github.com/omni-network/omni/monitor/app"
 	"github.com/omni-network/omni/monitor/loadgen"
 
@@ -8,6 +9,7 @@ import (
 )
 
 func bindRunFlags(flags *pflag.FlagSet, cfg *monitor.Config) {
+	xchain.BindFlags(flags, &cfg.RPCEndpoints)
 	flags.StringVar(&cfg.PrivateKey, "private-key", cfg.PrivateKey, "The path to the private key e.g path/private.key")
 	flags.StringVar(&cfg.NetworkFile, "network-file", cfg.NetworkFile, "The path to the network file e.g path/network.json")
 	flags.StringVar(&cfg.MonitoringAddr, "monitoring-addr", cfg.MonitoringAddr, "The address to bind the monitoring server")

--- a/monitor/loadgen/loadgen.go
+++ b/monitor/loadgen/loadgen.go
@@ -12,6 +12,7 @@ import (
 	"github.com/omni-network/omni/lib/ethclient"
 	"github.com/omni-network/omni/lib/ethclient/ethbackend"
 	"github.com/omni-network/omni/lib/netconf"
+	"github.com/omni-network/omni/lib/xchain"
 
 	"github.com/ethereum/go-ethereum/common"
 	ethcrypto "github.com/ethereum/go-ethereum/crypto"
@@ -26,7 +27,7 @@ type Config struct {
 // Start starts the validator self delegation load generator.
 // It does:
 // - Validator self-delegation on periodic basis.
-func Start(ctx context.Context, network netconf.Network, cfg Config) error {
+func Start(ctx context.Context, network netconf.Network, endpoints xchain.RPCEndpoints, cfg Config) error {
 	// Only generate load in ephemeral networks, devnet and staging.
 	if !network.ID.IsEphemeral() {
 		return nil
@@ -54,7 +55,12 @@ func Start(ctx context.Context, network netconf.Network, cfg Config) error {
 		return errors.New("omniEVM chain not found")
 	}
 
-	ethCl, err := ethclient.Dial(omniEVM.Name, omniEVM.RPCURL)
+	rpc, err := endpoints.GetByNameOrID(omniEVM.Name, omniEVM.ID)
+	if err != nil {
+		return err
+	}
+
+	ethCl, err := ethclient.Dial(omniEVM.Name, rpc)
 	if err != nil {
 		return err
 	}

--- a/relayer/app/config.go
+++ b/relayer/app/config.go
@@ -7,6 +7,7 @@ import (
 	"github.com/omni-network/omni/lib/buildinfo"
 	"github.com/omni-network/omni/lib/errors"
 	"github.com/omni-network/omni/lib/log"
+	"github.com/omni-network/omni/lib/xchain"
 
 	cmtos "github.com/cometbft/cometbft/libs/os"
 
@@ -14,6 +15,7 @@ import (
 )
 
 type Config struct {
+	RPCEndpoints   xchain.RPCEndpoints
 	PrivateKey     string
 	HaloURL        string
 	NetworkFile    string

--- a/relayer/app/config.toml.tmpl
+++ b/relayer/app/config.toml.tmpl
@@ -22,6 +22,22 @@ network-file = "{{ .NetworkFile }}"
 state-file = "{{ .StateFile }}"
 
 #######################################################################
+###                             X-Chain                             ###
+#######################################################################
+
+[xchain]
+
+# Cross-chain EVM RPC endpoints to use for relaying. One per supported EVM is required.
+[xchain.evm-rpc-endpoints]
+{{- if not .RPCEndpoints }}
+# ethereum = "http://my-ethreum-node:8545"
+# optimism = "https://my-op-node.com"
+{{ end -}}
+{{- range $key, $value := .RPCEndpoints }}
+{{ $key }} = "{{ $value }}"
+{{ end }}
+
+#######################################################################
 ###                         Logging Options                         ###
 #######################################################################
 

--- a/relayer/app/testdata/default_relayer.toml
+++ b/relayer/app/testdata/default_relayer.toml
@@ -22,6 +22,18 @@ network-file = "network.json"
 state-file = "relayer-state.json"
 
 #######################################################################
+###                             X-Chain                             ###
+#######################################################################
+
+[xchain]
+
+# Cross-chain EVM RPC endpoints to use for relaying. One per supported EVM is required.
+[xchain.evm-rpc-endpoints]
+# ethereum = "http://my-ethreum-node:8545"
+# optimism = "https://my-op-node.com"
+
+
+#######################################################################
 ###                         Logging Options                         ###
 #######################################################################
 

--- a/relayer/cmd/flags.go
+++ b/relayer/cmd/flags.go
@@ -1,12 +1,14 @@
 package cmd
 
 import (
+	"github.com/omni-network/omni/lib/xchain"
 	relayer "github.com/omni-network/omni/relayer/app"
 
 	"github.com/spf13/pflag"
 )
 
 func bindRunFlags(flags *pflag.FlagSet, cfg *relayer.Config) {
+	xchain.BindFlags(flags, &cfg.RPCEndpoints)
 	flags.StringVar(&cfg.PrivateKey, "private-key", cfg.PrivateKey, "The path to the private key e.g path/private.key")
 	flags.StringVar(&cfg.HaloURL, "halo-url", cfg.HaloURL, "The URL of the halo node e.g localhost:26657")
 	flags.StringVar(&cfg.NetworkFile, "network-file", cfg.NetworkFile, "The path to the network file e.g path/network.json")


### PR DESCRIPTION
Next step in on-chain netcorf: Removes `Chain.RPCURL` fields from `netconf`, move them to `--xchain-rpc-endpoints` flag for all services. 

task: none