### PR TITLE
fix(halo): fixes few post-refactor bugs

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -202,6 +202,22 @@
         "line_number": 101
       }
     ],
+    "e2e/app/key/key_test.go": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "e2e/app/key/key_test.go",
+        "hashed_secret": "7f206c47631fb0c250283516cc47fd85c370ce6f",
+        "is_verified": false,
+        "line_number": 97
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "e2e/app/key/key_test.go",
+        "hashed_secret": "480c5f9eeb3033bf2dfe86627210969af5e1a665",
+        "is_verified": false,
+        "line_number": 100
+      }
+    ],
     "e2e/app/setup.go": [
       {
         "type": "Secret Keyword",
@@ -2781,5 +2797,5 @@
       }
     ]
   },
-  "generated_at": "2024-04-28T11:28:13Z"
+  "generated_at": "2024-04-29T11:15:55Z"
 }

--- a/e2e/app/key/key_test.go
+++ b/e2e/app/key/key_test.go
@@ -3,6 +3,7 @@ package key_test
 import (
 	"context"
 	"flag"
+	"fmt"
 	"testing"
 
 	"github.com/omni-network/omni/e2e/app/key"
@@ -83,4 +84,18 @@ func TestIntegration(t *testing.T) {
 			key.DeleteSecretForT(ctx, t, network, name, typ, addr)
 		})
 	}
+}
+
+func TestGenInsecure(t *testing.T) {
+	t.Parallel()
+
+	require.Panics(t, func() {
+		key.GenerateInsecureDeterministic(netconf.Testnet, key.EOA, "")
+	})
+
+	k1 := key.GenerateInsecureDeterministic(netconf.Devnet, key.EOA, "test1")
+	require.Equal(t, "d4c14667192a5966002361dd08cdd30619ac553928c423593d744dbb50ff232a", fmt.Sprintf("%x", k1.Bytes()))
+
+	k2 := key.GenerateInsecureDeterministic(netconf.Devnet, key.P2PConsensus, "test2")
+	require.Equal(t, "4cf65aca4b199f5084b217b0728355b5ee93355c3f18324436b856337d60c07300e8fb91b5af3bc124e1b0f382a88377cb126b0989c5282959631596e4f8bc0b", fmt.Sprintf("%x", k2.Bytes()))
 }

--- a/e2e/app/valupdates.go
+++ b/e2e/app/valupdates.go
@@ -217,6 +217,7 @@ func StartValidatorUpdates(ctx context.Context, def Definition) func() error {
 
 				log.Info(ctx, "Deposited stake",
 					"validator", node.Name,
+					"address", addr.Hex(),
 					"power", power,
 					"height", rec.BlockNumber.Uint64(),
 				)

--- a/e2e/manifests/staging.toml
+++ b/e2e/manifests/staging.toml
@@ -1,6 +1,6 @@
 network = "staging"
 public_chains = ["op_sepolia"]
-anvil_chains = ["mock_l1"]
+anvil_chains = ["slow_l1"]
 multi_omni_evms = true
 prometheus = true
 explorer = true

--- a/e2e/test/app_test.go
+++ b/e2e/test/app_test.go
@@ -6,6 +6,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/omni-network/omni/lib/netconf"
+
 	e2e "github.com/cometbft/cometbft/test/e2e/pkg"
 
 	"github.com/stretchr/testify/require"
@@ -16,7 +18,7 @@ import (
 func TestApp_Hash(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
-	testNode(t, func(t *testing.T, node e2e.Node, _ []Portal) {
+	testNode(t, func(t *testing.T, _ netconf.Network, node *e2e.Node, _ []Portal) {
 		t.Helper()
 		client, err := node.Client()
 		require.NoError(t, err)

--- a/e2e/test/attestations_test.go
+++ b/e2e/test/attestations_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/omni-network/omni/lib/cchain"
 	"github.com/omni-network/omni/lib/cchain/provider"
+	"github.com/omni-network/omni/lib/k1util"
 	"github.com/omni-network/omni/lib/netconf"
 	"github.com/omni-network/omni/lib/xchain"
 
@@ -18,11 +19,11 @@ import (
 // for at least half of all the source chain blocks.
 func TestApprovedAttestations(t *testing.T) {
 	t.Parallel()
-	testNode(t, func(t *testing.T, node e2e.Node, portals []Portal) {
+	testNode(t, func(t *testing.T, network netconf.Network, node *e2e.Node, portals []Portal) {
 		t.Helper()
 		client, err := node.Client()
 		require.NoError(t, err)
-		cprov := provider.NewABCIProvider(client, netconf.Simnet, nil)
+		cprov := provider.NewABCIProvider(client, network.ID, nil)
 
 		ctx := context.Background()
 		for _, portal := range portals {
@@ -34,6 +35,68 @@ func TestApprovedAttestations(t *testing.T) {
 
 			totalBlocks := height - portal.Chain.DeployHeight
 			require.GreaterOrEqual(t, len(atts), int(totalBlocks/2)) // Assert that at least half of the blocks are approved
+		}
+
+		// Ensure at least one (genesis) consensus chain approved attestation
+		consChain, ok := network.OmniConsensusChain()
+		require.True(t, ok)
+		atts, err := fetchAllAtts(ctx, cprov, consChain.ID, consChain.DeployHeight)
+		require.NoError(t, err)
+		require.NotEmpty(t, len(atts))
+	})
+}
+
+// TestApprovedAttestations tests that all halo instances contain approved attestations
+// for at least half of all the source chain blocks.
+func TestApprovedValUpdates(t *testing.T) {
+	t.Parallel()
+	testNode(t, func(t *testing.T, network netconf.Network, node *e2e.Node, portals []Portal) {
+		t.Helper()
+		ctx := context.Background()
+
+		// See if this node has a validator update
+		var hasUpdate bool
+		var power int64
+		for _, powers := range node.Testnet.ValidatorUpdates {
+			for n, p := range powers {
+				if n.Name == node.Name {
+					hasUpdate = true
+					power = p
+				}
+			}
+		}
+
+		if !hasUpdate {
+			return // Nothing to test
+		}
+
+		client, err := node.Client()
+		require.NoError(t, err)
+		cprov := provider.NewABCIProvider(client, network.ID, nil)
+
+		addr, err := k1util.PubKeyToAddress(node.PrivvalKey.PubKey())
+		require.NoError(t, err)
+
+		t.Logf("Looking for validator update: %s, %d", addr.Hex(), power)
+
+		consChain, ok := network.OmniConsensusChain()
+		require.True(t, ok)
+
+		valSetID := consChain.DeployHeight
+		for {
+			vals, ok, err := cprov.ValidatorSet(ctx, valSetID)
+			require.NoError(t, err)
+			require.True(t, ok, "Validator update not found in any set: node=%s, valSetID=%v", node.Name, valSetID)
+
+			for _, val := range vals {
+				t.Logf("Got validator update set=%d: %s, %d", valSetID, val.Address.Hex(), val.Power)
+				if val.Address == addr && val.Power == power {
+					return // Validator update found and confirmed.
+				}
+			}
+
+			// If update not found, there must be more sets
+			valSetID++
 		}
 	})
 }

--- a/e2e/test/block_test.go
+++ b/e2e/test/block_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"testing"
 
+	"github.com/omni-network/omni/lib/netconf"
+
 	e2e "github.com/cometbft/cometbft/test/e2e/pkg"
 
 	"github.com/stretchr/testify/assert"
@@ -16,7 +18,7 @@ func TestBlock_Header(t *testing.T) {
 	ctx := context.Background()
 	blocks := fetchBlockChain(ctx, t)
 
-	testNode(t, func(t *testing.T, node e2e.Node, _ []Portal) {
+	testNode(t, func(t *testing.T, _ netconf.Network, node *e2e.Node, _ []Portal) {
 		t.Helper()
 		if node.Mode == e2e.ModeSeed {
 			return
@@ -57,7 +59,7 @@ func TestBlock_Range(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
 
-	testNode(t, func(t *testing.T, node e2e.Node, _ []Portal) {
+	testNode(t, func(t *testing.T, _ netconf.Network, node *e2e.Node, _ []Portal) {
 		t.Helper()
 		if node.Mode == e2e.ModeSeed {
 			return

--- a/e2e/test/e2e_test.go
+++ b/e2e/test/e2e_test.go
@@ -50,13 +50,13 @@ type Portal struct {
 }
 
 type testFunc struct {
-	TestNode    func(*testing.T, e2e.Node, []Portal)
+	TestNode    func(*testing.T, netconf.Network, *e2e.Node, []Portal)
 	TestPortal  func(*testing.T, Portal, []Portal)
 	TestOmniEVM func(*testing.T, ethclient.Client)
 	TestNetwork func(*testing.T, netconf.Network, xchain.RPCEndpoints)
 }
 
-func testNode(t *testing.T, fn func(*testing.T, e2e.Node, []Portal)) {
+func testNode(t *testing.T, fn func(*testing.T, netconf.Network, *e2e.Node, []Portal)) {
 	t.Helper()
 	test(t, testFunc{TestNode: fn})
 }
@@ -108,10 +108,9 @@ func test(t *testing.T, testFunc testFunc) {
 			continue
 		}
 
-		node := *node
 		t.Run(node.Name, func(t *testing.T) {
 			t.Parallel()
-			testFunc.TestNode(t, node, portals)
+			testFunc.TestNode(t, network, node, portals)
 		})
 	}
 

--- a/e2e/vmcompose/testdata/TestSetup_127_0_0_3_compose.yaml.golden
+++ b/e2e/vmcompose/testdata/TestSetup_127_0_0_3_compose.yaml.golden
@@ -16,7 +16,7 @@ services:
       - anvil
       - --host=0.0.0.0
       - --chain-id=1652
-      - --block-time=12
+      - --block-time=1
       - --silent
       - --load-state=/anvil/state.json
     ports:

--- a/halo/app/lazyvoter.go
+++ b/halo/app/lazyvoter.go
@@ -3,6 +3,7 @@ package app
 import (
 	"context"
 	"sync"
+	"time"
 
 	"github.com/omni-network/omni/contracts/bindings"
 	atypes "github.com/omni-network/omni/halo/attest/types"
@@ -90,7 +91,7 @@ func (l *voterLoader) LazyLoad(
 		// Note that this negatively affects chain liveness, but xchain liveness already negatively affected so rather
 		// highlight the issue to the operator by crashing. #allornothing
 
-		backoff := expbackoff.New(ctx)
+		backoff := expbackoff.New(ctx, expbackoff.WithPeriodicConfig(time.Second))
 		for !l.isValidator() {
 			backoff()
 			if ctx.Err() != nil {

--- a/halo/attest/voter/voter.go
+++ b/halo/attest/voter/voter.go
@@ -174,6 +174,8 @@ func (v *Voter) runOnce(ctx context.Context, chainID uint64) error {
 		fromHeight = latest + 1
 	}
 
+	log.Info(ctx, "Voting started for chain", "from_height", fromHeight)
+
 	first := true // Allow skipping on first attestation.
 
 	return v.provider.StreamBlocks(ctx, chainID, fromHeight,

--- a/lib/netconf/provider.go
+++ b/lib/netconf/provider.go
@@ -113,9 +113,10 @@ func networkFromPortals(network ID, portals []bindings.PortalRegistryDeployment)
 	// Add omni consensus chain
 	consensusMeta := MetadataByID(network, network.Static().OmniConsensusChainIDUint64())
 	chains = append(chains, Chain{
-		ID:          consensusMeta.ChainID,
-		Name:        consensusMeta.Name,
-		BlockPeriod: consensusMeta.BlockPeriod,
+		ID:           consensusMeta.ChainID,
+		Name:         consensusMeta.Name,
+		BlockPeriod:  consensusMeta.BlockPeriod,
+		DeployHeight: 1, // ValidatorSets start at 1, not 0.
 	})
 
 	return Network{

--- a/lib/xchain/provider/provider.go
+++ b/lib/xchain/provider/provider.go
@@ -127,6 +127,9 @@ func (p *Provider) stream(
 			break
 		}
 	}
+	if workers == 0 {
+		return errors.New("zero workers [BUG]")
+	}
 
 	deps := stream.Deps[xchain.Block]{
 		FetchWorkers: workers,


### PR DESCRIPTION
Fixes a few issues introduced by the netconf refactor:
 - omni_consensus chain validator sets start at 1, not 0, so set `DeployHeight=1`
   - Add e2e tests for validator updates (had to make devnet validator keys deterministic)
 - Replace `mock_l1` on staging with `slow_l1`
   - Also remove custom workarounds for slow staging chains since we now have explicit slow chains.

Also fix two bugs in attest keeper:
 - Boolean flip while ensuring strict-sequential approvals.
 - Don't delete anything after latest approve attestation since this could cause gaps once catching up.

task: none