### PR TITLE
fix(monitor): start app monitoring first

### DIFF
--- a/explorer/indexer/app/app.go
+++ b/explorer/indexer/app/app.go
@@ -27,6 +27,9 @@ func Run(ctx context.Context, cfg Config) error {
 
 	buildinfo.Instrument(ctx)
 
+	// Start monitoring first, so app is "up".s
+	monitorChan := serveMonitoring(cfg.MonitoringAddr)
+
 	portalReg, err := makePortalRegistry(cfg.Network, cfg.RPCEndpoints)
 	if err != nil {
 		return err
@@ -62,7 +65,7 @@ func Run(ctx context.Context, cfg Config) error {
 	case <-ctx.Done():
 		log.Info(ctx, "Shutdown detected, stopping...")
 		return nil
-	case err := <-serveMonitoring(cfg.MonitoringAddr):
+	case err := <-monitorChan:
 		return err
 	}
 }

--- a/monitor/app/app.go
+++ b/monitor/app/app.go
@@ -28,6 +28,9 @@ func Run(ctx context.Context, cfg Config) error {
 
 	buildinfo.Instrument(ctx)
 
+	// Start monitoring first, so app is "up"
+	monitorChan := serveMonitoring(cfg.MonitoringAddr)
+
 	portalReg, err := makePortalRegistry(cfg.Network, cfg.RPCEndpoints)
 	if err != nil {
 		return err
@@ -58,7 +61,7 @@ func Run(ctx context.Context, cfg Config) error {
 	case <-ctx.Done():
 		log.Info(ctx, "Shutdown detected, stopping...")
 		return nil
-	case err := <-serveMonitoring(cfg.MonitoringAddr):
+	case err := <-monitorChan:
 		return err
 	}
 }

--- a/relayer/app/app.go
+++ b/relayer/app/app.go
@@ -27,6 +27,9 @@ func Run(ctx context.Context, cfg Config) error {
 
 	buildinfo.Instrument(ctx)
 
+	// Start metrics first, so app is "up"
+	monitorChan := serveMonitoring(cfg.MonitoringAddr)
+
 	portalReg, err := makePortalRegistry(cfg.Network, cfg.RPCEndpoints)
 	if err != nil {
 		return err
@@ -101,7 +104,7 @@ func Run(ctx context.Context, cfg Config) error {
 	case <-ctx.Done():
 		log.Info(ctx, "Shutdown detected, stopping...")
 		return nil
-	case err := <-serveMonitoring(cfg.MonitoringAddr):
+	case err := <-monitorChan:
 		return err
 	}
 }


### PR DESCRIPTION
Starts serving prometheus metrics immediately on startup. Previously, we only did this after the network was loaded from portal registry which takes a long a time and results in `App Down` alerts.

task: none