### PR TITLE
ci(e2e): fix anvil chain id typo

### DIFF
--- a/lib/evmchain/evmchain.go
+++ b/lib/evmchain/evmchain.go
@@ -89,7 +89,7 @@ var static = map[uint64]Metadata{
 		BlockPeriod: time.Second,
 	},
 	IDMockL1Slow: {
-		ChainID:     IDMockL1Fast,
+		ChainID:     IDMockL1Slow,
 		Name:        "slow_l1",
 		BlockPeriod: time.Second * 12,
 	},

--- a/lib/evmchain/evmchain_internal_test.go
+++ b/lib/evmchain/evmchain_internal_test.go
@@ -1,0 +1,26 @@
+package evmchain
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestVerify(t *testing.T) {
+	t.Parallel()
+
+	uniqNames := make(map[string]bool)
+	uniqChainIDs := make(map[uint64]bool)
+
+	for chainID, metadata := range static {
+		require.Equal(t, chainID, metadata.ChainID)
+		require.NotEmpty(t, metadata.BlockPeriod)
+
+		if metadata.Name != omniEVMName {
+			require.False(t, uniqNames[metadata.Name])
+		}
+		require.False(t, uniqChainIDs[metadata.ChainID])
+		uniqNames[metadata.Name] = true
+		uniqChainIDs[metadata.ChainID] = true
+	}
+}


### PR DESCRIPTION
Fixes typo in evmchain config for anvil chains.

task: none