### PR TITLE
feat(halo/cmd): support trusted state sync init

### DIFF
--- a/halo/cmd/flags.go
+++ b/halo/cmd/flags.go
@@ -33,6 +33,7 @@ func bindRunFlags(cmd *cobra.Command, cfg *halocfg.Config) {
 func bindInitFlags(flags *pflag.FlagSet, cfg *InitConfig) {
 	libcmd.BindHomeFlag(flags, &cfg.HomeDir)
 	netconf.BindFlag(flags, &cfg.Network)
+	flags.BoolVar(&cfg.TrustedSync, "trusted-sync", cfg.TrustedSync, "Initialize trusted state-sync height and hash by querying the Omni RPC")
 	flags.BoolVar(&cfg.Force, "force", cfg.Force, "Force initialization (overwrite existing files)")
 	flags.BoolVar(&cfg.Clean, "clean", cfg.Clean, "Delete home directory before initialization")
 }

--- a/halo/cmd/testdata/TestCLIReference_init.golden
+++ b/halo/cmd/testdata/TestCLIReference_init.golden
@@ -24,4 +24,5 @@ Flags:
       --force            Force initialization (overwrite existing files)
   -h, --help             help for init
       --home string      The application home directory containing config and data (default "./halo")
-      --network string   Omni network to participate in: mainnet, testnet, devnet (default "simnet")
+      --network string   Omni network to participate in: mainnet, testnet, devnet
+      --trusted-sync     Initialize trusted state-sync height and hash by querying the Omni RPC


### PR DESCRIPTION
Adds a `--trusted-sync` flag to `halo init` which sets the trusted state-sync fields by querying the omni consensus RPC.

task: none