### PR TITLE
feat(explorer/graphql): add receipt revert reason

### DIFF
--- a/explorer/graphql/app/schema.graphql
+++ b/explorer/graphql/app/schema.graphql
@@ -148,6 +148,9 @@ type XReceipt {
 
   "Timestamp of the receipt"
   timestamp: Time!
+
+  "Revert reason if the message failed"
+  revertReason: String
 }
 
 """

--- a/explorer/graphql/mockresolver/resolver.go
+++ b/explorer/graphql/mockresolver/resolver.go
@@ -93,6 +93,7 @@ type XReceipt struct {
 	TxHash        common.Hash
 	TxHashURL     string
 	Timestamp     graphql.Time
+	RevertReason  *string
 }
 
 // Define the Go struct for the Chain type.
@@ -184,7 +185,11 @@ func New() *Resolver {
 			fuzzer.Fuzz(&xreceipt.Offset)
 			fuzzer.Fuzz(&xreceipt.TxHash)
 			fuzzer.Fuzz(&xreceipt.Timestamp)
-			fuzzer.Fuzz(&xreceipt.Success)
+			if xmsg.Status == StatusFailed {
+				xreceipt.Success = false
+				reason := "Insufficient funds"
+				xreceipt.RevertReason = &reason
+			}
 
 			xreceipt.TxHashURL = fmt.Sprintf("https://etherscan.io/tx/%s", xreceipt.TxHash.String())
 


### PR DESCRIPTION
* add a `revertReason` field to receipts
* update mock data to return a non-empty revert reason if `xmsg.status == "failed"`

task: https://app.asana.com/0/1206208509925075/1207157766307979/f
