### PR TITLE
chore(cli): add operator init-nodes

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -2247,6 +2247,78 @@
         "line_number": 3791
       }
     ],
+    "geth/genesis.json": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "geth/genesis.json",
+        "hashed_secret": "d4fb4b1e9f7f703e77484a402f6dab7468effca2",
+        "is_verified": false,
+        "line_number": 57
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "geth/genesis.json",
+        "hashed_secret": "47959f212f8a6e205225976db016bf8b4721ae81",
+        "is_verified": false,
+        "line_number": 60
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "geth/genesis.json",
+        "hashed_secret": "4483ea253088ed5b87217298fdd82afd36bc17e2",
+        "is_verified": false,
+        "line_number": 14404
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "geth/genesis.json",
+        "hashed_secret": "471394320cd7526cb50202735fd4156e9fac18bf",
+        "is_verified": false,
+        "line_number": 14407
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "geth/genesis.json",
+        "hashed_secret": "8a0fc4b42aa4ebca21452dc93322e9111fd74f32",
+        "is_verified": false,
+        "line_number": 14410
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "geth/genesis.json",
+        "hashed_secret": "581b15e4e2dc7c04ab1f63ded0b4ff057817c4bb",
+        "is_verified": false,
+        "line_number": 14413
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "geth/genesis.json",
+        "hashed_secret": "233acd2c6a405061068951aed3798c5c2e52df04",
+        "is_verified": false,
+        "line_number": 14416
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "geth/genesis.json",
+        "hashed_secret": "b19f7aa2889dd2b0a26524ae6df96250524743ec",
+        "is_verified": false,
+        "line_number": 14419
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "geth/genesis.json",
+        "hashed_secret": "9b203211f7abe5aceff7838c21633f8310c86406",
+        "is_verified": false,
+        "line_number": 14422
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "geth/genesis.json",
+        "hashed_secret": "b90fd3ae85361750377898f2a212638dfa6fd26b",
+        "is_verified": false,
+        "line_number": 14425
+      }
+    ],
     "halo/app/privval_internal_test.go": [
       {
         "type": "Secret Keyword",
@@ -2953,5 +3025,5 @@
       }
     ]
   },
-  "generated_at": "2024-05-07T12:17:45Z"
+  "generated_at": "2024-05-07T14:48:00Z"
 }

--- a/cli/cmd/cmd.go
+++ b/cli/cmd/cmd.go
@@ -29,6 +29,7 @@ func newOperatorCmds() *cobra.Command {
 
 	cmd.AddCommand(
 		newRegisterCmd(),
+		newInitCmd(),
 	)
 
 	return cmd

--- a/cli/cmd/devnet.go
+++ b/cli/cmd/devnet.go
@@ -179,7 +179,7 @@ func devnetDefinition(ctx context.Context) (app.Definition, error) {
 	}
 
 	def.Testnet.Name = "devnet0"
-	def.Testnet.Dir, err = devnetDir()
+	def.Testnet.Dir, err = homeDir(netconf.Devnet)
 	if err != nil {
 		return app.Definition{}, err
 	}
@@ -188,7 +188,7 @@ func devnetDefinition(ctx context.Context) (app.Definition, error) {
 }
 
 func loadDevnetNetwork(ctx context.Context) (netconf.Network, xchain.RPCEndpoints, error) {
-	devnetPath, err := devnetDir()
+	devnetPath, err := homeDir(netconf.Devnet)
 	if err != nil {
 		return netconf.Network{}, nil, err
 	}
@@ -364,13 +364,13 @@ func devnetBackend(ctx context.Context, rpcURL string) (common.Address, *ethback
 	return funderAddr, backend, nil
 }
 
-func devnetDir() (string, error) {
+func homeDir(network netconf.ID) (string, error) {
 	homeDir, err := os.UserHomeDir()
 	if err != nil {
 		return "", errors.Wrap(err, "user home dir")
 	}
 
-	return filepath.Join(homeDir, ".omni", "devnet"), nil
+	return filepath.Join(homeDir, ".omni", network.String()), nil
 }
 
 func makePortalRegistry(network netconf.ID, endpoints xchain.RPCEndpoints) (*bindings.PortalRegistry, error) {

--- a/cli/cmd/flags.go
+++ b/cli/cmd/flags.go
@@ -1,6 +1,10 @@
 package cmd
 
-import "github.com/spf13/cobra"
+import (
+	"github.com/omni-network/omni/lib/netconf"
+
+	"github.com/spf13/cobra"
+)
 
 func bindRegConfig(cmd *cobra.Command, cfg *RegConfig) {
 	bindAVSAddress(cmd, &cfg.AVSAddr)
@@ -8,6 +12,12 @@ func bindRegConfig(cmd *cobra.Command, cfg *RegConfig) {
 	const flagConfig = "config-file"
 	cmd.Flags().StringVar(&cfg.ConfigFile, flagConfig, cfg.ConfigFile, "Path to the Eigen-Layer yaml configuration file")
 	_ = cmd.MarkFlagRequired(flagConfig)
+}
+
+func bindInitConfig(cmd *cobra.Command, cfg *initConfig) {
+	netconf.BindFlag(cmd.Flags(), &cfg.Network)
+	cmd.Flags().StringVar(&cfg.Moniker, "moniker", "", "Human-readable node name used in p2p networking")
+	cmd.Flags().StringVar(&cfg.Home, "home", "", "Home directory. If empty, defaults to: $HOME/.omni/<network>/")
 }
 
 func bindAVSAddress(cmd *cobra.Command, addr *string) {

--- a/cli/cmd/operator.go
+++ b/cli/cmd/operator.go
@@ -1,0 +1,126 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+
+	"github.com/omni-network/omni/e2e/app/geth"
+	"github.com/omni-network/omni/lib/errors"
+	"github.com/omni-network/omni/lib/netconf"
+
+	"github.com/ethereum/go-ethereum/p2p/enode"
+
+	"github.com/spf13/cobra"
+)
+
+type initConfig struct {
+	Network netconf.ID
+	Home    string
+	Moniker string
+}
+
+func newInitCmd() *cobra.Command {
+	var cfg initConfig
+
+	cmd := &cobra.Command{
+		Use:   "init-nodes",
+		Short: "Initializes omni consensus and execution nodes",
+		Long:  `Initializes omni consensus node (halo) and execution node (geth) files and configuration in order to join the Omni mainnet or testnet as a full node`,
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			err := initNodes(cmd.Context(), cfg)
+			if err != nil {
+				return errors.Wrap(err, "init-node")
+			}
+
+			return nil
+		},
+	}
+
+	bindInitConfig(cmd, &cfg)
+
+	return cmd
+}
+
+func initNodes(ctx context.Context, cfg initConfig) error {
+	if cfg.Network == "" {
+		return errors.New("required flag --network not set")
+	} else if cfg.Moniker == "" {
+		return errors.New("required flag --moniker not set")
+	}
+
+	if cfg.Home == "" {
+		var err error
+		cfg.Home, err = homeDir(cfg.Network)
+		if err != nil {
+			return err
+		}
+	}
+
+	// TODO(corver): Init halo
+
+	return gethInit(ctx, cfg.Network, filepath.Join(cfg.Home, "geth"), cfg.Moniker)
+}
+
+func gethInit(ctx context.Context, network netconf.ID, dir string, moniker string) error {
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return errors.Wrap(err, "creating directory")
+	}
+
+	// Write genesis.json file
+	{
+		genesisJSON := network.Static().ExecutionGenesisJSON
+		if len(genesisJSON) == 0 {
+			return errors.New("genesis json is empty for network", "network", network)
+		}
+		if err := os.WriteFile(filepath.Join(dir, "genesis.json"), genesisJSON, 0o644); err != nil {
+			return errors.Wrap(err, "writing genesis file", "network", network)
+		}
+	}
+
+	// Write config.toml file
+	{
+		var bootnodes []*enode.Node
+		for _, seed := range network.Static().ExecutionSeeds() {
+			node, err := enode.ParseV4(seed)
+			if err != nil {
+				return errors.Wrap(err, "parsing seed", "seed", seed)
+			}
+			bootnodes = append(bootnodes, node)
+		}
+		cfg := geth.Config{
+			Moniker:      moniker,
+			ChainID:      network.Static().OmniExecutionChainID,
+			IsArchive:    false,
+			BootNodes:    bootnodes,
+			TrustedNodes: nil,
+		}
+		if err := geth.WriteConfigTOML(cfg, filepath.Join(dir, "config.toml")); err != nil {
+			return errors.Wrap(err, "writing config.toml", "network", network)
+		}
+	}
+
+	// Run geth init via docker
+	{
+		image := fmt.Sprintf("ethereum/client-go:%s", geth.Version)
+		//nolint:gosec // Command not "tainted"
+		cmd := exec.CommandContext(ctx,
+			"docker", "run",
+			"-v", dir+":/geth",
+			image, "--",
+			"--datadir=/geth",
+			"init",
+			"/geth/genesis.json")
+		cmd.Dir = dir
+
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			return errors.Wrap(err, "docker run geth init", "output", string(out))
+		}
+	}
+
+	return nil
+}

--- a/e2e/app/geth/config.go
+++ b/e2e/app/geth/config.go
@@ -52,7 +52,7 @@ func WriteAllConfig(testnet types.Testnet) error {
 			BootNodes:    evm.Peers, // TODO(corver): Use seed nodes once available.
 			TrustedNodes: evm.Peers,
 		}
-		if err := writeConfigTOML(conf, filepath.Join(testnet.Dir, evm.InstanceName, "config.toml")); err != nil {
+		if err := WriteConfigTOML(conf, filepath.Join(testnet.Dir, evm.InstanceName, "config.toml")); err != nil {
 			return errors.Wrap(err, "write geth config")
 		}
 	}
@@ -60,8 +60,8 @@ func WriteAllConfig(testnet types.Testnet) error {
 	return nil
 }
 
-// writeConfigTOML writes the geth config to a toml file.
-func writeConfigTOML(conf Config, path string) error {
+// WriteConfigTOML writes the geth config to a toml file.
+func WriteConfigTOML(conf Config, path string) error {
 	bz, err := tomlSettings.Marshal(MakeGethConfig(conf))
 	if err != nil {
 		return errors.Wrap(err, "marshal toml")

--- a/e2e/app/geth/config_internal_test.go
+++ b/e2e/app/geth/config_internal_test.go
@@ -47,7 +47,7 @@ func TestWriteConfigTOML(t *testing.T) {
 
 			tempFile := filepath.Join(t.TempDir(), name+".toml")
 
-			err := writeConfigTOML(data, tempFile)
+			err := WriteConfigTOML(data, tempFile)
 			require.NoError(t, err)
 
 			bz, err := os.ReadFile(tempFile)

--- a/lib/netconf/netconf_test.go
+++ b/lib/netconf/netconf_test.go
@@ -17,6 +17,8 @@ import (
 	"github.com/omni-network/omni/lib/netconf"
 	"github.com/omni-network/omni/lib/tutil"
 
+	"github.com/ethereum/go-ethereum/p2p/enode"
+
 	"github.com/BurntSushi/toml"
 	"github.com/stretchr/testify/require"
 )
@@ -147,20 +149,19 @@ func TestConsensusSeeds(t *testing.T) {
 	require.Len(t, netconf.Testnet.Static().ConsensusSeeds(), 2)
 }
 
-// Testnet longer active - so we comment out this test.
-//
-// func TestExecutionSeeds(t *testing.T) {
-// 	t.Parallel()
-//
-// 	seeds := netconf.Testnet.Static().ExecutionSeeds()
-// 	require.Len(t, seeds, 2)
-// 	for _, seed := range seeds {
-// 		node, err := enode.ParseV4(seed)
-// 		require.NoError(t, err)
-//
-// 		require.EqualValues(t, 30303, node.TCP())
-// 		require.EqualValues(t, 30303, node.UDP())
-// 		t.Logf("Seed IP: %s: %s", node.IP(), seed)
-// 		require.NotEmpty(t, node.IP())
-// 	}
-// }
+func TestExecutionSeeds(t *testing.T) {
+	t.Skip("testnet shutdown at the moment")
+	t.Parallel()
+
+	seeds := netconf.Testnet.Static().ExecutionSeeds()
+	require.Len(t, seeds, 2)
+	for _, seed := range seeds {
+		node, err := enode.ParseV4(seed)
+		require.NoError(t, err)
+
+		require.EqualValues(t, 30303, node.TCP())
+		require.EqualValues(t, 30303, node.UDP())
+		t.Logf("Seed IP: %s: %s", node.IP(), seed)
+		require.NotEmpty(t, node.IP())
+	}
+}


### PR DESCRIPTION
Adds the first part of the `omni operator init-nodes` command. So far it just inits geth, halo is next.

task: none