### PR TITLE
feat(halo/evmengine): harden engine api

### DIFF
--- a/e2e/app/definition.go
+++ b/e2e/app/definition.go
@@ -415,6 +415,7 @@ func TestnetFromManifest(ctx context.Context, manifest types.Manifest, infd type
 		AnvilChains:  anvils,
 		PublicChains: publics,
 		Explorer:     manifest.Explorer,
+		Perturb:      manifest.Perturb,
 	}, nil
 }
 

--- a/e2e/app/run.go
+++ b/e2e/app/run.go
@@ -171,7 +171,7 @@ func E2ETest(ctx context.Context, def Definition, cfg E2ETestConfig) error {
 	}
 
 	if def.Testnet.HasPerturbations() {
-		if err := perturb(ctx, def.Testnet.Testnet); err != nil {
+		if err := perturb(ctx, def.Testnet); err != nil {
 			return err
 		}
 	}

--- a/e2e/manifests/ci.toml
+++ b/e2e/manifests/ci.toml
@@ -19,3 +19,7 @@ perturb = ["restart"]
 # Trigger validator updates at height 10
 [validator_update.10]
 full01 = 2 # Add full01 as validator by depositing 2 ether $OMNI
+
+# Additional perturbations.
+[perturb]
+validator02_evm = ["stopstart"]

--- a/e2e/types/manifest.go
+++ b/e2e/types/manifest.go
@@ -47,7 +47,17 @@ const (
 	ModeLight = e2e.ModeLight
 )
 
+// Perturb defines non-cometBFT perturbations of components like omni_evm.
+type Perturb string
+
+const (
+	// PerturbStopStart defines a perturbation that stops and then starts a docker container.
+	PerturbStopStart = "stopstart"
+)
+
 // Manifest wraps e2e.Manifest with additional omni-specific fields.
+//
+//nolint:musttag // False positive
 type Manifest struct {
 	e2e.Manifest
 
@@ -70,6 +80,9 @@ type Manifest struct {
 
 	// Keys contains long-lived private keys (address by type) by node name.
 	Keys map[string]map[key.Type]string `toml:"keys"`
+
+	// Perturb defines additional (non-cometBFT) perturbations by service name.
+	Perturb map[string][]Perturb `json:"perturb"`
 
 	// Explorer defines whether to deploy the explorer.
 	Explorer bool `toml:"explorer"`

--- a/e2e/types/testnet.go
+++ b/e2e/types/testnet.go
@@ -27,6 +27,7 @@ type Testnet struct {
 	PublicChains []PublicChain
 	OnlyMonitor  bool
 	Explorer     bool
+	Perturb      map[string][]Perturb
 }
 
 // RandomHaloAddr returns a random halo address for cprovider and cometBFT rpc clients.
@@ -89,6 +90,15 @@ func (t Testnet) BroadcastNode() *e2e.Node {
 	}
 
 	return t.Nodes[0]
+}
+
+// HasPerturbations returns whether the network has any perturbations.
+func (t Testnet) HasPerturbations() bool {
+	if len(t.Perturb) > 0 {
+		return true
+	}
+
+	return t.Testnet.HasPerturbations()
 }
 
 func (t Testnet) HasOmniEVM() bool {

--- a/halo/evmengine/keeper/helpers.go
+++ b/halo/evmengine/keeper/helpers.go
@@ -1,0 +1,34 @@
+package keeper
+
+import (
+	"context"
+	"sync"
+
+	"github.com/omni-network/omni/lib/errors"
+	"github.com/omni-network/omni/lib/expbackoff"
+)
+
+// backoffFunc aliased for testing.
+var (
+	backoffFuncMu sync.RWMutex
+	backoffFunc   = expbackoff.New
+)
+
+func retryForever(ctx context.Context, fn func(ctx context.Context) (bool, error)) error {
+	backoffFuncMu.RLock()
+	backoff := backoffFunc(ctx)
+	backoffFuncMu.RUnlock()
+	for {
+		ok, err := fn(ctx)
+		if ctx.Err() != nil {
+			return errors.Wrap(ctx.Err(), "retry canceled")
+		} else if err != nil {
+			return err
+		} else if !ok {
+			backoff()
+			continue
+		}
+
+		return nil
+	}
+}

--- a/halo/evmengine/keeper/keeper_internal_test.go
+++ b/halo/evmengine/keeper/keeper_internal_test.go
@@ -116,7 +116,7 @@ func TestKeeper_isNextProposer(t *testing.T) {
 
 			cdc := getCodec(t)
 			txConfig := authtx.NewTxConfig(cdc, nil)
-			mockEngine, err := newMockEngineAPI(0)
+			mockEngine, err := newMockEngineAPI(0, true)
 			require.NoError(t, err)
 
 			cmtAPI := newMockCometAPI(t, tt.args.validatorsFunc)

--- a/halo/evmengine/keeper/msg_server_internal_test.go
+++ b/halo/evmengine/keeper/msg_server_internal_test.go
@@ -32,7 +32,7 @@ func Test_msgServer_ExecutionPayload(t *testing.T) {
 	cdc := getCodec(t)
 	txConfig := authtx.NewTxConfig(cdc, nil)
 
-	mockEngine, err := newMockEngineAPI(2)
+	mockEngine, err := newMockEngineAPI(2, false)
 	require.NoError(t, err)
 	cmtAPI := newMockCometAPI(t, nil)
 	// set the header and proposer so we have the correct next proposer
@@ -225,7 +225,7 @@ func Test_pushPayload(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			ctx := context.Background()
-			mockEngine, err := newMockEngineAPI(0)
+			mockEngine, err := newMockEngineAPI(0, false)
 			require.NoError(t, err)
 			mockEngine.newPayloadV3Func = tt.args.newPayloadV3Func
 			payload, payloadID := newPayload(ctx, mockEngine, common.Address{})

--- a/halo/evmengine/keeper/proposal_server.go
+++ b/halo/evmengine/keeper/proposal_server.go
@@ -2,11 +2,9 @@ package keeper
 
 import (
 	"context"
-	"sync"
 
 	"github.com/omni-network/omni/halo/evmengine/types"
 	"github.com/omni-network/omni/lib/errors"
-	"github.com/omni-network/omni/lib/expbackoff"
 	"github.com/omni-network/omni/lib/log"
 
 	"github.com/ethereum/go-ethereum/beacon/engine"
@@ -82,29 +80,4 @@ func evmEventsEqual(a, b []*types.EVMEvent) error {
 	}
 
 	return nil
-}
-
-// backoffFunc aliased for testing.
-var (
-	backoffFuncMu sync.RWMutex
-	backoffFunc   = expbackoff.New
-)
-
-func retryForever(ctx context.Context, fn func(ctx context.Context) (bool, error)) error {
-	backoffFuncMu.RLock()
-	backoff := backoffFunc(ctx)
-	backoffFuncMu.RUnlock()
-	for {
-		ok, err := fn(ctx)
-		if ctx.Err() != nil {
-			return errors.Wrap(ctx.Err(), "retry canceled")
-		} else if err != nil {
-			return err
-		} else if !ok {
-			backoff()
-			continue
-		}
-
-		return nil
-	}
 }

--- a/halo/evmengine/keeper/proposal_server_internal_test.go
+++ b/halo/evmengine/keeper/proposal_server_internal_test.go
@@ -25,7 +25,7 @@ func Test_proposalServer_ExecutionPayload(t *testing.T) {
 	cdc := getCodec(t)
 	txConfig := authtx.NewTxConfig(cdc, nil)
 
-	mockEngine, err := newMockEngineAPI(0)
+	mockEngine, err := newMockEngineAPI(0, false)
 	require.NoError(t, err)
 
 	ctx, storeService := setupCtxStore(t, nil)


### PR DESCRIPTION
Add `retryForever` when calling engine API inside consensus. 

task: none