### PR TITLE
fix(e2e): tmp docker compose fix for apple chip machines

### DIFF
--- a/e2e/docker/compose.yaml.tmpl
+++ b/e2e/docker/compose.yaml.tmpl
@@ -42,6 +42,7 @@ services:
     labels:
       e2e: true
     container_name: {{ .Chain.Name }}
+    platform: linux/amd64
     image: ghcr.io/foundry-rs/foundry:latest
     entrypoint:
       - anvil
@@ -206,6 +207,7 @@ services:
       e2e: true
     image: postgres:14-alpine
     container_name: explorer_db
+    platform: linux/amd64
     environment:
       POSTGRES_DB: omni_db
       POSTGRES_USER: omni

--- a/e2e/docker/testdata/TestComposeTemplate_commit_no_explorer.golden
+++ b/e2e/docker/testdata/TestComposeTemplate_commit_no_explorer.golden
@@ -34,6 +34,7 @@ services:
     labels:
       e2e: true
     container_name: mock_rollup
+    platform: linux/amd64
     image: ghcr.io/foundry-rs/foundry:latest
     entrypoint:
       - anvil
@@ -53,6 +54,7 @@ services:
     labels:
       e2e: true
     container_name: mock_l1
+    platform: linux/amd64
     image: ghcr.io/foundry-rs/foundry:latest
     entrypoint:
       - anvil

--- a/e2e/docker/testdata/TestComposeTemplate_empheral_network.golden
+++ b/e2e/docker/testdata/TestComposeTemplate_empheral_network.golden
@@ -34,6 +34,7 @@ services:
     labels:
       e2e: true
     container_name: mock_rollup
+    platform: linux/amd64
     image: ghcr.io/foundry-rs/foundry:latest
     entrypoint:
       - anvil
@@ -53,6 +54,7 @@ services:
     labels:
       e2e: true
     container_name: mock_l1
+    platform: linux/amd64
     image: ghcr.io/foundry-rs/foundry:latest
     entrypoint:
       - anvil
@@ -205,6 +207,7 @@ services:
       e2e: true
     image: postgres:14-alpine
     container_name: explorer_db
+    platform: linux/amd64
     environment:
       POSTGRES_DB: omni_db
       POSTGRES_USER: omni

--- a/e2e/docker/testdata/TestComposeTemplate_main_explorer.golden
+++ b/e2e/docker/testdata/TestComposeTemplate_main_explorer.golden
@@ -34,6 +34,7 @@ services:
     labels:
       e2e: true
     container_name: mock_rollup
+    platform: linux/amd64
     image: ghcr.io/foundry-rs/foundry:latest
     entrypoint:
       - anvil
@@ -53,6 +54,7 @@ services:
     labels:
       e2e: true
     container_name: mock_l1
+    platform: linux/amd64
     image: ghcr.io/foundry-rs/foundry:latest
     entrypoint:
       - anvil

--- a/e2e/vmcompose/testdata/TestSetup_127_0_0_3_compose.yaml.golden
+++ b/e2e/vmcompose/testdata/TestSetup_127_0_0_3_compose.yaml.golden
@@ -11,6 +11,7 @@ services:
     labels:
       e2e: true
     container_name: mock_l1
+    platform: linux/amd64
     image: ghcr.io/foundry-rs/foundry:latest
     entrypoint:
       - anvil

--- a/e2e/vmcompose/testdata/TestSetup_127_0_0_6_compose.yaml.golden
+++ b/e2e/vmcompose/testdata/TestSetup_127_0_0_6_compose.yaml.golden
@@ -55,6 +55,7 @@ services:
       e2e: true
     image: postgres:14-alpine
     container_name: explorer_db
+    platform: linux/amd64
     environment:
       POSTGRES_DB: omni_db
       POSTGRES_USER: omni


### PR DESCRIPTION
introduces a temporary fix to the docker compose file for images unavailable for apple chip machines

task: none
