### PR TITLE
feat(cli): rollups in devnet

### DIFF
--- a/e2e/app/avs.go
+++ b/e2e/app/avs.go
@@ -6,6 +6,7 @@ import (
 	"github.com/omni-network/omni/lib/contracts/avs"
 	"github.com/omni-network/omni/lib/errors"
 	"github.com/omni-network/omni/lib/log"
+	"github.com/omni-network/omni/lib/netconf"
 )
 
 // DeployAVSAndCreate3 deploys a create3 contract and the Omni AVS contract.
@@ -32,8 +33,8 @@ func deployAVS(ctx context.Context, def Definition) error {
 	network := networkFromDef(def)
 	chain, ok := network.EthereumChain()
 	if !ok {
-		if def.Manifest.Network == "devnet" {
-			log.Debug(ctx, "Skipping avs deployment for missing devnet L1")
+		if def.Manifest.Network == netconf.Devnet {
+			log.Debug(ctx, "Skipping avs deployment for not configured devnet L1")
 			return nil
 		}
 

--- a/e2e/app/avs.go
+++ b/e2e/app/avs.go
@@ -32,6 +32,11 @@ func deployAVS(ctx context.Context, def Definition) error {
 	network := networkFromDef(def)
 	chain, ok := network.EthereumChain()
 	if !ok {
+		if def.Manifest.Network == "devnet" {
+			log.Debug(ctx, "Skipping avs deployment for missing devnet L1")
+			return nil
+		}
+
 		return errors.New("no ethereum l1 chain")
 	}
 

--- a/e2e/manifests/devnet0.toml
+++ b/e2e/manifests/devnet0.toml
@@ -2,6 +2,6 @@
 # This is aimed at local dev environments.
 
 network = "devnet"
-anvil_chains = ["mock_l1", "mock_l2"]
+anvil_chains = ["mock_l1", "mock_op", "mock_arb"]
 
 [node.validator01]

--- a/e2e/manifests/devnet0.toml
+++ b/e2e/manifests/devnet0.toml
@@ -2,6 +2,6 @@
 # This is aimed at local dev environments.
 
 network = "devnet"
-anvil_chains = ["mock_l1", "mock_op", "mock_arb"]
+anvil_chains = ["mock_op", "mock_arb"]
 
 [node.validator01]

--- a/e2e/netman/manager.go
+++ b/e2e/netman/manager.go
@@ -355,6 +355,7 @@ func (m *manager) deployIfNeeded(ctx context.Context, chain types.EVMChain, back
 	} else if receipt == nil {
 		return common.Address{}, 0, errors.New("no receipt", "chain", chain.Name)
 	}
+	log.Info(ctx, "Deployed portal", "chain", chain.Name, "address", addr.Hex(), "height", receipt.BlockNumber.Uint64())
 
 	return addr, receipt.BlockNumber.Uint64(), nil
 }

--- a/lib/evmchain/evmchain.go
+++ b/lib/evmchain/evmchain.go
@@ -23,6 +23,8 @@ const (
 	IDMockL1Fast    uint64 = 1652
 	IDMockL1Slow    uint64 = 1653
 	IDMockL2        uint64 = 1654
+	IDMockOp        uint64 = 1655
+	IDMockArb       uint64 = 1656
 
 	omniEVMName        = "omni_evm"
 	omniEVMBlockPeriod = time.Second * 2
@@ -109,6 +111,18 @@ var static = map[uint64]Metadata{
 		ChainID:     IDMockL2,
 		Name:        "mock_l2",
 		BlockPeriod: time.Second,
+		NativeToken: tokens.ETH,
+	},
+	IDMockOp: {
+		ChainID:     IDMockOp,
+		Name:        "mock_op",
+		BlockPeriod: time.Second * 2,
+		NativeToken: tokens.ETH,
+	},
+	IDMockArb: {
+		ChainID:     IDMockArb,
+		Name:        "mock_arb",
+		BlockPeriod: time.Second / 4,
 		NativeToken: tokens.ETH,
 	},
 }

--- a/lib/log/logger.go
+++ b/lib/log/logger.go
@@ -90,11 +90,10 @@ func newJSONLogger(opts ...func(*options)) *slog.Logger {
 // newCLILogger returns a new cli logger which doesn't print timestamps, level, source or stacktraces.
 func newCLILogger(opts ...func(*options)) *slog.Logger {
 	o := defaultOptions()
+	o.Level = slog.LevelInfo // Only show info and above
 	for _, opt := range opts {
 		opt(&o)
 	}
-
-	o.Level = slog.LevelInfo // Only show info and above
 
 	charmLevel, _ := charm.ParseLevel(o.Level.String()) // Ignore error as all slog levels are valid charm levels.
 

--- a/lib/log/logger.go
+++ b/lib/log/logger.go
@@ -94,6 +94,8 @@ func newCLILogger(opts ...func(*options)) *slog.Logger {
 		opt(&o)
 	}
 
+	o.Level = slog.LevelInfo // Only show info and above
+
 	charmLevel, _ := charm.ParseLevel(o.Level.String()) // Ignore error as all slog levels are valid charm levels.
 
 	logger := charm.NewWithOptions(o.Writer, charm.Options{

--- a/lib/log/testdata/TestSimpleLogs_cli.golden
+++ b/lib/log/testdata/TestSimpleLogs_cli.golden
@@ -1,9 +1,7 @@
 info message                                                                               with=args
-debug this code for me please                                                              number=1
 watch out!                                                                                 err="file already exists"
 something went wrong                                                                       float=1.234 err=EOF
 err1                                                                                       err=first 1=1
 err2                                                                                       err="second: first" 2=2 1=1
-ctx debug message                                                                          ctx_key1=ctx_value1 debug_key1=debug_value1
 ctx info message                                                                           ctx_key1=ctx_value1 ctx_key2=ctx_value2 info_key2=info_value2
 Pkg wrapped error                                                                          err="pkg wrap: omni wrap: new" wrap=wrap new=new

--- a/lib/log/testdata/TestSimpleLogs_cli.golden
+++ b/lib/log/testdata/TestSimpleLogs_cli.golden
@@ -1,7 +1,9 @@
 info message                                                                               with=args
+debug this code for me please                                                              number=1
 watch out!                                                                                 err="file already exists"
 something went wrong                                                                       float=1.234 err=EOF
 err1                                                                                       err=first 1=1
 err2                                                                                       err="second: first" 2=2 1=1
+ctx debug message                                                                          ctx_key1=ctx_value1 debug_key1=debug_value1
 ctx info message                                                                           ctx_key1=ctx_value1 ctx_key2=ctx_value2 info_key2=info_value2
 Pkg wrapped error                                                                          err="pkg wrap: omni wrap: new" wrap=wrap new=new


### PR DESCRIPTION
adds `mock_op` and `mock_arb` to `devnet0` and makes cli logs info-only, as well as adding a log line when a portal is private-deployed

task: none