### PR TITLE
feat(halo/evmengine): set apphash as beaconblockroot

### DIFF
--- a/halo/app/app.go
+++ b/halo/app/app.go
@@ -114,7 +114,7 @@ func newApp(
 		// postpone them to the next block. Nit: we could drop some vote extensions though...?
 		bapp.SetPrepareProposal(app.EVMEngKeeper.PrepareProposal)
 
-		// Route proposed messaged to keepers for verification and external state updates.
+		// Route proposed messages to keepers for verification and external state updates.
 		bapp.SetProcessProposal(makeProcessProposalHandler(app))
 
 		// Use attest keeper to extend votes.

--- a/halo/app/rollback.go
+++ b/halo/app/rollback.go
@@ -1,0 +1,77 @@
+package app
+
+import (
+	"context"
+	"fmt"
+	"math/big"
+
+	"github.com/omni-network/omni/lib/errors"
+	"github.com/omni-network/omni/lib/log"
+
+	cmtcmd "github.com/cometbft/cometbft/cmd/cometbft/commands"
+
+	"github.com/ethereum/go-ethereum/common"
+
+	"cosmossdk.io/store"
+	storemetrics "cosmossdk.io/store/metrics"
+	dbm "github.com/cosmos/cosmos-db"
+)
+
+func Rollback(ctx context.Context, cfg Config, removeBlock bool) error {
+	engineCl, err := newEngineClient(ctx, cfg, cfg.Network, nil)
+	if err != nil {
+		return err
+	}
+
+	latestHeigth, err := engineCl.BlockNumber(ctx)
+	if err != nil {
+		return err
+	}
+
+	latestBlock, err := engineCl.BlockByNumber(ctx, big.NewInt(int64(latestHeigth)))
+	if err != nil {
+		return err
+	} else if latestBlock.BeaconRoot() == nil {
+		return errors.New("cannot rollback EVM with nil beacon root", "height", latestHeigth)
+	}
+
+	db, err := dbm.NewDB("application", cfg.BackendType(), cfg.DataDir())
+	if err != nil {
+		return errors.Wrap(err, "create db")
+	}
+
+	// Rollback CometBFT state
+	height, hash, err := cmtcmd.RollbackState(&cfg.Comet, removeBlock)
+	if err != nil {
+		return errors.Wrap(err, "rollback comet state")
+	}
+
+	// Rollback the multistore
+	cms := store.NewCommitMultiStore(db, newSDKLogger(ctx), storemetrics.NewNoOpMetrics())
+	if err := cms.RollbackToVersion(height); err != nil {
+		return errors.Wrap(err, "rollback to height")
+	}
+
+	log.Info(ctx, "Rolled back consensus state", "height", height, "hash", fmt.Sprintf("%X", hash))
+
+	// Rollback EVM if latest EVM block built on-top of new rolled-back consensus head.
+	if *latestBlock.BeaconRoot() != common.BytesToHash(hash) {
+		return errors.New("cannot rollback EVM, latest EVM block not built on new rolled-back state",
+			"evm_height", latestHeigth,
+			"evm_beacon_root", *latestBlock.BeaconRoot(),
+		)
+	}
+
+	if err := engineCl.SetHead(ctx, latestHeigth-1); err != nil {
+		return errors.Wrap(err, "set head")
+	}
+
+	rolledBackBlock, err := engineCl.BlockByNumber(ctx, big.NewInt(int64(latestHeigth-1)))
+	if err != nil {
+		return err
+	}
+
+	log.Info(ctx, "Rolled back execution state", "height", rolledBackBlock.Number(), "hash", rolledBackBlock.Hash())
+
+	return nil
+}

--- a/halo/app/sdklog.go
+++ b/halo/app/sdklog.go
@@ -8,7 +8,7 @@ import (
 	sdklog "cosmossdk.io/log"
 )
 
-var _ sdklog.Logger = (*sdkLogger)(nil)
+var _ sdklog.Logger = sdkLogger{}
 
 // dropCosmosDebugs is a map of cosmosSDK debug messages that should be dropped.
 // These are super noisy and not useful.

--- a/halo/app/start.go
+++ b/halo/app/start.go
@@ -205,10 +205,15 @@ func newCometNode(ctx context.Context, cfg *cmtcfg.Config, app *App, privVal cmt
 		return nil, err
 	}
 
+	wrapper := newABCIWrapper(
+		server.NewCometABCIWrapper(app),
+		app.EVMEngKeeper.Finalize,
+	)
+
 	cmtNode, err := node.NewNode(cfg,
 		privVal,
 		nodeKey,
-		proxy.NewLocalClientCreator(loggingABCIApp{server.NewCometABCIWrapper(app)}),
+		proxy.NewLocalClientCreator(wrapper),
 		node.DefaultGenesisDocProviderFunc(cfg),
 		cmtcfg.DefaultDBProvider,
 		node.DefaultMetricsProvider(cfg.Instrumentation),

--- a/halo/evmengine/keeper/keeper_internal_test.go
+++ b/halo/evmengine/keeper/keeper_internal_test.go
@@ -116,7 +116,7 @@ func TestKeeper_isNextProposer(t *testing.T) {
 
 			cdc := getCodec(t)
 			txConfig := authtx.NewTxConfig(cdc, nil)
-			mockEngine, err := newMockEngineAPI(0, true)
+			mockEngine, err := newMockEngineAPI(0)
 			require.NoError(t, err)
 
 			cmtAPI := newMockCometAPI(t, tt.args.validatorsFunc)
@@ -133,16 +133,13 @@ func TestKeeper_isNextProposer(t *testing.T) {
 			keeper := NewKeeper(cdc, storeService, &mockEngine, txConfig, ap)
 			keeper.SetCometAPI(&cmtAPI)
 
-			got, gotHeight, err := keeper.isNextProposer(ctx)
+			got, err := keeper.isNextProposer(ctx, ctx.BlockHeader().ProposerAddress, ctx.BlockHeader().Height)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("isNextProposer() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
 			if got != tt.want {
 				t.Errorf("isNextProposer() got = %v, want %v", got, tt.want)
-			}
-			if gotHeight != tt.wantHeight {
-				t.Errorf("isNextProposer() gotHeight = %v, want %v", gotHeight, tt.wantHeight)
 			}
 			// make sure that height passed into Validators is correct
 			require.Equal(t, tt.args.height, cmtAPI.height)

--- a/lib/ethclient/ethclient.go
+++ b/lib/ethclient/ethclient.go
@@ -112,6 +112,27 @@ func (w Wrapper) HeaderByType(ctx context.Context, typ HeadType) (*types.Header,
 	return header, nil
 }
 
+// SetHead sets the current head of the local chain by block number.
+// Note, this is a destructive action and may severely damage your chain.
+// Use with extreme caution.
+func (w Wrapper) SetHead(ctx context.Context, height uint64) error {
+	const endpoint = "set_head"
+	defer latency(w.chain, endpoint)()
+
+	err := w.cl.Client().CallContext(
+		ctx,
+		nil,
+		"debug_setHead",
+		height,
+	)
+	if err != nil {
+		incError(w.chain, endpoint)
+		return errors.Wrap(err, "set head")
+	}
+
+	return nil
+}
+
 // PeerCount returns the number of p2p peers as reported by the net_peerCount method.
 func (w Wrapper) PeerCount(ctx context.Context) (uint64, error) {
 	const endpoint = "peer_count"

--- a/lib/ethclient/ethclient_gen.go
+++ b/lib/ethclient/ethclient_gen.go
@@ -31,6 +31,7 @@ type Client interface {
 	HeaderByType(ctx context.Context, typ HeadType) (*types.Header, error)
 	EtherBalanceAt(ctx context.Context, addr common.Address) (float64, error)
 	PeerCount(ctx context.Context) (uint64, error)
+	SetHead(ctx context.Context, height uint64) error
 	Address() string
 	Close()
 }

--- a/lib/ethclient/genwrap/genwrap.go
+++ b/lib/ethclient/genwrap/genwrap.go
@@ -46,7 +46,8 @@ type Client interface {
     {{end -}}
 	HeaderByType(ctx context.Context, typ HeadType) (*types.Header, error)
 	EtherBalanceAt(ctx context.Context, addr common.Address) (float64, error)
-    PeerCount(ctx context.Context) (uint64, error)
+	PeerCount(ctx context.Context) (uint64, error)
+	SetHead(ctx context.Context, height uint64) error
 	Address() string
 	Close()
 }

--- a/lib/ethclient/mock/mock_interfaces.go
+++ b/lib/ethclient/mock/mock_interfaces.go
@@ -384,6 +384,20 @@ func (mr *MockClientMockRecorder) SendTransaction(ctx, tx any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SendTransaction", reflect.TypeOf((*MockClient)(nil).SendTransaction), ctx, tx)
 }
 
+// SetHead mocks base method.
+func (m *MockClient) SetHead(ctx context.Context, height uint64) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SetHead", ctx, height)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// SetHead indicates an expected call of SetHead.
+func (mr *MockClientMockRecorder) SetHead(ctx, height any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetHead", reflect.TypeOf((*MockClient)(nil).SetHead), ctx, height)
+}
+
 // StorageAt mocks base method.
 func (m *MockClient) StorageAt(ctx context.Context, account common.Address, key common.Hash, blockNumber *big.Int) ([]byte, error) {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
Sets cometBFT `AppHash` as the EVM `BeaconBlockRoot` when building EVM blocks.

This required moving optimistic building from `msg_server` to it's own custom hook called after `abci.finaliseblock` so we have access to the final appHash.

Also includes a PoC rollback function, this will be completed and tested in following PR.

task: none