### PR TITLE
chore(relayer/monitor): align emit cursor with finalisation strat

### DIFF
--- a/halo/attest/voter/voter_test.go
+++ b/halo/attest/voter/voter_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/omni-network/omni/halo/attest/types"
 	"github.com/omni-network/omni/halo/attest/voter"
+	"github.com/omni-network/omni/lib/ethclient"
 	"github.com/omni-network/omni/lib/k1util"
 	"github.com/omni-network/omni/lib/xchain"
 
@@ -457,7 +458,7 @@ func (stubProvider) GetSubmittedCursor(context.Context, uint64, uint64) (xchain.
 	panic("unexpected")
 }
 
-func (stubProvider) GetEmittedCursor(context.Context, uint64, uint64) (xchain.StreamCursor, bool, error) {
+func (stubProvider) GetEmittedCursor(context.Context, ethclient.HeadType, uint64, uint64) (xchain.StreamCursor, bool, error) {
 	panic("unexpected")
 }
 

--- a/lib/xchain/provider.go
+++ b/lib/xchain/provider.go
@@ -2,6 +2,8 @@ package xchain
 
 import (
 	"context"
+
+	"github.com/omni-network/omni/lib/ethclient"
 )
 
 // ProviderCallback is the callback function signature that will be called with every finalized.
@@ -41,5 +43,5 @@ type Provider interface {
 	//
 	// Note that the BlockOffset field is not populated for emit cursors, since it isn't stored on-chain
 	// but tracked off-chain.
-	GetEmittedCursor(ctx context.Context, srcChainID uint64, destChainID uint64) (StreamCursor, bool, error)
+	GetEmittedCursor(ctx context.Context, headType ethclient.HeadType, srcChainID uint64, destChainID uint64) (StreamCursor, bool, error)
 }

--- a/lib/xchain/provider/mock.go
+++ b/lib/xchain/provider/mock.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/omni-network/omni/lib/cchain"
+	"github.com/omni-network/omni/lib/ethclient"
 	"github.com/omni-network/omni/lib/log"
 	"github.com/omni-network/omni/lib/xchain"
 )
@@ -142,7 +143,7 @@ func (*Mock) GetSubmittedCursor(_ context.Context, destChain uint64, srcChain ui
 	}}, true, nil
 }
 
-func (*Mock) GetEmittedCursor(_ context.Context, srcChainID uint64, destChainID uint64,
+func (*Mock) GetEmittedCursor(_ context.Context, _ ethclient.HeadType, srcChainID uint64, destChainID uint64,
 ) (xchain.StreamCursor, bool, error) {
 	return xchain.StreamCursor{StreamID: xchain.StreamID{
 		SourceChainID: srcChainID,

--- a/relayer/app/cursors_internal_test.go
+++ b/relayer/app/cursors_internal_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/omni-network/omni/lib/cchain"
+	"github.com/omni-network/omni/lib/ethclient"
 	"github.com/omni-network/omni/lib/netconf"
 	"github.com/omni-network/omni/lib/xchain"
 
@@ -106,7 +107,7 @@ var (
 type mockXChainClient struct {
 	GetBlockFn           func(context.Context, uint64, uint64, uint64) (xchain.Block, bool, error)
 	GetSubmittedCursorFn func(context.Context, uint64, uint64) (xchain.StreamCursor, bool, error)
-	GetEmittedCursorFn   func(context.Context, uint64, uint64) (xchain.StreamCursor, bool, error)
+	GetEmittedCursorFn   func(context.Context, ethclient.HeadType, uint64, uint64) (xchain.StreamCursor, bool, error)
 }
 
 func (m *mockXChainClient) StreamAsync(context.Context, uint64, uint64, uint64, xchain.ProviderCallback) error {
@@ -134,9 +135,9 @@ func (m *mockXChainClient) GetSubmittedCursor(ctx context.Context, chainID uint6
 	return m.GetSubmittedCursorFn(ctx, chainID, sourceChain)
 }
 
-func (m *mockXChainClient) GetEmittedCursor(ctx context.Context, srcChainID uint64, destChainID uint64,
+func (m *mockXChainClient) GetEmittedCursor(ctx context.Context, head ethclient.HeadType, srcChainID uint64, destChainID uint64,
 ) (xchain.StreamCursor, bool, error) {
-	return m.GetEmittedCursorFn(ctx, srcChainID, destChainID)
+	return m.GetEmittedCursorFn(ctx, head, srcChainID, destChainID)
 }
 
 type mockSender struct {

--- a/relayer/app/worker_internal_test.go
+++ b/relayer/app/worker_internal_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/omni-network/omni/lib/cchain"
+	"github.com/omni-network/omni/lib/ethclient"
 	"github.com/omni-network/omni/lib/netconf"
 	"github.com/omni-network/omni/lib/xchain"
 
@@ -58,7 +59,7 @@ func TestWorker_Run(t *testing.T) {
 		GetSubmittedCursorFn: func(_ context.Context, srcChainID uint64, _ uint64) (xchain.StreamCursor, bool, error) {
 			return cursors[srcChainID], true, nil
 		},
-		GetEmittedCursorFn: func(_ context.Context, _ uint64, destChainID uint64) (xchain.StreamCursor, bool, error) {
+		GetEmittedCursorFn: func(_ context.Context, _ ethclient.HeadType, _ uint64, destChainID uint64) (xchain.StreamCursor, bool, error) {
 			return cursors[destChainID], true, nil
 		},
 	}


### PR DESCRIPTION
Align emit cursor metrics with finalisation strategy so they don't artificially show lag.

task: none