### PR TITLE
chore(relayer): refactor proper stream metrics

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -76,6 +76,10 @@
       "path": "detect_secrets.filters.allowlist.is_line_allowlisted"
     },
     {
+      "path": "detect_secrets.filters.common.is_baseline_file",
+      "filename": ".secrets.baseline"
+    },
+    {
       "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
       "min_level": 2
     },
@@ -2334,7 +2338,7 @@
         "filename": "halo/attest/voter/voter.go",
         "hashed_secret": "9dd83331ff39a93b5b457a8b6b8835f7086a7d6c",
         "is_verified": false,
-        "line_number": 86
+        "line_number": 87
       }
     ],
     "halo/genutil/evm/testdata/TestMakeGenesis.golden": [
@@ -3025,5 +3029,5 @@
       }
     ]
   },
-  "generated_at": "2024-05-07T14:48:00Z"
+  "generated_at": "2024-05-15T14:10:04Z"
 }

--- a/halo/attest/voter/metrics.go
+++ b/halo/attest/voter/metrics.go
@@ -33,7 +33,7 @@ var (
 		Subsystem: "voter",
 		Name:      "create_stream_offset",
 		Help:      "Latest created vote xmsg offset per stream",
-	}, []string{"src_chain", "dst_chain"})
+	}, []string{"stream"})
 
 	commitHeight = promauto.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: "halo",

--- a/halo/attest/voter/voter.go
+++ b/halo/attest/voter/voter.go
@@ -3,6 +3,7 @@ package voter
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"os"
 	"slices"
 	"sort"
@@ -253,7 +254,7 @@ func (v *Voter) Vote(block xchain.Block, allowSkip bool) error {
 	createHeight.WithLabelValues(v.chains[vote.BlockHeader.ChainId]).Set(float64(vote.BlockHeader.Height))
 	createBlockOffset.WithLabelValues(v.chains[vote.BlockHeader.ChainId]).Set(float64(vote.BlockHeader.Offset))
 	for stream, msgOffset := range latestMsgOffsets(block.Msgs) {
-		createMsgOffset.WithLabelValues(v.chains[stream.SourceChainID], v.chains[stream.DestChainID]).Set(float64(msgOffset))
+		createMsgOffset.WithLabelValues(v.streamName(stream)).Set(float64(msgOffset))
 	}
 
 	return v.saveUnsafe()
@@ -443,6 +444,10 @@ func (v *Voter) saveUnsafe() error {
 	v.instrumentUnsafe()
 
 	return nil
+}
+
+func (v *Voter) streamName(streamID xchain.StreamID) string {
+	return fmt.Sprintf("%s|%s", v.chains[streamID.SourceChainID], v.chains[streamID.DestChainID])
 }
 
 // instrumentUnsafe updates metrics. It is unsafe since it assumes the lock is held.

--- a/relayer/app/metrics.go
+++ b/relayer/app/metrics.go
@@ -61,14 +61,14 @@ var (
 		Subsystem: "monitor",
 		Name:      "emit_stream_offset",
 		Help:      "The latest emitted xmsg offset on a source chain for a specific destination chain",
-	}, []string{"src_chain", "dst_chain"})
+	}, []string{"stream"})
 
 	submitMsgOffset = promauto.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: "relayer",
 		Subsystem: "monitor",
 		Name:      "submit_stream_offset",
 		Help:      "The latest submitted xmsg stream offset on a destination chain for a specific source chain",
-	}, []string{"src_chain", "dst_chain"})
+	}, []string{"stream"})
 
 	submitBlockOffset = promauto.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: "relayer",
@@ -112,10 +112,10 @@ var (
 		Help:      "The latest halo attested block offset of a specific chain",
 	}, []string{"chain"})
 
-	attestedMsgBlockOffset = promauto.NewGaugeVec(prometheus.GaugeOpts{
+	attestedMsgOffset = promauto.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: "relayer",
 		Subsystem: "monitor",
 		Name:      "halo_attested_stream_offset",
 		Help:      "The latest halo attested msg offset of a specific stream",
-	}, []string{"src_chain", "dst_chain"})
+	}, []string{"stream"})
 )


### PR DESCRIPTION
Refactor north star lag metrics to use a single stream name instead of src and dst chain names.

This makes grafana queries much easier and allows the table view to work.

task: none