### PR TITLE
chore(relayer): query onchain attested stream offsets

### DIFF
--- a/halo/attest/voter/voter_test.go
+++ b/halo/attest/voter/voter_test.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/omni-network/omni/halo/attest/types"
 	"github.com/omni-network/omni/halo/attest/voter"
-	"github.com/omni-network/omni/lib/ethclient"
 	"github.com/omni-network/omni/lib/k1util"
 	"github.com/omni-network/omni/lib/xchain"
 
@@ -458,7 +457,7 @@ func (stubProvider) GetSubmittedCursor(context.Context, uint64, uint64) (xchain.
 	panic("unexpected")
 }
 
-func (stubProvider) GetEmittedCursor(context.Context, ethclient.HeadType, uint64, uint64) (xchain.StreamCursor, bool, error) {
+func (stubProvider) GetEmittedCursor(context.Context, xchain.EmitRef, uint64, uint64) (xchain.StreamCursor, bool, error) {
 	panic("unexpected")
 }
 

--- a/lib/xchain/provider.go
+++ b/lib/xchain/provider.go
@@ -43,5 +43,10 @@ type Provider interface {
 	//
 	// Note that the BlockOffset field is not populated for emit cursors, since it isn't stored on-chain
 	// but tracked off-chain.
-	GetEmittedCursor(ctx context.Context, headType ethclient.HeadType, srcChainID uint64, destChainID uint64) (StreamCursor, bool, error)
+	GetEmittedCursor(ctx context.Context, ref EmitRef, srcChainID uint64, destChainID uint64) (StreamCursor, bool, error)
+}
+
+type EmitRef struct {
+	Height   *uint64
+	HeadType *ethclient.HeadType
 }

--- a/lib/xchain/provider/mock.go
+++ b/lib/xchain/provider/mock.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	"github.com/omni-network/omni/lib/cchain"
-	"github.com/omni-network/omni/lib/ethclient"
 	"github.com/omni-network/omni/lib/log"
 	"github.com/omni-network/omni/lib/xchain"
 )
@@ -143,7 +142,7 @@ func (*Mock) GetSubmittedCursor(_ context.Context, destChain uint64, srcChain ui
 	}}, true, nil
 }
 
-func (*Mock) GetEmittedCursor(_ context.Context, _ ethclient.HeadType, srcChainID uint64, destChainID uint64,
+func (*Mock) GetEmittedCursor(_ context.Context, _ xchain.EmitRef, srcChainID uint64, destChainID uint64,
 ) (xchain.StreamCursor, bool, error) {
 	return xchain.StreamCursor{StreamID: xchain.StreamID{
 		SourceChainID: srcChainID,

--- a/relayer/app/cursors_internal_test.go
+++ b/relayer/app/cursors_internal_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 
 	"github.com/omni-network/omni/lib/cchain"
-	"github.com/omni-network/omni/lib/ethclient"
 	"github.com/omni-network/omni/lib/netconf"
 	"github.com/omni-network/omni/lib/xchain"
 
@@ -107,7 +106,7 @@ var (
 type mockXChainClient struct {
 	GetBlockFn           func(context.Context, uint64, uint64, uint64) (xchain.Block, bool, error)
 	GetSubmittedCursorFn func(context.Context, uint64, uint64) (xchain.StreamCursor, bool, error)
-	GetEmittedCursorFn   func(context.Context, ethclient.HeadType, uint64, uint64) (xchain.StreamCursor, bool, error)
+	GetEmittedCursorFn   func(context.Context, xchain.EmitRef, uint64, uint64) (xchain.StreamCursor, bool, error)
 }
 
 func (m *mockXChainClient) StreamAsync(context.Context, uint64, uint64, uint64, xchain.ProviderCallback) error {
@@ -135,9 +134,9 @@ func (m *mockXChainClient) GetSubmittedCursor(ctx context.Context, chainID uint6
 	return m.GetSubmittedCursorFn(ctx, chainID, sourceChain)
 }
 
-func (m *mockXChainClient) GetEmittedCursor(ctx context.Context, head ethclient.HeadType, srcChainID uint64, destChainID uint64,
+func (m *mockXChainClient) GetEmittedCursor(ctx context.Context, ref xchain.EmitRef, srcChainID uint64, destChainID uint64,
 ) (xchain.StreamCursor, bool, error) {
-	return m.GetEmittedCursorFn(ctx, head, srcChainID, destChainID)
+	return m.GetEmittedCursorFn(ctx, ref, srcChainID, destChainID)
 }
 
 type mockSender struct {

--- a/relayer/app/worker_internal_test.go
+++ b/relayer/app/worker_internal_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 
 	"github.com/omni-network/omni/lib/cchain"
-	"github.com/omni-network/omni/lib/ethclient"
 	"github.com/omni-network/omni/lib/netconf"
 	"github.com/omni-network/omni/lib/xchain"
 
@@ -59,7 +58,7 @@ func TestWorker_Run(t *testing.T) {
 		GetSubmittedCursorFn: func(_ context.Context, srcChainID uint64, _ uint64) (xchain.StreamCursor, bool, error) {
 			return cursors[srcChainID], true, nil
 		},
-		GetEmittedCursorFn: func(_ context.Context, _ ethclient.HeadType, _ uint64, destChainID uint64) (xchain.StreamCursor, bool, error) {
+		GetEmittedCursorFn: func(_ context.Context, _ xchain.EmitRef, _ uint64, destChainID uint64) (xchain.StreamCursor, bool, error) {
 			return cursors[destChainID], true, nil
 		},
 	}


### PR DESCRIPTION
Fix attested stream offsets by querying emitted xmsg offsets on-chain instead of using xmsgs from the attested block since it doesn't contain xmsgs from all streams.

task: none