### PR TITLE
feat(cli): simulated fee params for devnet when no network is available

### DIFF
--- a/lib/contracts/feeoraclev1/deploy.go
+++ b/lib/contracts/feeoraclev1/deploy.go
@@ -9,6 +9,7 @@ import (
 	"github.com/omni-network/omni/lib/contracts"
 	"github.com/omni-network/omni/lib/errors"
 	"github.com/omni-network/omni/lib/ethclient/ethbackend"
+	"github.com/omni-network/omni/lib/log"
 	"github.com/omni-network/omni/lib/netconf"
 	"github.com/omni-network/omni/lib/tokens/coingecko"
 
@@ -126,7 +127,12 @@ func Deploy(ctx context.Context, network netconf.ID, chainID uint64, destChainID
 
 	feeparams, err := feeParams(ctx, chainID, destChainIDs, backends, coingecko.New())
 	if err != nil {
-		return common.Address{}, nil, errors.Wrap(err, "fee params")
+		if network != netconf.Devnet {
+			return common.Address{}, nil, errors.Wrap(err, "fee params")
+		}
+		// use simulated values for devnet when coingecko is not available
+		log.Debug(ctx, "Using simulated fee params for devnet")
+		feeparams = simulatedFeeParams(destChainIDs)
 	}
 
 	feeOracleAbi, err := bindings.FeeOracleV1MetaData.GetAbi()

--- a/lib/contracts/feeoraclev1/feeparams.go
+++ b/lib/contracts/feeoraclev1/feeparams.go
@@ -109,3 +109,47 @@ func withGasPriceShield(gasPrice *big.Int) *big.Int {
 	gasPriceF := float64(gasPrice.Uint64())
 	return new(big.Int).SetUint64(uint64(gasPriceF + (xfeemngr.GasPriceShield * gasPriceF)))
 }
+
+// Simulate devnet feeParams for testing purposes.
+func simulatedFeeParams(destChainIDs []uint64) []bindings.IFeeOracleV1ChainFeeParams {
+	var feeParamsList []bindings.IFeeOracleV1ChainFeeParams
+
+	for _, destChainID := range destChainIDs {
+		feeParam := bindings.IFeeOracleV1ChainFeeParams{
+			ChainId:      destChainID,
+			ToNativeRate: getToNativeRate(destChainID),
+			GasPrice:     getGasPrice(destChainID),
+		}
+		feeParamsList = append(feeParamsList, feeParam)
+	}
+
+	return feeParamsList
+}
+
+// Simulate realistic ToNativeRate based on observed patterns.
+func getToNativeRate(destChainID uint64) *big.Int {
+	switch destChainID {
+	case 1651:
+		return big.NewInt(5032)
+	case 1655:
+		return big.NewInt(198412371)
+	case 1656:
+		return big.NewInt(1000000)
+	default:
+		return big.NewInt(1e18) // Default fallback
+	}
+}
+
+// Simulate realistic GasPrice based on observed patterns.
+func getGasPrice(destChainID uint64) *big.Int {
+	switch destChainID {
+	case 1651:
+		return big.NewInt(1665895282)
+	case 1655:
+		return big.NewInt(1668524179)
+	case 1656:
+		return big.NewInt(1104645571)
+	default:
+		return big.NewInt(1e9) // Default fallback
+	}
+}


### PR DESCRIPTION
simulates `feeparams` when starting a local devnet without network connectivity

so folks can code in the plane

task: none
