### PR TITLE
refactor(halo): remove evm from rollback

### DIFF
--- a/halo/app/app.go
+++ b/halo/app/app.go
@@ -156,12 +156,6 @@ func (a App) SetCometAPI(api comet.API) {
 	a.EVMEngKeeper.SetCometAPI(api)
 }
 
-// SetVoter sets the voter.
-// TODO(corver): Figure out how to use depinject to set this.
-func (a App) SetVoter(voter atypes.Voter) {
-	a.ValSyncKeeper.SetSubscriber(voter)
-}
-
 var (
 	_ runtime.AppI            = (*App)(nil)
 	_ servertypes.Application = (*App)(nil)

--- a/halo/app/start.go
+++ b/halo/app/start.go
@@ -164,8 +164,6 @@ func Start(ctx context.Context, cfg Config) (<-chan error, func(context.Context)
 		}
 	}()
 
-	app.SetVoter(voter)
-
 	log.Info(ctx, "Starting CometBFT", "listeners", cmtNode.Listeners())
 
 	if err := cmtNode.Start(); err != nil {

--- a/halo/cmd/cmd_internal_test.go
+++ b/halo/cmd/cmd_internal_test.go
@@ -75,6 +75,7 @@ func TestCLIReference(t *testing.T) {
 		{root},
 		{"run"},
 		{"init"},
+		{"rollback"},
 	}
 
 	for _, test := range tests {

--- a/halo/cmd/flags.go
+++ b/halo/cmd/flags.go
@@ -32,8 +32,7 @@ func bindRunFlags(cmd *cobra.Command, cfg *halocfg.Config) {
 }
 
 func bindRollbackFlags(flags *pflag.FlagSet, cfg *app.RollbackConfig) {
-	flags.BoolVar(&cfg.RollbackEVM, "rollback-evm", false, "Attempt to rollback the Omni EVM to previous height via Engine API")
-	flags.BoolVar(&cfg.RemoveCometBlock, "hard", false, "Remove last block as well as state")
+	flags.BoolVar(&cfg.RemoveCometBlock, "hard", cfg.RemoveCometBlock, "Remove last block as well as state")
 }
 
 func bindInitFlags(flags *pflag.FlagSet, cfg *InitConfig) {

--- a/halo/cmd/testdata/TestCLIReference_halo.golden
+++ b/halo/cmd/testdata/TestCLIReference_halo.golden
@@ -7,7 +7,7 @@ Available Commands:
   completion  Generate the autocompletion script for the specified shell
   help        Help about any command
   init        Initializes required halo files and directories
-  rollback    rollback Cosmos SDK, and CometBFT, and optionally the Omni EVM, state by one height
+  rollback    Rollback Cosmos SDK and CometBFT state by one height
   run         Runs the halo consensus client
   version     Print the version information of this binary
 

--- a/halo/cmd/testdata/TestCLIReference_rollback.golden
+++ b/halo/cmd/testdata/TestCLIReference_rollback.golden
@@ -1,0 +1,33 @@
+
+A state rollback is performed to recover from an incorrect application state transition,
+when CometBFT has persisted an incorrect app hash and is thus unable to make
+progress. Rollback overwrites a state at height n with the state at height n - 1.
+The application also rolls back to height n - 1. Upon restarting the transactions
+in block n will be re-executed against the application. If --hard=true, the block
+itself will also be deleted and re-downloaded from the p2p network. Note that a
+different block N cannot be re-built/re-proposed since that would result in validator slashing.
+
+Usage:
+  halo rollback [flags]
+
+Flags:
+      --app-db-backend string                     The type of database for application and snapshots databases (default "goleveldb")
+      --eigenlayer-key-password string            Eigenlayer generated operator key password. Not required if CombetBFT priv_validator_key.json is used
+      --engine-endpoint string                    An EVM execution client Engine API http endpoint
+      --engine-jwt-file string                    The path to the Engine API JWT file
+      --evm-build-delay duration                  Minimum delay between triggering and fetching a EVM payload build (default 600ms)
+      --evm-build-optimistic                      Enables optimistic building of EVM payloads on previous block finalize (default true)
+      --hard                                      Remove last block as well as state
+  -h, --help                                      help for rollback
+      --home string                               The application home directory containing config and data (default "./halo")
+      --log-color string                          Log color (only applicable to console format); auto, force, disable (default "auto")
+      --log-format string                         Log format; console, json (default "console")
+      --log-level string                          Log level; debug, info, warn, error (default "info")
+      --min-retain-blocks uint                    Minimum block height offset during ABCI commit to prune CometBFT blocks
+      --network string                            Omni network to participate in: mainnet, testnet, devnet
+      --pruning string                            Pruning strategy (default|nothing|everything) (default "nothing")
+      --snapshot-interval uint                    State sync snapshot interval (default 1000)
+      --snapshot-keep-recent uint                 State sync snapshot to keep (default 2)
+      --tracing-endpoint string                   Tracing OTLP endpoint
+      --tracing-headers string                    Tracing OTLP headers
+      --xchain-evm-rpc-endpoints stringToString   Cross-chain EVM RPC endpoints. e.g. "ethereum=http://geth:8545,optimism=https://optimism.io" (default [])

--- a/halo/valsync/keeper/common_internal_test.go
+++ b/halo/valsync/keeper/common_internal_test.go
@@ -46,9 +46,8 @@ func setupKeeper(t *testing.T, expectations ...expectation) (*Keeper, sdk.Contex
 		exp(ctx, m)
 	}
 
-	k, err := NewKeeper(codec, storeSvc, m.sKeeper, m.aKeeper)
+	k, err := NewKeeper(codec, storeSvc, m.sKeeper, m.aKeeper, m.subscriber)
 	require.NoError(t, err, "new keeper")
-	k.SetSubscriber(m.subscriber)
 
 	return k, ctx
 }

--- a/halo/valsync/module/module.go
+++ b/halo/valsync/module/module.go
@@ -141,6 +141,7 @@ type ModuleInputs struct {
 	Config       *Module
 	SKeeper      types.StakingKeeper
 	AKeeper      types.AttestKeeper
+	Subscriber   types.ValSetSubscriber
 }
 
 type ModuleOutputs struct {
@@ -156,6 +157,7 @@ func ProvideModule(in ModuleInputs) (ModuleOutputs, error) {
 		in.StoreService,
 		in.SKeeper,
 		in.AKeeper,
+		in.Subscriber,
 	)
 	if err != nil {
 		return ModuleOutputs{}, err


### PR DESCRIPTION
Remove `--rollback-evm` flag and logic to attempt EVM rollback as this isn't possible without recreating the block which isn't possible without slashing risk.

Also fix a panic `valsync` module by providing voter in constructor.

task: none