### PR TITLE
chore(lib/buildinfo): bump two patch versions higher

### DIFF
--- a/lib/buildinfo/buildinfo.go
+++ b/lib/buildinfo/buildinfo.go
@@ -13,7 +13,7 @@ import (
 
 // version of the whole omni-monorepo and all binaries built from this git commit.
 // This value is set by goreleaser at build-time and should be the git tag for official releases.
-var version = "v0.1.5"
+var version = "v0.1.7"
 
 // Version returns the version of the whole omni-monorepo and all binaries built from this git commit.
 func Version() string {


### PR DESCRIPTION
bumps buildinfo version two versions higher as the there has been an intermediate release (static portal addresses for CLI) and current version includes new scaffolding functionality (seen in #1080)

task: https://app.asana.com/0/1206208509925075/1207372351528365/f