### PR TITLE
ci(e2e): implement forkproxy

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -51,6 +51,13 @@ builds:
     ldflags:
       - -s -w -X github.com/omni-network/omni/lib/buildinfo.version={{.Version}}
 
+  - id: forkproxy
+    main: ./e2e/forkproxy
+    binary: forkproxy
+    env: [ CGO_ENABLED=0 ]
+    goos: [ linux, darwin ]
+    goarch: [ amd64, arm64 ]
+
 dockers:
   - ids: [halo]
     dockerfile: ./halo/Dockerfile

--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,10 @@ build-halo-relayer: ensure-go-releaser ## Builds the halo and relayer docker ima
 build-explorer-ui:
 	@make -C ./explorer build-ui
 
+.PHONY: build-forkproxy
+build-forkproxy: ensure-go-releaser ## Builds the forkproxy:main docker image.
+	@scripts/build_docker.sh forkproxy 'e2e' 'main' 'amd64'
+
 ###############################################################################
 ###                                Contracts                                 ###
 ###############################################################################

--- a/e2e/docker/compose.yaml.tmpl
+++ b/e2e/docker/compose.yaml.tmpl
@@ -34,20 +34,16 @@ services:
 {{end}}
 
 {{- range .Anvils }}
-  # Initialises geth files and folder from provided genesis file.
   {{ .Chain.Name }}:
     labels:
       e2e: true
     container_name: {{ .Chain.Name }}
     platform: linux/amd64
-    image: ghcr.io/foundry-rs/foundry:latest
-    entrypoint:
-      - anvil
-      - --host=0.0.0.0
-      - --chain-id={{ .Chain.ChainID }}
-      - --block-time={{.Chain.BlockPeriod.Seconds}}
-      - --silent
-      {{ if .LoadState }}- --load-state=/anvil/state.json{{ end }}
+    image: omniops/forkproxy:main
+    environment:
+      - FORKPROXY_CHAIN_ID={{ .Chain.ChainID }}
+      - FORKPROXY_BLOCK_TIME={{.Chain.BlockPeriod.Seconds}}
+      {{ if .LoadState }}- FORKPROXY_LOAD_STATE=/anvil/state.json{{ end }}
     ports:
       - {{ if .ProxyPort }}{{ .ProxyPort }}:{{ end }}8545
     networks:

--- a/e2e/docker/testdata/TestComposeTemplate_commit_no_explorer.golden
+++ b/e2e/docker/testdata/TestComposeTemplate_commit_no_explorer.golden
@@ -26,19 +26,15 @@ services:
       test:
         ipv4_address: 10.186.73.0
 
-  # Initialises geth files and folder from provided genesis file.
   mock_rollup:
     labels:
       e2e: true
     container_name: mock_rollup
     platform: linux/amd64
-    image: ghcr.io/foundry-rs/foundry:latest
-    entrypoint:
-      - anvil
-      - --host=0.0.0.0
-      - --chain-id=99
-      - --block-time=1
-      - --silent
+    image: omniops/forkproxy:main
+    environment:
+      - FORKPROXY_CHAIN_ID=99
+      - FORKPROXY_BLOCK_TIME=1
       
     ports:
       - 9000:8545
@@ -46,20 +42,16 @@ services:
       test:
         ipv4_address: 10.186.73.0
     
-  # Initialises geth files and folder from provided genesis file.
   mock_l1:
     labels:
       e2e: true
     container_name: mock_l1
     platform: linux/amd64
-    image: ghcr.io/foundry-rs/foundry:latest
-    entrypoint:
-      - anvil
-      - --host=0.0.0.0
-      - --chain-id=1
-      - --block-time=3600
-      - --silent
-      - --load-state=/anvil/state.json
+    image: omniops/forkproxy:main
+    environment:
+      - FORKPROXY_CHAIN_ID=1
+      - FORKPROXY_BLOCK_TIME=3600
+      - FORKPROXY_LOAD_STATE=/anvil/state.json
     ports:
       - 9000:8545
     networks:

--- a/e2e/docker/testdata/TestComposeTemplate_empheral_network.golden
+++ b/e2e/docker/testdata/TestComposeTemplate_empheral_network.golden
@@ -26,19 +26,15 @@ services:
       test:
         ipv4_address: 10.186.73.0
 
-  # Initialises geth files and folder from provided genesis file.
   mock_rollup:
     labels:
       e2e: true
     container_name: mock_rollup
     platform: linux/amd64
-    image: ghcr.io/foundry-rs/foundry:latest
-    entrypoint:
-      - anvil
-      - --host=0.0.0.0
-      - --chain-id=99
-      - --block-time=1
-      - --silent
+    image: omniops/forkproxy:main
+    environment:
+      - FORKPROXY_CHAIN_ID=99
+      - FORKPROXY_BLOCK_TIME=1
       
     ports:
       - 9000:8545
@@ -46,20 +42,16 @@ services:
       test:
         ipv4_address: 10.186.73.0
     
-  # Initialises geth files and folder from provided genesis file.
   mock_l1:
     labels:
       e2e: true
     container_name: mock_l1
     platform: linux/amd64
-    image: ghcr.io/foundry-rs/foundry:latest
-    entrypoint:
-      - anvil
-      - --host=0.0.0.0
-      - --chain-id=1
-      - --block-time=3600
-      - --silent
-      - --load-state=/anvil/state.json
+    image: omniops/forkproxy:main
+    environment:
+      - FORKPROXY_CHAIN_ID=1
+      - FORKPROXY_BLOCK_TIME=3600
+      - FORKPROXY_LOAD_STATE=/anvil/state.json
     ports:
       - 9000:8545
     networks:

--- a/e2e/docker/testdata/TestComposeTemplate_main_explorer.golden
+++ b/e2e/docker/testdata/TestComposeTemplate_main_explorer.golden
@@ -26,19 +26,15 @@ services:
       test:
         ipv4_address: 10.186.73.0
 
-  # Initialises geth files and folder from provided genesis file.
   mock_rollup:
     labels:
       e2e: true
     container_name: mock_rollup
     platform: linux/amd64
-    image: ghcr.io/foundry-rs/foundry:latest
-    entrypoint:
-      - anvil
-      - --host=0.0.0.0
-      - --chain-id=99
-      - --block-time=1
-      - --silent
+    image: omniops/forkproxy:main
+    environment:
+      - FORKPROXY_CHAIN_ID=99
+      - FORKPROXY_BLOCK_TIME=1
       
     ports:
       - 9000:8545
@@ -46,20 +42,16 @@ services:
       test:
         ipv4_address: 10.186.73.0
     
-  # Initialises geth files and folder from provided genesis file.
   mock_l1:
     labels:
       e2e: true
     container_name: mock_l1
     platform: linux/amd64
-    image: ghcr.io/foundry-rs/foundry:latest
-    entrypoint:
-      - anvil
-      - --host=0.0.0.0
-      - --chain-id=1
-      - --block-time=3600
-      - --silent
-      - --load-state=/anvil/state.json
+    image: omniops/forkproxy:main
+    environment:
+      - FORKPROXY_CHAIN_ID=1
+      - FORKPROXY_BLOCK_TIME=3600
+      - FORKPROXY_LOAD_STATE=/anvil/state.json
     ports:
       - 9000:8545
     networks:

--- a/e2e/forkproxy/Dockerfile
+++ b/e2e/forkproxy/Dockerfile
@@ -1,0 +1,14 @@
+FROM --platform=linux/amd64 ghcr.io/foundry-rs/foundry:latest
+
+# Copy forkproxy binary and rename to /app
+COPY forkproxy /app
+
+EXPOSE 8545
+
+# Mount config directory at /forkproxy
+VOLUME ["/forkproxy"]
+
+# Set working directory to /forkproxy, so it automatically reads config from here.
+WORKDIR /forkproxy
+
+ENTRYPOINT ["/app"]

--- a/e2e/forkproxy/app/app.go
+++ b/e2e/forkproxy/app/app.go
@@ -1,0 +1,245 @@
+package app
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httputil"
+	"net/url"
+	"os/exec"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/omni-network/omni/lib/errors"
+	"github.com/omni-network/omni/lib/log"
+
+	"golang.org/x/sync/errgroup"
+)
+
+type Config struct {
+	ListenAddr    string
+	ChainID       uint64
+	LoadState     string
+	BlockTimeSecs uint64
+	Silent        bool
+}
+
+func DefaultConfig() Config {
+	return Config{
+		ListenAddr:    "0.0.0.0:8545",
+		ChainID:       1337,
+		LoadState:     "",
+		Silent:        true,
+		BlockTimeSecs: 1,
+	}
+}
+
+func Run(ctx context.Context, cfg Config) error {
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	portProvider := newPortProvider()
+	rootCfg := anvilConfig{
+		Config: cfg,
+		Port:   portProvider(),
+	}
+	root, err := startAnvil(ctx, rootCfg)
+	if err != nil {
+		return errors.Wrap(err, "start root anvil")
+	}
+
+	proxy, err := newProxy(root)
+	if err != nil {
+		return errors.Wrap(err, "new proxy")
+	}
+
+	httpServer := &http.Server{
+		Addr:              cfg.ListenAddr,
+		ReadHeaderTimeout: 30 * time.Second,
+		IdleTimeout:       30 * time.Second,
+		WriteTimeout:      30 * time.Second,
+		Handler:           proxy,
+	}
+
+	log.Info(ctx, "Starting forkproxy server", "address", cfg.ListenAddr)
+
+	var eg errgroup.Group
+	// TODO(corver): Start a goroutines that forks the instance every few seconds.
+	eg.Go(func() error {
+		defer cancel() // Cancel the app context if serving fails.
+
+		// ListenAndServe always returns an error.
+		return errors.Wrap(httpServer.ListenAndServe(), "serve")
+	})
+	eg.Go(func() error {
+		<-ctx.Done()
+		log.Info(ctx, "Shutdown detected, stopping server")
+
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+
+		if err := httpServer.Shutdown(shutdownCtx); err != nil { //nolint:contextcheck // Explicit new shutdown context.
+			return errors.Wrap(err, "server shutdown")
+		}
+
+		proxy.stopInstance()
+
+		return nil
+	})
+
+	if err := eg.Wait(); errors.Is(err, http.ErrServerClosed) {
+		return nil // No error on shutdown.
+	} else if err != nil {
+		return errors.Wrap(err, "server")
+	}
+
+	return nil
+}
+
+func newProxy(instance anvilInstance) (*proxy, error) {
+	resp := new(proxy)
+	if err := resp.setTarget(instance); err != nil {
+		return nil, err
+	}
+
+	return resp, nil
+}
+
+type proxy struct {
+	mu       sync.RWMutex
+	instance anvilInstance
+	target   *url.URL
+}
+
+func (p *proxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	httputil.NewSingleHostReverseProxy(p.getTarget()).ServeHTTP(w, r)
+}
+
+func (p *proxy) getTarget() *url.URL {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+
+	return p.target
+}
+
+func (p *proxy) stopInstance() {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	p.instance.stop()
+}
+
+func (p *proxy) setTarget(target anvilInstance) error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	u, err := url.Parse(target.URL())
+	if err != nil {
+		return errors.Wrap(err, "parse target url")
+	}
+
+	p.instance = target
+	p.target = u
+
+	return nil
+}
+
+type anvilConfig struct {
+	Config
+	Port         int
+	ForkHeight   uint64
+	ForkInstance *anvilInstance
+}
+
+type anvilInstance struct {
+	Cfg  anvilConfig
+	stop func()
+	Cmd  *exec.Cmd
+	Out  bytes.Buffer
+}
+
+func (i anvilInstance) URL() string {
+	return fmt.Sprintf("http://127.0.0.1:%d", i.Cfg.Port)
+}
+
+//nolint:govet // Context is canceled when instance stopped.
+func startAnvil(ctx context.Context, cfg anvilConfig) (anvilInstance, error) {
+	ctx, cancel := context.WithCancel(ctx)
+
+	args := []string{
+		"--port", strconv.Itoa(cfg.Port),
+		"--chain-id", strconv.FormatUint(cfg.ChainID, 10),
+		"--block-time", strconv.FormatUint(cfg.BlockTimeSecs, 10),
+	}
+	if cfg.LoadState != "" {
+		args = append(args, "--load-state", cfg.LoadState)
+	}
+	if cfg.Silent {
+		args = append(args, "--silent")
+	}
+	if cfg.ForkInstance != nil {
+		args = append(args,
+			"--fork-url", cfg.ForkInstance.URL(),
+			"--fork-block-number", strconv.FormatUint(cfg.ForkHeight, 10),
+		)
+	}
+
+	log.Info(ctx, "Starting anvil", "command", strings.Join(args, " "))
+
+	var out bytes.Buffer
+	cmd := exec.CommandContext(ctx, "anvil", args...)
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Start(); err != nil {
+		return anvilInstance{}, errors.Wrap(err, "start anvil", "out", out.String())
+	}
+
+	go func() {
+		err := logLines(ctx, &out)
+		if err != nil {
+			log.Error(ctx, "Failed logging lines", err)
+		}
+	}()
+
+	return anvilInstance{
+		stop: func() {
+			cancel()
+			_ = cmd.Wait()
+		},
+		Cfg: cfg,
+		Out: out,
+		Cmd: cmd,
+	}, nil
+}
+
+func newPortProvider() func() int {
+	next := 9000 - 1
+	return func() int {
+		next++
+		return next
+	}
+}
+
+// logLines blocks, reading lines from the reader and logging them.
+// It returns when the reader is closed; io.EOF.
+func logLines(ctx context.Context, r io.Reader) error {
+	scanner := bufio.NewReader(r)
+	for ctx.Err() == nil {
+		line, err := scanner.ReadString('\n')
+		if errors.Is(err, io.EOF) {
+			// Just backoff
+			time.Sleep(time.Millisecond * 10)
+		} else if err != nil {
+			return errors.Wrap(err, "read line")
+		} else {
+			fmt.Println(line) //nolint:forbidigo // Logging this doesn't make sense.
+		}
+	}
+
+	return nil
+}

--- a/e2e/forkproxy/cmd/cmd.go
+++ b/e2e/forkproxy/cmd/cmd.go
@@ -1,0 +1,48 @@
+// Package cmd provides the cli for running the api.
+package cmd
+
+import (
+	"github.com/omni-network/omni/e2e/forkproxy/app"
+	libcmd "github.com/omni-network/omni/lib/cmd"
+	"github.com/omni-network/omni/lib/log"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+)
+
+// New returns a new root cobra command that runs the forkproxy server.
+func New() *cobra.Command {
+	cmd := libcmd.NewRootCmd(
+		"forkproxy",
+		"Forkproxy Server",
+	)
+
+	cfg := app.DefaultConfig()
+	bindFlags(cmd.Flags(), &cfg)
+
+	logCfg := log.DefaultConfig()
+	log.BindFlags(cmd.Flags(), &logCfg)
+
+	cmd.RunE = func(cmd *cobra.Command, args []string) error {
+		ctx, err := log.Init(cmd.Context(), logCfg)
+		if err != nil {
+			return err
+		}
+
+		if err := libcmd.LogFlags(ctx, cmd.Flags()); err != nil {
+			return err
+		}
+
+		return app.Run(ctx, cfg)
+	}
+
+	return cmd
+}
+
+func bindFlags(flags *pflag.FlagSet, cfg *app.Config) {
+	flags.StringVar(&cfg.ListenAddr, "listen-addr", cfg.ListenAddr, "Address for proxy to listen on")
+	flags.Uint64Var(&cfg.ChainID, "chain-id", cfg.ChainID, "Anvil chain id")
+	flags.StringVar(&cfg.LoadState, "load-state", cfg.LoadState, "Initialize the chain from a previously saved state snapshot")
+	flags.Uint64Var(&cfg.BlockTimeSecs, "block-time", cfg.BlockTimeSecs, "Block time in seconds for interval mining")
+	flags.BoolVar(&cfg.Silent, "silent", cfg.Silent, "Don't print anything on startup and don't print logs")
+}

--- a/e2e/forkproxy/main.go
+++ b/e2e/forkproxy/main.go
@@ -1,0 +1,11 @@
+// Command forkproxy is the main entry point for the forkproxy.
+package main
+
+import (
+	forkproxycmd "github.com/omni-network/omni/e2e/forkproxy/cmd"
+	libcmd "github.com/omni-network/omni/lib/cmd"
+)
+
+func main() {
+	libcmd.Main(forkproxycmd.New())
+}

--- a/e2e/vmcompose/testdata/TestSetup_127-0-0-3-compose.yaml.golden
+++ b/e2e/vmcompose/testdata/TestSetup_127-0-0-3-compose.yaml.golden
@@ -6,20 +6,16 @@ networks:
     driver: bridge
 
 services:
-  # Initialises geth files and folder from provided genesis file.
   mock_l1:
     labels:
       e2e: true
     container_name: mock_l1
     platform: linux/amd64
-    image: ghcr.io/foundry-rs/foundry:latest
-    entrypoint:
-      - anvil
-      - --host=0.0.0.0
-      - --chain-id=1652
-      - --block-time=1
-      - --silent
-      - --load-state=/anvil/state.json
+    image: omniops/forkproxy:main
+    environment:
+      - FORKPROXY_CHAIN_ID=1652
+      - FORKPROXY_BLOCK_TIME=1
+      - FORKPROXY_LOAD_STATE=/anvil/state.json
     ports:
       - 8545:8545
     networks:

--- a/scripts/build_docker.sh
+++ b/scripts/build_docker.sh
@@ -3,19 +3,29 @@
 # ./build_docker.sh <app_name>
 # Builds a single docker image for the provided app using local git ref.
 
-APP=$1
+APP="${1}"
+PARENT_DIR="${2}" # Defaults to repo root
+GITREF="${3}"     # Defaults to git rev-parse HEAD
+ARC="${4}"        # Defaults to go env GOARCH
 
 if [ -z "$APP" ]; then
   echo "Please provide the app name: ./single_docker.sh <app_name>"
   exit 1
 fi
+if [ -z "${PARENT_DIR}" ]; then
+    PARENT_DIR="."
+fi
+if [ -z "${GITREF}" ]; then
+    GITREF=$(git rev-parse --short=7 HEAD)
+fi
+if [ -z "${ARC}" ]; then
+    ARC=$(go env GOARCH)
+fi
 
-GOOS=linux goreleaser build --single-target --snapshot --clean --id="${APP}"
-
-GITREF=$(git rev-parse --short=7 HEAD)
+GOOS=linux GOARCH="${ARC}" goreleaser build --single-target --snapshot --clean --id="${APP}"
 
 cd dist/${APP}* || exit 1
 
-docker build -f "../../${APP}/Dockerfile" . -t "omniops/${APP}:${GITREF}"
+docker build -f "../../${PARENT_DIR}/${APP}/Dockerfile" . -t "omniops/${APP}:${GITREF}"
 
 echo "Built docker image: omniops/${APP}:${GITREF}"


### PR DESCRIPTION
Add the forkproxy binary (and docker image already manually upload to dockerhub).

Forkproxy:
- It wraps anvil an internal anvil instance
- Proxying requests to that instance

TODO:
- Add support for forking the anvil instance if configured.
- Proxy requests to forked instance. 

task: none