### PR TITLE
ci(e2e): support forking proxy

### DIFF
--- a/e2e/forkproxy/cmd/cmd.go
+++ b/e2e/forkproxy/cmd/cmd.go
@@ -45,4 +45,5 @@ func bindFlags(flags *pflag.FlagSet, cfg *app.Config) {
 	flags.StringVar(&cfg.LoadState, "load-state", cfg.LoadState, "Initialize the chain from a previously saved state snapshot")
 	flags.Uint64Var(&cfg.BlockTimeSecs, "block-time", cfg.BlockTimeSecs, "Block time in seconds for interval mining")
 	flags.BoolVar(&cfg.Silent, "silent", cfg.Silent, "Don't print anything on startup and don't print logs")
+	flags.BoolVar(&cfg.EnableForking, "fork", cfg.EnableForking, "Enable constant forking")
 }


### PR DESCRIPTION
Add support for constant forking of underlying anvil in forkproxy if `--fork=true`.

It waits a bit, then starts a fork of the current anvil a few blocks deep. Rinse-and-repeat.

task: none