### PR TITLE
fix(goreleaser): use tags instead of version in ldflags

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -10,7 +10,7 @@ builds:
     goos: [linux, darwin]
     goarch: [amd64, arm64]
     ldflags:
-      - -s -w -X github.com/omni-network/omni/lib/buildinfo.version={{.Version}}
+      - -s -w -X github.com/omni-network/omni/lib/buildinfo.version={{.Tag}}
 
   - id: relayer
     main: ./relayer
@@ -19,7 +19,7 @@ builds:
     goos: [linux, darwin]
     goarch: [amd64, arm64]
     ldflags:
-      - -s -w -X github.com/omni-network/omni/lib/buildinfo.version={{.Version}}
+      - -s -w -X github.com/omni-network/omni/lib/buildinfo.version={{.Tag}}
 
   - id: monitor
     main: ./monitor
@@ -49,7 +49,7 @@ builds:
     goos: [ linux, darwin ]
     goarch: [ amd64, arm64 ]
     ldflags:
-      - -s -w -X github.com/omni-network/omni/lib/buildinfo.version={{.Version}}
+      - -s -w -X github.com/omni-network/omni/lib/buildinfo.version={{.Tag}}
 
 dockers:
   - ids: [halo]


### PR DESCRIPTION
use tags instead of version for goreleaser, as version might trim prefix "v" (https://goreleaser.com/customization/templates/)

task: https://app.asana.com/0/1206208509925075/1207372351528377/f
