### PR TITLE
chore(relayer): logging improvements

### DIFF
--- a/e2e/forkproxy/app/app.go
+++ b/e2e/forkproxy/app/app.go
@@ -61,7 +61,7 @@ func Run(ctx context.Context, cfg Config) error {
 	root, err := startAnvil(ctx, rootCfg)
 	if err != nil {
 		return errors.Wrap(err, "start root anvil")
-	} else if err := root.AwaitHeight(ctx, 1, time.Second*5); err != nil {
+	} else if err := root.AwaitHeight(ctx, 0, time.Second*5); err != nil {
 		return errors.Wrap(err, "start anvil")
 	}
 
@@ -119,6 +119,9 @@ func forkForever(ctx context.Context, cfg Config, newPort func() int, proxy *pro
 	if !cfg.EnableForking {
 		<-ctx.Done()
 		return nil
+	}
+	if cfg.BlockTimeSecs != 1 {
+		return errors.New("forking only supported for 1s block times")
 	}
 
 	for ctx.Err() == nil {

--- a/relayer/app/monitor.go
+++ b/relayer/app/monitor.go
@@ -6,7 +6,6 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/omni-network/omni/explorer/db/ent/chain"
 	"github.com/omni-network/omni/lib/cchain"
 	"github.com/omni-network/omni/lib/errors"
 	"github.com/omni-network/omni/lib/ethclient"
@@ -170,15 +169,17 @@ func monitorAttestedForever(
 					Height: &att.BlockHeight,
 				}
 
+				name := streamName(network.ChainName, stream)
+
 				cursor, ok, err := xprovider.GetEmittedCursor(ctx, ref, stream)
 				if err != nil {
-					log.Error(ctx, "Monitoring attested stream offset failed (will retry)", err, "chain", chain.Name)
-					break
+					log.Error(ctx, "Fetching stream offsets for attestation failed (will retry)", err, "stream", name)
+					continue
 				} else if !ok {
 					continue
 				}
 
-				attestedMsgOffset.WithLabelValues(streamName(network.ChainName, stream)).Set(float64(cursor.MsgOffset))
+				attestedMsgOffset.WithLabelValues(name).Set(float64(cursor.MsgOffset))
 			}
 		}
 	}


### PR DESCRIPTION
Fixes incorrect logging in relayer.

Also, fix forkproxy startup issue.

task: none