### PR TITLE
fix(devnet0): non sub second block times for anvil nodes

### DIFF
--- a/lib/evmchain/evmchain.go
+++ b/lib/evmchain/evmchain.go
@@ -122,7 +122,7 @@ var static = map[uint64]Metadata{
 	IDMockArb: {
 		ChainID:     IDMockArb,
 		Name:        "mock_arb",
-		BlockPeriod: time.Second / 4,
+		BlockPeriod: time.Second,
 		NativeToken: tokens.ETH,
 	},
 }


### PR DESCRIPTION
makes devnet0 anvil node have non sub second block time, which would lead to errors, fixes cli devnet start command

task: none