### PR TITLE
refactor(lib/xchain): support conf level when querying xprovider

### DIFF
--- a/e2e/app/monitor.go
+++ b/e2e/app/monitor.go
@@ -48,7 +48,12 @@ func StartMonitoringReceipts(ctx context.Context, def Definition) func() error {
 	var msgCache sync.Map
 
 	streamReceipts := func(ctx context.Context, chain netconf.Chain) (void, error) {
-		return nil, xProvider.StreamBlocksNoOffset(ctx, chain.ID, chain.DeployHeight,
+		req := xchain.ProviderRequest{
+			ChainID:   chain.ID,
+			ConfLevel: xchain.ConfLatest,
+		}
+
+		return nil, xProvider.StreamBlocks(ctx, req,
 			func(ctx context.Context, block xchain.Block) error {
 				for _, msg := range block.Msgs {
 					msgCache.Store(msg.MsgID, msg)

--- a/explorer/indexer/app/app.go
+++ b/explorer/indexer/app/app.go
@@ -90,9 +90,13 @@ func startXProvider(ctx context.Context, network netconf.Network, entCl *ent.Cli
 		}
 		log.Info(ctx, "Subscribing to chain", "chain_id", chain.ID, "from_height", height)
 
-		// TODO(corver): Store MsgOffset along with heights in cursor table
-		//  Currently XBlockOffset isn't supported in x-explorer.
-		err = xprovider.StreamAsync(ctx, chain.ID, height, offset+1, callback)
+		req := xchain.ProviderRequest{
+			ChainID:   chain.ID,
+			Height:    height,
+			ConfLevel: chain.ConfLevels()[0], // TODO(corver): Add support for multiple confirmation levels.
+			Offset:    offset,
+		}
+		err = xprovider.StreamAsync(ctx, req, callback)
 		if err != nil {
 			return errors.Wrap(err, "subscribe", "chain_id", chain.ID)
 		}

--- a/halo/attest/voter/voter.go
+++ b/halo/attest/voter/voter.go
@@ -190,7 +190,14 @@ func (v *Voter) runOnce(ctx context.Context, chainVer types.ChainVersion) error 
 
 	first := true // Allow skipping on first attestation.
 
-	return v.provider.StreamBlocks(ctx, chainVer.ChainID, fromHeight, fromOffset,
+	req := xchain.ProviderRequest{
+		ChainID:   chainVer.ChainID,
+		Height:    fromHeight,
+		ConfLevel: xchain.ConfLevel(chainVer.ConfLevel),
+		Offset:    fromOffset,
+	}
+
+	return v.provider.StreamBlocks(ctx, req,
 		func(ctx context.Context, block xchain.Block) error {
 			if !v.isValidator() {
 				return errors.New("not a validator anymore")

--- a/lib/netconf/netconf.go
+++ b/lib/netconf/netconf.go
@@ -248,9 +248,8 @@ const (
 // the Omni cross chain protocol. This is most supported Rollup EVMs, but
 // also the Omni EVM, and the Omni Consensus chain.
 type Chain struct {
-	ID   uint64 // Chain ID asa per https://chainlist.org
-	Name string // Chain name as per https://chainlist.org
-	// RPCURL            string            // RPC URL of the chain
+	ID                uint64            // Chain ID asa per https://chainlist.org
+	Name              string            // Chain name as per https://chainlist.org
 	PortalAddress     common.Address    // Address of the omni portal contract on the chain
 	DeployHeight      uint64            // Height that the portal contracts were deployed
 	BlockPeriod       time.Duration     // Block period of the chain

--- a/lib/xchain/provider/mock_internal_test.go
+++ b/lib/xchain/provider/mock_internal_test.go
@@ -23,8 +23,14 @@ func TestMock(t *testing.T) {
 
 	mock := NewMock(time.Millisecond, 0, nil)
 
+	req := xchain.ProviderRequest{
+		ChainID:   chainID,
+		Height:    fromHeight,
+		Offset:    fromOffset,
+		ConfLevel: xchain.ConfLatest,
+	}
 	var blocks []xchain.Block
-	err := mock.StreamAsync(ctx, chainID, fromHeight, fromOffset, func(ctx context.Context, block xchain.Block) error {
+	err := mock.StreamAsync(ctx, req, func(ctx context.Context, block xchain.Block) error {
 		blocks = append(blocks, block)
 		if len(blocks) == total {
 			cancel()

--- a/lib/xchain/provider/provider_internal_test.go
+++ b/lib/xchain/provider/provider_internal_test.go
@@ -25,6 +25,6 @@ func NewForT(
 		network:     network,
 		ethClients:  rpcClients,
 		backoffFunc: backoffFunc,
-		stratHeads:  make(map[uint64]uint64),
+		confHeads:   make(map[chainVersion]uint64),
 	}
 }

--- a/lib/xchain/types.go
+++ b/lib/xchain/types.go
@@ -8,6 +8,12 @@ import (
 
 //go:generate stringer -type=ConfLevel -trimprefix=Conf
 
+// ChainVersion defines a version of a source chain; either some draft (fuzzy) version or finalized.
+type ChainVersion struct {
+	ID        uint64    // Source chain ID as per https://chainlist.org/
+	ConfLevel ConfLevel // ConfLevel defines the block "version"; either some fuzzy version or finalized.
+}
+
 // ConfLevel defines a xblock confirmation level.
 // This is similar to a "version"; with ConfFinalized being the final version and fuzzy conf levels being drafts.
 type ConfLevel byte

--- a/relayer/app/cursors_internal_test.go
+++ b/relayer/app/cursors_internal_test.go
@@ -127,29 +127,21 @@ var (
 )
 
 type mockXChainClient struct {
-	GetBlockFn           func(context.Context, uint64, uint64, uint64) (xchain.Block, bool, error)
+	GetBlockFn           func(context.Context, xchain.ProviderRequest) (xchain.Block, bool, error)
 	GetSubmittedCursorFn func(context.Context, xchain.StreamID) (xchain.StreamCursor, bool, error)
 	GetEmittedCursorFn   func(context.Context, xchain.EmitRef, xchain.StreamID) (xchain.StreamCursor, bool, error)
 }
 
-func (m *mockXChainClient) StreamAsync(context.Context, uint64, uint64, uint64, xchain.ProviderCallback) error {
+func (m *mockXChainClient) StreamAsync(context.Context, xchain.ProviderRequest, xchain.ProviderCallback) error {
 	panic("unexpected")
 }
 
-func (m *mockXChainClient) StreamAsyncNoOffset(context.Context, uint64, uint64, xchain.ProviderCallback) error {
+func (m *mockXChainClient) StreamBlocks(context.Context, xchain.ProviderRequest, xchain.ProviderCallback) error {
 	panic("unexpected")
 }
 
-func (m *mockXChainClient) StreamBlocks(context.Context, uint64, uint64, uint64, xchain.ProviderCallback) error {
-	panic("unexpected")
-}
-
-func (m *mockXChainClient) StreamBlocksNoOffset(context.Context, uint64, uint64, xchain.ProviderCallback) error {
-	panic("unexpected")
-}
-
-func (m *mockXChainClient) GetBlock(ctx context.Context, chainID uint64, height uint64, xOffset uint64) (xchain.Block, bool, error) {
-	return m.GetBlockFn(ctx, chainID, height, xOffset)
+func (m *mockXChainClient) GetBlock(ctx context.Context, req xchain.ProviderRequest) (xchain.Block, bool, error) {
+	return m.GetBlockFn(ctx, req)
 }
 
 func (m *mockXChainClient) GetSubmittedCursor(ctx context.Context, stream xchain.StreamID,

--- a/relayer/app/worker.go
+++ b/relayer/app/worker.go
@@ -256,7 +256,13 @@ func fetchXBlock(rootCtx context.Context, xProvider xchain.Provider, att xchain.
 
 	backoff := expbackoff.New(ctx, expbackoff.WithPeriodicConfig(time.Second))
 	for {
-		block, ok, err := xProvider.GetBlock(ctx, att.SourceChainID, att.BlockHeight, att.BlockOffset)
+		req := xchain.ProviderRequest{
+			ChainID:   att.SourceChainID,
+			Height:    att.BlockHeight,
+			Offset:    att.BlockOffset,
+			ConfLevel: att.ConfLevel,
+		}
+		block, ok, err := xProvider.GetBlock(ctx, req)
 		if rootCtx.Err() != nil { //nolint:nestif // Just a series of if-elses
 			return xchain.Block{}, errors.Wrap(rootCtx.Err(), "canceled") // Root context closed, shutting down
 		} else if ctx.Err() != nil {

--- a/relayer/app/worker_internal_test.go
+++ b/relayer/app/worker_internal_test.go
@@ -43,15 +43,15 @@ func TestWorker_Run(t *testing.T) {
 
 	// Return mock blocks (with a single msg per dest chain).
 	mockXClient := &mockXChainClient{
-		GetBlockFn: func(ctx context.Context, chainID uint64, height uint64, xOffset uint64) (xchain.Block, bool, error) {
-			require.EqualValues(t, srcChain, chainID) // Only fetch blocks for source chains.
+		GetBlockFn: func(ctx context.Context, req xchain.ProviderRequest) (xchain.Block, bool, error) {
+			require.EqualValues(t, srcChain, req.ChainID) // Only fetch blocks for source chains.
 
 			// Each block has two messages, one for each stream.
 			return xchain.Block{
-				BlockHeader: xchain.BlockHeader{SourceChainID: chainID, BlockOffset: xOffset, BlockHeight: height},
+				BlockHeader: xchain.BlockHeader{SourceChainID: req.ChainID, BlockOffset: req.Offset, BlockHeight: req.Height},
 				Msgs: []xchain.Msg{
-					{MsgID: xchain.MsgID{StreamID: streamA, StreamOffset: xOffset}},
-					{MsgID: xchain.MsgID{StreamID: streamB, StreamOffset: xOffset}},
+					{MsgID: xchain.MsgID{StreamID: streamA, StreamOffset: req.Offset}},
+					{MsgID: xchain.MsgID{StreamID: streamB, StreamOffset: req.Offset}},
 				},
 			}, true, nil
 		},


### PR DESCRIPTION
Add support for `ConfLevel` qhen streaming/querying xblocks from xprovider.

task: none