### PR TITLE
refactor(lib/xchain): introduce chain version type

### DIFF
--- a/e2e/app/monitor.go
+++ b/e2e/app/monitor.go
@@ -155,13 +155,13 @@ func MonitorCProvider(ctx context.Context, node *e2e.Node, network netconf.Netwo
 	cprov := cprovider.NewABCIProvider(client, network.ID, netconf.ChainNamer(network.ID))
 
 	for _, chain := range network.Chains {
-		for _, conf := range chain.ConfLevels() {
-			atts, err := cprov.AttestationsFrom(ctx, chain.ID, conf, 1)
+		for _, chainVer := range chain.ChainVersions() {
+			atts, err := cprov.AttestationsFrom(ctx, chainVer, 1)
 			if err != nil {
 				return errors.Wrap(err, "getting approved attestations")
 			}
 
-			log.Debug(ctx, "Halo approved attestations", "chain", chain.Name, "conf", conf, "count", len(atts))
+			log.Debug(ctx, "Halo approved attestations", "chain", chain.Name, "conf", chainVer.ConfLevel, "count", len(atts))
 		}
 	}
 

--- a/halo/app/lazyvoter.go
+++ b/halo/app/lazyvoter.go
@@ -242,7 +242,7 @@ func (l *voterLoader) LocalAddress() common.Address {
 	return common.Address{}
 }
 
-func (l *voterLoader) TrimBehind(minsByChain map[atypes.ChainVersion]uint64) int {
+func (l *voterLoader) TrimBehind(minsByChain map[xchain.ChainVersion]uint64) int {
 	if v, ok := l.getVoter(); ok {
 		return v.TrimBehind(minsByChain)
 	}

--- a/halo/app/start_test.go
+++ b/halo/app/start_test.go
@@ -59,7 +59,7 @@ func TestSmoke(t *testing.T) {
 		return s.SyncInfo.LatestBlockHeight >= int64(target)
 	}, time.Second*time.Duration(target*2), time.Millisecond*100)
 
-	_, ok, err := cprov.LatestAttestation(ctx, 0, 0) // Ensure it doesn't error for unknown chains.
+	_, ok, err := cprov.LatestAttestation(ctx, xchain.ChainVersion{}) // Ensure it doesn't error for unknown chains.
 	require.NoError(t, err)
 	require.False(t, ok)
 
@@ -87,10 +87,12 @@ func TestSmoke(t *testing.T) {
 	}, time.Second*time.Duration(target*2), time.Millisecond*100)
 
 	srcChain := netconf.Simnet.Static().OmniExecutionChainID
+	chainVer := xchain.ChainVersion{ID: srcChain, ConfLevel: xchain.ConfFinalized}
+
 	// Ensure all blocks are attested and approved.
-	cprov.Subscribe(ctx, srcChain, xchain.ConfFinalized, 1, "test", func(ctx context.Context, approved xchain.Attestation) error {
+	cprov.Subscribe(ctx, chainVer, 1, "test", func(ctx context.Context, approved xchain.Attestation) error {
 		// Sanity check we can fetch latest directly as well.
-		att, ok, err := cprov.LatestAttestation(ctx, srcChain, xchain.ConfFinalized)
+		att, ok, err := cprov.LatestAttestation(ctx, chainVer)
 		tutil.RequireNoError(t, err)
 		require.True(t, ok)
 		require.Equal(t, srcChain, att.SourceChainID)

--- a/halo/attest/keeper/helper.go
+++ b/halo/attest/keeper/helper.go
@@ -6,6 +6,13 @@ func (a *Attestation) XChainConfLevel() xchain.ConfLevel {
 	return xchain.ConfLevel(a.GetConfLevel())
 }
 
+func (a *Attestation) XChainVersion() xchain.ChainVersion {
+	return xchain.ChainVersion{
+		ID:        a.GetChainId(),
+		ConfLevel: a.XChainConfLevel(),
+	}
+}
+
 func (a *Attestation) XChainConfLevelStr() string {
 	return xchain.ConfLevel(a.GetConfLevel()).String()
 }

--- a/halo/attest/keeper/query.go
+++ b/halo/attest/keeper/query.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/omni-network/omni/halo/attest/types"
+	"github.com/omni-network/omni/lib/xchain"
 
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -31,7 +32,9 @@ func (k *Keeper) LatestAttestation(ctx context.Context, req *types.LatestAttesta
 		return nil, status.Error(codes.InvalidArgument, "invalid request")
 	}
 
-	att, ok, err := k.latestAttestation(ctx, req.ChainId, req.ConfLevel)
+	chainVer := xchain.ChainVersion{ID: req.ChainId, ConfLevel: xchain.ConfLevel(req.ConfLevel)}
+
+	att, ok, err := k.latestAttestation(ctx, chainVer)
 	if err != nil {
 		return nil, status.Error(codes.Internal, err.Error())
 	} else if !ok {

--- a/halo/attest/testutil/mock_interfaces.go
+++ b/halo/attest/testutil/mock_interfaces.go
@@ -19,6 +19,7 @@ import (
 	common "github.com/ethereum/go-ethereum/common"
 	types1 "github.com/omni-network/omni/halo/attest/types"
 	types2 "github.com/omni-network/omni/halo/valsync/types"
+	xchain "github.com/omni-network/omni/lib/xchain"
 	gomock "go.uber.org/mock/gomock"
 )
 
@@ -140,7 +141,7 @@ func (mr *MockVoterMockRecorder) SetProposed(headers any) *gomock.Call {
 }
 
 // TrimBehind mocks base method.
-func (m *MockVoter) TrimBehind(minsByChain map[types1.ChainVersion]uint64) int {
+func (m *MockVoter) TrimBehind(minsByChain map[xchain.ChainVersion]uint64) int {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "TrimBehind", minsByChain)
 	ret0, _ := ret[0].(int)

--- a/halo/attest/types/interface.go
+++ b/halo/attest/types/interface.go
@@ -10,12 +10,6 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 )
 
-// ChainVersion represents a version of the chain wrt Attestations; either fuzzy (draft) or finalized (final).
-type ChainVersion struct {
-	ChainID   uint64
-	ConfLevel uint32
-}
-
 // Voter abstracts the validator duty of v∂oting for all
 // XBlocks for all source chains.
 //
@@ -45,7 +39,7 @@ type Voter interface {
 
 	// TrimBehind deletes all available votes that are behind the vote window minimums (map[chainID]minimum) since
 	// they will never be committed. It returns the number that was deleted.
-	TrimBehind(minsByChain map[ChainVersion]uint64) int
+	TrimBehind(minsByChain map[xchain.ChainVersion]uint64) int
 
 	// UpdateValidators sets the latest validator set when passed to cometBFT.
 	// This is used to calculate whether the voter is in-or-out of the validator set.
@@ -55,8 +49,8 @@ type Voter interface {
 // VoterDeps abstracts the Voter's internal cosmosSDK dependencies; basically the attest keeper.
 // They have a circular dependency.
 type VoterDeps interface {
-	// LatestAttestation returns the latest approved attestation for the given chain.
-	LatestAttestation(ctx context.Context, chainID uint64, conf xchain.ConfLevel) (xchain.Attestation, bool, error)
+	// LatestAttestation returns the latest approved attestation for the given chain version.
+	LatestAttestation(ctx context.Context, chainVer xchain.ChainVersion) (xchain.Attestation, bool, error)
 }
 
 // ChainNameFunc is a function that returns the name of a chain given its ID.

--- a/halo/attest/types/translate.go
+++ b/halo/attest/types/translate.go
@@ -6,10 +6,10 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 )
 
-func (h *BlockHeader) ChainVersion() ChainVersion {
-	return ChainVersion{
-		ChainID:   h.ChainId,
-		ConfLevel: h.ConfLevel,
+func (h *BlockHeader) XChainVersion() xchain.ChainVersion {
+	return xchain.ChainVersion{
+		ID:        h.ChainId,
+		ConfLevel: xchain.ConfLevel(h.ConfLevel),
 	}
 }
 

--- a/halo/attest/voter/voter_internal_test.go
+++ b/halo/attest/voter/voter_internal_test.go
@@ -28,6 +28,6 @@ func LoadVoterForT(t *testing.T, privKey crypto.PrivKey, path string, provider x
 }
 
 // LatestByChain returns the latest vote by chain for testing purposes only.
-func (v *Voter) LatestByChain(chainID uint64, conf uint32) (*types.Vote, bool) {
-	return v.latestByChain(types.ChainVersion{ChainID: chainID, ConfLevel: conf})
+func (v *Voter) LatestByChain(chainVer xchain.ChainVersion) (*types.Vote, bool) {
+	return v.latestByChain(chainVer)
 }

--- a/halo/attest/voter/voter_test.go
+++ b/halo/attest/voter/voter_test.go
@@ -177,7 +177,7 @@ func TestVoteWindow(t *testing.T) {
 	w.Available(t, chain1, 3, false)
 
 	// Ensure latest by chain not trimmed.
-	latest, ok := w.v.LatestByChain(chain1, uint32(xchain.ConfFinalized))
+	latest, ok := w.v.LatestByChain(xchain.ChainVersion{ID: chain1, ConfLevel: xchain.ConfFinalized})
 	require.True(t, ok)
 	require.EqualValues(t, 3, latest.BlockHeader.Offset)
 }
@@ -417,7 +417,7 @@ func (m *mockDeps) SetHeightAndOffset(height, offset uint64) {
 	m.offset = offset
 }
 
-func (m *mockDeps) LatestAttestation(context.Context, uint64, xchain.ConfLevel) (xchain.Attestation, bool, error) {
+func (m *mockDeps) LatestAttestation(context.Context, xchain.ChainVersion) (xchain.Attestation, bool, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
@@ -430,7 +430,7 @@ func (m *mockDeps) LatestAttestation(context.Context, uint64, xchain.ConfLevel) 
 
 type stubDeps struct{}
 
-func (stubDeps) LatestAttestation(context.Context, uint64, xchain.ConfLevel) (xchain.Attestation, bool, error) {
+func (stubDeps) LatestAttestation(context.Context, xchain.ChainVersion) (xchain.Attestation, bool, error) {
 	return xchain.Attestation{}, false, nil
 }
 
@@ -522,11 +522,10 @@ func testNetwork(chainIDs ...uint64) netconf.Network {
 }
 
 //nolint:unparam // ChainID will change in future
-func minByChain(network netconf.Network, chainID uint64, min uint64) map[types.ChainVersion]uint64 {
+func minByChain(network netconf.Network, chainID uint64, min uint64) map[xchain.ChainVersion]uint64 {
 	chain, _ := network.Chain(chainID)
-	chainVer := types.ChainVersion{ChainID: chain.ID, ConfLevel: uint32(chain.FinalizationStrat.ConfLevel())}
 
-	return map[types.ChainVersion]uint64{
-		chainVer: min,
+	return map[xchain.ChainVersion]uint64{
+		chain.ChainVersions()[0]: min,
 	}
 }

--- a/lib/cchain/provider.go
+++ b/lib/cchain/provider.go
@@ -24,21 +24,21 @@ type Provider interface {
 	// the provided source chain ID, confLevel and XBlockOffset (inclusive).
 	//
 	// Worker name is only used for metrics.
-	Subscribe(ctx context.Context, sourceChainID uint64, conf xchain.ConfLevel, xBlockOffset uint64,
+	Subscribe(ctx context.Context, chainVer xchain.ChainVersion, xBlockOffset uint64,
 		workerName string, callback ProviderCallback)
 
 	// AttestationsFrom returns the subsequent approved attestations for the provided source chain
 	// and XBlockOffset (inclusive). It will return max 100 attestations per call.
-	AttestationsFrom(ctx context.Context, sourceChainID uint64, conf xchain.ConfLevel, xBlockOffset uint64) ([]xchain.Attestation, error)
+	AttestationsFrom(ctx context.Context, chainVer xchain.ChainVersion, xBlockOffset uint64) ([]xchain.Attestation, error)
 
 	// LatestAttestation returns the latest approved attestation for the provided source chain or false
 	// if none exist.
-	LatestAttestation(ctx context.Context, sourceChainID uint64, conf xchain.ConfLevel) (xchain.Attestation, bool, error)
+	LatestAttestation(ctx context.Context, chainVer xchain.ChainVersion) (xchain.Attestation, bool, error)
 
 	// WindowCompare returns whether the given attestation block header is behind (-1), or in (0), or ahead (1)
 	// of the current vote window. The vote window is a configured number of blocks around the latest approved
 	// attestation for the provided chain.
-	WindowCompare(ctx context.Context, sourceChainID uint64, conf xchain.ConfLevel, xBlockOffset uint64) (int, error)
+	WindowCompare(ctx context.Context, chainVer xchain.ChainVersion, xBlockOffset uint64) (int, error)
 
 	// ValidatorSet returns the validators for the given validator set ID or false if none exist or an error.
 	// Note the genesis validator set has ID 1.

--- a/lib/cchain/provider/abci.go
+++ b/lib/cchain/provider/abci.go
@@ -114,7 +114,7 @@ func newABCIValsetFunc(cl vtypes.QueryClient) valsetFunc {
 }
 
 func newABCIFetchFunc(cl atypes.QueryClient) fetchFunc {
-	return func(ctx context.Context, chainID uint64, conf xchain.ConfLevel, fromOffset uint64) ([]xchain.Attestation, error) {
+	return func(ctx context.Context, chainVer xchain.ChainVersion, fromOffset uint64) ([]xchain.Attestation, error) {
 		const endpoint = "attestations_from"
 		defer latency(endpoint)()
 
@@ -122,8 +122,8 @@ func newABCIFetchFunc(cl atypes.QueryClient) fetchFunc {
 		defer span.End()
 
 		resp, err := cl.AttestationsFrom(ctx, &atypes.AttestationsFromRequest{
-			ChainId:    chainID,
-			ConfLevel:  uint32(conf),
+			ChainId:    chainVer.ID,
+			ConfLevel:  uint32(chainVer.ConfLevel),
 			FromOffset: fromOffset,
 		})
 		if err != nil {
@@ -141,7 +141,7 @@ func newABCIFetchFunc(cl atypes.QueryClient) fetchFunc {
 }
 
 func newABCIWindowFunc(cl atypes.QueryClient) windowFunc {
-	return func(ctx context.Context, chainID uint64, conf xchain.ConfLevel, xBlockOffset uint64) (int, error) {
+	return func(ctx context.Context, chainVer xchain.ChainVersion, xBlockOffset uint64) (int, error) {
 		const endpoint = "window_compare"
 		defer latency(endpoint)()
 
@@ -149,8 +149,8 @@ func newABCIWindowFunc(cl atypes.QueryClient) windowFunc {
 		defer span.End()
 
 		resp, err := cl.WindowCompare(ctx, &atypes.WindowCompareRequest{
-			ChainId:     chainID,
-			ConfLevel:   uint32(conf),
+			ChainId:     chainVer.ID,
+			ConfLevel:   uint32(chainVer.ConfLevel),
 			BlockOffset: xBlockOffset,
 		})
 		if err != nil {
@@ -163,7 +163,7 @@ func newABCIWindowFunc(cl atypes.QueryClient) windowFunc {
 }
 
 func newABCILatestFunc(cl atypes.QueryClient) latestFunc {
-	return func(ctx context.Context, chainID uint64, conf xchain.ConfLevel) (xchain.Attestation, bool, error) {
+	return func(ctx context.Context, chainVer xchain.ChainVersion) (xchain.Attestation, bool, error) {
 		const endpoint = "latest_attestation"
 		defer latency(endpoint)()
 
@@ -171,8 +171,8 @@ func newABCILatestFunc(cl atypes.QueryClient) latestFunc {
 		defer span.End()
 
 		resp, err := cl.LatestAttestation(ctx, &atypes.LatestAttestationRequest{
-			ChainId:   chainID,
-			ConfLevel: uint32(conf),
+			ChainId:   chainVer.ID,
+			ConfLevel: uint32(chainVer.ConfLevel),
 		})
 		if errors.Is(err, sdkerrors.ErrKeyNotFound) {
 			return xchain.Attestation{}, false, nil

--- a/lib/cchain/provider/provider_test.go
+++ b/lib/cchain/provider/provider_test.go
@@ -36,7 +36,8 @@ func TestProvider(t *testing.T) {
 	var wg sync.WaitGroup
 	wg.Add(1)
 
-	p.Subscribe(ctx, chainID, conf, fromHeight, "test", func(ctx context.Context, approved xchain.Attestation) error {
+	chainVer := xchain.ChainVersion{ID: chainID, ConfLevel: conf}
+	p.Subscribe(ctx, chainVer, fromHeight, "test", func(ctx context.Context, approved xchain.Attestation) error {
 		actual = append(actual, approved)
 		if len(actual) == total {
 			cancel()  // Cancel the context to stop further fetch operations
@@ -101,7 +102,7 @@ func (f *testFetcher) Errs() int {
 	return f.errs
 }
 
-func (f *testFetcher) Fetch(_ context.Context, chainID uint64, conf xchain.ConfLevel, fromHeight uint64,
+func (f *testFetcher) Fetch(_ context.Context, chainVer xchain.ChainVersion, fromHeight uint64,
 ) ([]xchain.Attestation, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
@@ -118,8 +119,8 @@ func (f *testFetcher) Fetch(_ context.Context, chainID uint64, conf xchain.ConfL
 	for i := 0; i < toReturn; i++ {
 		resp = append(resp, xchain.Attestation{
 			BlockHeader: xchain.BlockHeader{
-				SourceChainID: chainID,
-				ConfLevel:     conf,
+				SourceChainID: chainVer.ID,
+				ConfLevel:     chainVer.ConfLevel,
 				BlockOffset:   fromHeight + uint64(i),
 			},
 		})

--- a/lib/netconf/netconf.go
+++ b/lib/netconf/netconf.go
@@ -288,3 +288,17 @@ func (c Chain) ConfLevels() []xchain.ConfLevel {
 
 	return confs
 }
+
+// ChainVersions returns the uniq set of chain versions
+// supported by the chain. This is inferred from the supported shards.
+func (c Chain) ChainVersions() []xchain.ChainVersion {
+	var resp []xchain.ChainVersion
+	for _, conf := range c.ConfLevels() {
+		resp = append(resp, xchain.ChainVersion{
+			ID:        c.ID,
+			ConfLevel: conf,
+		})
+	}
+
+	return resp
+}

--- a/lib/xchain/types.go
+++ b/lib/xchain/types.go
@@ -58,6 +58,10 @@ func (s StreamID) ConfLevel() ConfLevel {
 	return ConfLevel(s.ShardID)
 }
 
+func (s StreamID) ChainVersion() ChainVersion {
+	return ChainVersion{ID: s.SourceChainID, ConfLevel: s.ConfLevel()}
+}
+
 // MsgID uniquely identifies a cross-chain message.
 type MsgID struct {
 	StreamID            // Unique ID of the Stream this message belongs to
@@ -92,6 +96,10 @@ type BlockHeader struct {
 	BlockOffset   uint64      // MsgOffset of the cross-chain block
 	BlockHeight   uint64      // Height of the source-chain block
 	BlockHash     common.Hash // Hash of the source-chain block
+}
+
+func (b BlockHeader) ChainVersion() ChainVersion {
+	return ChainVersion{ID: b.SourceChainID, ConfLevel: b.ConfLevel}
 }
 
 // Block is a deterministic representation of the omni cross-chain properties of a source chain EVM block.

--- a/relayer/app/cursors_internal_test.go
+++ b/relayer/app/cursors_internal_test.go
@@ -164,11 +164,11 @@ func (m *mockSender) SendTransaction(ctx context.Context, submission xchain.Subm
 
 type mockProvider struct {
 	cchain.Provider
-	SubscribeFn func(ctx context.Context, sourceChainID uint64, conf xchain.ConfLevel, xBlockOffset uint64, callback cchain.ProviderCallback)
+	SubscribeFn func(ctx context.Context, chainVer xchain.ChainVersion, xBlockOffset uint64, callback cchain.ProviderCallback)
 }
 
-func (m *mockProvider) Subscribe(ctx context.Context, sourceChainID uint64, conf xchain.ConfLevel, xBlockOffset uint64,
+func (m *mockProvider) Subscribe(ctx context.Context, chainVer xchain.ChainVersion, xBlockOffset uint64,
 	_ string, callback cchain.ProviderCallback,
 ) {
-	m.SubscribeFn(ctx, sourceChainID, conf, xBlockOffset, callback)
+	m.SubscribeFn(ctx, chainVer, xBlockOffset, callback)
 }

--- a/relayer/app/monitor.go
+++ b/relayer/app/monitor.go
@@ -144,6 +144,8 @@ func monitorAttestedForever(
 	xprovider xchain.Provider,
 	network netconf.Network,
 ) {
+	chainVer := srcChain.ChainVersions()[0]
+
 	ticker := time.NewTicker(time.Minute)
 	defer ticker.Stop()
 
@@ -153,7 +155,7 @@ func monitorAttestedForever(
 			return
 		case <-ticker.C:
 			// First get attested head (so it can't be lower than heads).
-			att, err := getAttested(ctx, srcChain.ID, srcChain.FinalizationStrat.ConfLevel(), cprovider)
+			att, err := getAttested(ctx, chainVer, cprovider)
 			// Then populate gauges "at the same time" so they update "atomically".
 			if err != nil {
 				log.Error(ctx, "Monitoring attested failed (will retry)", err, "chain", srcChain.Name)
@@ -219,8 +221,8 @@ func getEVMHeads(ctx context.Context, client ethclient.Client) map[ethclient.Hea
 }
 
 // monitorAttestedOnce monitors of the latest attested height by chain.
-func getAttested(ctx context.Context, chainID uint64, conf xchain.ConfLevel, cprovider cchain.Provider) (xchain.Attestation, error) {
-	att, ok, err := cprovider.LatestAttestation(ctx, chainID, conf)
+func getAttested(ctx context.Context, chainVer xchain.ChainVersion, cprovider cchain.Provider) (xchain.Attestation, error) {
+	att, ok, err := cprovider.LatestAttestation(ctx, chainVer)
 	if err != nil {
 		return xchain.Attestation{}, errors.Wrap(err, "latest attestation")
 	} else if !ok {

--- a/relayer/app/worker.go
+++ b/relayer/app/worker.go
@@ -106,7 +106,7 @@ func (w *Worker) runOnce(ctx context.Context) error {
 		callback := newCallback(w.xProvider, initialOffsets, w.creator, buf.AddInput, w.destChain.ID, newMsgStreamMapper(w.network), w.awaitValSet)
 		wrapCb := wrapStatePersist(callback, w.state, w.destChain.ID)
 
-		w.cProvider.Subscribe(ctx, stream.SourceChainID, stream.ConfLevel(), fromOffset, w.destChain.Name, wrapCb)
+		w.cProvider.Subscribe(ctx, stream.ChainVersion(), fromOffset, w.destChain.Name, wrapCb)
 
 		logAttrs = append(logAttrs, srcChain.Name, fromOffset)
 	}

--- a/relayer/app/worker_internal_test.go
+++ b/relayer/app/worker_internal_test.go
@@ -95,8 +95,8 @@ func TestWorker_Run(t *testing.T) {
 
 	// Provider mock attestations as requested until context canceled.
 	mockProvider := &mockProvider{
-		SubscribeFn: func(ctx context.Context, chainID uint64, conf xchain.ConfLevel, xBlockOffset uint64, callback cchain.ProviderCallback) {
-			if chainID != srcChain {
+		SubscribeFn: func(ctx context.Context, chainVer xchain.ChainVersion, xBlockOffset uint64, callback cchain.ProviderCallback) {
+			if chainVer.ID != srcChain {
 				return // Only subscribe to source chain.
 			}
 			// require.EqualValues(t, destChainACursor, xBlockOffset)
@@ -109,8 +109,8 @@ func TestWorker_Run(t *testing.T) {
 				defer func() { offset++ }()
 				return xchain.Attestation{
 					BlockHeader: xchain.BlockHeader{
-						SourceChainID: chainID,
-						ConfLevel:     conf,
+						SourceChainID: chainVer.ID,
+						ConfLevel:     chainVer.ConfLevel,
 						BlockOffset:   offset},
 				}
 			}


### PR DESCRIPTION
Formalize the `xchain.ChainVersion` type. Use it in `CProvider` and `attest` module and `voter`

task: none