### PR TITLE
ci(e2e): harden e2e tests

### DIFF
--- a/e2e/app/run.go
+++ b/e2e/app/run.go
@@ -301,7 +301,7 @@ func deployMonitorOnly(ctx context.Context, def Definition, cfg DeployConfig) er
 
 // waitForSupportedChains waits for all dest chains to be supported by all src chains.
 func waitForSupportedChains(ctx context.Context, def Definition) error {
-	ticker := time.NewTicker(10 * time.Second)
+	ticker := time.NewTicker(time.Second)
 	defer ticker.Stop()
 	attempt := 1
 
@@ -320,8 +320,8 @@ func waitForSupportedChains(ctx context.Context, def Definition) error {
 				return nil
 			}
 
-			if attempt > 10 {
-				return errors.New(" wait for supported chains")
+			if attempt > 60 {
+				return errors.New("timeout waiting for supported chains")
 			}
 
 			log.Debug(ctx, "Waiting for supported chains", "attempt", attempt)

--- a/lib/cchain/provider/abci.go
+++ b/lib/cchain/provider/abci.go
@@ -3,6 +3,7 @@ package provider
 import (
 	"context"
 	"sync"
+	"time"
 
 	atypes "github.com/omni-network/omni/halo/attest/types"
 	vtypes "github.com/omni-network/omni/halo/valsync/types"
@@ -31,8 +32,9 @@ type ABCIClient interface {
 }
 
 func NewABCIProvider(abci ABCIClient, network netconf.ID, chainNamer func(uint64) string) Provider {
+	// Stream backoff for 1s, querying new attestations after 1 consensus block
 	backoffFunc := func(ctx context.Context) func() {
-		return expbackoff.New(ctx)
+		return expbackoff.New(ctx, expbackoff.WithPeriodicConfig(time.Second))
 	}
 
 	acl := atypes.NewQueryClient(rpcAdaptor{abci: abci})

--- a/lib/xchain/provider/provider.go
+++ b/lib/xchain/provider/provider.go
@@ -64,7 +64,12 @@ type Provider struct {
 // subscriptions for respective destination XBlocks.
 func New(network netconf.Network, rpcClients map[uint64]ethclient.Client, cProvider cchain.Provider) *Provider {
 	backoffFunc := func(ctx context.Context) func() {
-		return expbackoff.New(ctx)
+		// Limit backoff to 10s for all EVM chains.
+		const maxDelay = time.Second * 10
+		cfg := expbackoff.DefaultConfig
+		cfg.MaxDelay = maxDelay
+
+		return expbackoff.New(ctx, expbackoff.With(cfg))
 	}
 
 	cChain, _ := network.OmniConsensusChain()

--- a/relayer/app/sender.go
+++ b/relayer/app/sender.go
@@ -95,7 +95,8 @@ func (o Sender) SendTransaction(ctx context.Context, sub xchain.Submission) erro
 
 	ctx = log.WithCtx(ctx, reqAttrs...)
 	log.Debug(ctx, "Received submission",
-		"start_offset", startOffset,
+		"block_offset", sub.BlockHeader.BlockOffset,
+		"start_msg_offset", startOffset,
 		"msgs", len(sub.Msgs),
 	)
 


### PR DESCRIPTION
Harden e2e tests:
 - decrease waiting for supported chain (make it faster)
 - prevent blocking in evmengine retry forever
 - limit cprovider backoffs to 1s (consensus block time) (previous 2min could cause timeouts)
 - limit xprovider backoffs to 10s (good average between all evm finalizations)
 - Add `block_offset` to relayer logs

task: none