### PR TITLE
chore(relayer): merge finalized and latest streams

### DIFF
--- a/lib/netconf/netconf.go
+++ b/lib/netconf/netconf.go
@@ -3,6 +3,7 @@
 package netconf
 
 import (
+	"fmt"
 	"sort"
 	"time"
 
@@ -118,6 +119,13 @@ func (n Network) ChainName(id uint64) string {
 	return chain.Name
 }
 
+// ChainVersionName returns the chain version name for the given ID or an empty string if it does not exist.
+func (n Network) ChainVersionName(chainVer xchain.ChainVersion) string {
+	chain, _ := n.Chain(chainVer.ID)
+
+	return fmt.Sprintf("%s-%s", chain.Name, chainVer.ConfLevel)
+}
+
 // Chain returns the chain config for the given ID or false if it does not exist.
 func (n Network) Chain(id uint64) (Chain, bool) {
 	for _, chain := range n.Chains {
@@ -127,6 +135,20 @@ func (n Network) Chain(id uint64) (Chain, bool) {
 	}
 
 	return Chain{}, false
+}
+
+// ChainVersionsTo returns the all chain versions submitted to the provided destination chain.
+func (n Network) ChainVersionsTo(dstChainID uint64) []xchain.ChainVersion {
+	var resp []xchain.ChainVersion
+	for _, chain := range n.Chains {
+		if chain.ID == dstChainID {
+			continue // Skip self
+		}
+
+		resp = append(resp, chain.ChainVersions()...)
+	}
+
+	return resp
 }
 
 // StreamsTo returns the all streams to the provided destination chain.

--- a/lib/xchain/types.go
+++ b/lib/xchain/types.go
@@ -66,7 +66,7 @@ func (s StreamID) ChainVersion() ChainVersion {
 // MsgID uniquely identifies a cross-chain message.
 type MsgID struct {
 	StreamID            // Unique ID of the Stream this message belongs to
-	StreamOffset uint64 // Monotonically incremented offset of Msg in the Steam
+	StreamOffset uint64 // Monotonically incremented offset of Msg in the Steam (1-indexed)
 }
 
 // Msg is a cross-chain message.

--- a/relayer/app/cursors.go
+++ b/relayer/app/cursors.go
@@ -3,8 +3,11 @@ package relayer
 import (
 	"context"
 	"sort"
+	"sync"
 
 	"github.com/omni-network/omni/lib/errors"
+	"github.com/omni-network/omni/lib/expbackoff"
+	"github.com/omni-network/omni/lib/log"
 	"github.com/omni-network/omni/lib/netconf"
 	"github.com/omni-network/omni/lib/xchain"
 )
@@ -13,64 +16,71 @@ import (
 const initialXBlockOffset = 1
 
 // getSubmittedCursors returns the last submitted cursor for each source chain on the destination chain.
-// It also returns the offsets indexed by streamID for each stream.
 func getSubmittedCursors(ctx context.Context, network netconf.Network, dstChainID uint64, xClient xchain.Provider,
-) ([]xchain.StreamCursor, map[xchain.StreamID]uint64, error) {
-	var cursors []xchain.StreamCursor                  //nolint:prealloc // Not worth it.
-	initialOffsets := make(map[xchain.StreamID]uint64) // Initial submitted offsets for each stream.
+) ([]xchain.StreamCursor, error) {
+	var cursors []xchain.StreamCursor //nolint:prealloc // Not worth it.
 	for _, stream := range network.StreamsTo(dstChainID) {
 		cursor, ok, err := xClient.GetSubmittedCursor(ctx, stream)
 		if err != nil {
-			return nil, nil, errors.Wrap(err, "failed to get submitted cursors", "src_chain", stream.SourceChainID)
+			return nil, errors.Wrap(err, "failed to get submitted cursors", "src_chain", stream.SourceChainID)
 		} else if !ok {
 			continue
 		}
 
-		initialOffsets[cursor.StreamID] = cursor.MsgOffset
 		cursors = append(cursors, cursor)
 	}
 
-	return cursors, initialOffsets, nil
+	return cursors, nil
 }
 
 // filterMsgs filters messages based on offsets for a specific stream.
 // It takes a slice of messages, offsets indexed by stream ID, and the target stream ID,
 // and returns a filtered slice containing only messages with offsets greater than the specified offset.
-func filterMsgs(msgs []xchain.Msg, offsets map[xchain.StreamID]uint64, streamID xchain.StreamID) []xchain.Msg {
-	offset, ok := offsets[streamID]
-	if !ok {
-		return msgs // No offset, so no filtering.
-	}
-
+func filterMsgs(ctx context.Context, streamID xchain.StreamID, msgs []xchain.Msg, msgFilter *msgOffsetFilter) ([]xchain.Msg, error) {
+	backoff := expbackoff.New(ctx)
 	res := make([]xchain.Msg, 0, len(msgs)) // Res might have over-capacity, but that's fine, we only filter on startup.
-	for _, msg := range msgs {
-		if msg.StreamOffset <= offset {
-			// filter msgs lower than offset
-			continue
+	for i := 0; i < len(msgs); {
+		msg := msgs[i]
+
+		check := msgFilter.Check(streamID, msg.StreamOffset)
+		if check == checkProcess {
+			res = append(res, msg)
 		}
-		res = append(res, msg)
+		if check != checkGap {
+			i++
+			continue // Continue to next message
+		}
+		// else checkGap
+
+		if !streamID.ConfLevel().IsFuzzy() {
+			return nil, errors.New("unexpected gap in finalized msg offsets [BUG]", "offset", msg.StreamOffset)
+		}
+
+		// Re-orgs of fuzzy conf levels are expected and can create gaps, block until ConfFinalized fills the gap.
+		log.Warn(ctx, "Gap in fuzzy msg offsets, waiting for ConfFinalized", nil, "stream", streamID, "offset", msg.StreamOffset)
+		backoff()
+		// Retry the same message again
 	}
 
-	return res
+	return res, nil
 }
 
-// fromOffsets calculates the starting offsets for all streams (to the destination chain).
-// It takes submitted stream cursors, destination and source chains, and the current state, and returns
-// a map where keys are source chain IDs and values are the starting offsets for streaming.
-func fromOffsets(
+// fromChainVersionOffsets calculates the starting block offsets for all chain versions (to the destination chain).
+func fromChainVersionOffsets(
+	destChainID uint64, // Destination chain ID
 	cursors []xchain.StreamCursor, // All actual on-chain submit cursors
-	streams []xchain.StreamID, // All expected streams
+	chainVers []xchain.ChainVersion, // All expected chain versions
 	state *State, // On-disk local state
-) (map[xchain.StreamID]uint64, error) {
-	res := make(map[xchain.StreamID]uint64)
+) (map[xchain.ChainVersion]uint64, error) {
+	res := make(map[xchain.ChainVersion]uint64)
 
-	// Initialize all streams to start at 1 by default or if local state is present
-	for _, stream := range streams {
-		res[stream] = initialXBlockOffset
+	// Initialize all chain versions to start at 1 by default or if local state is present
+	for _, chainVer := range chainVers {
+		res[chainVer] = initialXBlockOffset
 
 		// If local persisted state is higher, use that instead, skipping a bunch of empty blocks on startup.
-		if offset := state.GetOffset(stream.DestChainID, stream.SourceChainID); offset > initialXBlockOffset {
-			res[stream] = offset
+		if offset := state.GetOffset(destChainID, chainVer); offset > initialXBlockOffset {
+			res[chainVer] = offset
 		}
 	}
 
@@ -80,7 +90,11 @@ func fromOffsets(
 	})
 
 	for _, cursor := range cursors {
-		offset, ok := res[cursor.StreamID]
+		if cursor.DestChainID != destChainID {
+			return nil, errors.New("unexpected cursor [BUG]")
+		}
+
+		offset, ok := res[cursor.ChainVersion()]
 		if !ok {
 			return nil, errors.New("unexpected cursor [BUG]")
 		}
@@ -89,8 +103,59 @@ func fromOffsets(
 			continue // Skip if local state is higher than cursor
 		}
 
-		res[cursor.StreamID] = cursor.BlockOffset
+		res[cursor.ChainVersion()] = cursor.BlockOffset
 	}
 
 	return res, nil
+}
+
+// msgOffsetFilter is a filter that keeps track of the last processed message offset for each stream.
+// It is used to filter out messages that have already been processed.
+//
+// More specifically, it ensures that fuzzy msgs are submitted either from fuzzy or finalized attestations, whichever comes first.
+type msgOffsetFilter struct {
+	mu      sync.Mutex
+	offsets map[xchain.StreamID]uint64
+}
+
+func newMsgOffsetFilter(cursors []xchain.StreamCursor) *msgOffsetFilter {
+	offsets := make(map[xchain.StreamID]uint64, len(cursors))
+	for _, cursor := range cursors {
+		offsets[cursor.StreamID] = cursor.MsgOffset
+	}
+
+	return &msgOffsetFilter{
+		offsets: offsets,
+	}
+}
+
+type checkResult int
+
+const (
+	// checkProcess indicates that the message offset is sequential and should be processed.
+	checkProcess checkResult = iota
+	// checkGap indicates that the message offset is too far ahead and therefore contains a gap.
+	checkGap
+	// checkIgnore indicates that the message offset was already processed and should be ignored.
+	checkIgnore
+)
+
+// Check updates the stream state and returns checkProcess if the provided offset is sequential.
+// Otherwise it does not update the state and returns checkGap if the next message is too far ahead,
+// or checkIgnore if the next message was already processed.
+func (f *msgOffsetFilter) Check(stream xchain.StreamID, msgOffset uint64) checkResult {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	expect := f.offsets[stream] + 1
+	if msgOffset > expect {
+		return checkGap
+	} else if msgOffset < expect {
+		return checkIgnore
+	}
+
+	// Update the offset
+	f.offsets[stream] = msgOffset
+
+	return checkProcess
 }

--- a/relayer/app/state.go
+++ b/relayer/app/state.go
@@ -6,31 +6,33 @@ import (
 	"sync"
 
 	"github.com/omni-network/omni/lib/errors"
+	"github.com/omni-network/omni/lib/xchain"
 
 	"github.com/cometbft/cometbft/libs/tempfile"
 )
 
-// State represents the state of the relayer. It keeps track of the last successfully processed block.
+// State represents the state of the relayer workers. It keeps track of the last successfully processed block offset
+// per source chain version per dest chain worker.
 type State struct {
 	mu       sync.Mutex
 	filePath string
-	cursors  map[uint64]map[uint64]uint64 // destChainID -> srcChainID -> offset
+	cursors  map[uint64]map[uint64]map[xchain.ConfLevel]uint64 // destChainID -> srcChainID -> ConfLevel -> blockOffset
 }
 
 // NewEmptyState creates a new empty state with the given file path.
 func NewEmptyState(filePath string) *State {
 	return &State{
 		filePath: filePath,
-		cursors:  make(map[uint64]map[uint64]uint64),
+		cursors:  make(map[uint64]map[uint64]map[xchain.ConfLevel]uint64),
 	}
 }
 
 // GetOffset returns the last submitted offset for the given destChainID and srcChainID.
-func (s *State) GetOffset(dstID, srcID uint64) uint64 {
+func (s *State) GetOffset(dstID uint64, chainVer xchain.ChainVersion) uint64 {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	return s.cursors[dstID][srcID]
+	return s.cursors[dstID][chainVer.ID][chainVer.ConfLevel]
 }
 
 // Clear deletes all destination chain cursors.
@@ -44,17 +46,18 @@ func (s *State) Clear(dstID uint64) error {
 }
 
 // Persist saves the given offset for the given src and dest chain pair..
-func (s *State) Persist(dstID, srcID, offset uint64) error {
+func (s *State) Persist(dstID uint64, srcID xchain.ChainVersion, offset uint64) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	srcMap, ok := s.cursors[dstID]
-	if !ok {
-		srcMap = make(map[uint64]uint64)
+	if _, ok := s.cursors[dstID]; !ok {
+		s.cursors[dstID] = make(map[uint64]map[xchain.ConfLevel]uint64)
 	}
-	srcMap[srcID] = offset
+	if _, ok := s.cursors[dstID][srcID.ID]; !ok {
+		s.cursors[dstID][srcID.ID] = make(map[xchain.ConfLevel]uint64)
+	}
 
-	s.cursors[dstID] = srcMap
+	s.cursors[dstID][srcID.ID][srcID.ConfLevel] = offset
 
 	return s.saveUnsafe()
 }
@@ -62,12 +65,12 @@ func (s *State) Persist(dstID, srcID, offset uint64) error {
 // saveUnsafe saves the state to disk. It is labeled as "unsafe" because it assumes the caller holds the necessary lock to ensure
 // concurrent access safety. This function serializes the state to JSON format and atomically writes it to the specified file path.
 func (s *State) saveUnsafe() error {
-	bytes, err := json.Marshal(s.cursors)
+	bz, err := json.Marshal(s.cursors)
 	if err != nil {
 		return errors.Wrap(err, "marshal file")
 	}
 
-	if err := tempfile.WriteFileAtomic(s.filePath, bytes, 0o600); err != nil {
+	if err := tempfile.WriteFileAtomic(s.filePath, bz, 0o600); err != nil {
 		return errors.Wrap(err, "write persistent file")
 	}
 
@@ -85,7 +88,7 @@ func LoadCursors(path string) (*State, bool, error) {
 		return nil, false, errors.Wrap(err, "read state file")
 	}
 
-	cursors := make(map[uint64]map[uint64]uint64)
+	cursors := make(map[uint64]map[uint64]map[xchain.ConfLevel]uint64)
 	if err := json.Unmarshal(bytes, &cursors); err != nil {
 		return nil, false, errors.Wrap(err, "unmarshal state file")
 	}


### PR DESCRIPTION
Refactor relayer to support multiple attestation streams:
 - Subscribe to attestations per `ChainVer`, track state per DestChain-ChainVer pair.
 - Implement `MsgOffsetFilter` to pick the first MsgOffset from either `Fuzzy` or `Finalized` chains.
 

task: none