### PR TITLE
docs(cli): use latest tag with src install

### DIFF
--- a/docs/site/docs/tools/cli/cli.md
+++ b/docs/site/docs/tools/cli/cli.md
@@ -28,6 +28,8 @@ curl -sSfL https://raw.githubusercontent.com/omni-network/omni/main/scripts/inst
     ```bash
     git clone https://github.com/omni-network/omni.git
     cd omni
+    latest_tag=$(curl -s https://api.github.com/repos/omni-network/omni/releases/latest | jq -r .tag_name)
+    git checkout $latest_tag
     make install-cli
     ```
   </TabItem>
@@ -35,6 +37,8 @@ curl -sSfL https://raw.githubusercontent.com/omni-network/omni/main/scripts/inst
     ```bash
     git clone https://github.com/omni-network/omni.git
     cd omni
+    latest_tag=$(curl -s https://api.github.com/repos/omni-network/omni/releases/latest | jq -r .tag_name)
+    git checkout $latest_tag
     go install ./cli/cmd/omni
     ```
   </TabItem>


### PR DESCRIPTION
related to #1151 CLI devnet will use commit tag when fetching docker images

task: none