### PR TITLE
refactor(relayer): skip mismatching fuzzy attestations

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -103,6 +103,7 @@ dockers:
 
 archives:
   - format: tar.gz
+    allow_different_binary_count: true # Required since anvilproxy only has linux-amd64
     # this name template makes the OS and Arch compatible with the results of `uname`.
     name_template: >-
       {{ .ProjectName }}_

--- a/e2e/app/monitor.go
+++ b/e2e/app/monitor.go
@@ -41,7 +41,7 @@ func StartMonitoringReceipts(ctx context.Context, def Definition) func() error {
 	}
 
 	network := networkFromDef(def)
-	cProvider := cprovider.NewABCIProvider(client, def.Testnet.Network, netconf.ChainNamer(def.Testnet.Network))
+	cProvider := cprovider.NewABCIProvider(client, def.Testnet.Network, netconf.ChainVersionNamer(def.Testnet.Network))
 	xProvider := xprovider.New(network, def.Backends().RPCClients(), cProvider)
 	cChainID := def.Testnet.Network.Static().OmniConsensusChainIDUint64()
 
@@ -155,7 +155,7 @@ func MonitorCProvider(ctx context.Context, node *e2e.Node, network netconf.Netwo
 		return errors.Wrap(err, "getting client")
 	}
 
-	cprov := cprovider.NewABCIProvider(client, network.ID, netconf.ChainNamer(network.ID))
+	cprov := cprovider.NewABCIProvider(client, network.ID, netconf.ChainVersionNamer(network.ID))
 
 	for _, chain := range network.Chains {
 		for _, chainVer := range chain.ChainVersions() {

--- a/halo/app/start.go
+++ b/halo/app/start.go
@@ -145,7 +145,7 @@ func Start(ctx context.Context, cfg Config) (<-chan error, func(context.Context)
 	cmtAPI := comet.NewAPI(rpcClient)
 	app.SetCometAPI(cmtAPI)
 
-	cProvider := cprovider.NewABCIProvider(rpcClient, cfg.Network, netconf.ChainNamer(cfg.Network))
+	cProvider := cprovider.NewABCIProvider(rpcClient, cfg.Network, netconf.ChainVersionNamer(cfg.Network))
 
 	async := make(chan error, 1)
 	go func() {

--- a/halo/app/start_test.go
+++ b/halo/app/start_test.go
@@ -45,7 +45,7 @@ func TestSmoke(t *testing.T) {
 	cl, err := rpchttp.New("http://localhost:26657", "/websocket")
 	require.NoError(t, err)
 
-	cprov := cprovider.NewABCIProvider(cl, netconf.Simnet, netconf.ChainNamer(netconf.Simnet))
+	cprov := cprovider.NewABCIProvider(cl, netconf.Simnet, netconf.ChainVersionNamer(netconf.Simnet))
 
 	// Wait until we get to block 3.
 	const target = uint64(3)

--- a/lib/cchain/provider/abci.go
+++ b/lib/cchain/provider/abci.go
@@ -31,7 +31,7 @@ type ABCIClient interface {
 	rpcclient.SignClient
 }
 
-func NewABCIProvider(abci ABCIClient, network netconf.ID, chainNamer func(uint64) string) Provider {
+func NewABCIProvider(abci ABCIClient, network netconf.ID, chainNamer func(xchain.ChainVersion) string) Provider {
 	// Stream backoff for 1s, querying new attestations after 1 consensus block
 	backoffFunc := func(ctx context.Context) func() {
 		return expbackoff.New(ctx, expbackoff.WithPeriodicConfig(time.Second))

--- a/lib/netconf/provider.go
+++ b/lib/netconf/provider.go
@@ -11,6 +11,7 @@ import (
 	"github.com/omni-network/omni/lib/evmchain"
 	"github.com/omni-network/omni/lib/expbackoff"
 	"github.com/omni-network/omni/lib/log"
+	"github.com/omni-network/omni/lib/xchain"
 
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
@@ -156,5 +157,11 @@ func MetadataByID(network ID, chainID uint64) evmchain.Metadata {
 func ChainNamer(network ID) func(uint64) string {
 	return func(chainID uint64) string {
 		return MetadataByID(network, chainID).Name
+	}
+}
+
+func ChainVersionNamer(network ID) func(version xchain.ChainVersion) string {
+	return func(chainVer xchain.ChainVersion) string {
+		return fmt.Sprintf("%s-%s", MetadataByID(network, chainVer.ID).Name, chainVer.ConfLevel)
 	}
 }

--- a/relayer/app/app.go
+++ b/relayer/app/app.go
@@ -55,7 +55,7 @@ func Run(ctx context.Context, cfg Config) error {
 		return err
 	}
 
-	cprov := cprovider.NewABCIProvider(tmClient, network.ID, netconf.ChainNamer(cfg.Network))
+	cprov := cprovider.NewABCIProvider(tmClient, network.ID, netconf.ChainVersionNamer(cfg.Network))
 	xprov := xprovider.New(network, rpcClientPerChain, cprov)
 
 	state, ok, err := LoadCursors(cfg.StateFile)

--- a/relayer/app/sender.go
+++ b/relayer/app/sender.go
@@ -95,6 +95,7 @@ func (o Sender) SendTransaction(ctx context.Context, sub xchain.Submission) erro
 
 	ctx = log.WithCtx(ctx, reqAttrs...)
 	log.Debug(ctx, "Received submission",
+		"conf", sub.BlockHeader.ConfLevel,
 		"block_offset", sub.BlockHeader.BlockOffset,
 		"start_msg_offset", startOffset,
 		"msgs", len(sub.Msgs),

--- a/relayer/app/worker_internal_test.go
+++ b/relayer/app/worker_internal_test.go
@@ -107,7 +107,17 @@ func TestWorker_Run(t *testing.T) {
 			offset := xBlockOffset
 			nextAtt := func() xchain.Attestation {
 				defer func() { offset++ }()
+
+				// Calculate the attestation root
+				block, _, _ := mockXClient.GetBlock(ctx, xchain.ProviderRequest{
+					ChainID:   chainVer.ID,
+					Offset:    offset,
+					ConfLevel: chainVer.ConfLevel,
+				})
+				tree, _ := xchain.NewBlockTree(block)
+
 				return xchain.Attestation{
+					AttestationRoot: tree.Root(),
 					BlockHeader: xchain.BlockHeader{
 						SourceChainID: chainVer.ID,
 						ConfLevel:     chainVer.ConfLevel,


### PR DESCRIPTION
Do not attempt to submit fuzzy attestations that do not match the fetched XBlock. Just skip since they will be submitted by finalized attestations.

Also improve logging and fix snapshot github action.

task: none