### PR TITLE
ci(e2e): support explicit fuzzy perturbations

### DIFF
--- a/e2e/anvilproxy/app/app.go
+++ b/e2e/anvilproxy/app/app.go
@@ -32,8 +32,8 @@ func Run(ctx context.Context, cfg Config) error {
 
 	mux := http.NewServeMux()
 	mux.Handle("/", http.HandlerFunc(proxy.Proxy))
-	mux.Handle("/fuzzy_head_enable", http.HandlerFunc(proxy.EnableFuzzyHead))
-	mux.Handle("/fuzzy_head_disable", http.HandlerFunc(proxy.DisableFuzzyHead))
+	mux.Handle("/fuzzy_enable", http.HandlerFunc(proxy.EnableFuzzyHead))
+	mux.Handle("/fuzzy_disable", http.HandlerFunc(proxy.DisableFuzzyHead))
 
 	httpServer := &http.Server{
 		Addr:              cfg.ListenAddr,

--- a/e2e/app/perturb.go
+++ b/e2e/app/perturb.go
@@ -65,13 +65,13 @@ func perturbService(ctx context.Context, service string, testnetDir string, pert
 		if err := docker.ExecCompose(ctx, testnetDir, "start", service); err != nil {
 			return errors.Wrap(err, "start service")
 		}
-	case types.PerturbFuzzyHead:
-		if err := docker.ExecCompose(ctx, testnetDir, "exec", service, "wget", "-O-", "localhost:8545/fuzzy_head_enable"); err != nil {
-			return errors.Wrap(err, "enable fork")
+	case types.PerturbFuzzyHeadAttRoot, types.PerturbFuzzyHeadDropBlocks, types.PerturbFuzzyHeadDropMsgs, types.PerturbFuzzyHeadMoreMsgs:
+		if err := docker.ExecCompose(ctx, testnetDir, "exec", service, "wget", "-O-", "localhost:8545/fuzzy_enable?perturb="+string(perturb)); err != nil {
+			return errors.Wrap(err, "enable fuzzy head")
 		}
-		time.Sleep(10 * time.Second)
-		if err := docker.ExecCompose(ctx, testnetDir, "exec", service, "wget", "-O-", "localhost:8545/fuzzy_head_disable"); err != nil {
-			return errors.Wrap(err, "disable fork")
+		time.Sleep(6 * time.Second)
+		if err := docker.ExecCompose(ctx, testnetDir, "exec", service, "wget", "-O-", "localhost:8545/fuzzy_disable"); err != nil {
+			return errors.Wrap(err, "disable fuzzy head")
 		}
 	default:
 		return errors.New("unknown service perturbation")

--- a/e2e/manifests/fuzzyhead.toml
+++ b/e2e/manifests/fuzzyhead.toml
@@ -9,4 +9,4 @@ pingpong_n = 6 # Increased ping pong to span forks
 [node.validator04]
 
 [perturb]
-mock_l1 = ["fuzzyhead","fuzzyhead","fuzzyhead"]
+mock_l1 = ["fuzzyhead_dropmsgs","fuzzyhead_dropblocks","fuzzyhead_attroot","fuzzyhead_moremsgs"]

--- a/e2e/types/manifest.go
+++ b/e2e/types/manifest.go
@@ -51,14 +51,22 @@ const (
 type Perturb string
 
 const (
+	PerturbUnknown Perturb = ""
 	// PerturbRestart defines a perturbation that restarts a docker container.
 	PerturbRestart Perturb = "restart"
 	// PerturbStopStart defines a perturbation that stops and then starts a docker container.
 	PerturbStopStart Perturb = "stopstart"
 	// PerturbRollback defines a perturbation that stops a halo node, performs a rollback, then starts it again.
 	PerturbRollback Perturb = "rollback"
-	// PerturbFuzzyHead defines a perturbation that enables fuzzyhead xmsgs on the anvilproxy for a while.
-	PerturbFuzzyHead Perturb = "fuzzyhead"
+
+	// PerturbFuzzyHeadDropBlocks defines a perturbation that enables fuzzyhead dropping xblock for a while.
+	PerturbFuzzyHeadDropBlocks Perturb = "fuzzyhead_dropblocks"
+	// PerturbFuzzyHeadDropMsgs defines a perturbation that enables fuzzyhead drop xmsgs for a while.
+	PerturbFuzzyHeadDropMsgs Perturb = "fuzzyhead_dropmsgs"
+	// PerturbFuzzyHeadAttRoot defines a perturbation that enables fuzzyhead inconsistent attestation root for a while.
+	PerturbFuzzyHeadAttRoot Perturb = "fuzzyhead_attroot"
+	// PerturbFuzzyHeadMoreMsgs defines a perturbation that enables fuzzyhead more/duplicate xmsgs for a while.
+	PerturbFuzzyHeadMoreMsgs Perturb = "fuzzyhead_moremsgs"
 )
 
 // Manifest wraps e2e.Manifest with additional omni-specific fields.


### PR DESCRIPTION
Support explicit fuzy perturbations instead of coming all fuzzy head types into a single pertubation.

Also add two more fuzzy perturbations.

task: none