### PR TITLE
chore(relayer): ensure increnting valsetid per shard

### DIFF
--- a/halo/attest/voter/voter_test.go
+++ b/halo/attest/voter/voter_test.go
@@ -465,11 +465,11 @@ func (stubProvider) GetBlock(context.Context, xchain.ProviderRequest) (xchain.Bl
 	panic("unexpected")
 }
 
-func (stubProvider) GetSubmittedCursor(context.Context, xchain.StreamID) (xchain.StreamCursor, bool, error) {
+func (stubProvider) GetSubmittedCursor(context.Context, xchain.StreamID) (xchain.SubmitCursor, bool, error) {
 	panic("unexpected")
 }
 
-func (stubProvider) GetEmittedCursor(context.Context, xchain.EmitRef, xchain.StreamID) (xchain.StreamCursor, bool, error) {
+func (stubProvider) GetEmittedCursor(context.Context, xchain.EmitRef, xchain.StreamID) (xchain.EmitCursor, bool, error) {
 	panic("unexpected")
 }
 

--- a/lib/xchain/merkle.go
+++ b/lib/xchain/merkle.go
@@ -30,6 +30,7 @@ func (t BlockTree) Proof(header BlockHeader, msgs []Msg) (merkle.MultiProof, err
 	indices = append(indices, headerIndex)
 
 	for _, msg := range msgs {
+		// TODO(corver): Filter msg shards by block confirmation level
 		msgLeaf, err := msgLeaf(msg)
 		if err != nil {
 			return merkle.MultiProof{}, err

--- a/lib/xchain/provider.go
+++ b/lib/xchain/provider.go
@@ -39,7 +39,7 @@ type Provider interface {
 	// or false if not available, or an error.
 	// Calls the destination chain portal InXStreamOffset method.
 	// Note this is only supported for EVM chains, no the consensus chain.
-	GetSubmittedCursor(ctx context.Context, stream StreamID) (StreamCursor, bool, error)
+	GetSubmittedCursor(ctx context.Context, stream StreamID) (SubmitCursor, bool, error)
 
 	// GetEmittedCursor returns the emitted cursor for the provided stream,
 	// or false if not available, or an error.
@@ -47,7 +47,7 @@ type Provider interface {
 	//
 	// Note that the BlockOffset field is not populated for emit cursors, since it isn't stored on-chain
 	// but tracked off-chain.
-	GetEmittedCursor(ctx context.Context, ref EmitRef, stream StreamID) (StreamCursor, bool, error)
+	GetEmittedCursor(ctx context.Context, ref EmitRef, stream StreamID) (EmitCursor, bool, error)
 }
 
 type EmitRef struct {

--- a/lib/xchain/provider/mock.go
+++ b/lib/xchain/provider/mock.go
@@ -147,13 +147,13 @@ func (m *Mock) GetBlock(_ context.Context, req xchain.ProviderRequest) (xchain.B
 }
 
 func (*Mock) GetSubmittedCursor(_ context.Context, stream xchain.StreamID,
-) (xchain.StreamCursor, bool, error) {
-	return xchain.StreamCursor{StreamID: stream}, true, nil
+) (xchain.SubmitCursor, bool, error) {
+	return xchain.SubmitCursor{StreamID: stream}, true, nil
 }
 
 func (*Mock) GetEmittedCursor(_ context.Context, _ xchain.EmitRef, stream xchain.StreamID,
-) (xchain.StreamCursor, bool, error) {
-	return xchain.StreamCursor{StreamID: stream}, true, nil
+) (xchain.EmitCursor, bool, error) {
+	return xchain.EmitCursor{StreamID: stream}, true, nil
 }
 
 func (m *Mock) parentBlockHash(chainVer xchain.ChainVersion, height uint64) common.Hash {

--- a/lib/xchain/types.go
+++ b/lib/xchain/types.go
@@ -151,9 +151,16 @@ type Submission struct {
 	DestChainID     uint64      // Destination chain ID, for internal use only
 }
 
-// StreamCursor is a cursor that tracks the progress of a cross-chain stream on destination portal contracts.
-type StreamCursor struct {
-	StreamID           // Stream ID of the Stream this cursor belongs to
-	MsgOffset   uint64 // Latest applied Msg offset of the Stream
-	BlockOffset uint64 // Latest applied cross chain block offset
+// SubmitCursor is a cursor that tracks the progress of a cross-chain stream on destination portal contracts.
+type SubmitCursor struct {
+	StreamID              // Stream ID of the Stream this cursor belongs to
+	MsgOffset      uint64 // Latest submitted Msg offset of the Stream
+	BlockOffset    uint64 // Latest submitted cross chain block offset
+	ValidatorSetID uint64 // Validator set that submitted the message.
+}
+
+// EmitCursor is a cursor that tracks the progress of a cross-chain stream on source portal contracts.
+type EmitCursor struct {
+	StreamID         // Stream ID of the Stream this cursor belongs to
+	MsgOffset uint64 // Latest emitted Msg offset of the Stream
 }

--- a/relayer/app/cursors_internal_test.go
+++ b/relayer/app/cursors_internal_test.go
@@ -55,16 +55,16 @@ func Test_fromOffsets(t *testing.T) {
 		return state
 	}
 
-	makeCursors := func(offset1, offset2, offset3 uint64) []xchain.StreamCursor {
-		var resp []xchain.StreamCursor
+	makeCursors := func(offset1, offset2, offset3 uint64) []xchain.SubmitCursor {
+		var resp []xchain.SubmitCursor
 		if offset1 != 0 {
-			resp = append(resp, xchain.StreamCursor{StreamID: stream1, BlockOffset: offset1})
+			resp = append(resp, xchain.SubmitCursor{StreamID: stream1, BlockOffset: offset1})
 		}
 		if offset2 != 0 {
-			resp = append(resp, xchain.StreamCursor{StreamID: stream2, BlockOffset: offset2})
+			resp = append(resp, xchain.SubmitCursor{StreamID: stream2, BlockOffset: offset2})
 		}
 		if offset3 != 0 {
-			resp = append(resp, xchain.StreamCursor{StreamID: stream3, BlockOffset: offset3})
+			resp = append(resp, xchain.SubmitCursor{StreamID: stream3, BlockOffset: offset3})
 		}
 
 		return resp
@@ -80,7 +80,7 @@ func Test_fromOffsets(t *testing.T) {
 
 	tests := []struct {
 		name    string
-		onChain []xchain.StreamCursor
+		onChain []xchain.SubmitCursor
 		onDisk  *State
 		want    map[xchain.ChainVersion]uint64
 	}{
@@ -138,8 +138,8 @@ var (
 
 type mockXChainClient struct {
 	GetBlockFn           func(context.Context, xchain.ProviderRequest) (xchain.Block, bool, error)
-	GetSubmittedCursorFn func(context.Context, xchain.StreamID) (xchain.StreamCursor, bool, error)
-	GetEmittedCursorFn   func(context.Context, xchain.EmitRef, xchain.StreamID) (xchain.StreamCursor, bool, error)
+	GetSubmittedCursorFn func(context.Context, xchain.StreamID) (xchain.SubmitCursor, bool, error)
+	GetEmittedCursorFn   func(context.Context, xchain.EmitRef, xchain.StreamID) (xchain.EmitCursor, bool, error)
 }
 
 func (m *mockXChainClient) StreamAsync(context.Context, xchain.ProviderRequest, xchain.ProviderCallback) error {
@@ -155,12 +155,12 @@ func (m *mockXChainClient) GetBlock(ctx context.Context, req xchain.ProviderRequ
 }
 
 func (m *mockXChainClient) GetSubmittedCursor(ctx context.Context, stream xchain.StreamID,
-) (xchain.StreamCursor, bool, error) {
+) (xchain.SubmitCursor, bool, error) {
 	return m.GetSubmittedCursorFn(ctx, stream)
 }
 
 func (m *mockXChainClient) GetEmittedCursor(ctx context.Context, ref xchain.EmitRef, stream xchain.StreamID,
-) (xchain.StreamCursor, bool, error) {
+) (xchain.EmitCursor, bool, error) {
 	return m.GetEmittedCursorFn(ctx, ref, stream)
 }
 

--- a/relayer/app/worker.go
+++ b/relayer/app/worker.go
@@ -92,7 +92,10 @@ func (w *Worker) runOnce(ctx context.Context) error {
 		return err
 	}
 
-	msgFilter := newMsgOffsetFilter(cursors)
+	msgFilter, err := newMsgOffsetFilter(cursors)
+	if err != nil {
+		return err
+	}
 
 	var logAttrs []any //nolint:prealloc // Not worth it
 	for chainVer, fromOffset := range blockOffsets {
@@ -183,7 +186,7 @@ func newMsgStreamMapper(network netconf.Network) msgStreamMapper {
 
 func newCallback(
 	xProvider xchain.Provider,
-	msgFilter *msgOffsetFilter,
+	msgFilter *msgCursorFilter,
 	creator CreateFunc,
 	sender SendFunc,
 	destChainID uint64,
@@ -216,7 +219,7 @@ func newCallback(
 			}
 
 			// Filter out any previously submitted message offsets
-			msgs, err = filterMsgs(ctx, streamID, msgs, msgFilter)
+			msgs, err = filterMsgs(ctx, streamID, att.ValidatorSetID, msgs, msgFilter)
 			if err != nil {
 				return err
 			} else if len(msgs) == 0 {

--- a/relayer/app/worker_internal_test.go
+++ b/relayer/app/worker_internal_test.go
@@ -38,7 +38,7 @@ func TestWorker_Run(t *testing.T) {
 		DestChainID:   destChainB,
 		ShardID:       netconf.ShardLatest0,
 	}
-	cursors := map[xchain.StreamID]xchain.StreamCursor{
+	cursors := map[xchain.StreamID]xchain.SubmitCursor{
 		streamA: {StreamID: streamA, MsgOffset: destChainACursor, BlockOffset: destChainACursor},
 		streamB: {StreamID: streamB, MsgOffset: destChainBCursor, BlockOffset: destChainBCursor},
 	}
@@ -57,11 +57,7 @@ func TestWorker_Run(t *testing.T) {
 				},
 			}, true, nil
 		},
-		GetSubmittedCursorFn: func(_ context.Context, stream xchain.StreamID) (xchain.StreamCursor, bool, error) {
-			resp, ok := cursors[stream]
-			return resp, ok, nil
-		},
-		GetEmittedCursorFn: func(_ context.Context, _ xchain.EmitRef, stream xchain.StreamID) (xchain.StreamCursor, bool, error) {
+		GetSubmittedCursorFn: func(_ context.Context, stream xchain.StreamID) (xchain.SubmitCursor, bool, error) {
 			resp, ok := cursors[stream]
 			return resp, ok, nil
 		},


### PR DESCRIPTION
Ensure we submit incrementing valSetID per stream. This is enforced by the portal contract, so relayer should not submit fuzzy attestations from pervious validator sets. It should stick with finalized until the new validator set attests to the fuzzy shards.

task: none