### PR TITLE
chore(relayer): harden offset metrics

### DIFF
--- a/relayer/app/metrics.go
+++ b/relayer/app/metrics.go
@@ -75,7 +75,7 @@ var (
 		Subsystem: "monitor",
 		Name:      "submit_block_offset",
 		Help:      "The latest submitted xblock offset on a destination chain for a specific source chain",
-	}, []string{"src_chain", "dst_chain"})
+	}, []string{"stream"})
 
 	accountBalance = promauto.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: "relayer",


### PR DESCRIPTION
Continue fetching offsets for all streams even though some failed. This mitigates startup issue on staging with op_sepolia having very slow finalization which prevents metrics from being initialised for latest as well.

task: none