### PR TITLE
fix(e2e): temp mac chip fix for explorer images

### DIFF
--- a/e2e/docker/compose.yaml.tmpl
+++ b/e2e/docker/compose.yaml.tmpl
@@ -141,6 +141,7 @@ services:
     labels:
       e2e: true
     container_name: explorer_indexer
+    platform: linux/amd64
     image: omniops/explorer-indexer:{{or .OmniTag "main"}}
     restart: unless-stopped # Restart on crash to mitigate startup race issues
     volumes:
@@ -153,6 +154,7 @@ services:
     labels:
       e2e: true
     container_name: explorer_graphql
+    platform: linux/amd64
     image: omniops/explorer-graphql:{{or .OmniTag "main"}}
     restart: unless-stopped # Restart on crash to mitigate startup race issues
     volumes:
@@ -167,6 +169,7 @@ services:
     labels:
       e2e: true
     container_name: explorer_ui
+    platform: linux/amd64
     image: omniops/explorer-ui:{{or .OmniTag "main"}}
     restart: unless-stopped # Restart on crash to mitigate startup race issues
     environment:

--- a/e2e/docker/testdata/TestComposeTemplate_empheral_network.golden
+++ b/e2e/docker/testdata/TestComposeTemplate_empheral_network.golden
@@ -140,6 +140,7 @@ services:
     labels:
       e2e: true
     container_name: explorer_indexer
+    platform: linux/amd64
     image: omniops/explorer-indexer:main
     restart: unless-stopped # Restart on crash to mitigate startup race issues
     volumes:
@@ -152,6 +153,7 @@ services:
     labels:
       e2e: true
     container_name: explorer_graphql
+    platform: linux/amd64
     image: omniops/explorer-graphql:main
     restart: unless-stopped # Restart on crash to mitigate startup race issues
     volumes:
@@ -166,6 +168,7 @@ services:
     labels:
       e2e: true
     container_name: explorer_ui
+    platform: linux/amd64
     image: omniops/explorer-ui:main
     restart: unless-stopped # Restart on crash to mitigate startup race issues
     environment:

--- a/e2e/docker/testdata/TestComposeTemplate_main_explorer.golden
+++ b/e2e/docker/testdata/TestComposeTemplate_main_explorer.golden
@@ -140,6 +140,7 @@ services:
     labels:
       e2e: true
     container_name: explorer_indexer
+    platform: linux/amd64
     image: omniops/explorer-indexer:main
     restart: unless-stopped # Restart on crash to mitigate startup race issues
     volumes:
@@ -152,6 +153,7 @@ services:
     labels:
       e2e: true
     container_name: explorer_graphql
+    platform: linux/amd64
     image: omniops/explorer-graphql:main
     restart: unless-stopped # Restart on crash to mitigate startup race issues
     volumes:
@@ -166,6 +168,7 @@ services:
     labels:
       e2e: true
     container_name: explorer_ui
+    platform: linux/amd64
     image: omniops/explorer-ui:main
     restart: unless-stopped # Restart on crash to mitigate startup race issues
     environment:

--- a/e2e/vmcompose/testdata/TestSetup_127-0-0-6-compose.yaml.golden
+++ b/e2e/vmcompose/testdata/TestSetup_127-0-0-6-compose.yaml.golden
@@ -12,6 +12,7 @@ services:
     labels:
       e2e: true
     container_name: explorer_indexer
+    platform: linux/amd64
     image: omniops/explorer-indexer:7d1ae53
     restart: unless-stopped # Restart on crash to mitigate startup race issues
     volumes:
@@ -24,6 +25,7 @@ services:
     labels:
       e2e: true
     container_name: explorer_graphql
+    platform: linux/amd64
     image: omniops/explorer-graphql:7d1ae53
     restart: unless-stopped # Restart on crash to mitigate startup race issues
     volumes:
@@ -38,6 +40,7 @@ services:
     labels:
       e2e: true
     container_name: explorer_ui
+    platform: linux/amd64
     image: omniops/explorer-ui:7d1ae53
     restart: unless-stopped # Restart on crash to mitigate startup race issues
     environment:


### PR DESCRIPTION
introduces temp fix of platform assignment to `linux/amd64` for all explorer-related images for runs in mac chip machines

task: none