### PR TITLE
feat(halo/attest): gate votes by supported portals

### DIFF
--- a/halo/app/app.go
+++ b/halo/app/app.go
@@ -125,6 +125,7 @@ func newApp(
 	app.EVMEngKeeper.AddEventProcessor(evmSlashing)
 	app.EVMEngKeeper.AddEventProcessor(app.RegistryKeeper)
 	app.AttestKeeper.SetValidatorProvider(app.ValSyncKeeper)
+	app.AttestKeeper.SetPortalRegistry(app.RegistryKeeper)
 
 	baseAppOpts = append(baseAppOpts, func(bapp *baseapp.BaseApp) {
 		// Use evm engine to create block proposals.

--- a/halo/app/start.go
+++ b/halo/app/start.go
@@ -283,7 +283,7 @@ func newEngineClient(ctx context.Context, cfg Config, network netconf.ID, pubkey
 	if network == netconf.Simnet {
 		return ethclient.NewEngineMock(
 			ethclient.WithMockSelfDelegation(pubkey, 1),
-			ethclient.WithMockPortalRegister(),
+			ethclient.WithPortalRegister(netconf.SimnetNetwork()),
 		)
 	}
 

--- a/halo/attest/keeper/cpayload_internal_test.go
+++ b/halo/attest/keeper/cpayload_internal_test.go
@@ -149,7 +149,11 @@ func TestVotesFromCommit(t *testing.T) {
 		return 0, nil
 	}
 
-	resp, err := votesFromLastCommit(context.Background(), comparer, info)
+	supported := func(ctx context.Context, chainID uint64) (bool, error) {
+		return true, nil
+	}
+
+	resp, err := votesFromLastCommit(context.Background(), comparer, supported, info)
 	require.NoError(t, err)
 
 	require.Len(t, resp.Votes, total)

--- a/halo/registry/keeper/cache.go
+++ b/halo/registry/keeper/cache.go
@@ -1,0 +1,90 @@
+package keeper
+
+import (
+	"context"
+	"sync"
+
+	"github.com/omni-network/omni/halo/registry/types"
+	"github.com/omni-network/omni/lib/errors"
+	"github.com/omni-network/omni/lib/netconf"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+)
+
+var _ types.PortalRegistry = Keeper{}
+
+// cache caches the latest network portals to mitigate DB lookups.
+type cache struct {
+	sync.RWMutex
+	network *Network
+}
+
+func (c *cache) Set(network *Network) {
+	c.Lock()
+	c.network = network
+	c.Unlock()
+}
+
+func (c *cache) Get() (*Network, bool) {
+	c.RLock()
+	defer c.RUnlock()
+
+	return c.network, c.network != nil
+}
+
+func (k Keeper) updateNetwork(ctx context.Context, network *Network) error {
+	if err := k.networkTable.Update(ctx, network); err != nil {
+		return errors.Wrap(err, "update network")
+	}
+
+	k.latestCache.Set(network)
+
+	return nil
+}
+
+func (k Keeper) SupportedChain(ctx context.Context, chainID uint64) (bool, error) {
+	portal, err := k.getLatestPortals(ctx)
+	if err != nil {
+		return false, errors.Wrap(err, "get latest portals")
+	}
+
+	for _, p := range portal {
+		if p.GetChainId() == chainID {
+			return true, nil
+		}
+	}
+
+	// Always allow the consensus chain
+	sdkCtx := sdk.UnwrapSDKContext(ctx)
+	consensusID, err := netconf.ConsensusChainIDStr2Uint64(sdkCtx.ChainID())
+	if err != nil {
+		return false, errors.Wrap(err, "parse chain id")
+	} else if consensusID == chainID {
+		return true, nil
+	}
+
+	return false, nil
+}
+
+func (k Keeper) getLatestPortals(ctx context.Context) ([]*Portal, error) {
+	if network, ok := k.latestCache.Get(); ok {
+		return network.GetPortals(), nil
+	}
+
+	latestNetworkID, err := k.networkTable.LastInsertedSequence(ctx)
+	if err != nil {
+		return nil, errors.Wrap(err, "get last network ID")
+	} else if latestNetworkID == 0 {
+		// No network exists yet, return empty list
+		return nil, nil
+	}
+
+	lastNetwork, err := k.networkTable.Get(ctx, latestNetworkID)
+	if err != nil {
+		return nil, errors.Wrap(err, "get network")
+	}
+
+	k.latestCache.Set(lastNetwork)
+
+	return lastNetwork.GetPortals(), nil
+}

--- a/halo/registry/keeper/keeper.go
+++ b/halo/registry/keeper/keeper.go
@@ -23,6 +23,8 @@ type Keeper struct {
 	ethCl           ethclient.Client
 	portalRegAdress common.Address
 	portalRegistry  *bindings.PortalRegistryFilterer
+
+	latestCache *cache
 }
 
 func NewKeeper(emilPortal ptypes.EmitPortal, storeService store.KVStoreService, ethCl ethclient.Client) (Keeper, error) {
@@ -52,6 +54,7 @@ func NewKeeper(emilPortal ptypes.EmitPortal, storeService store.KVStoreService, 
 		ethCl:           ethCl,
 		portalRegAdress: address,
 		portalRegistry:  protalReg,
+		latestCache:     new(cache),
 	}, nil
 }
 
@@ -95,6 +98,8 @@ func (k Keeper) getOrCreateNetwork(ctx context.Context) (*Network, error) {
 	if err != nil {
 		return nil, errors.Wrap(err, "insert next network")
 	}
+
+	k.latestCache.Set(network)
 
 	return network, nil
 }

--- a/halo/registry/keeper/logeventproc.go
+++ b/halo/registry/keeper/logeventproc.go
@@ -93,7 +93,7 @@ func (k Keeper) addPortal(ctx context.Context, portal *Portal) error {
 	// Add new portal to the network
 	network.Portals = append(network.GetPortals(), portal)
 
-	if err := k.networkTable.Update(ctx, network); err != nil {
+	if err := k.updateNetwork(ctx, network); err != nil {
 		return errors.Wrap(err, "insert network")
 	}
 

--- a/halo/registry/types/interface.go
+++ b/halo/registry/types/interface.go
@@ -1,0 +1,9 @@
+package types
+
+import (
+	"context"
+)
+
+type PortalRegistry interface {
+	SupportedChain(ctx context.Context, chainID uint64) (bool, error)
+}

--- a/lib/netconf/netconf.go
+++ b/lib/netconf/netconf.go
@@ -299,3 +299,12 @@ func (c Chain) ChainVersions() []xchain.ChainVersion {
 
 	return resp
 }
+
+func (c Chain) ShardsUint64() []uint64 {
+	var resp []uint64
+	for _, shard := range c.Shards {
+		resp = append(resp, uint64(shard))
+	}
+
+	return resp
+}

--- a/lib/netconf/static.go
+++ b/lib/netconf/static.go
@@ -57,7 +57,7 @@ func (s Static) OmniConsensusChain() Chain {
 		Name:         "omni_consensus",
 		BlockPeriod:  time.Second * 2,
 		Shards:       []xchain.ShardID{xchain.ShardBroadcast0}, // Consensus chain only supports broadcast shard.
-		DeployHeight: 1,                                        // ValidatorSets start at 1, not 0.
+		DeployHeight: 1,                                        // Emit portal blocks start at 1, not 0.
 	}
 }
 


### PR DESCRIPTION
Add `PortalProvider` interface to `attest` module and gate votes to supported portals only.

Implement it as a cache in `registry` module to mitigate DB lookups.

task: none