### PR TITLE
chore(*): remove secrets baseline

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,10 +50,6 @@ install-cli: ## Install the omni cli to $GOPATH/bin/omni.
 ensure-go-releaser: ## Installs the go-releaser tool.
 	@which goreleaser > /dev/null || echo "go-releaser not installed, see https://goreleaser.com/install/"
 
-.PHONY: ensure-detect-secrets
-ensure-detect-secrets: ## Checks if detect-secrets is installed.
-	@which detect-secrets > /dev/null || echo "detect-secrets not installed, see https://github.com/Yelp/detect-secrets?tab=readme-ov-file#installation"
-
 .PHONY: install-pre-commit
 install-pre-commit: ## Installs the pre-commit tool as the git pre-commit hook for this repo.
 	@which pre-commit > /dev/null || echo "pre-commit not installed, see https://pre-commit.com/#install"
@@ -70,10 +66,6 @@ lint: ## Runs linters via pre-commit.
 .PHONY: bufgen
 bufgen: ## Generates protobufs using buf generate.
 	@./scripts/buf_generate.sh
-
-.PHONY:
-secrets-baseline: ensure-detect-secrets ## Update secrets baseline.
-	@detect-secrets scan --exclude-file pnpm-lock.yaml > .secrets.baseline
 
 .PHONY: fix-golden
 fix-golden: ## Fixes golden test fixtures.


### PR DESCRIPTION
deprecate secrets-baseline in favour of native github secrets scanning. fewer tools ❤️

task: none
