### PR TITLE
chore(buildinfo): bump minor version

### DIFF
--- a/halo/config/testdata/default_halo.toml
+++ b/halo/config/testdata/default_halo.toml
@@ -3,7 +3,7 @@
 
 # The version of the Halo binary that created or
 # last modified the config file. Do not modify this.
-version = "v0.1.9"
+version = "v0.2.0"
 
 # Omni network to participate in: mainnet, testnet, or devnet.
 network = ""

--- a/halo/genutil/testdata/TestMakeGenesis.golden
+++ b/halo/genutil/testdata/TestMakeGenesis.golden
@@ -1,6 +1,6 @@
 {
  "app_name": "halo",
- "app_version": "v0.1.9",
+ "app_version": "v0.2.0",
  "genesis_time": "1970-01-01T00:00:01Z",
  "chain_id": "omni-1001651",
  "initial_height": 1,

--- a/lib/buildinfo/buildinfo.go
+++ b/lib/buildinfo/buildinfo.go
@@ -13,7 +13,7 @@ import (
 
 // version of the whole omni-monorepo and all binaries built from this git commit.
 // This value is set by goreleaser at build-time and should be the git tag for official releases.
-var version = "v0.1.9"
+var version = "v0.2.0"
 
 // unknown is the default value for the git commit hash and timestamp.
 const unknown = "unknown"

--- a/monitor/app/testdata/default_monitor.toml
+++ b/monitor/app/testdata/default_monitor.toml
@@ -3,7 +3,7 @@
 
 # The version of the Halo binary that created or
 # last modified the config file. Do not modify this.
-version = "v0.1.9"
+version = "v0.2.0"
 
 # Omni network to participate in: mainnet, testnet, or devnet.
 network = ""

--- a/relayer/app/testdata/default_relayer.toml
+++ b/relayer/app/testdata/default_relayer.toml
@@ -3,7 +3,7 @@
 
 # The version of the Halo binary that created or
 # last modified the config file. Do not modify this.
-version = "v0.1.9"
+version = "v0.2.0"
 
 # Omni network to participate in: mainnet, testnet, or devnet.
 network = ""


### PR DESCRIPTION
updates buildinfo minor version, as there are breaking changes in the syntax for `XApp` introduced by confirmation level features (and bumping the major feels wrong before mainnet)

task: https://app.asana.com/0/1206208509925075/1207453993335053/f
