### PR TITLE
fix(ci): use ref name in tag releases

### DIFF
--- a/.github/workflows/release-official.yml
+++ b/.github/workflows/release-official.yml
@@ -37,5 +37,5 @@ jobs:
         with:
           context: "{{defaultContext}}:explorer/ui"
           push: true
-          tags: omniops/explorer-ui:main,omniops/explorer-ui:${{ steps.git_ref.outputs.short_sha }},omniops/explorer-ui:${GITHUB_REF##*/}
+          tags: omniops/explorer-ui:main,omniops/explorer-ui:${{ steps.git_ref.outputs.short_sha }},omniops/explorer-ui:${{ github.ref_name }}
           platforms: linux/amd64 # Only build for linux/amd64, node:21-slim unsupported for darwin


### PR DESCRIPTION
fixes parsing error found in https://github.com/omni-network/omni/actions/runs/9501746339/job/26188033774

task: https://app.asana.com/0/1206208509925075/1207453993335053/f