### PR TITLE
feat(xchain): attest at constant interval even if empty

### DIFF
--- a/e2e/app/definition.go
+++ b/e2e/app/definition.go
@@ -517,17 +517,22 @@ func externalEndpoints(def Definition) xchain.RPCEndpoints {
 func networkFromDef(def Definition) netconf.Network {
 	var chains []netconf.Chain
 
+	newChain := func(chain types.EVMChain) netconf.Chain {
+		depInfo := def.DeployInfos()[chain.ChainID]
+		return netconf.Chain{
+			ID:             chain.ChainID,
+			Name:           chain.Name,
+			BlockPeriod:    chain.BlockPeriod,
+			Shards:         chain.Shards,
+			AttestInterval: chain.AttestInterval(def.Testnet.Network),
+			PortalAddress:  depInfo[types.ContractPortal].Address,
+			DeployHeight:   depInfo[types.ContractPortal].Height,
+		}
+	}
+
 	// Add all public chains
 	for _, public := range def.Testnet.PublicChains {
-		depInfo := def.DeployInfos()[public.Chain().ChainID]
-		chains = append(chains, netconf.Chain{
-			ID:            public.Chain().ChainID,
-			Name:          public.Chain().Name,
-			BlockPeriod:   public.Chain().BlockPeriod,
-			Shards:        public.Chain().Shards,
-			PortalAddress: depInfo[types.ContractPortal].Address,
-			DeployHeight:  depInfo[types.ContractPortal].Height,
-		})
+		chains = append(chains, newChain(public.Chain()))
 	}
 
 	// In monitor only mode, there is only public chains, so skip omni and anvil chains.
@@ -540,30 +545,14 @@ func networkFromDef(def Definition) netconf.Network {
 
 	// Connect to a proper omni_evm that isn't unavailable
 	omniEVM := def.Testnet.BroadcastOmniEVM()
-	omniEVMDepInfo := def.DeployInfos()[omniEVM.Chain.ChainID]
-	chains = append(chains, netconf.Chain{
-		ID:            omniEVM.Chain.ChainID,
-		Name:          omniEVM.Chain.Name,
-		BlockPeriod:   omniEVM.Chain.BlockPeriod,
-		Shards:        omniEVM.Chain.Shards,
-		PortalAddress: omniEVMDepInfo[types.ContractPortal].Address,
-		DeployHeight:  omniEVMDepInfo[types.ContractPortal].Height,
-	})
+	chains = append(chains, newChain(omniEVM.Chain))
 
 	// Add omni consensus chain
 	chains = append(chains, def.Testnet.Network.Static().OmniConsensusChain())
 
 	// Add all anvil chains
 	for _, anvil := range def.Testnet.AnvilChains {
-		depInfo := def.DeployInfos()[anvil.Chain.ChainID]
-		chains = append(chains, netconf.Chain{
-			ID:            anvil.Chain.ChainID,
-			Name:          anvil.Chain.Name,
-			BlockPeriod:   anvil.Chain.BlockPeriod,
-			Shards:        anvil.Chain.Shards,
-			PortalAddress: depInfo[types.ContractPortal].Address,
-			DeployHeight:  depInfo[types.ContractPortal].Height,
-		})
+		chains = append(chains, newChain(anvil.Chain))
 	}
 
 	return netconf.Network{

--- a/e2e/types/chain.go
+++ b/e2e/types/chain.go
@@ -43,8 +43,10 @@ func OmniEVMByNetwork(network netconf.ID) EVMChain {
 		shards = allShards // Enable all shards for testing.
 	}
 
+	chainID := network.Static().OmniExecutionChainID
+
 	return EVMChain{
-		Metadata: mustMetadata(network.Static().OmniExecutionChainID),
+		Metadata: mustMetadata(chainID),
 		Shards:   shards,
 	}
 }

--- a/e2e/types/testnet.go
+++ b/e2e/types/testnet.go
@@ -112,6 +112,11 @@ type EVMChain struct {
 	IsPublic bool
 }
 
+// AttestInterval returns the a constant interval for which attestations are always required, even if empty..
+func (c EVMChain) AttestInterval(network netconf.ID) uint64 {
+	return netconf.IntervalFromPeriod(network, c.BlockPeriod)
+}
+
 func (c EVMChain) ShardsUint64() []uint64 {
 	var shards []uint64
 	for _, shard := range c.Shards {

--- a/halo/attest/voter/voter.go
+++ b/halo/attest/voter/voter.go
@@ -160,6 +160,11 @@ func (v *Voter) runForever(ctx context.Context, chainVer xchain.ChainVersion) {
 // runOnce blocks, streaming xblocks from the provided chain until an error is encountered.
 // It always returns a non-nil error.
 func (v *Voter) runOnce(ctx context.Context, chainVer xchain.ChainVersion) error {
+	chain, ok := v.network.Chain(chainVer.ID)
+	if !ok {
+		return errors.New("unknown chain ID")
+	}
+
 	maybeDebugLog := newDebugLogFilterer(time.Minute) // Log empty blocks once per minute.
 	first := true                                     // Allow skipping on first attestation.
 
@@ -199,7 +204,7 @@ func (v *Voter) runOnce(ctx context.Context, chainVer xchain.ChainVersion) error
 			}
 			prevBlock = block
 
-			if !block.ShouldAttest() {
+			if !block.ShouldAttest(chain.AttestInterval) {
 				maybeDebugLog(ctx, "Not creating vote for empty cross chain block")
 
 				return nil // Do not vote for empty blocks.

--- a/lib/netconf/netconf.go
+++ b/lib/netconf/netconf.go
@@ -250,12 +250,13 @@ func (n Network) StreamsBetween(srcChainID uint64, dstChainID uint64) []xchain.S
 // the Omni cross chain protocol. This is most supported Rollup EVMs, but
 // also the Omni EVM, and the Omni Consensus chain.
 type Chain struct {
-	ID            uint64           // Chain ID asa per https://chainlist.org
-	Name          string           // Chain name as per https://chainlist.org
-	PortalAddress common.Address   // Address of the omni portal contract on the chain
-	DeployHeight  uint64           // Height that the portal contracts were deployed
-	BlockPeriod   time.Duration    // Block period of the chain
-	Shards        []xchain.ShardID // Supported xmsg shards
+	ID             uint64           // Chain ID asa per https://chainlist.org
+	Name           string           // Chain name as per https://chainlist.org
+	PortalAddress  common.Address   // Address of the omni portal contract on the chain
+	DeployHeight   uint64           // Height that the portal contracts were deployed
+	BlockPeriod    time.Duration    // Block period of the chain
+	Shards         []xchain.ShardID // Supported xmsg shards
+	AttestInterval uint64           // Attest to every Nth block, even if empty.
 }
 
 // ConfLevels returns the uniq set of confirmation levels

--- a/lib/netconf/network.go
+++ b/lib/netconf/network.go
@@ -1,8 +1,6 @@
 package netconf
 
 import (
-	"fmt"
-
 	"github.com/omni-network/omni/lib/errors"
 )
 
@@ -38,22 +36,6 @@ func (i ID) String() string {
 
 func (i ID) Version() string {
 	return i.Static().Version
-}
-
-func (i ID) ExecutionRPC() string {
-	if i == Devnet {
-		return "http://localhost:8001"
-	}
-
-	return fmt.Sprintf("https://%s.omni.network", i)
-}
-
-func (i ID) ConsensusRPC() string {
-	if i == Devnet {
-		return "http://localhost:5701"
-	}
-
-	return fmt.Sprintf("https://rpc.consensus.%s.omni.network", i)
 }
 
 const (

--- a/lib/netconf/provider.go
+++ b/lib/netconf/provider.go
@@ -76,12 +76,13 @@ func networkFromPortals(network ID, portals []bindings.PortalRegistryDeployment)
 	for _, portal := range portals {
 		metadata := MetadataByID(network, portal.ChainId)
 		chains = append(chains, Chain{
-			ID:            portal.ChainId,
-			Name:          metadata.Name,
-			PortalAddress: portal.Addr,
-			DeployHeight:  portal.DeployHeight,
-			BlockPeriod:   metadata.BlockPeriod,
-			Shards:        toShardIDs(portal.Shards),
+			ID:             portal.ChainId,
+			Name:           metadata.Name,
+			PortalAddress:  portal.Addr,
+			DeployHeight:   portal.DeployHeight,
+			BlockPeriod:    metadata.BlockPeriod,
+			Shards:         toShardIDs(portal.Shards),
+			AttestInterval: IntervalFromPeriod(network, metadata.BlockPeriod),
 		})
 	}
 
@@ -92,6 +93,19 @@ func networkFromPortals(network ID, portals []bindings.PortalRegistryDeployment)
 		ID:     network,
 		Chains: chains,
 	}
+}
+
+// IntervalFromPeriod returns the minimum number of blocks between attestations for a given block period.
+// TODO(kevin): Move this to e2e/types once MinAttestPeriod is added to PortalRegistry.
+func IntervalFromPeriod(network ID, period time.Duration) uint64 {
+	target := time.Hour
+	if network == Staging {
+		target = time.Minute * 10
+	} else if network == Devnet {
+		target = time.Second * 10
+	}
+
+	return uint64(target / period)
 }
 
 func MetadataByID(network ID, chainID uint64) evmchain.Metadata {

--- a/lib/netconf/static.go
+++ b/lib/netconf/static.go
@@ -21,6 +21,7 @@ const maxValidators = 10
 
 // Static defines static config and data for a network.
 type Static struct {
+	Network              ID
 	Version              string
 	OmniExecutionChainID uint64
 	AVSContractAddress   common.Address
@@ -53,11 +54,12 @@ func (s Static) OmniConsensusChainIDUint64() uint64 {
 // OmniConsensusChain returns the omni consensus Chain struct.
 func (s Static) OmniConsensusChain() Chain {
 	return Chain{
-		ID:           s.OmniConsensusChainIDUint64(),
-		Name:         "omni_consensus",
-		BlockPeriod:  time.Second * 2,
-		Shards:       []xchain.ShardID{xchain.ShardBroadcast0}, // Consensus chain only supports broadcast shard.
-		DeployHeight: 1,                                        // Emit portal blocks start at 1, not 0.
+		ID:             s.OmniConsensusChainIDUint64(),
+		Name:           "omni_consensus",
+		BlockPeriod:    time.Second * 2,
+		Shards:         []xchain.ShardID{xchain.ShardBroadcast0}, // Consensus chain only supports broadcast shard.
+		DeployHeight:   1,                                        // Emit portal blocks start at 1, not 0.
+		AttestInterval: 0,                                        // Emit portal blocks are never empty, so this isn't required.
 	}
 }
 
@@ -95,6 +97,22 @@ func (s Static) ExecutionSeeds() []string {
 	return resp
 }
 
+func (s Static) ExecutionRPC() string {
+	if s.Network == Devnet {
+		return "http://localhost:8001"
+	}
+
+	return fmt.Sprintf("https://%s.omni.network", s.Network)
+}
+
+func (s Static) ConsensusRPC() string {
+	if s.Network == Devnet {
+		return "http://localhost:5701"
+	}
+
+	return fmt.Sprintf("https://rpc.consensus.%s.omni.network", s.Network)
+}
+
 // Use random runid for staging version.
 //
 //nolint:gochecknoglobals // Static ID
@@ -111,21 +129,25 @@ var (
 //nolint:gochecknoglobals // Static mappings.
 var statics = map[ID]Static{
 	Simnet: {
+		Network:              Simnet,
 		Version:              "simnet",
 		OmniExecutionChainID: evmchain.IDOmniEphemeral,
 		MaxValidators:        maxValidators,
 	},
 	Devnet: {
+		Network:              Devnet,
 		Version:              "devnet",
 		OmniExecutionChainID: evmchain.IDOmniEphemeral,
 		MaxValidators:        maxValidators,
 	},
 	Staging: {
+		Network:              Staging,
 		Version:              runid,
 		OmniExecutionChainID: evmchain.IDOmniEphemeral,
 		MaxValidators:        maxValidators,
 	},
 	Omega: {
+		Network:              Omega,
 		Version:              "v0.0.2",
 		AVSContractAddress:   testnetAVS,
 		OmniExecutionChainID: evmchain.IDOmniOmega,
@@ -133,6 +155,7 @@ var statics = map[ID]Static{
 		Portals:              []Deployment{},
 	},
 	Mainnet: {
+		Network:            Mainnet,
 		Version:            "v0.0.1",
 		AVSContractAddress: mainnetAVS,
 		MaxValidators:      maxValidators,

--- a/lib/xchain/connect/connect.go
+++ b/lib/xchain/connect/connect.go
@@ -58,12 +58,12 @@ func New(ctx context.Context, netID netconf.ID, endpoints xchain.RPCEndpoints) (
 		return Connector{}, errors.New("omni evm metadata not found")
 	}
 	if _, err := endpoints.ByNameOrID(omniEVMMetadata.Name, omniEVMMetadata.ChainID); err != nil {
-		endpoints[omniEVMMetadata.Name] = netID.ExecutionRPC()
+		endpoints[omniEVMMetadata.Name] = netID.Static().ExecutionRPC()
 	}
 
 	omniCons := netID.Static().OmniConsensusChain()
 	if _, err := endpoints.ByNameOrID(omniCons.Name, omniCons.ID); err != nil {
-		endpoints[omniCons.Name] = netID.ConsensusRPC()
+		endpoints[omniCons.Name] = netID.Static().ConsensusRPC()
 	}
 
 	portalReg, err := makePortalRegistry(netID, endpoints)

--- a/lib/xchain/provider/fetch.go
+++ b/lib/xchain/provider/fetch.go
@@ -148,7 +148,7 @@ func (p *Provider) GetBlock(ctx context.Context, req xchain.ProviderRequest) (xc
 		return b, true, nil
 	}
 
-	_, ethCl, err := p.getEVMChain(req.ChainID)
+	chain, ethCl, err := p.getEVMChain(req.ChainID)
 	if err != nil {
 		return xchain.Block{}, false, err
 	}
@@ -222,7 +222,7 @@ func (p *Provider) GetBlock(ctx context.Context, req xchain.ProviderRequest) (xc
 		ParentHash: header.ParentHash,
 		Timestamp:  time.Unix(int64(header.Time), 0),
 	}
-	if resp.ShouldAttest() {
+	if resp.ShouldAttest(chain.AttestInterval) {
 		resp.BlockOffset = req.Offset
 	}
 

--- a/lib/xchain/provider/mock.go
+++ b/lib/xchain/provider/mock.go
@@ -219,7 +219,7 @@ func (m *Mock) nextBlock(
 
 	switch height % 4 {
 	case 0:
-		// Empty block, no messages or receipts
+		// Empty block, no messages or receipts, no attestation
 	case 1:
 		msgs = append(msgs, newMsgA()) // Msgs: 1*chainA, 0*chainB
 	case 2:
@@ -241,7 +241,8 @@ func (m *Mock) nextBlock(
 		ParentHash: m.parentBlockHash(chainVer, height),
 	}
 
-	if b.ShouldAttest() {
+	const noEmptyAttestations uint64 = 0
+	if b.ShouldAttest(noEmptyAttestations) {
 		b.BlockHeader.BlockOffset = bOffsetFunc()
 	}
 

--- a/lib/xchain/provider/mock_internal_test.go
+++ b/lib/xchain/provider/mock_internal_test.go
@@ -60,7 +60,7 @@ func assertOffsets(t *testing.T, blocks []xchain.Block) {
 	bOffset := 1
 
 	for _, block := range blocks {
-		if block.ShouldAttest() {
+		if block.ShouldAttest(0) {
 			require.EqualValues(t, bOffset, block.BlockOffset)
 			bOffset++
 		} else {

--- a/lib/xchain/provider/provider.go
+++ b/lib/xchain/provider/provider.go
@@ -178,7 +178,7 @@ func (p *Provider) stream(
 				return nil, nil
 			}
 
-			if xBlock.ShouldAttest() {
+			if xBlock.ShouldAttest(chain.AttestInterval) {
 				if err := tracker.assignOffset(height); err != nil {
 					return nil, err
 				}
@@ -197,7 +197,7 @@ func (p *Provider) stream(
 				return errors.New("invalid block source chain id")
 			} else if block.BlockHeight != h {
 				return errors.New("invalid block height")
-			} else if block.ShouldAttest() && block.BlockOffset == 0 {
+			} else if block.ShouldAttest(chain.AttestInterval) && block.BlockOffset == 0 {
 				return errors.New("invalid block offset")
 			}
 

--- a/lib/xchain/provider/provider_test.go
+++ b/lib/xchain/provider/provider_test.go
@@ -105,7 +105,7 @@ func TestProvider(t *testing.T) {
 	for i, block := range actual {
 		require.Equal(t, chainID, block.SourceChainID)
 		require.Equal(t, fromHeight+uint64(i), block.BlockHeight)
-		if block.ShouldAttest() {
+		if block.ShouldAttest(0) {
 			require.Equal(t, nextXBlockOffset, block.BlockOffset)
 			nextXBlockOffset++
 		} else {

--- a/lib/xchain/types.go
+++ b/lib/xchain/types.go
@@ -162,9 +162,19 @@ type Block struct {
 }
 
 // ShouldAttest returns true if the xblock should be attested by the omni consensus chain validators.
-// All "non-empty" xblocks should be attested to and are assigned an incremented XBlockOffset.
-func (b Block) ShouldAttest() bool {
-	return len(b.Msgs) > 0
+// All "non-empty" xblocks should be attested to.
+// Every Nth block based on the chain's attest interval should be attested to.
+// Attested blocks are assigned an incremented XBlockOffset.
+func (b Block) ShouldAttest(attestInterval uint64) bool {
+	if len(b.Msgs) > 0 {
+		return true
+	}
+
+	if attestInterval == 0 {
+		return false // Avoid empty attestations for zero interval.
+	}
+
+	return b.BlockHeight%attestInterval == 0
 }
 
 // Vote by a validator of a cross-chain Block.

--- a/relayer/app/worker.go
+++ b/relayer/app/worker.go
@@ -295,9 +295,6 @@ func verifyAttBlock(att xchain.Attestation, block xchain.Block) error {
 			log.Hex7("attestation_hash", att.BlockHash[:]),
 			log.Hex7("block_hash", block.BlockHash[:]),
 		)
-	} else if len(block.Msgs) == 0 {
-		// All attestations must map to non-empty xblocks
-		return errors.New("unexpected empty xblock")
 	} else if block.BlockOffset != att.BlockOffset {
 		// All attestations must map to non-empty xblocks with XBlockOffset populated.
 		return errors.New("unexpected XBlockOffset")


### PR DESCRIPTION
Introduce the `AttestInterval` portal registry and netconf chain field that defines the constant period for attestations even if blocks are empty.

This ensures the "attest head" of quiet chains do not get too stale which requires historical queries.

task: none
