### PR TITLE
feat(octane): support custom fee recipient

### DIFF
--- a/halo/app/app.go
+++ b/halo/app/app.go
@@ -11,6 +11,7 @@ import (
 	"github.com/omni-network/omni/lib/errors"
 	"github.com/omni-network/omni/lib/ethclient"
 	evmengkeeper "github.com/omni-network/omni/octane/evmengine/keeper"
+	etypes "github.com/omni-network/omni/octane/evmengine/types"
 
 	"cosmossdk.io/depinject"
 	"cosmossdk.io/log"
@@ -73,6 +74,7 @@ func newApp(
 	engineCl ethclient.EngineClient,
 	voter atypes.Voter,
 	namer atypes.ChainVerNameFunc,
+	feeRecProvider etypes.FeeRecipientProvider,
 	baseAppOpts ...func(*baseapp.BaseApp),
 ) (*App, error) {
 	depCfg := depinject.Configs(
@@ -82,6 +84,7 @@ func newApp(
 			engineCl,
 			namer,
 			voter,
+			feeRecProvider,
 		),
 	)
 

--- a/halo/app/rollback.go
+++ b/halo/app/rollback.go
@@ -58,6 +58,7 @@ func Rollback(ctx context.Context, cfg Config, rCfg RollbackConfig) error {
 		engineCl,
 		voter,
 		netconf.ChainVersionNamer(cfg.Network),
+		burnEVMFees{},
 		baseAppOpts...,
 	)
 	if err != nil {

--- a/octane/evmengine/keeper/abci.go
+++ b/octane/evmengine/keeper/abci.go
@@ -56,7 +56,13 @@ func (k *Keeper) PrepareProposal(ctx sdk.Context, req *abci.RequestPreparePropos
 	if uint64(req.Height) != height {
 		// Create a new payload (retrying on network errors).
 		err := retryForever(ctx, func(ctx context.Context) (bool, error) {
-			response, err := submitPayload(ctx, k.engineCl, req.Time, k.addrProvider.LocalAddress(), appHash)
+			response, err := submitPayload(
+				ctx,
+				k.engineCl,
+				req.Time,
+				k.feeRecProvider.LocalFeeRecipient(),
+				appHash,
+			)
 			if err != nil {
 				log.Warn(ctx, "Preparing proposal failed: build new evm payload (will retry)", err)
 				return false, nil
@@ -209,7 +215,7 @@ func (k *Keeper) startOptimisticBuild(ctx context.Context, appHash common.Hash, 
 	attrs := &engine.PayloadAttributes{
 		Timestamp:             ts,
 		Random:                latestEBlock.Hash(), // We use head block hash as randao.
-		SuggestedFeeRecipient: k.addrProvider.LocalAddress(),
+		SuggestedFeeRecipient: k.feeRecProvider.LocalFeeRecipient(),
 		Withdrawals:           []*etypes.Withdrawal{}, // Withdrawals not supported yet.
 		BeaconRoot:            &appHash,
 	}
@@ -226,7 +232,7 @@ func submitPayload(
 	ctx context.Context,
 	engineCl ethclient.EngineClient,
 	ts time.Time,
-	proposer common.Address,
+	feeRecipient common.Address,
 	appHash common.Hash,
 ) (engine.ForkChoiceResponse, error) {
 	latestEHeight, err := engineCl.BlockNumber(ctx)
@@ -258,7 +264,7 @@ func submitPayload(
 	payloadAttrs := engine.PayloadAttributes{
 		Timestamp:             timestamp,
 		Random:                latestEBlock.Hash(), // TODO(corver): implement proper randao.
-		SuggestedFeeRecipient: proposer,
+		SuggestedFeeRecipient: feeRecipient,
 		Withdrawals:           []*etypes.Withdrawal{}, // Withdrawals not supported yet.
 		BeaconRoot:            &appHash,
 	}

--- a/octane/evmengine/keeper/keeper.go
+++ b/octane/evmengine/keeper/keeper.go
@@ -28,6 +28,7 @@ type Keeper struct {
 	eventProcs      []types.EvmEventProcessor
 	cmtAPI          comet.API
 	addrProvider    types.AddressProvider
+	feeRecProvider  types.FeeRecipientProvider
 	buildDelay      time.Duration
 	buildOptimistic bool
 
@@ -48,13 +49,15 @@ func NewKeeper(
 	engineCl ethclient.EngineClient,
 	txConfig client.TxConfig,
 	addrProvider types.AddressProvider,
+	feeRecProvider types.FeeRecipientProvider,
 ) *Keeper {
 	return &Keeper{
-		cdc:          cdc,
-		storeService: storeService,
-		engineCl:     engineCl,
-		txConfig:     txConfig,
-		addrProvider: addrProvider,
+		cdc:            cdc,
+		storeService:   storeService,
+		engineCl:       engineCl,
+		txConfig:       txConfig,
+		addrProvider:   addrProvider,
+		feeRecProvider: feeRecProvider,
 	}
 }
 

--- a/octane/evmengine/keeper/keeper_internal_test.go
+++ b/octane/evmengine/keeper/keeper_internal_test.go
@@ -130,7 +130,8 @@ func TestKeeper_isNextProposer(t *testing.T) {
 			ap := mockAddressProvider{
 				address: nxtAddr,
 			}
-			keeper := NewKeeper(cdc, storeService, &mockEngine, txConfig, ap)
+			frp := newRandomFeeRecipientProvider()
+			keeper := NewKeeper(cdc, storeService, &mockEngine, txConfig, ap, frp)
 			keeper.SetCometAPI(cmtAPI)
 
 			got, err := keeper.isNextProposer(ctx, ctx.BlockHeader().ProposerAddress, ctx.BlockHeader().Height)

--- a/octane/evmengine/keeper/msg_server_internal_test.go
+++ b/octane/evmengine/keeper/msg_server_internal_test.go
@@ -48,8 +48,9 @@ func Test_msgServer_ExecutionPayload(t *testing.T) {
 	ap := mockAddressProvider{
 		address: nxtAddr,
 	}
+	frp := newRandomFeeRecipientProvider()
 	evmLogProc := mockLogProvider{deliverErr: errors.New("test error")}
-	keeper := NewKeeper(cdc, storeService, &mockEngine, txConfig, ap)
+	keeper := NewKeeper(cdc, storeService, &mockEngine, txConfig, ap, frp)
 	keeper.SetCometAPI(cmtAPI)
 	keeper.AddEventProcessor(evmLogProc)
 	msgSrv := NewMsgServerImpl(keeper)

--- a/octane/evmengine/keeper/proposal_server.go
+++ b/octane/evmengine/keeper/proposal_server.go
@@ -46,6 +46,10 @@ func (s proposalServer) ExecutionPayload(ctx context.Context, msg *types.MsgExec
 		return nil, err
 	}
 
+	if err := s.feeRecProvider.VerifyFeeRecipient(payload.FeeRecipient); err != nil {
+		return nil, errors.Wrap(err, "verify proposed fee recipient")
+	}
+
 	// Collect local view of the evm logs from the previous payload.
 	evmEvents, err := s.evmEvents(ctx, payload.ParentHash)
 	if err != nil {

--- a/octane/evmengine/module/module.go
+++ b/octane/evmengine/module/module.go
@@ -101,12 +101,13 @@ func init() {
 type ModuleInputs struct {
 	depinject.In
 
-	StoreService store.KVStoreService
-	Cdc          codec.Codec
-	Config       *Module
-	TXConfig     client.TxConfig
-	EngineCl     ethclient.EngineClient
-	AddrProvider types.AddressProvider
+	StoreService   store.KVStoreService
+	Cdc            codec.Codec
+	Config         *Module
+	TXConfig       client.TxConfig
+	EngineCl       ethclient.EngineClient
+	AddrProvider   types.AddressProvider
+	FeeRecProvider types.FeeRecipientProvider
 }
 
 type ModuleOutputs struct {
@@ -124,6 +125,7 @@ func ProvideModule(in ModuleInputs) ModuleOutputs {
 		in.EngineCl,
 		in.TXConfig,
 		in.AddrProvider,
+		in.FeeRecProvider,
 	)
 	m := NewAppModule(
 		in.Cdc,

--- a/octane/evmengine/types/types.go
+++ b/octane/evmengine/types/types.go
@@ -6,3 +6,10 @@ type AddressProvider interface {
 	// LocalAddress returns the local validator's ethereum address.
 	LocalAddress() common.Address
 }
+
+type FeeRecipientProvider interface {
+	// LocalFeeRecipient returns the local validator's fee recipient address.
+	LocalFeeRecipient() common.Address
+	// VerifyFeeRecipient returns true if the given address is a valid fee recipient
+	VerifyFeeRecipient(proposedFeeRecipient common.Address) error
+}


### PR DESCRIPTION
Adds support for a custom `FeeRecipientProvider` to Octane. Halo configures it to burn all execution fees. This is enforced by the protocol.

task: none