### PR TITLE
ci(e2e): improve debug logging

### DIFF
--- a/e2e/app/setup.go
+++ b/e2e/app/setup.go
@@ -123,6 +123,9 @@ func Setup(ctx context.Context, def Definition, depCfg DeployConfig) error {
 		if err != nil {
 			return err
 		}
+		if def.Testnet.Network == netconf.Devnet {
+			cfg.LogLevel = "debug" // TODO(corver): Remove this once we find the cause of sporadic chain stalls.
+		}
 		config.WriteConfigFile(filepath.Join(nodeDir, "config", "config.toml"), cfg) // panics
 
 		endpoints := internalEndpoints(def, node.Name)

--- a/halo/app/cmtlog.go
+++ b/halo/app/cmtlog.go
@@ -32,9 +32,14 @@ var levels = map[string]int{
 //
 //nolint:gochecknoglobals // Static mapping
 var dropCometDebugs = map[string]bool{
-	"Read PacketMsg": true,
-	"Received bytes": true,
-	"Send":           true,
+	"Read PacketMsg":       true,
+	"Received bytes":       true,
+	"Send":                 true,
+	"Receive":              true,
+	"Sending vote message": true,
+	"Flush":                true,
+	"setHasVote":           true,
+	"TrySend":              true,
 }
 
 // cmtLogger implements cmtlog.Logger by using the omni logging pattern.

--- a/monitor/loadgen/loadgen.go
+++ b/monitor/loadgen/loadgen.go
@@ -77,7 +77,7 @@ func Start(ctx context.Context, network netconf.Network, endpoints xchain.RPCEnd
 
 	var period = time.Hour
 	if network.ID == netconf.Devnet {
-		period = time.Second * 10
+		period = time.Second * 5
 	}
 
 	for _, key := range keys {


### PR DESCRIPTION
Enable cometBFT debug logs in CI. Decrease more very noisy cometBFT debug logs. Generate more validator updates in CI. This is aimed at identifying the root cause of sporadic chain stalls in CI.

task: none