### PR TITLE
chore(halo): bump max validators to 30

### DIFF
--- a/halo/genutil/testdata/TestMakeGenesis.golden
+++ b/halo/genutil/testdata/TestMakeGenesis.golden
@@ -196,7 +196,7 @@
   "staking": {
    "params": {
     "unbonding_time": "1814400s",
-    "max_validators": 10,
+    "max_validators": 30,
     "max_entries": 7,
     "historical_entries": 10000,
     "bond_denom": "stake",

--- a/lib/netconf/static.go
+++ b/lib/netconf/static.go
@@ -17,7 +17,7 @@ import (
 
 const consensusIDPrefix = "omni-"
 const consensusIDOffset = 1_000_000
-const maxValidators = 10
+const maxValidators = 30
 
 // Static defines static config and data for a network.
 type Static struct {


### PR DESCRIPTION
Increase maximum validators per network to 30 as we are implementing a whitelist in the omni staking contract.

task: none