### PR TITLE
fix(octane/emvengine): more payload verifications

### DIFF
--- a/lib/ethclient/enginemock.go
+++ b/lib/ethclient/enginemock.go
@@ -238,6 +238,19 @@ func (m *engineMock) HeaderByNumber(ctx context.Context, height *big.Int) (*type
 	return b.Header(), nil
 }
 
+func (m *engineMock) HeaderByType(ctx context.Context, typ HeadType) (*types.Header, error) {
+	if typ != HeadLatest {
+		return nil, errors.New("only support latest block")
+	}
+
+	number, err := m.BlockNumber(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	return m.HeaderByNumber(ctx, big.NewInt(int64(number)))
+}
+
 func (m *engineMock) BlockByNumber(ctx context.Context, number *big.Int) (*types.Block, error) {
 	if err := m.maybeErr(ctx); err != nil {
 		return nil, err

--- a/octane/evmengine/keeper/abci.go
+++ b/octane/evmengine/keeper/abci.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"math/big"
 	"runtime/debug"
 	"strings"
 	"time"
@@ -198,7 +197,7 @@ func (k *Keeper) Finalize(ctx context.Context, req *abci.RequestFinalizeBlock, r
 }
 
 func (k *Keeper) startOptimisticBuild(ctx context.Context, appHash common.Hash, timestamp time.Time) (engine.ForkChoiceResponse, error) {
-	latestEBlock, err := k.engineCl.HeaderByNumber(ctx, nil)
+	latestEBlock, err := k.engineCl.HeaderByType(ctx, ethclient.HeadLatest)
 	if err != nil {
 		return engine.ForkChoiceResponse{}, errors.Wrap(err, "get head")
 	}
@@ -238,12 +237,7 @@ func submitPayload(
 	feeRecipient common.Address,
 	appHash common.Hash,
 ) (engine.ForkChoiceResponse, error) {
-	latestEHeight, err := engineCl.BlockNumber(ctx)
-	if err != nil {
-		return engine.ForkChoiceResponse{}, errors.Wrap(err, "latest execution block number")
-	}
-
-	latestEBlock, err := engineCl.HeaderByNumber(ctx, big.NewInt(int64(latestEHeight)))
+	latestEBlock, err := engineCl.HeaderByType(ctx, ethclient.HeadLatest)
 	if err != nil {
 		return engine.ForkChoiceResponse{}, errors.Wrap(err, "latest execution block")
 	}

--- a/octane/evmengine/keeper/proposal_server.go
+++ b/octane/evmengine/keeper/proposal_server.go
@@ -7,8 +7,6 @@ import (
 	"github.com/omni-network/omni/lib/log"
 	"github.com/omni-network/omni/octane/evmengine/types"
 
-	"github.com/ethereum/go-ethereum/beacon/engine"
-
 	"github.com/cosmos/gogoproto/proto"
 )
 
@@ -20,10 +18,14 @@ type proposalServer struct {
 // ExecutionPayload handles a new execution payload proposed in a block.
 func (s proposalServer) ExecutionPayload(ctx context.Context, msg *types.MsgExecutionPayload,
 ) (*types.ExecutionPayloadResponse, error) {
-	// Push the payload to the EVM, ensuring it is valid.
-	var payload engine.ExecutableData
-	err := retryForever(ctx, func(ctx context.Context) (bool, error) {
-		pload, status, err := pushPayload(ctx, s.engineCl, msg)
+	payload, err := s.parseAndVerifyProposedPayload(ctx, msg)
+	if err != nil {
+		return nil, err
+	}
+
+	// Push the payload to the EVM.
+	err = retryForever(ctx, func(ctx context.Context) (bool, error) {
+		status, err := pushPayload(ctx, s.engineCl, payload)
 		if err != nil || isUnknown(status) {
 			// We need to retry forever on networking errors, but can't easily identify them, so retry all errors.
 			log.Warn(ctx, "Verifying proposal failed: push new payload to evm (will retry)", err,
@@ -35,19 +37,13 @@ func (s proposalServer) ExecutionPayload(ctx context.Context, msg *types.MsgExec
 		} else if isSyncing(status) {
 			// If this is initial sync, we need to continue and set a target head to sync to, so don't retry.
 			log.Warn(ctx, "Can't properly verifying proposal: evm syncing", err,
-				"payload_height", pload.Number)
+				"payload_height", payload.Number)
 		}
-
-		payload = pload
 
 		return true, nil // We are done, don't retry.
 	})
 	if err != nil {
 		return nil, err
-	}
-
-	if err := s.feeRecProvider.VerifyFeeRecipient(payload.FeeRecipient); err != nil {
-		return nil, errors.Wrap(err, "verify proposed fee recipient")
 	}
 
 	// Collect local view of the evm logs from the previous payload.


### PR DESCRIPTION
Add additional execution payload validation:
- `ParentHash` must match latest block.
- `Timestamp` must match consensus block or latest execution+1.
- `Withdrawals` must be empty.
- `FeeRecipient` must be expected.

task: none