### PR TITLE
fix(cli): remove depth from git clone cmd

### DIFF
--- a/cli/cmd/develop.go
+++ b/cli/cmd/develop.go
@@ -13,7 +13,7 @@ import (
 
 const (
 	defaultTemplate       = "hello-world-template"
-	defaultTemplateCommit = "1d0ba3c" // Commit hash of the template, update as needed
+	defaultTemplateCommit = "f4002e9" // Commit hash of the template, update as needed
 )
 
 func newDeveloperCmds() *cobra.Command {
@@ -61,7 +61,7 @@ func newForgeProjectTemplate(ctx context.Context, cfg developerForgeProjectConfi
 
 	// Clone the repository
 	//nolint:gosec // This is a command-line tool, not a library
-	cmd := exec.CommandContext(ctx, "git", "clone", "--depth", "1", "https://github.com/omni-network/"+cfg.templateName+".git", destinationPath)
+	cmd := exec.CommandContext(ctx, "git", "clone", "https://github.com/omni-network/"+cfg.templateName+".git", destinationPath)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	if err := cmd.Run(); err != nil {


### PR DESCRIPTION
removes depth from git clone command, allowing template repo to be updated without breaking the scaffolding command fixing [broken pipelines](https://github.com/omni-network/omni/actions/runs/9571036989)

also updates the template to the newest commit

task: none