### PR TITLE
fix(halo/registry): add tests and fix issues

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -103,6 +103,7 @@ issues:
         - contextcheck # Context not an issue here
         - maintidx     # Relax linter for table driven tests
         - dupl         # Many tests share similar testing logic but call different methods with different args
+        - forcetypeassert # Asserting casts in tests not required.
     - path: '(.*)(e2e)(.*)'
       linters:         # Relax linters for both e2e (performance not required)
         - perfsprint   # Performance not an issue here

--- a/e2e/app/run.go
+++ b/e2e/app/run.go
@@ -185,6 +185,8 @@ func E2ETest(ctx context.Context, def Definition, cfg E2ETestConfig) error {
 
 	stopValidatorUpdates := StartValidatorUpdates(ctx, def)
 
+	stopAddingPortals := startAddingMockPortals(ctx, def)
+
 	msgBatches := []int{3, 2, 1} // Send 6 msgs from each chain to each other chain
 	msgsErr := StartSendingXMsgs(ctx, def.Netman(), def.Backends(), msgBatches...)
 
@@ -220,6 +222,10 @@ func E2ETest(ctx context.Context, def Definition, cfg E2ETestConfig) error {
 		if err != nil {
 			return err
 		}
+	}
+
+	if err := stopAddingPortals(); err != nil {
+		return errors.Wrap(err, "stop adding portals")
 	}
 
 	network := networkFromDef(def)

--- a/e2e/app/setup.go
+++ b/e2e/app/setup.go
@@ -138,9 +138,6 @@ func Setup(ctx context.Context, def Definition, depCfg DeployConfig) error {
 		if err != nil {
 			return err
 		}
-		if def.Testnet.Network == netconf.Devnet {
-			cfg.LogLevel = "debug" // TODO(corver): Remove this once we find the cause of sporadic chain stalls.
-		}
 		config.WriteConfigFile(filepath.Join(nodeDir, "config", "config.toml"), cfg) // panics
 
 		endpoints := internalEndpoints(def, node.Name)

--- a/e2e/test/e2e_test.go
+++ b/e2e/test/e2e_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/omni-network/omni/halo/genutil/evm/predeploys"
 	"github.com/omni-network/omni/lib/errors"
 	"github.com/omni-network/omni/lib/ethclient"
+	"github.com/omni-network/omni/lib/evmchain"
 	"github.com/omni-network/omni/lib/log"
 	"github.com/omni-network/omni/lib/netconf"
 	"github.com/omni-network/omni/lib/tutil"
@@ -155,6 +156,11 @@ func makePortals(t *testing.T, network netconf.Network, endpoints xchain.RPCEndp
 	t.Helper()
 	resp := make([]Portal, 0, len(network.EVMChains()))
 	for _, chain := range network.EVMChains() {
+		if _, ok := evmchain.MetadataByID(chain.ID); !ok {
+			t.Log("Skipping mock chain", chain.ID)
+			continue
+		}
+
 		rpc, err := endpoints.ByNameOrID(chain.Name, chain.ID)
 		tutil.RequireNoError(t, err)
 

--- a/halo/registry/keeper/helper.go
+++ b/halo/registry/keeper/helper.go
@@ -1,0 +1,31 @@
+package keeper
+
+import (
+	"github.com/omni-network/omni/lib/errors"
+
+	"github.com/ethereum/go-ethereum/common"
+)
+
+func (p *Portal) Verify() error {
+	if p.GetChainId() == 0 {
+		return errors.New("zero chain id")
+	}
+
+	if len(p.GetAddress()) != common.AddressLength {
+		return errors.New("invalid address length")
+	}
+
+	if len(p.GetShardIds()) == 0 {
+		return errors.New("no shards")
+	}
+
+	dupShards := make(map[uint64]bool)
+	for _, s := range p.GetShardIds() {
+		if dupShards[s] {
+			return errors.New("duplicate shard id")
+		}
+		dupShards[s] = true
+	}
+
+	return nil
+}

--- a/halo/registry/keeper/keeper.go
+++ b/halo/registry/keeper/keeper.go
@@ -67,46 +67,28 @@ func (k Keeper) getOrCreateNetwork(ctx context.Context) (*Network, error) {
 	sdkCtx := sdk.UnwrapSDKContext(ctx)
 	createHeight := uint64(sdkCtx.BlockHeight())
 
+	var lastPortals []*Portal
+
 	latestNetworkID, err := k.networkTable.LastInsertedSequence(ctx)
 	if err != nil {
 		return nil, errors.Wrap(err, "get last network ID")
-	} else if latestNetworkID == 0 {
-		// Create the first empty network
-		network := &Network{
-			CreatedHeight: createHeight,
-		}
-
-		network.Id, err = k.networkTable.InsertReturningId(ctx, network)
+	} else if latestNetworkID != 0 {
+		// Get the latest network
+		lastNetwork, err := k.networkTable.Get(ctx, latestNetworkID)
 		if err != nil {
-			return nil, errors.Wrap(err, "insert first network")
+			return nil, errors.Wrap(err, "get network")
+		} else if lastNetwork.GetCreatedHeight() == createHeight {
+			// This network was created in this block, use it as is.
+			return lastNetwork, nil
 		}
 
-		_, err := k.emilPortal.EmitMsg(
-			sdkCtx,
-			ptypes.MsgTypeNetwork,
-			network.GetId(),
-			xchain.BroadcastChainID,
-			xchain.ShardBroadcast0,
-		)
-		if err != nil {
-			return nil, errors.Wrap(err, "emit portal message")
-		}
-
-		return network, nil
-	}
-
-	lastNetwork, err := k.networkTable.Get(ctx, latestNetworkID)
-	if err != nil {
-		return nil, errors.Wrap(err, "get network")
-	} else if lastNetwork.GetCreatedHeight() == createHeight {
-		// This network was created in this block, use it as is.
-		return lastNetwork, nil
+		lastPortals = lastNetwork.GetPortals()
 	}
 
 	// Create a new network using the latest network as base
 	network := &Network{
 		CreatedHeight: createHeight,
-		Portals:       lastNetwork.GetPortals(),
+		Portals:       lastPortals,
 	}
 	network.Id, err = k.networkTable.InsertReturningId(ctx, network)
 	if err != nil {
@@ -114,6 +96,17 @@ func (k Keeper) getOrCreateNetwork(ctx context.Context) (*Network, error) {
 	}
 
 	k.latestCache.Set(network)
+
+	_, err = k.emilPortal.EmitMsg(
+		sdkCtx,
+		ptypes.MsgTypeNetwork,
+		network.GetId(),
+		xchain.BroadcastChainID,
+		xchain.ShardBroadcast0,
+	)
+	if err != nil {
+		return nil, errors.Wrap(err, "emit portal message")
+	}
 
 	return network, nil
 }

--- a/halo/registry/keeper/logeventproc_internal_test.go
+++ b/halo/registry/keeper/logeventproc_internal_test.go
@@ -1,0 +1,149 @@
+package keeper
+
+import (
+	"testing"
+
+	ptypes "github.com/omni-network/omni/halo/portal/types"
+	"github.com/omni-network/omni/halo/registry/types"
+	"github.com/omni-network/omni/lib/errors"
+	"github.com/omni-network/omni/lib/netconf"
+	"github.com/omni-network/omni/lib/tutil"
+	"github.com/omni-network/omni/lib/xchain"
+
+	storetypes "cosmossdk.io/store/types"
+	"github.com/cosmos/cosmos-sdk/runtime"
+	sdktestutil "github.com/cosmos/cosmos-sdk/testutil"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	fuzz "github.com/google/gofuzz"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
+)
+
+func TestAddPortal(t *testing.T) {
+	t.Parallel()
+	fuzzer := fuzz.New().NumElements(1, 8).NilChance(0)
+	dupChainIDs := make(map[uint64]bool)
+	newPortal := func() *Portal {
+		var p Portal
+		for {
+			fuzzer.Fuzz(&p)
+			p.Address = tutil.RandomAddress().Bytes()
+			if dupChainIDs[p.GetChainId()] {
+				continue
+			} else if err := p.Verify(); err != nil {
+				t.Log("retrying due to invalid fuzz")
+				continue
+			}
+
+			break
+		}
+		dupChainIDs[p.GetChainId()] = true
+
+		return &p
+	}
+
+	ctx, keeper, emitPortal := setupKeeper(t)
+
+	ensurePortals := func(t *testing.T, portals ...*Portal) {
+		t.Helper()
+		latestPortals, err := keeper.getLatestPortals(ctx)
+		require.NoError(t, err)
+
+		cmpOpts := cmp.Options{cmpopts.IgnoreUnexported(Portal{})}
+		if !cmp.Equal(portals, latestPortals, cmpOpts) {
+			t.Error(cmp.Diff(portals, latestPortals, cmpOpts))
+		}
+
+		for _, p := range portals {
+			ok, err := keeper.SupportedChain(ctx, p.GetChainId())
+			require.NoError(t, err)
+			require.True(t, ok)
+		}
+	}
+
+	portals, err := keeper.getLatestPortals(ctx)
+	require.NoError(t, err)
+	require.Empty(t, portals)
+	ok, err := keeper.SupportedChain(ctx, 99)
+	require.NoError(t, err)
+	require.False(t, ok)
+
+	ctx = ctx.WithBlockHeight(1)
+
+	// Add a new portal (in block 1)
+	p1 := newPortal()
+	require.NoError(t, keeper.addPortal(ctx, p1))
+	ensurePortals(t, p1)
+
+	// Add a second portal (also in block 1)
+	p2 := newPortal()
+	require.NoError(t, keeper.addPortal(ctx, p2))
+	ensurePortals(t, p1, p2)
+
+	ctx = ctx.WithBlockHeight(2)
+
+	// Add p1 with an additional shard (in block 2), thats fine
+	p1.ShardIds = append(p1.ShardIds, p1.GetShardIds()[0]+1) // Note there is a non-zero probability of this adding a duplicate shard that will cause the test to fail.
+	require.NoError(t, keeper.addPortal(ctx, p1))
+	ensurePortals(t, p1, p2)
+
+	// Add p1 again (in block 2), that errors
+	require.Error(t, keeper.addPortal(ctx, p1))
+
+	// Add p1 with a different address, that errors
+	p3 := proto.Clone(p1).(*Portal)
+	p3.Address = tutil.RandomAddress().Bytes()
+	require.Error(t, keeper.addPortal(ctx, p3))
+	ensurePortals(t, p1, p2)
+
+	// Add p1 with a different deploy height, that errors
+	p4 := proto.Clone(p1).(*Portal)
+	p4.DeployHeight++
+	require.Error(t, keeper.addPortal(ctx, p4))
+	ensurePortals(t, p1, p2)
+
+	// Add p1 again (in block 2), that errors
+	require.Error(t, keeper.addPortal(ctx, p1))
+
+	// We added portals in two blocks.
+	require.Len(t, emitPortal.emittedIDs, 2)
+	require.EqualValues(t, []uint64{1, 2}, emitPortal.emittedIDs)
+}
+
+func setupKeeper(t *testing.T) (sdk.Context, Keeper, *testEmitPortal) {
+	t.Helper()
+
+	key := storetypes.NewKVStoreKey(types.ModuleName)
+	storeSvc := runtime.NewKVStoreService(key)
+	ctx := sdktestutil.DefaultContext(key, storetypes.NewTransientStoreKey("test_key"))
+	ctx = ctx.WithBlockHeight(1)
+	ctx = ctx.WithChainID(netconf.Simnet.Static().OmniConsensusChainIDStr())
+
+	emitPortal := new(testEmitPortal)
+	k, err := NewKeeper(emitPortal, storeSvc, nil)
+	require.NoError(t, err, "new keeper")
+
+	return ctx, k, emitPortal
+}
+
+var _ ptypes.EmitPortal = &testEmitPortal{}
+
+type testEmitPortal struct {
+	emittedIDs []uint64
+}
+
+func (t *testEmitPortal) EmitMsg(_ sdk.Context, typ ptypes.MsgType, msgTypeID uint64, destChainID uint64, shardID xchain.ShardID) (uint64, error) {
+	if typ != ptypes.MsgTypeNetwork {
+		return 0, errors.New("invalid message type")
+	} else if destChainID != xchain.BroadcastChainID {
+		return 0, errors.New("invalid destination chain id")
+	} else if shardID != xchain.ShardBroadcast0 {
+		return 0, errors.New("invalid shard id")
+	}
+
+	t.emittedIDs = append(t.emittedIDs, msgTypeID)
+
+	return uint64(len(t.emittedIDs)), nil
+}

--- a/lib/fireblocks/client_test.go
+++ b/lib/fireblocks/client_test.go
@@ -90,7 +90,7 @@ func parseKey(t *testing.T, data []byte) *rsa.PrivateKey {
 	k, err := x509.ParsePKCS8PrivateKey(p.Bytes)
 	require.NoError(t, err)
 
-	return k.(*rsa.PrivateKey) //nolint:forcetypeassert // parseKey is only used for testing
+	return k.(*rsa.PrivateKey)
 }
 
 // Populate this or run TestSmoke via terminal

--- a/lib/tracer/trace_test.go
+++ b/lib/tracer/trace_test.go
@@ -77,7 +77,6 @@ func TestDefaultNoopTracer(_ *testing.T) {
 	inner(ctx)
 }
 
-//nolint:forcetypeassert // Ok for tests
 func TestStdOutTracer(t *testing.T) {
 	ctx := context.Background()
 

--- a/lib/tutil/random.go
+++ b/lib/tutil/random.go
@@ -21,3 +21,11 @@ func RandomHash() common.Hash {
 
 	return resp
 }
+
+// RandomAddress returns a random 20-byte ethereum address.
+func RandomAddress() common.Address {
+	var resp common.Address
+	_, _ = rand.Read(resp[:])
+
+	return resp
+}

--- a/relayer/app/creator_test.go
+++ b/relayer/app/creator_test.go
@@ -42,7 +42,8 @@ func TestCreatorService_CreateSubmissions(t *testing.T) {
 	)
 
 	var block xchain.Block
-	fuzzer.NilChance(0).NumElements(1, 64).Fuzz(&block)
+	fuzzer.NilChance(0).NumElements(2, 64).Fuzz(&block)
+	require.NotEmpty(t, block.Msgs)
 
 	var valSetID uint64
 	fuzzer.Fuzz(&valSetID)
@@ -109,8 +110,8 @@ func TestCreatorService_CreateSubmissions(t *testing.T) {
 				attRoot, err := att.AttestationRoot()
 				require.NoError(t, err)
 				require.Equal(t, sub.AttestationRoot.Bytes(), attRoot[:])
-				require.NotNil(t, sub.ProofFlags)
-				require.NotNil(t, sub.Signatures)
+				require.NotEmpty(t, sub.ProofFlags)
+				require.NotEmpty(t, sub.Signatures)
 				for _, msg := range sub.Msgs {
 					require.Equal(t, msg.DestChainID, sub.DestChainID)
 				}


### PR DESCRIPTION
Add unit tests and more e2e tests to halo registry. 

Fix some issues:
- Ensure emit portal messages are created for all networks
- Error if duplicate portals are added.
- Add basic validation

task: none