### PR TITLE
docs(quickstart): add deployment env vars

### DIFF
--- a/docs/site/docs/develop/quickstart/quickstart.md
+++ b/docs/site/docs/develop/quickstart/quickstart.md
@@ -82,10 +82,14 @@ This `.env` file is used by the bash `deploy.sh` script to deploy the contracts.
 </details>
 
 ```bash
+export PORTAL_ADDRESS=0xb835dc695c6bfc8373c0d56973b5d9e9b083e97b
+export GLOBAL_GREETER_ADDRESS=0x8464135c8F25Da09e49BC8782676a84730C318bC
 forge script DeployGlobalGreeter --broadcast --rpc-url http://localhost:8000 --private-key 0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d
 forge script DeployRollupGreeter --broadcast --rpc-url http://localhost:8001 --private-key 0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d
 forge script DeployRollupGreeter --broadcast --rpc-url http://localhost:8002 --private-key 0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d
 ```
+
+Note: we know the address the `GlobalGreeter` will be deployed to as a new network is started and the nonce for the account used to deploy is always the same (0). The `RollupGreeter` contract is deployed to the same address on both the mock chains, since these are also new networks and the account has no actions on that account.
 
 ### Step 5: Perform a Cross-Chain Greet
 


### PR DESCRIPTION
add missing env vars required for foundry deployment scripts

task: none