### PR TITLE
fix(halo/relayer): increase gas limit of consensus chain submissions

### DIFF
--- a/relayer/app/app.go
+++ b/relayer/app/app.go
@@ -58,9 +58,15 @@ func Run(ctx context.Context, cfg Config) error {
 	xprov := xprovider.New(network, rpcClientPerChain, cprov)
 
 	for _, destChain := range network.EVMChains() {
-		// Setup sender
+		// Setup sender provider
 		sendProvider := func() (SendFunc, error) {
-			sender, err := NewSender(destChain, rpcClientPerChain[destChain.ID], *privateKey, network.ChainVersionNames())
+			sender, err := NewSender(
+				network.ID,
+				destChain,
+				rpcClientPerChain[destChain.ID],
+				*privateKey,
+				network.ChainVersionNames(),
+			)
 			if err != nil {
 				return nil, err
 			}


### PR DESCRIPTION
Fix issue introduces by `adding mock portals` that resulted in `out-of-gas` submission reverted issues of large `setNetwork` consensus chain messages by increasing gas limit for ephemeral chains and using proper gas estimation for protected chains. 

Also prevent ephemeral chains from loading mock portals into netconf. 

task: none