### PR TITLE
fix(e2e/pp): check if latest shard is enabled for pp

### DIFF
--- a/e2e/netman/pingpong/pingpong.go
+++ b/e2e/netman/pingpong/pingpong.go
@@ -5,6 +5,7 @@ import (
 	"crypto/rand"
 	"encoding/hex"
 	"math/big"
+	"slices"
 	"time"
 
 	"github.com/omni-network/omni/contracts/bindings/examples"
@@ -166,10 +167,12 @@ func (d *XDapp) StartAllEdges(ctx context.Context, latest, parallel, count uint6
 			"count", count,
 		)
 
+		shards := from.Chain.Shards
 		for i := uint64(0); i < parallel; i++ {
 			// First are latest, rest is finalized
 			conf := xchain.ConfFinalized
-			if i < latest {
+			// Only use latest shard if the chain has it and "latest" is enabled (i.e. not 0)
+			if slices.Contains(shards, xchain.ShardLatest0) && i < latest {
 				conf = xchain.ConfLatest
 			}
 


### PR DESCRIPTION
Only allow the latest shard in the pingping XDapp if it is supported.

task: none
