### PR TITLE
fix(octane/keeper): avoid division by zero

### DIFF
--- a/e2e/app/definition.go
+++ b/e2e/app/definition.go
@@ -603,6 +603,11 @@ func nodeByPrefix(testnet types.Testnet, prefix string) *e2e.Node {
 
 // random returns a random item from a slice.
 func random[T any](items []T) T {
+	var zero T
+	if len(items) == 0 {
+		return zero
+	}
+
 	return items[int(time.Now().UnixNano())%len(items)]
 }
 

--- a/lib/contracts/feeoraclev1/feeparams.go
+++ b/lib/contracts/feeoraclev1/feeparams.go
@@ -108,8 +108,8 @@ func conversionRate(ctx context.Context, pricer tokens.Pricer, from, to tokens.T
 	}
 
 	has := func(t tokens.Token) bool {
-		_, ok := prices[t]
-		return ok
+		p, ok := prices[t]
+		return ok && p > 0
 	}
 	if !has(to) {
 		return 0, errors.New("missing to token price", "to", to)

--- a/lib/netconf/provider.go
+++ b/lib/netconf/provider.go
@@ -111,6 +111,10 @@ func IntervalFromPeriod(network ID, period time.Duration) uint64 {
 		target = time.Second * 10
 	}
 
+	if period == 0 {
+		return 0
+	}
+
 	return uint64(target / period)
 }
 

--- a/octane/evmengine/keeper/keeper.go
+++ b/octane/evmengine/keeper/keeper.go
@@ -176,7 +176,7 @@ func (k *Keeper) isNextProposer(ctx context.Context, currentProposer []byte, cur
 	valset, ok, err := k.cmtAPI.Validators(ctx, currentHeight)
 	if err != nil {
 		return false, err
-	} else if !ok {
+	} else if !ok || len(valset.Validators) == 0 {
 		return false, errors.New("validators not available")
 	}
 


### PR DESCRIPTION
Avoid division by zero.

This fixes OMP-25 as per sigma prime audit.

task: none