### PR TITLE
fix(lib/xchain): avoid linear merkle index search

### DIFF
--- a/lib/merkle/msg_test.go
+++ b/lib/merkle/msg_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestBlockTree(t *testing.T) {
+func TestMsgTree(t *testing.T) {
 	t.Parallel()
 
 	var msgs []xchain.Msg


### PR DESCRIPTION
Fixes linear search of large merkle trees by populating a reverse lookup table in constructor.

Fixes OMP-24 as per Sigma Prime audit.

task: none