### PR TITLE
fix(lib/k1util): add invalid pubkey error handling

### DIFF
--- a/lib/contracts/avs/register.go
+++ b/lib/contracts/avs/register.go
@@ -62,7 +62,10 @@ func RegisterOperatorWithAVS(ctx context.Context, addr common.Address, backend *
 		return errors.Wrap(err, "public key")
 	}
 
-	pubkey64 := k1util.PubKeyToBytes64(pubkey)
+	pubkey64, err := k1util.PubKeyToBytes64(pubkey)
+	if err != nil {
+		return err
+	}
 
 	tx, err := avs.RegisterOperator(txOpts, pubkey64, bindings.ISignatureUtilsSignatureWithSaltAndExpiry{
 		Signature: sig[:],

--- a/lib/k1util/k1util.go
+++ b/lib/k1util/k1util.go
@@ -145,8 +145,13 @@ func PubKeyPBToAddress(pubkey cryptopb.PublicKey) (common.Address, error) {
 }
 
 // PubKeyToBytes64 returns the 64 byte uncompressed version of the public key, by removing the prefix (0x04 for uncompressed keys).
-func PubKeyToBytes64(pubkey *stdecdsa.PublicKey) []byte {
-	return ethcrypto.FromECDSAPub(pubkey)[1:]
+func PubKeyToBytes64(pubkey *stdecdsa.PublicKey) ([]byte, error) {
+	bz := ethcrypto.FromECDSAPub(pubkey)
+	if len(bz) != pubkeyUncompressedLen {
+		return nil, errors.New("invalid pubkey")
+	}
+
+	return bz[1:], nil
 }
 
 // PubKeyFromBytes64 returns the public key from the 64 byte uncompressed version.

--- a/lib/k1util/k1util_test.go
+++ b/lib/k1util/k1util_test.go
@@ -123,7 +123,8 @@ func TestPubkey64(t *testing.T) {
 	priv, err := crypto.GenerateKey()
 	require.NoError(t, err)
 
-	bz64 := k1util.PubKeyToBytes64(&priv.PublicKey)
+	bz64, err := k1util.PubKeyToBytes64(&priv.PublicKey)
+	require.NoError(t, err)
 	require.Len(t, bz64, 64)
 
 	pub, err := k1util.PubKeyFromBytes64(bz64)

--- a/lib/netconf/netconf_test.go
+++ b/lib/netconf/netconf_test.go
@@ -112,7 +112,8 @@ func TestGenExecutionSeeds(t *testing.T) {
 					stdPrivKey, err := key.ECDSA()
 					require.NoError(t, err)
 
-					pubkey64 := k1util.PubKeyToBytes64(&stdPrivKey.PublicKey)
+					pubkey64, err := k1util.PubKeyToBytes64(&stdPrivKey.PublicKey)
+					require.NoError(t, err)
 					pubkeyHex := hex.EncodeToString(pubkey64)
 					nodeName := strings.TrimSuffix(node, "_evm")
 


### PR DESCRIPTION
Adds additional error handling for invalid pubkeys.

Fixes OMP-16 as per Sigma Prime audit.

task: none