### PR TITLE
fix(lib/merkle): ensure trees have odd number of nodes

### DIFF
--- a/lib/merkle/core.go
+++ b/lib/merkle/core.go
@@ -40,6 +40,11 @@ func MakeTree(leaves [][32]byte) ([][32]byte, error) {
 		tree[i] = hashPair(tree[leftChildIndex(i)], tree[rightChildIndex(i)])
 	}
 
+	// Ensure the tree always has an odd number of nodes.
+	if treeLen%2 == 0 {
+		return nil, errors.New("invalid even tree [BUG]")
+	}
+
 	return tree, nil
 }
 
@@ -54,6 +59,8 @@ type MultiProof struct {
 func GetMultiProof(tree [][32]byte, indices ...int) (MultiProof, error) {
 	if len(indices) == 0 {
 		return MultiProof{}, errors.New("no indices provided")
+	} else if len(tree)%2 == 0 {
+		return MultiProof{}, errors.New("invalid even tree [BUG]")
 	}
 
 	for _, i := range indices {
@@ -86,6 +93,10 @@ func GetMultiProof(tree [][32]byte, indices ...int) (MultiProof, error) {
 
 		s := siblingIndex(j)
 		p := parentIndex(j)
+
+		if s >= len(tree) {
+			return MultiProof{}, errors.New("invalid sibling index, invalid tree [BUG]")
+		}
 
 		if len(stack) > 0 && s == stack[0] {
 			proofFlags = append(proofFlags, true)

--- a/lib/merkle/core_test.go
+++ b/lib/merkle/core_test.go
@@ -6,6 +6,8 @@ import (
 
 	"github.com/omni-network/omni/lib/merkle"
 
+	"github.com/ethereum/go-ethereum/crypto"
+
 	fuzz "github.com/google/gofuzz"
 	"github.com/stretchr/testify/require"
 )
@@ -68,6 +70,20 @@ func TestLeavesProvable(t *testing.T) {
 	root, err := merkle.ProcessMultiProof(multi)
 	require.NoError(t, err)
 	require.Equal(t, tree[0], root)
+}
+
+func TestEvenTree(t *testing.T) {
+	t.Parallel()
+
+	// Invalid tree with an even number of nodes.
+	tree := [][32]byte{
+		crypto.Keccak256Hash([]byte("node1")),
+		crypto.Keccak256Hash([]byte("node2")),
+	}
+	treeIndices := []int{1}
+
+	_, err := merkle.GetMultiProof(tree, treeIndices...)
+	require.ErrorContains(t, err, "invalid even tree")
 }
 
 // randomIndicesRange returns a random range of indices of the provided slice.


### PR DESCRIPTION
Adds validations that ensures that merkle trees have an odd number of nodes.

This protects against panics due to malformed trees and fixes OMP-12 as per Sigma Prime audit.

task: none