### PR TITLE
chore: mention discussions in issue page

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: "GitHub Discussions"
+    url: "https://github.com/orgs/omni-network/discussions"
+    about: "Make sure to also give our GitHub Discussions site a look too."


### PR DESCRIPTION
mentions the org discussions page on the page where new issues are created

task: none