### PR TITLE
fix(lib/txmgr): handle network errors while querying receipts

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -73,6 +73,8 @@ linters-settings:
         arguments:
          - 'fmt.Printf'
          - 'fmt.Println'
+      - name: max-control-nesting
+        arguments: [10] # We allow more nesting
   staticcheck:
     checks:
      - "all"

--- a/lib/txmgr/txmgr.go
+++ b/lib/txmgr/txmgr.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"log/slog"
 	"math/big"
+	"net"
 	"strings"
 	"sync"
 	"time"
@@ -18,6 +19,7 @@ import (
 	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/core/txpool"
 	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/p2p/netutil"
 	"github.com/ethereum/go-ethereum/params"
 )
 
@@ -411,6 +413,8 @@ func (m *simple) waitMined(ctx context.Context, tx *types.Transaction,
 	const logFreqFactor = 10 // Log every 10th attempt
 	attempt := 1
 
+	netErrBackoff := expbackoff.New(ctx) // Additional backoff on network errors.
+
 	queryTicker := time.NewTicker(m.cfg.ReceiptQueryInterval)
 	defer queryTicker.Stop()
 	for {
@@ -419,7 +423,12 @@ func (m *simple) waitMined(ctx context.Context, tx *types.Transaction,
 			return nil, errors.Wrap(ctx.Err(), "context canceled")
 		case <-queryTicker.C:
 			receipt, ok, err := m.queryReceipt(ctx, txHash, sendState)
-			if err != nil {
+			if netutil.IsTemporaryError(err) || isNetworkError(err) {
+				// Treat all network errors as temporary, since we know we submitted the tx already.
+				// Network issues might resolve, and the tx might still be mined, don't give up.
+				log.Warn(ctx, "Temporary network error querying receipt (will retry)", err, "attempt", attempt)
+				netErrBackoff()
+			} else if err != nil {
 				return nil, err
 			} else if !ok && attempt%logFreqFactor == 0 {
 				log.Warn(ctx, "Transaction not yet mined", nil, "attempt", attempt)
@@ -676,4 +685,15 @@ func maybeSetTimeout(ctx context.Context, timeout time.Duration) (context.Contex
 	}
 
 	return context.WithTimeout(ctx, timeout)
+}
+
+// isNetworkError returns true if the error is a network error.
+func isNetworkError(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	opErr := new(net.OpError)
+
+	return errors.As(err, &opErr)
 }

--- a/lib/txmgr/txmgr_internal_test.go
+++ b/lib/txmgr/txmgr_internal_test.go
@@ -814,7 +814,7 @@ func TestWaitMinedReturnsReceiptAfterNotFound(t *testing.T) {
 	require.Equal(t, receipt.TxHash, txHash)
 }
 
-func TestWaitMinedRetiesNetError(t *testing.T) {
+func TestWaitMinedRetriesNetError(t *testing.T) {
 	t.Parallel()
 
 	// Temporary errors or any net.OpError results in retries.

--- a/lib/txmgr/txmgr_internal_test.go
+++ b/lib/txmgr/txmgr_internal_test.go
@@ -3,7 +3,10 @@ package txmgr
 import (
 	"context"
 	"errors"
+	"io"
 	"math/big"
+	"math/rand/v2"
+	"net"
 	"strconv"
 	"sync"
 	"testing"
@@ -668,7 +671,7 @@ func TestWaitMinedReturnsReceiptOnFirstSuccess(t *testing.T) {
 	require.Equal(t, receipt.TxHash, txHash)
 }
 
-// TestWaitMinedCanBeCanceled ensures that waitMined exits of the passed context
+// TestWaitMinedCanBeCanceled ensures that waitMined exits if the passed context
 // is canceled before a receipt is found.
 func TestWaitMinedCanBeCanceled(t *testing.T) {
 	t.Parallel()
@@ -722,6 +725,7 @@ func TestWaitMinedMultipleConfs(t *testing.T) {
 // inner loop of waitMined properly handles this case.
 type failingBackend struct {
 	ethclient.Client
+	txReceiptErr             error // Defaults to ethereum.NotFound if nil
 	returnSuccessBlockNumber bool
 	returnSuccessHeader      bool
 	returnSuccessReceipt     bool
@@ -747,7 +751,13 @@ func (b *failingBackend) TransactionReceipt(
 ) (*types.Receipt, error) {
 	if !b.returnSuccessReceipt {
 		b.returnSuccessReceipt = true
-		return nil, ethereum.NotFound
+
+		err := ethereum.NotFound
+		if b.txReceiptErr != nil {
+			err = b.txReceiptErr
+		}
+
+		return nil, err
 	}
 
 	return &types.Receipt{
@@ -789,6 +799,40 @@ func TestWaitMinedReturnsReceiptAfterNotFound(t *testing.T) {
 		},
 		chainName: "TEST",
 		backend:   &borkedBackend,
+	}
+
+	// Don't mine the tx with the default backend. The failingBackend will
+	// return the txHash on the second call.
+	tx := types.NewTx(&types.LegacyTx{})
+	txHash := tx.Hash()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	receipt, err := mgr.waitMined(ctx, tx, testSendState())
+	require.NoError(t, err)
+	require.NotNil(t, receipt)
+	require.Equal(t, receipt.TxHash, txHash)
+}
+
+func TestWaitMinedRetiesNetError(t *testing.T) {
+	t.Parallel()
+
+	// Temporary errors or any net.OpError results in retries.
+	netErr := context.DeadlineExceeded
+	if rand.Float64() > 0.5 {
+		netErr = &net.OpError{Op: "read", Err: io.EOF}
+	}
+	netErrBackend := failingBackend{txReceiptErr: netErr}
+
+	mgr := &simple{
+		cfg: Config{
+			ResubmissionTimeout:       time.Second,
+			ReceiptQueryInterval:      50 * time.Millisecond,
+			NumConfirmations:          1,
+			SafeAbortNonceTooLowCount: 3,
+		},
+		chainName: "TEST",
+		backend:   &netErrBackend,
 	}
 
 	// Don't mine the tx with the default backend. The failingBackend will


### PR DESCRIPTION
Treats all network errors while querying receipts as temporary; retrying fetching receipts, don't give up.

This fixes the issue where a network error occurs, but the tx is mined, txmgr gives up querying receipt, and then gets stuck trying to bump fees and resubmit the tx (getting ErrNonceToLow). 

This caused flapping e2e tests when perturbations restart the EVM. 

task: https://app.asana.com/0/1206208509925075/1207634096794277
