### PR TITLE
ci(e2e): ensure nodes are synced

### DIFF
--- a/e2e/app/definition.go
+++ b/e2e/app/definition.go
@@ -170,7 +170,7 @@ func newBackends(ctx context.Context, cfg DefinitionConfig, testnet types.Testne
 
 	// If no fireblocks API key, use in-memory keys.
 	if cfg.FireAPIKey == "" {
-		return ethbackend.NewBackends(testnet, cfg.DeployKeyFile)
+		return ethbackend.NewBackends(ctx, testnet, cfg.DeployKeyFile)
 	}
 
 	key, err := fireblocks.LoadKey(cfg.FireKeyPath)

--- a/lib/ethclient/ethbackend/backend.go
+++ b/lib/ethclient/ethbackend/backend.go
@@ -242,6 +242,23 @@ func (b *Backend) SendTransaction(ctx context.Context, in *ethtypes.Transaction)
 	return nil
 }
 
+// EnsureSynced returns an error if the backend is not synced.
+func (b *Backend) EnsureSynced(ctx context.Context) error {
+	syncing, err := b.SyncProgress(ctx)
+	if err != nil {
+		return err
+	} else if syncing == nil {
+		return nil // Syncing is nil if node is not syncing.
+	} else if !syncing.Done() {
+		return errors.New("backend not synced",
+			"lag", syncing.HighestBlock-syncing.CurrentBlock,
+			"indexing", syncing.TxIndexRemainingBlocks,
+		)
+	}
+
+	return nil
+}
+
 func randomHex7() string {
 	bytes := make([]byte, 4)
 	_, _ = rand.Read(bytes)

--- a/lib/txmgr/txmgr_internal_test.go
+++ b/lib/txmgr/txmgr_internal_test.go
@@ -210,6 +210,14 @@ func (b *mockBackend) BlockNumber(ctx context.Context) (uint64, error) {
 	return b.blockHeight, nil
 }
 
+// SyncProgress returns the nil syncing progress; i.e. not syncing.
+func (b *mockBackend) SyncProgress(ctx context.Context) (*ethereum.SyncProgress, error) {
+	b.mu.RLock()
+	defer b.mu.RUnlock()
+
+	return nil, nil //nolint:nilnil // This is how geth does it.
+}
+
 func (b *mockBackend) HeaderByNumber(ctx context.Context, number *big.Int) (*types.Header, error) {
 	b.mu.RLock()
 	defer b.mu.RUnlock()


### PR DESCRIPTION
Ensure RPC nodes are synced when deploying/upgrading any network. This mitigates against nonce-too-low issues caused by out-of-sync RPC nodes.

task: none