### PR TITLE
chore(verifypr): allow linking issues

### DIFF
--- a/scripts/verifypr/verify.go
+++ b/scripts/verifypr/verify.go
@@ -15,10 +15,11 @@ import (
 )
 
 var (
+	optionalLink    = `(fix\w*\s|close\w*\s|resolve\w*\s)?`    // Optional issue linking prefix, see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue.
 	descRegex       = regexp.MustCompile(`^[a-z][-\w\s]+$`)    // e.g. "add foo-bar"
 	scopeRegex      = regexp.MustCompile(`^[*\w]+(/[*\w]+)?$`) // e.g. "*" or "foo" or "foo/bar"
-	issueRegexFull  = regexp.MustCompile(`^https://github.com/omni-network/omni/issues/\d+$`)
-	issueRegexShort = regexp.MustCompile(`^#\d+$`) // e.g. "#1334"
+	issueRegexFull  = regexp.MustCompile(`^` + optionalLink + `https://github.com/omni-network/omni/issues/\d+$`)
+	issueRegexShort = regexp.MustCompile(`^` + optionalLink + `#\d+$`) // e.g. "#1334"
 )
 
 // run runs the verification.

--- a/scripts/verifypr/verify_internal_test.go
+++ b/scripts/verifypr/verify_internal_test.go
@@ -77,6 +77,30 @@ foo bar baz
 issue: #1334`,
 		},
 		{
+			name: "fix valid short github issue",
+			commit: `feat(*): add foo bar
+
+foo bar baz
+
+issue: fix #1334`,
+		},
+		{
+			name: "resolves valid short github issue",
+			commit: `feat(*): add foo bar
+
+foo bar baz
+
+issue: resolves #1334`,
+		},
+		{
+			name: "closed full github issue",
+			commit: `feat(*): add foo bar
+
+foo bar baz
+
+issue: closed https://github.com/omni-network/omni/issues/1334`,
+		},
+		{
 			name:    "invalid description title case",
 			wantErr: true,
 			commit: `feat(*): Add foo bar
@@ -84,6 +108,15 @@ issue: #1334`,
 foo bar baz
 
 issue: none`,
+		},
+		{
+			name:    "invalid link short github issue",
+			wantErr: true,
+			commit: `feat(*): add foo bar
+
+foo bar baz
+
+issue: ifix #1334`,
 		},
 		{
 			name:    "invalid description punctuation",


### PR DESCRIPTION
Allow linking issues to PRs with optional `fixes/close/resolved` prefix.

[e.g.](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
```
issue: fix #1234
```

issue: none