### PR TITLE
ci(e2e): enable arb_sepolia on staging

### DIFF
--- a/e2e/app/run.go
+++ b/e2e/app/run.go
@@ -91,6 +91,10 @@ func Deploy(ctx context.Context, def Definition, cfg DeployConfig) (*pingpong.XD
 		return nil, err
 	}
 
+	if err := waitForEVMs(ctx, networkFromDef(def), def.Backends()); err != nil {
+		return nil, err
+	}
+
 	if err := fundAccounts(ctx, def); err != nil {
 		return nil, err
 	}

--- a/e2e/app/start.go
+++ b/e2e/app/start.go
@@ -5,10 +5,14 @@ import (
 	"path/filepath"
 	"slices"
 	"sort"
+	"sync"
 	"time"
 
 	"github.com/omni-network/omni/lib/errors"
+	"github.com/omni-network/omni/lib/ethclient/ethbackend"
+	"github.com/omni-network/omni/lib/expbackoff"
 	"github.com/omni-network/omni/lib/log"
+	"github.com/omni-network/omni/lib/netconf"
 
 	e2e "github.com/cometbft/cometbft/test/e2e/pkg"
 	"github.com/cometbft/cometbft/test/e2e/pkg/infra"
@@ -167,4 +171,44 @@ func getSortedNodes(testnet *e2e.Testnet) ([]*e2e.Node, error) {
 	})
 
 	return nodeQueue, nil
+}
+
+// waitForEVMs waits for EVMs to be available.
+// This mitigates any issues if starting anvils or omni evms is slow.
+// It also ensures the public RPCs are accessible.
+func waitForEVMs(ctx context.Context, network netconf.Network, backends ethbackend.Backends) error {
+	for _, chain := range network.EVMChains() {
+		backend, err := backends.Backend(chain.ID)
+		if err != nil {
+			return errors.Wrap(err, "backend")
+		}
+
+		innerCtx := log.WithCtx(ctx, "chain", chain.Name)
+		if err := waitForEVM(innerCtx, backend); err != nil {
+			return errors.Wrap(err, "waiting for EVM", "chain", chain.Name)
+		}
+	}
+
+	return nil
+}
+
+func waitForEVM(ctx context.Context, backend *ethbackend.Backend) error {
+	ctx, cancel := context.WithTimeout(ctx, time.Second*10)
+	defer cancel()
+
+	var once sync.Once
+
+	backoff := expbackoff.New(ctx)
+	for ctx.Err() == nil {
+		_, err := backend.BlockNumber(ctx)
+		if err == nil {
+			return nil
+		}
+		once.Do(func() {
+			log.Warn(ctx, "Waiting for EVM chain to be available", err, "address", backend.Address())
+		})
+		backoff()
+	}
+
+	return errors.Wrap(ctx.Err(), "timeout")
 }

--- a/e2e/manifests/staging.toml
+++ b/e2e/manifests/staging.toml
@@ -1,5 +1,5 @@
 network = "staging"
-public_chains = ["op_sepolia", "base_sepolia"]
+public_chains = ["op_sepolia","base_sepolia","arb_sepolia"]
 anvil_chains = ["slow_l1"]
 multi_omni_evms = true
 prometheus = true

--- a/e2e/netman/pingpong/pingpong.go
+++ b/e2e/netman/pingpong/pingpong.go
@@ -19,7 +19,6 @@ import (
 
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
-	ethtypes "github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/params"
 
 	"golang.org/x/sync/errgroup"
@@ -142,10 +141,8 @@ func (d *XDapp) fund(ctx context.Context) error {
 			return errors.Wrap(err, "fund ping pong", "chain", contract.Chain.Name)
 		}
 
-		if rec, err := bind.WaitMined(ctx, backend, tx); err != nil {
+		if _, err := backend.WaitMined(ctx, tx); err != nil {
 			return errors.Wrap(err, "wait mined", "chain", contract.Chain.Name, "tx", tx.Hash())
-		} else if rec.Status != ethtypes.ReceiptStatusSuccessful {
-			return errors.New("fund unsuccessful", "chain", contract.Chain.Name)
 		}
 	}
 

--- a/lib/contracts/avs/deploy.go
+++ b/lib/contracts/avs/deploy.go
@@ -259,11 +259,8 @@ func deploy(ctx context.Context, cfg DeploymentConfig, backend *ethbackend.Backe
 		return common.Address{}, nil, errors.Wrap(err, "deploy impl")
 	}
 
-	receipt, err := backend.WaitMined(ctx, tx)
-	if err != nil {
+	if _, err := backend.WaitMined(ctx, tx); err != nil {
 		return common.Address{}, nil, errors.Wrap(err, "wait mined portal")
-	} else if receipt.Status != ethtypes.ReceiptStatusSuccessful {
-		return common.Address{}, nil, errors.New("deploy impl failed")
 	}
 
 	initCode, err := packInitCode(cfg, impl)
@@ -276,11 +273,9 @@ func deploy(ctx context.Context, cfg DeploymentConfig, backend *ethbackend.Backe
 		return common.Address{}, nil, errors.Wrap(err, "deploy avs")
 	}
 
-	receipt, err = backend.WaitMined(ctx, tx)
+	receipt, err := backend.WaitMined(ctx, tx)
 	if err != nil {
 		return common.Address{}, nil, errors.Wrap(err, "wait mined avs")
-	} else if receipt.Status != ethtypes.ReceiptStatusSuccessful {
-		return common.Address{}, nil, errors.New("deploy avs failed")
 	}
 
 	return addr, receipt, nil

--- a/lib/contracts/create3/deploy.go
+++ b/lib/contracts/create3/deploy.go
@@ -10,7 +10,6 @@ import (
 	"github.com/omni-network/omni/lib/ethclient/ethbackend"
 	"github.com/omni-network/omni/lib/netconf"
 
-	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
 	ethtypes "github.com/ethereum/go-ethereum/core/types"
 )
@@ -157,11 +156,9 @@ func deploy(ctx context.Context, cfg DeploymentConfig, backend *ethbackend.Backe
 		return common.Address{}, nil, errors.Wrap(err, "deploy create3")
 	}
 
-	receipt, err := bind.WaitMined(ctx, backend, tx)
+	receipt, err := backend.WaitMined(ctx, tx)
 	if err != nil {
 		return common.Address{}, nil, errors.Wrap(err, "wait mined")
-	} else if receipt.Status != ethtypes.ReceiptStatusSuccessful {
-		return common.Address{}, nil, errors.New("receipt status failed")
 	}
 
 	return addr, receipt, nil

--- a/lib/contracts/proxyadmin/deploy.go
+++ b/lib/contracts/proxyadmin/deploy.go
@@ -11,7 +11,6 @@ import (
 	"github.com/omni-network/omni/lib/ethclient/ethbackend"
 	"github.com/omni-network/omni/lib/netconf"
 
-	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
 	ethtypes "github.com/ethereum/go-ethereum/core/types"
 )
@@ -196,11 +195,9 @@ func deploy(ctx context.Context, cfg DeploymentConfig, backend *ethbackend.Backe
 		return common.Address{}, nil, errors.Wrap(err, "deploy proxy admin")
 	}
 
-	receipt, err := bind.WaitMined(ctx, backend, tx)
+	receipt, err := backend.WaitMined(ctx, tx)
 	if err != nil {
 		return common.Address{}, nil, errors.Wrap(err, "wait mined proxy admin")
-	} else if receipt.Status != ethtypes.ReceiptStatusSuccessful {
-		return common.Address{}, nil, errors.New("deploy proxy failed")
 	}
 
 	return addr, receipt, nil

--- a/lib/ethclient/ethbackend/backend.go
+++ b/lib/ethclient/ethbackend/backend.go
@@ -162,7 +162,7 @@ func (b *Backend) WaitMined(ctx context.Context, tx *ethtypes.Transaction) (*eth
 	if err != nil {
 		return nil, errors.Wrap(err, "wait mined", "chain", b.chainName)
 	} else if rec.Status != ethtypes.ReceiptStatusSuccessful {
-		return rec, errors.New("receipt status unsuccessful", "status", rec.Status)
+		return rec, errors.New("receipt status unsuccessful", "status", rec.Status, "tx", tx.Hash())
 	}
 
 	return rec, nil
@@ -245,7 +245,9 @@ func (b *Backend) SendTransaction(ctx context.Context, in *ethtypes.Transaction)
 // EnsureSynced returns an error if the backend is not synced.
 func (b *Backend) EnsureSynced(ctx context.Context) error {
 	syncing, err := b.SyncProgress(ctx)
-	if err != nil {
+	if ethclient.IsErrMethodNotAvailable(err) {
+		return nil // Assume synced if method not available.
+	} else if err != nil {
 		return err
 	} else if syncing == nil {
 		return nil // Syncing is nil if node is not syncing.

--- a/lib/ethclient/ethbackend/wait.go
+++ b/lib/ethclient/ethbackend/wait.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/omni-network/omni/lib/errors"
 
-	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	ethtypes "github.com/ethereum/go-ethereum/core/types"
 )
 
@@ -53,11 +52,9 @@ func (w *Waiter) Wait(ctx context.Context) error {
 
 	for chainID, txs := range w.txs {
 		for _, tx := range txs {
-			rec, err := bind.WaitMined(ctx, w.b.backends[chainID], tx)
+			_, err := w.b.backends[chainID].WaitMined(ctx, tx)
 			if err != nil {
 				return errors.Wrap(err, "wait mined", "chain_id", chainID)
-			} else if rec.Status != ethtypes.ReceiptStatusSuccessful {
-				return errors.New("tx status unsuccessful", "chain_id", chainID)
 			}
 		}
 	}

--- a/lib/ethclient/helper.go
+++ b/lib/ethclient/helper.go
@@ -1,0 +1,17 @@
+package ethclient
+
+import "strings"
+
+// IsErrMethodNotAvailable returns true if the error indicates that the
+// RPC method is not available on the server.
+// This is useful to handle some endpoints that are not always enabled/configured.
+func IsErrMethodNotAvailable(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	// See go-ethereum/rpc/errors.go: return fmt.Sprintf("the method %s does not exist/is not available", e.method)
+
+	return strings.Contains(err.Error(), "the method") &&
+		strings.Contains(err.Error(), "not available")
+}

--- a/lib/txmgr/txmgr.go
+++ b/lib/txmgr/txmgr.go
@@ -80,7 +80,10 @@ func (m *simple) ReserveNextNonce(ctx context.Context) (uint64, error) {
 
 	if m.nonce == nil {
 		// Ensure the node is synced before fetching the nonce
-		if syncing, err := m.backend.SyncProgress(ctx); err != nil {
+		syncing, err := m.backend.SyncProgress(ctx)
+		if ethclient.IsErrMethodNotAvailable(err) { //nolint:revive // Empty block skips error handling below.
+			// Skip if method not available.
+		} else if err != nil {
 			return 0, errors.Wrap(err, "sync progress")
 		} else if syncing != nil && !syncing.Done() { // Note syncing is nil if node is not syncing.
 			return 0, errors.New("backend not synced",


### PR DESCRIPTION
Enable arb_sepolia on staging.

Also:
 - Remove receipt checking not required.
 - Wait for EVMs on e2e startup
 - Handle `syncProgress` not available error

issue: none