### PR TITLE
chore(lib/netconf): bumps omega version to support a new deployment

### DIFF
--- a/lib/netconf/static.go
+++ b/lib/netconf/static.go
@@ -147,7 +147,7 @@ var statics = map[ID]Static{
 	},
 	Omega: {
 		Network:              Omega,
-		Version:              "v0.0.6",
+		Version:              "v0.0.7",
 		AVSContractAddress:   omegaAVS,
 		OmniExecutionChainID: evmchain.IDOmniOmega,
 		MaxValidators:        maxValidators,


### PR DESCRIPTION
new omega deployment requires a version bump

issue: none
