### PR TITLE
fix(xchain/provider): fix concurrent offset tracker issue

### DIFF
--- a/lib/xchain/provider/provider_internal_test.go
+++ b/lib/xchain/provider/provider_internal_test.go
@@ -3,9 +3,14 @@ package provider
 import (
 	"context"
 	"testing"
+	"time"
 
+	"github.com/omni-network/omni/lib/errors"
 	"github.com/omni-network/omni/lib/ethclient"
 	"github.com/omni-network/omni/lib/netconf"
+	"github.com/omni-network/omni/lib/xchain"
+
+	"github.com/stretchr/testify/require"
 )
 
 // NewForT returns a new provider for testing. Note that cprovider isn't supported yet.
@@ -26,5 +31,57 @@ func NewForT(
 		ethClients:  rpcClients,
 		backoffFunc: backoffFunc,
 		confHeads:   make(map[chainVersion]uint64),
+	}
+}
+
+func TestOffsetTracker(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
+	defer cancel()
+
+	expectedOffsetsByHeight := map[uint64]uint64{ // map[height]offset
+		1: 1,
+		2: 0,
+		3: 0,
+		4: 2,
+		5: 3,
+		6: 0,
+		7: 4,
+	}
+
+	// Start at 1,1
+	tracker := newOffsetTracker(1, 1, 0)
+
+	errChan := make(chan error)
+
+	// Concurrently (and in random order), call awaitOffset.
+	for height, offset := range expectedOffsetsByHeight {
+		go func() {
+			var msgs []xchain.Msg
+			if offset > 0 {
+				// If an offset is expected, include an xmsg in the block.
+				msgs = append(msgs, xchain.Msg{})
+			}
+
+			actualOffset, err := tracker.awaitOffset(ctx, xchain.Block{
+				BlockHeader: xchain.BlockHeader{BlockHeight: height},
+				Msgs:        msgs,
+			})
+			if err != nil {
+				errChan <- err
+				return
+			}
+			if offset != actualOffset {
+				errChan <- errors.New("unexpected offset", "actual", actualOffset, "expected", offset)
+				return
+			}
+			errChan <- nil // All good
+		}()
+	}
+
+	// Collect the results, ensuring no errors.
+	for range expectedOffsetsByHeight {
+		require.NoError(t, <-errChan)
 	}
 }


### PR DESCRIPTION
Fixes concurrent fetch workers causing race in offset tracker. 

Instead, wait for "next height" before assigning the offset.

issue: fix #1372