### PR TITLE
fix(halo): disable optimistic exectution

### DIFF
--- a/halo/app/start.go
+++ b/halo/app/start.go
@@ -253,7 +253,7 @@ func makeBaseAppOpts(cfg Config) ([]func(*baseapp.BaseApp), error) {
 	}
 
 	return []func(*baseapp.BaseApp){
-		baseapp.SetOptimisticExecution(),
+		// baseapp.SetOptimisticExecution(), // Octane doesn't support this.
 		baseapp.SetChainID(chainID),
 		baseapp.SetMinRetainBlocks(cfg.MinRetainBlocks),
 		baseapp.SetPruning(pruneOpts),


### PR DESCRIPTION
Disable optimistic execution since octane doesn't support it at this point. Currently it results in omni_evm reorgs, both "allowed" and "impossible". 

issue: none