### PR TITLE
chore(e2e/eoa): decrease large threshold within sane max

### DIFF
--- a/e2e/app/eoa/fund.go
+++ b/e2e/app/eoa/fund.go
@@ -35,7 +35,7 @@ var (
 	// to last a weekend without topping up even if fees are spiking.
 	thresholdLarge = FundThresholds{
 		minEther:    5,
-		targetEther: 50,
+		targetEther: 20, // TODO(corver): Increase along with e2e/app#saneMaxEther
 	}
 
 	defaultThresholdsByRole = map[Role]FundThresholds{


### PR DESCRIPTION
Decrease large eoa fund threshold to within sane max so that these accounts can be funded and alerts cleared.

issue: none