### PR TITLE
chore(halo/genutil): disable cometBFT max block bytes

### DIFF
--- a/halo/genutil/defaults.go
+++ b/halo/genutil/defaults.go
@@ -7,6 +7,7 @@ func DefaultConsensusParams() *types.ConsensusParams {
 	resp := types.DefaultConsensusParams()
 	resp.ABCI.VoteExtensionsEnableHeight = 1                             // Enable vote extensions from the start.
 	resp.Validator.PubKeyTypes = []string{types.ABCIPubKeyTypeSecp256k1} // Only k1 keys.
+	resp.Block.MaxBytes = -1                                             // Disable max block bytes, since we MUST include the whole EVM block, which is limited by max gas per block.
 
 	return resp
 }

--- a/halo/genutil/genutil_internal_test.go
+++ b/halo/genutil/genutil_internal_test.go
@@ -19,6 +19,8 @@ func TestDefaultConsensusParams(t *testing.T) {
 	cons := defaultConsensusGenesis()
 	require.EqualValues(t, 1, cons.Params.ABCI.VoteExtensionsEnableHeight)
 	require.EqualValues(t, types.ABCIPubKeyTypeSecp256k1, cons.Params.Validator.PubKeyTypes[0])
+	require.EqualValues(t, -1, cons.Params.Block.MaxBytes)
+	require.EqualValues(t, -1, cons.Params.Block.MaxGas)
 }
 
 func TestEncodeTXs(t *testing.T) {

--- a/halo/genutil/testdata/TestMakeGenesis.golden
+++ b/halo/genutil/testdata/TestMakeGenesis.golden
@@ -218,7 +218,7 @@
  "consensus": {
   "params": {
    "block": {
-    "max_bytes": "22020096",
+    "max_bytes": "-1",
     "max_gas": "-1"
    },
    "evidence": {

--- a/octane/evmengine/keeper/abci.go
+++ b/octane/evmengine/keeper/abci.go
@@ -14,6 +14,7 @@ import (
 	"github.com/omni-network/omni/octane/evmengine/types"
 
 	abci "github.com/cometbft/cometbft/abci/types"
+	cmttypes "github.com/cometbft/cometbft/types"
 
 	"github.com/ethereum/go-ethereum/beacon/engine"
 	"github.com/ethereum/go-ethereum/common"
@@ -37,6 +38,9 @@ func (k *Keeper) PrepareProposal(ctx sdk.Context, req *abci.RequestPreparePropos
 	}()
 	if len(req.Txs) > 0 {
 		return nil, errors.New("unexpected transactions in proposal")
+	} else if req.MaxTxBytes < cmttypes.MaxBlockSizeBytes*9/10 {
+		// ConsensusParams.Block.MaxBytes is set to -1, so req.MaxTxBytes should be close to MaxBlockSizeBytes.
+		return nil, errors.New("invalid max tx bytes [BUG]", "max_tx_bytes", req.MaxTxBytes)
 	}
 
 	if req.Height == 1 {

--- a/octane/evmengine/keeper/abci_internal_test.go
+++ b/octane/evmengine/keeper/abci_internal_test.go
@@ -17,6 +17,7 @@ import (
 
 	abci "github.com/cometbft/cometbft/abci/types"
 	cmtproto "github.com/cometbft/cometbft/proto/tendermint/types"
+	cmttypes "github.com/cometbft/cometbft/types"
 	cmttime "github.com/cometbft/cometbft/types/time"
 
 	"github.com/ethereum/go-ethereum"
@@ -131,6 +132,8 @@ func TestKeeper_PrepareProposal(t *testing.T) {
 				require.NoError(t, err)
 				populateGenesisHead(ctx, t, k)
 
+				tt.req.MaxTxBytes = cmttypes.MaxBlockSizeBytes
+
 				_, err = k.PrepareProposal(withRandomErrs(t, ctx), tt.req)
 				if (err != nil) != tt.wantErr {
 					t.Errorf("PrepareProposal() error = %v, wantErr %v", err, tt.wantErr)
@@ -177,9 +180,10 @@ func TestKeeper_PrepareProposal(t *testing.T) {
 		payloadID := mockEngine.pushPayload(t, ctx, frp.LocalFeeRecipient(), nextBlock.Hash(), ts, appHash2)
 
 		req := &abci.RequestPrepareProposal{
-			Txs:    nil,
-			Height: int64(2),
-			Time:   time.Now(),
+			Txs:        nil,
+			Height:     int64(2),
+			Time:       time.Now(),
+			MaxTxBytes: cmttypes.MaxBlockSizeBytes,
 		}
 
 		// initialize mutable payload so we trigger the optimistic flow
@@ -227,9 +231,10 @@ func TestKeeper_PrepareProposal(t *testing.T) {
 		require.NoError(t, err)
 
 		req := &abci.RequestPrepareProposal{
-			Txs:    nil,
-			Height: int64(2),
-			Time:   time.Now(),
+			Txs:        nil,
+			Height:     int64(2),
+			Time:       time.Now(),
+			MaxTxBytes: cmttypes.MaxBlockSizeBytes,
 		}
 
 		resp, err := keeper.PrepareProposal(withRandomErrs(t, ctx), req)


### PR DESCRIPTION
Explicitly disable cometBFT block max bytes. This effectively increases maximum block size from 21MB (default) to 100MB. 

We MUST include the EVM block, which is limited to `MaxGas` (30M), not bytes. In practice, 30M gas results in +-3MB blocks. 

issue: none