### PR TITLE
refactor(monitor): use emit cursor cache for offset monitor

### DIFF
--- a/halo/attest/voter/voter_test.go
+++ b/halo/attest/voter/voter_test.go
@@ -478,6 +478,10 @@ func (stubProvider) GetEmittedCursor(context.Context, xchain.EmitRef, xchain.Str
 	panic("unexpected")
 }
 
+func (stubProvider) ChainVersionHeight(context.Context, xchain.ChainVersion) (uint64, error) {
+	panic("unexpected")
+}
+
 type testBackOff struct {
 	mu      sync.Mutex
 	backoff int

--- a/lib/ethclient/ethbackend/backend.go
+++ b/lib/ethclient/ethbackend/backend.go
@@ -235,6 +235,7 @@ func (b *Backend) SendTransaction(ctx context.Context, in *ethtypes.Transaction)
 		"gas_used", resp.GasUsed,
 		"status", resp.Status,
 		"height", resp.BlockNumber.Uint64(),
+		"tx", out.Hash(),
 	)
 
 	*in = *out //nolint:govet // Copy lock (caches) isn't a problem since we are overwriting the object.

--- a/lib/xchain/provider.go
+++ b/lib/xchain/provider.go
@@ -48,6 +48,9 @@ type Provider interface {
 	// Note that the BlockOffset field is not populated for emit cursors, since it isn't stored on-chain
 	// but tracked off-chain.
 	GetEmittedCursor(ctx context.Context, ref EmitRef, stream StreamID) (EmitCursor, bool, error)
+
+	// ChainVersionHeight returns the height for the provided chain version.
+	ChainVersionHeight(ctx context.Context, chainVer ChainVersion) (uint64, error)
 }
 
 // EmitRef specifies which block to query for emit cursors.

--- a/lib/xchain/provider/mock.go
+++ b/lib/xchain/provider/mock.go
@@ -69,6 +69,10 @@ func (m *Mock) StreamBlocks(ctx context.Context, req xchain.ProviderRequest, cal
 	return m.stream(ctx, req, callback, false)
 }
 
+func (*Mock) ChainVersionHeight(context.Context, xchain.ChainVersion) (uint64, error) {
+	return 0, errors.New("unsupported")
+}
+
 func (m *Mock) stream(
 	ctx context.Context,
 	req xchain.ProviderRequest,

--- a/relayer/app/cursors_internal_test.go
+++ b/relayer/app/cursors_internal_test.go
@@ -105,6 +105,10 @@ func (m *mockXChainClient) StreamBlocks(context.Context, xchain.ProviderRequest,
 	panic("unexpected")
 }
 
+func (*mockXChainClient) ChainVersionHeight(context.Context, xchain.ChainVersion) (uint64, error) {
+	panic("unexpected")
+}
+
 func (m *mockXChainClient) GetBlock(ctx context.Context, req xchain.ProviderRequest) (xchain.Block, bool, error) {
 	return m.GetBlockFn(ctx, req)
 }


### PR DESCRIPTION
Refactor `monitorOffsets` to use the `emitCursorCache`. 

Had to add a method to xprovider in order to map `ConfLevel` to `Height`:
```
	// ChainVersionHeight returns the latest height for the provided chain version.
	ChainVersionHeight(ctx context.Context, chainVer ChainVersion) (uint64, error)
```

issue: none