### PR TITLE
feat(attest): only store the most recent attestations in state

### DIFF
--- a/halo/app/app_config.go
+++ b/halo/app/app_config.go
@@ -46,7 +46,7 @@ const (
 	// TODO(corver): Maybe move these to genesis itself.
 	genesisVoteWindow   = 64
 	genesisVoteExtLimit = 256
-	genesisTrimLag      = 72_000 // Delete attestations state after +-1 day (given a period of 1.2s).
+	genesisTrimLag      = 1      // Delete attestations state after each epoch, only storing the very latest attestations.
 	genesisCTrimLag     = 72_000 // Delete consensus attestations state after +-1 day (given a period of 1.2s).
 
 	defaultPruningKeep     = 72_000 // Keep 1 day's of application state by default (given period of 1.2s).

--- a/halo/attest/keeper/builder_test.go
+++ b/halo/attest/keeper/builder_test.go
@@ -25,7 +25,7 @@ const (
 	defaultConfLevel = uint32(xchain.ConfFinalized)
 	defaultOffset    = uint64(1)
 	defaultHeight    = uint64(700)
-	trimLag          = 4
+	trimLag          = 1
 	cTrimLag         = 5
 )
 

--- a/halo/attest/keeper/keeper_test.go
+++ b/halo/attest/keeper/keeper_test.go
@@ -538,12 +538,9 @@ func TestKeeper_Approve(t *testing.T) {
 			},
 			want: want{
 				atts: []*keeper.Attestation{
-					expectApprovedAtt(3, defaultOffset+2, valset1_2, 18),
 					expectApprovedAtt(4, defaultOffset+3, valset1_2, 19),
 				},
 				sigs: []*keeper.Signature{
-					expectValSig(5, 3, val1, defaultOffset+2),
-					expectValSig(6, 3, val2, defaultOffset+2),
 					expectValSig(7, 4, val1, defaultOffset+3),
 					expectValSig(8, 4, val2, defaultOffset+3),
 				},


### PR DESCRIPTION
Reduce the trimLag to 1, keeping only the last epoch's attestations in state.

issue: #1343
