### PR TITLE
chore(deps): update to goreleaser v2

### DIFF
--- a/.github/workflows/clicommand.yml
+++ b/.github/workflows/clicommand.yml
@@ -35,7 +35,7 @@ jobs:
       env:
         GOOS: linux
       with:
-        version: latest
+        version: 2
         args: build --single-target --snapshot --clean --id=halo --id=relayer --id=monitor --id=anvilproxy
 
     - name: Build halo image

--- a/.github/workflows/pr-e2etest.yml
+++ b/.github/workflows/pr-e2etest.yml
@@ -19,7 +19,7 @@ jobs:
         env:
           GOOS: linux
         with:
-          version: latest
+          version: 2
           args: build --single-target --snapshot --clean --id=halo --id=relayer --id=monitor --id=anvilproxy
 
       - name: Build halo image

--- a/.github/workflows/release-official.yml
+++ b/.github/workflows/release-official.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Build docker images
         uses: goreleaser/goreleaser-action@v5
         with:
-          version: latest
+          version: 2
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-snapshot.yml
+++ b/.github/workflows/release-snapshot.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Build docker images
         uses: goreleaser/goreleaser-action@v5
         with:
-          version: latest
+          version: 2
           # Use --snapshot to build current HEAD commit (this doesn't publish images)
           args: release --snapshot --clean
         env:


### PR DESCRIPTION
Fixes CI builds such as https://github.com/omni-network/omni/actions/runs/9844777751/job/27178902859

issue: none

