### PR TITLE
refactor(halo/valsync): improve subscriber interface

### DIFF
--- a/halo/attest/testutil/mock_interfaces.go
+++ b/halo/attest/testutil/mock_interfaces.go
@@ -13,12 +13,11 @@ import (
 	context "context"
 	reflect "reflect"
 
-	types "github.com/cometbft/cometbft/abci/types"
 	crypto "github.com/cometbft/cometbft/proto/tendermint/crypto"
-	types0 "github.com/cosmos/cosmos-sdk/types"
+	types "github.com/cosmos/cosmos-sdk/types"
 	common "github.com/ethereum/go-ethereum/common"
-	types1 "github.com/omni-network/omni/halo/attest/types"
-	types2 "github.com/omni-network/omni/halo/valsync/types"
+	types0 "github.com/omni-network/omni/halo/attest/types"
+	types1 "github.com/omni-network/omni/halo/valsync/types"
 	xchain "github.com/omni-network/omni/lib/xchain"
 	gomock "go.uber.org/mock/gomock"
 )
@@ -47,7 +46,7 @@ func (m *MockStakingKeeper) EXPECT() *MockStakingKeeperMockRecorder {
 }
 
 // GetPubKeyByConsAddr mocks base method.
-func (m *MockStakingKeeper) GetPubKeyByConsAddr(arg0 context.Context, arg1 types0.ConsAddress) (crypto.PublicKey, error) {
+func (m *MockStakingKeeper) GetPubKeyByConsAddr(arg0 context.Context, arg1 types.ConsAddress) (crypto.PublicKey, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetPubKeyByConsAddr", arg0, arg1)
 	ret0, _ := ret[0].(crypto.PublicKey)
@@ -85,10 +84,10 @@ func (m *MockVoter) EXPECT() *MockVoterMockRecorder {
 }
 
 // GetAvailable mocks base method.
-func (m *MockVoter) GetAvailable() []*types1.Vote {
+func (m *MockVoter) GetAvailable() []*types0.Vote {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetAvailable")
-	ret0, _ := ret[0].([]*types1.Vote)
+	ret0, _ := ret[0].([]*types0.Vote)
 	return ret0
 }
 
@@ -113,7 +112,7 @@ func (mr *MockVoterMockRecorder) LocalAddress() *gomock.Call {
 }
 
 // SetCommitted mocks base method.
-func (m *MockVoter) SetCommitted(headers []*types1.BlockHeader) error {
+func (m *MockVoter) SetCommitted(headers []*types0.BlockHeader) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SetCommitted", headers)
 	ret0, _ := ret[0].(error)
@@ -127,7 +126,7 @@ func (mr *MockVoterMockRecorder) SetCommitted(headers any) *gomock.Call {
 }
 
 // SetProposed mocks base method.
-func (m *MockVoter) SetProposed(headers []*types1.BlockHeader) error {
+func (m *MockVoter) SetProposed(headers []*types0.BlockHeader) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SetProposed", headers)
 	ret0, _ := ret[0].(error)
@@ -154,16 +153,18 @@ func (mr *MockVoterMockRecorder) TrimBehind(minsByChain any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TrimBehind", reflect.TypeOf((*MockVoter)(nil).TrimBehind), minsByChain)
 }
 
-// UpdateValidators mocks base method.
-func (m *MockVoter) UpdateValidators(valset []types.ValidatorUpdate) {
+// UpdateValidatorSet mocks base method.
+func (m *MockVoter) UpdateValidatorSet(set *types1.ValidatorSetResponse) error {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "UpdateValidators", valset)
+	ret := m.ctrl.Call(m, "UpdateValidatorSet", set)
+	ret0, _ := ret[0].(error)
+	return ret0
 }
 
-// UpdateValidators indicates an expected call of UpdateValidators.
-func (mr *MockVoterMockRecorder) UpdateValidators(valset any) *gomock.Call {
+// UpdateValidatorSet indicates an expected call of UpdateValidatorSet.
+func (mr *MockVoterMockRecorder) UpdateValidatorSet(set any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateValidators", reflect.TypeOf((*MockVoter)(nil).UpdateValidators), valset)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateValidatorSet", reflect.TypeOf((*MockVoter)(nil).UpdateValidatorSet), set)
 }
 
 // MockValProvider is a mock of ValProvider interface.
@@ -190,10 +191,10 @@ func (m *MockValProvider) EXPECT() *MockValProviderMockRecorder {
 }
 
 // ActiveSetByHeight mocks base method.
-func (m *MockValProvider) ActiveSetByHeight(ctx context.Context, height uint64) (*types2.ValidatorSetResponse, error) {
+func (m *MockValProvider) ActiveSetByHeight(ctx context.Context, height uint64) (*types1.ValidatorSetResponse, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ActiveSetByHeight", ctx, height)
-	ret0, _ := ret[0].(*types2.ValidatorSetResponse)
+	ret0, _ := ret[0].(*types1.ValidatorSetResponse)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -228,15 +229,15 @@ func (m *MockChainNamer) EXPECT() *MockChainNamerMockRecorder {
 }
 
 // ChainName mocks base method.
-func (m *MockChainNamer) ChainName(arg0 xchain.ChainVersion) string {
+func (m *MockChainNamer) ChainName(chainVer xchain.ChainVersion) string {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ChainName", arg0)
+	ret := m.ctrl.Call(m, "ChainName", chainVer)
 	ret0, _ := ret[0].(string)
 	return ret0
 }
 
 // ChainName indicates an expected call of ChainName.
-func (mr *MockChainNamerMockRecorder) ChainName(arg0 any) *gomock.Call {
+func (mr *MockChainNamerMockRecorder) ChainName(chainVer any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ChainName", reflect.TypeOf((*MockChainNamer)(nil).ChainName), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ChainName", reflect.TypeOf((*MockChainNamer)(nil).ChainName), chainVer)
 }

--- a/halo/attest/types/interface.go
+++ b/halo/attest/types/interface.go
@@ -3,9 +3,8 @@ package types
 import (
 	"context"
 
+	vtypes "github.com/omni-network/omni/halo/valsync/types"
 	"github.com/omni-network/omni/lib/xchain"
-
-	abci "github.com/cometbft/cometbft/abci/types"
 
 	"github.com/ethereum/go-ethereum/common"
 )
@@ -41,9 +40,9 @@ type Voter interface {
 	// they will never be committed. It returns the number that was deleted.
 	TrimBehind(minsByChain map[xchain.ChainVersion]uint64) int
 
-	// UpdateValidators sets the latest validator set when passed to cometBFT.
+	// UpdateValidatorSet sets the latest active validator set when updated.
 	// This is used to calculate whether the voter is in-or-out of the validator set.
-	UpdateValidators(valset []abci.ValidatorUpdate)
+	UpdateValidatorSet(set *vtypes.ValidatorSetResponse) error
 }
 
 // VoterDeps abstracts the Voter's internal cosmosSDK dependencies; basically the attest keeper.
@@ -55,3 +54,7 @@ type VoterDeps interface {
 
 // ChainVerNameFunc is a function that returns the name of a chain version.
 type ChainVerNameFunc func(xchain.ChainVersion) string
+
+type AttestKeeper interface {
+	ListAttestationsFrom(ctx context.Context, chainID uint64, confLevel uint32, offset uint64, max uint64) ([]*Attestation, error)
+}

--- a/halo/valsync/keeper/query.go
+++ b/halo/valsync/keeper/query.go
@@ -22,20 +22,7 @@ func (k *Keeper) ActiveSetByHeight(ctx context.Context, height uint64) (*types.V
 		return nil, err
 	}
 
-	var validators []*types.Validator
-	for _, val := range vals {
-		validators = append(validators, &types.Validator{
-			ConsensusPubkey: val.GetPubKey(),
-			Power:           val.GetPower(),
-		})
-	}
-
-	return &types.ValidatorSetResponse{
-		Id:              valset.GetId(),
-		CreatedHeight:   valset.GetCreatedHeight(),
-		ActivatedHeight: valset.GetActivatedHeight(),
-		Validators:      validators,
-	}, nil
+	return valSetResponse(valset, vals), nil
 }
 
 // ActiveSetByHeight returns the active cometBFT validator set at the given height. Zero power validators are skipped.
@@ -136,4 +123,21 @@ func (k *Keeper) ValidatorSet(ctx context.Context, req *types.ValidatorSetReques
 		ActivatedHeight: vatset.GetActivatedHeight(),
 		Validators:      vals,
 	}, nil
+}
+
+func valSetResponse(set *ValidatorSet, vals []*Validator) *types.ValidatorSetResponse {
+	var validators []*types.Validator
+	for _, val := range vals {
+		validators = append(validators, &types.Validator{
+			ConsensusPubkey: val.GetPubKey(),
+			Power:           val.GetPower(),
+		})
+	}
+
+	return &types.ValidatorSetResponse{
+		Id:              set.GetId(),
+		CreatedHeight:   set.GetCreatedHeight(),
+		ActivatedHeight: set.GetActivatedHeight(),
+		Validators:      validators,
+	}
 }

--- a/halo/valsync/keeper/query_internal_test.go
+++ b/halo/valsync/keeper/query_internal_test.go
@@ -119,7 +119,24 @@ func approvedExpectation() expectation {
 		).AnyTimes().
 			Return([]*types1.Attestation{{}}, nil)
 
-		m.subscriber.EXPECT().UpdateValidators(gomock.Any()).AnyTimes()
+		m.subscriber.EXPECT().UpdateValidatorSet(gomock.Any()).Do(
+			func(set *types.ValidatorSetResponse) {
+				if set.Id == 0 {
+					panic("validator set id is zero")
+				}
+				if set.ActivatedHeight < set.CreatedHeight {
+					panic("validator set activated height is less than created")
+				}
+				if len(set.Validators) == 0 {
+					panic("validator set is empty")
+				}
+				for _, val := range set.Validators {
+					if val.Power == 0 {
+						panic("zero power validator in active set")
+					}
+				}
+			},
+		).AnyTimes()
 	}
 }
 

--- a/halo/valsync/module/module.go
+++ b/halo/valsync/module/module.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 
+	atypes "github.com/omni-network/omni/halo/attest/types"
 	ptypes "github.com/omni-network/omni/halo/portal/types"
 	"github.com/omni-network/omni/halo/valsync/keeper"
 	"github.com/omni-network/omni/halo/valsync/types"
@@ -142,7 +143,7 @@ type ModuleInputs struct {
 	Cdc          codec.Codec
 	Config       *Module
 	SKeeper      types.StakingKeeper
-	AKeeper      types.AttestKeeper
+	AKeeper      atypes.AttestKeeper
 	Subscriber   types.ValSetSubscriber
 	Portal       ptypes.EmitPortal
 	EthClient    ethclient.Client

--- a/halo/valsync/testutil/expected_interfaces.go
+++ b/halo/valsync/testutil/expected_interfaces.go
@@ -2,6 +2,7 @@
 package testutil
 
 import (
+	atypes "github.com/omni-network/omni/halo/attest/types"
 	"github.com/omni-network/omni/halo/valsync/types"
 )
 
@@ -10,7 +11,7 @@ type StakingKeeper interface {
 }
 
 type AttestKeeper interface {
-	types.AttestKeeper
+	atypes.AttestKeeper
 }
 
 type Subscriber interface {

--- a/halo/valsync/testutil/mock_interfaces.go
+++ b/halo/valsync/testutil/mock_interfaces.go
@@ -16,6 +16,7 @@ import (
 	types "github.com/cometbft/cometbft/abci/types"
 	types0 "github.com/cosmos/cosmos-sdk/x/staking/types"
 	types1 "github.com/omni-network/omni/halo/attest/types"
+	types2 "github.com/omni-network/omni/halo/valsync/types"
 	gomock "go.uber.org/mock/gomock"
 )
 
@@ -133,14 +134,16 @@ func (m *MockSubscriber) EXPECT() *MockSubscriberMockRecorder {
 	return m.recorder
 }
 
-// UpdateValidators mocks base method.
-func (m *MockSubscriber) UpdateValidators(valset []types.ValidatorUpdate) {
+// UpdateValidatorSet mocks base method.
+func (m *MockSubscriber) UpdateValidatorSet(arg0 *types2.ValidatorSetResponse) error {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "UpdateValidators", valset)
+	ret := m.ctrl.Call(m, "UpdateValidatorSet", arg0)
+	ret0, _ := ret[0].(error)
+	return ret0
 }
 
-// UpdateValidators indicates an expected call of UpdateValidators.
-func (mr *MockSubscriberMockRecorder) UpdateValidators(valset any) *gomock.Call {
+// UpdateValidatorSet indicates an expected call of UpdateValidatorSet.
+func (mr *MockSubscriberMockRecorder) UpdateValidatorSet(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateValidators", reflect.TypeOf((*MockSubscriber)(nil).UpdateValidators), valset)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateValidatorSet", reflect.TypeOf((*MockSubscriber)(nil).UpdateValidatorSet), arg0)
 }

--- a/halo/valsync/types/interfaces.go
+++ b/halo/valsync/types/interfaces.go
@@ -3,16 +3,10 @@ package types
 import (
 	"context"
 
-	atypes "github.com/omni-network/omni/halo/attest/types"
-
 	abci "github.com/cometbft/cometbft/abci/types"
 
 	stypes "github.com/cosmos/cosmos-sdk/x/staking/types"
 )
-
-type AttestKeeper interface {
-	ListAttestationsFrom(ctx context.Context, chainID uint64, confLevel uint32, offset uint64, max uint64) ([]*atypes.Attestation, error)
-}
 
 type StakingKeeper interface {
 	EndBlocker(ctx context.Context) ([]abci.ValidatorUpdate, error)
@@ -20,5 +14,5 @@ type StakingKeeper interface {
 }
 
 type ValSetSubscriber interface {
-	UpdateValidators(valset []abci.ValidatorUpdate)
+	UpdateValidatorSet(valset *ValidatorSetResponse) error
 }

--- a/halo/valsync/types/query.go
+++ b/halo/valsync/types/query.go
@@ -35,3 +35,27 @@ func (v *Validator) CometAddress() (crypto.Address, error) {
 
 	return pk.Address(), nil
 }
+
+// IsValidator returns true if the provided address is a validator in the set.
+func (v *ValidatorSetResponse) IsValidator(addr common.Address) (bool, error) {
+	if len(v.Validators) == 0 {
+		return false, errors.New("empty validators")
+	}
+
+	for _, val := range v.Validators {
+		if val.Power == 0 {
+			return false, errors.New("invalid active validator [BUG]")
+		}
+
+		ethAddr, err := val.EthereumAddress()
+		if err != nil {
+			return false, err
+		}
+
+		if ethAddr == addr {
+			return true, nil
+		}
+	}
+
+	return false, nil
+}


### PR DESCRIPTION
Refactor valsync `Subscriber` interface. 

Providing the whole active set (instead of only validator update deltas), simplifies and hardens the logic avoiding unexpected silent out-of-order updates.

This was raised by the Zellic audit.

issue: #1390
