### PR TITLE
fix(attest): make log human-readable

### DIFF
--- a/halo/attest/keeper/keeper.go
+++ b/halo/attest/keeper/keeper.go
@@ -315,7 +315,7 @@ func (k *Keeper) Approve(ctx context.Context, valset ValSet) error {
 			"chain", chainVerName,
 			"offset", att.GetBlockOffset(),
 			"height", att.GetBlockHeight(),
-			"hash", att.GetBlockHash(),
+			log.Hex7("hash", att.GetBlockHash()),
 		)
 	}
 
@@ -440,7 +440,7 @@ func (k *Keeper) maybeOverrideFinalized(ctx context.Context, att *Attestation) (
 		"chain", k.namer(att.XChainVersion()),
 		"offset", att.GetBlockOffset(),
 		"height", att.GetBlockHeight(),
-		"hash", att.GetBlockHash(),
+		log.Hex7("hash", att.GetBlockHash()),
 	)
 
 	return true, nil


### PR DESCRIPTION
These logs added in #1291 are not human-readable.

Before:
![image](https://github.com/omni-network/omni/assets/6530144/77d6a5ed-2add-48ab-9a46-e1780900350d)

After:
![image](https://github.com/omni-network/omni/assets/6530144/993350f0-2d17-455b-882e-056d117a56c8)


issue: none
