### PR TITLE
chore(monitor/xchain): start populating emit cache from head-128

### DIFF
--- a/monitor/xmonitor/monitor.go
+++ b/monitor/xmonitor/monitor.go
@@ -20,7 +20,7 @@ func Start(
 	cprovider cchain.Provider,
 	rpcClients map[uint64]ethclient.Client,
 ) error {
-	cache, err := startEmitCursorCache(ctx, network, xprovider, cprovider)
+	cache, err := startEmitCursorCache(ctx, network, xprovider)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
When populating the emitcursorcache, don't start from DeployHeight or LatestAttestation, since that can esily be more than 128 block old. Our fullnodes only store 128 blocks with of historical state, so just start there.

issue: none