### PR TITLE
feat(e2e): fireblocks rpc proxy

### DIFF
--- a/e2e/fbproxy/app/app.go
+++ b/e2e/fbproxy/app/app.go
@@ -1,0 +1,90 @@
+package app
+
+import (
+	"context"
+	"math/big"
+	"net/http"
+	"time"
+
+	"github.com/omni-network/omni/lib/errors"
+	"github.com/omni-network/omni/lib/log"
+
+	"github.com/ethereum/go-ethereum/ethclient"
+
+	"golang.org/x/sync/errgroup"
+)
+
+func Run(ctx context.Context, cfg Config) error {
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	chainID, err := getChainID(ctx, cfg.BaseRPC)
+	if err != nil {
+		return errors.Wrap(err, "get chain ID")
+	}
+
+	fireCl, err := newFireblocks(cfg, chainID)
+	if err != nil {
+		return errors.Wrap(err, "new fireblocks")
+	}
+
+	proxy, err := newProxy(cfg.BaseRPC, NewSendTxMiddleware(fireCl, chainID))
+	if err != nil {
+		return errors.Wrap(err, "new proxy")
+	}
+
+	mux := http.NewServeMux()
+	mux.Handle("/", http.HandlerFunc(proxy.Proxy))
+
+	httpServer := &http.Server{
+		Addr:              cfg.ListenAddr,
+		ReadHeaderTimeout: 30 * time.Second,
+		IdleTimeout:       30 * time.Second,
+		WriteTimeout:      30 * time.Second,
+		Handler:           mux,
+	}
+
+	log.Info(ctx, "Starting fbproxy server", "address", cfg.ListenAddr)
+
+	var eg errgroup.Group
+	eg.Go(func() error {
+		defer cancel() // Cancel the app context if serving fails.
+
+		// ListenAndServe always returns an error.
+		return errors.Wrap(httpServer.ListenAndServe(), "serve")
+	})
+
+	eg.Go(func() error {
+		<-ctx.Done()
+		log.Info(ctx, "Shutdown detected, stopping server")
+
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+
+		if err := httpServer.Shutdown(shutdownCtx); err != nil { //nolint:contextcheck // Explicit new shutdown context.
+			return errors.Wrap(err, "server shutdown")
+		}
+
+		return nil
+	})
+
+	if err := eg.Wait(); errors.Is(err, http.ErrServerClosed) {
+		return nil // No error on shutdown.
+	} else if err != nil {
+		return errors.Wrap(err, "run server")
+	}
+
+	return nil
+}
+
+func getChainID(ctx context.Context, rpc string) (*big.Int, error) {
+	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+
+	client, err := ethclient.DialContext(ctx, rpc)
+	if err != nil {
+		return nil, errors.Wrap(err, "dial base rpc")
+	}
+
+	return client.ChainID(ctx)
+}

--- a/e2e/fbproxy/app/config.go
+++ b/e2e/fbproxy/app/config.go
@@ -1,8 +1,10 @@
 package app
 
+import "github.com/omni-network/omni/lib/netconf"
+
 type Config struct {
 	ListenAddr  string
-	Network     string
+	Network     netconf.ID
 	BaseRPC     string
 	FireAPIKey  string
 	FireKeyPath string
@@ -10,9 +12,9 @@ type Config struct {
 
 func DefaultConfig() Config {
 	return Config{
-		Network:     "devnet",
+		Network:     netconf.Devnet,
 		ListenAddr:  "0.0.0.0:8545",
-		BaseRPC:     "http://localhost:8545",
+		BaseRPC:     "",
 		FireAPIKey:  "",
 		FireKeyPath: "",
 	}

--- a/e2e/fbproxy/app/config.go
+++ b/e2e/fbproxy/app/config.go
@@ -1,0 +1,19 @@
+package app
+
+type Config struct {
+	ListenAddr  string
+	Network     string
+	BaseRPC     string
+	FireAPIKey  string
+	FireKeyPath string
+}
+
+func DefaultConfig() Config {
+	return Config{
+		Network:     "devnet",
+		ListenAddr:  "0.0.0.0:8545",
+		BaseRPC:     "http://localhost:8545",
+		FireAPIKey:  "",
+		FireKeyPath: "",
+	}
+}

--- a/e2e/fbproxy/app/fireblocks.go
+++ b/e2e/fbproxy/app/fireblocks.go
@@ -1,0 +1,35 @@
+package app
+
+import (
+	"fmt"
+	"math/big"
+	"time"
+
+	"github.com/omni-network/omni/lib/errors"
+	"github.com/omni-network/omni/lib/fireblocks"
+	"github.com/omni-network/omni/lib/netconf"
+)
+
+func newFireblocks(cfg Config, chainID *big.Int) (fireblocks.Client, error) {
+	key, err := fireblocks.LoadKey(cfg.FireKeyPath)
+	if err != nil {
+		return fireblocks.Client{}, errors.Wrap(err, "load fireblocks key")
+	}
+
+	opts := []fireblocks.Option{
+		fireblocks.WithSignNote(fmt.Sprintf("fireblocks proxy to chainID=%d, network=%s", chainID.Int64(), cfg.Network)),
+		fireblocks.WithQueryInterval(5 * time.Second),
+	}
+
+	network := netconf.ID(cfg.Network)
+	if err := network.Verify(); err != nil {
+		return fireblocks.Client{}, errors.Wrap(err, "invalid network", "network", cfg.Network)
+	}
+
+	fireCl, err := fireblocks.New(network, cfg.FireAPIKey, key, opts...)
+	if err != nil {
+		return fireblocks.Client{}, errors.Wrap(err, "new fireblocks")
+	}
+
+	return fireCl, nil
+}

--- a/e2e/fbproxy/app/fireblocks.go
+++ b/e2e/fbproxy/app/fireblocks.go
@@ -2,28 +2,27 @@ package app
 
 import (
 	"fmt"
-	"math/big"
 	"time"
 
 	"github.com/omni-network/omni/lib/errors"
 	"github.com/omni-network/omni/lib/fireblocks"
-	"github.com/omni-network/omni/lib/netconf"
 )
 
-func newFireblocks(cfg Config, chainID *big.Int) (fireblocks.Client, error) {
+func newFireblocks(cfg Config, chainID uint64) (fireblocks.Client, error) {
 	key, err := fireblocks.LoadKey(cfg.FireKeyPath)
 	if err != nil {
 		return fireblocks.Client{}, errors.Wrap(err, "load fireblocks key")
 	}
 
+	network := cfg.Network
+
 	opts := []fireblocks.Option{
-		fireblocks.WithSignNote(fmt.Sprintf("fireblocks proxy to chainID=%d, network=%s", chainID.Int64(), cfg.Network)),
+		fireblocks.WithSignNote(fmt.Sprintf("fireblocks proxy to chainID=%d, network=%s", chainID, network)),
 		fireblocks.WithQueryInterval(5 * time.Second),
 	}
 
-	network := netconf.ID(cfg.Network)
 	if err := network.Verify(); err != nil {
-		return fireblocks.Client{}, errors.Wrap(err, "invalid network", "network", cfg.Network)
+		return fireblocks.Client{}, errors.Wrap(err, "invalid network", "network", network)
 	}
 
 	fireCl, err := fireblocks.New(network, cfg.FireAPIKey, key, opts...)

--- a/e2e/fbproxy/app/middleware.go
+++ b/e2e/fbproxy/app/middleware.go
@@ -1,0 +1,78 @@
+package app
+
+import (
+	"context"
+	"encoding/json"
+	"math/big"
+
+	"github.com/omni-network/omni/lib/errors"
+	"github.com/omni-network/omni/lib/log"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/core/types"
+)
+
+type txSigner interface {
+	Sign(ctx context.Context, digest common.Hash, signer common.Address) ([65]byte, error)
+}
+
+// NewSendTxMiddleware returns a middleware func that
+//   - intercepts eth_sendTransaction requests, signs them `txsigner`
+//     and replaces them with eth_sendRawTransaction requests
+//   - leaves all other requests unmodified
+func NewSendTxMiddleware(txsigner txSigner, chainID *big.Int) Middleware {
+	// signer used to create signaure hash and recover tx sender,
+	// not for actual signing which is left to txsigner
+	signer := types.LatestSignerForChainID(chainID)
+
+	return func(ctx context.Context, req JSONRPCMessage) (JSONRPCMessage, error) {
+		if req.Method != "eth_sendTransaction" {
+			return req, nil
+		}
+
+		log.Debug(ctx, "Intercepted eth_sendTransaction")
+
+		var paramsIn []TransactionArgs
+		err := json.Unmarshal(req.Params, &paramsIn)
+		if err != nil {
+			return JSONRPCMessage{}, errors.Wrap(err, "unmarshal tx")
+		}
+
+		if len(paramsIn) != 1 {
+			return JSONRPCMessage{}, errors.New("only one transaction supported")
+		}
+
+		args := paramsIn[0]
+		tx := args.ToTransaction()
+
+		sig, err := txsigner.Sign(ctx, signer.Hash(tx), *args.From)
+		if err != nil {
+			return JSONRPCMessage{}, errors.Wrap(err, "sign")
+		}
+
+		log.Debug(ctx, "Signed tx", "tx", tx.Hash().Hex(), "from", args.From.Hex())
+
+		signed, err := tx.WithSignature(signer, sig[:])
+		if err != nil {
+			return JSONRPCMessage{}, errors.Wrap(err, "with signature")
+		}
+
+		data, err := signed.MarshalBinary()
+		if err != nil {
+			return JSONRPCMessage{}, errors.Wrap(err, "marshal binary")
+		}
+
+		paramsOut, err := json.Marshal([]string{hexutil.Encode(data)})
+		if err != nil {
+			return JSONRPCMessage{}, errors.Wrap(err, "marshal hex")
+		}
+
+		return JSONRPCMessage{
+			Version: req.Version,
+			ID:      req.ID,
+			Method:  "eth_sendRawTransaction",
+			Params:  paramsOut,
+		}, nil
+	}
+}

--- a/e2e/fbproxy/app/middleware_test.go
+++ b/e2e/fbproxy/app/middleware_test.go
@@ -1,0 +1,480 @@
+package app_test
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"encoding/json"
+	"math/big"
+	"testing"
+
+	"github.com/omni-network/omni/e2e/fbproxy/app"
+	"github.com/omni-network/omni/lib/errors"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/crypto"
+
+	"github.com/stretchr/testify/require"
+)
+
+type mockTxSigner struct {
+	pk *ecdsa.PrivateKey
+}
+
+const (
+	testSigner   = "0x71562b71999873db5b286df957af199ec94617f7"
+	testSignerPK = "b71c71a67e1177ad4e901695e1b4b9ee17ae16c6668d313eac2f96dbcda3f291"
+)
+
+var (
+	chainID = big.NewInt(1337)
+)
+
+func (b *mockTxSigner) Sign(ctx context.Context, digest common.Hash, signer common.Address) ([65]byte, error) {
+	if signer != common.HexToAddress(testSigner) {
+		return [65]byte{}, errors.New("invalid signer")
+	}
+
+	sig, err := crypto.Sign(digest.Bytes(), b.pk)
+	if err != nil {
+		return [65]byte{}, errors.Wrap(err, "sign")
+	}
+
+	return [65]byte(sig), nil
+}
+
+func newMockTxSigner() *mockTxSigner {
+	pk, err := crypto.HexToECDSA(testSignerPK)
+	if err != nil {
+		panic(err)
+	}
+
+	return &mockTxSigner{pk: pk}
+}
+
+// testSendTxMiddlewareOnce tests that the middleware correctly signs a transaction
+// and replaces the eth_sendTransaction request with an eth_sendRawTransaction request.
+func testSendTxMiddlewareOnce(t *testing.T, tt testTx) {
+	t.Helper()
+
+	txsigner := newMockTxSigner()
+
+	var txargs app.TransactionArgs
+	err := json.Unmarshal([]byte(tt.txArgsJSON), &txargs)
+	require.NoError(t, err)
+
+	mw := app.NewSendTxMiddleware(txsigner, chainID)
+	req := app.JSONRPCMessage{
+		Method:  "eth_sendTransaction",
+		Params:  mustMarshal(t, []app.TransactionArgs{txargs}),
+		ID:      mustMarshal(t, 1),
+		Version: "2.0",
+	}
+
+	// Test that the middleware signs the transaction
+	resp, err := mw(context.Background(), req)
+	require.NoError(t, err)
+	require.Equal(t, "eth_sendRawTransaction", resp.Method)
+
+	var params []string
+	err = json.Unmarshal(resp.Params, &params)
+	require.NoError(t, err)
+
+	// tx returned from middleware
+	var tx1 types.Transaction
+	err = tx1.UnmarshalBinary(hexutil.MustDecode(params[0]))
+	require.NoError(t, err)
+
+	// tx signed now
+	signer := types.LatestSignerForChainID(chainID)
+	tx2, err := types.SignNewTx(txsigner.pk, signer, tt.tx)
+	require.NoError(t, err)
+
+	// tx with hardcoded sig values
+	var tx3 types.Transaction
+	err = tx3.UnmarshalJSON([]byte(tt.txJSON))
+	require.NoError(t, err)
+
+	// check hashes are equal
+	require.Equal(t, tx1.Hash(), tx2.Hash())
+	require.Equal(t, tx1.Hash(), tx3.Hash())
+
+	// check that the signature values are equal
+	v1, r1, s1 := tx1.RawSignatureValues()
+	v2, r2, s2 := tx2.RawSignatureValues()
+	v3, r3, s3 := tx3.RawSignatureValues()
+
+	require.Equal(t, v1, v2)
+	require.Equal(t, r1, r2)
+	require.Equal(t, s1, s2)
+	require.Equal(t, v1, v3)
+	require.Equal(t, r1, r3)
+	require.Equal(t, s1, s3)
+}
+
+func TestSendTxMiddleware(t *testing.T) {
+	t.Parallel()
+
+	for _, tt := range testTxns() {
+		testSendTxMiddlewareOnce(t, tt)
+	}
+}
+
+type testTx struct {
+	tx         types.TxData
+	txJSON     string
+	txArgsJSON string
+}
+
+// testTxns returns a list of test transactions.
+// Repurposed from test cases go-ethereum/internal/ethapi/api_test.go
+// TxArgsJson is trimmed TxJson, removing fields that are not part of the TransactionArgs.
+func testTxns() []testTx {
+	dead := common.HexToAddress("0xdead000000000000000000000000000000000000")
+
+	return []testTx{
+		{
+			tx: &types.LegacyTx{
+				Nonce:    5,
+				GasPrice: big.NewInt(6),
+				Gas:      7,
+				To:       &dead,
+				Value:    big.NewInt(8),
+				Data:     []byte{0, 1, 2, 3, 4},
+				V:        big.NewInt(9),
+				R:        big.NewInt(10),
+				S:        big.NewInt(11),
+			},
+			txArgsJSON: `{
+				"from": "0x71562b71999873db5b286df957af199ec94617f7",
+				"gas": "0x7",
+				"gasPrice": "0x6",
+				"input": "0x0001020304",
+				"nonce": "0x5",
+				"to": "0xdead000000000000000000000000000000000000",
+				"value": "0x8",
+				"chainId": "0x539"
+			}`,
+			txJSON: `{
+				"blockHash": null,
+				"blockNumber": null,
+				"from": "0x71562b71999873db5b286df957af199ec94617f7",
+				"gas": "0x7",
+				"gasPrice": "0x6",
+				"hash": "0x5f3240454cd09a5d8b1c5d651eefae7a339262875bcd2d0e6676f3d989967008",
+				"input": "0x0001020304",
+				"nonce": "0x5",
+				"to": "0xdead000000000000000000000000000000000000",
+				"transactionIndex": null,
+				"value": "0x8",
+				"type": "0x0",
+				"chainId": "0x539",
+				"v": "0xa96",
+				"r": "0xbc85e96592b95f7160825d837abb407f009df9ebe8f1b9158a4b8dd093377f75",
+				"s": "0x1b55ea3af5574c536967b039ba6999ef6c89cf22fc04bcb296e0e8b0b9b576f5"
+			}`,
+		},
+		{
+			tx: &types.LegacyTx{
+				Nonce:    5,
+				GasPrice: big.NewInt(6),
+				Gas:      7,
+				To:       nil,
+				Value:    big.NewInt(8),
+				Data:     []byte{0, 1, 2, 3, 4},
+				V:        big.NewInt(32),
+				R:        big.NewInt(10),
+				S:        big.NewInt(11),
+			},
+			txArgsJSON: `{
+				"from": "0x71562b71999873db5b286df957af199ec94617f7",
+				"gas": "0x7",
+				"gasPrice": "0x6",
+				"hash": "0x806e97f9d712b6cb7e781122001380a2837531b0fc1e5f5d78174ad4cb699873",
+				"input": "0x0001020304",
+				"nonce": "0x5",
+				"to": null,
+				"value": "0x8",
+				"chainId": "0x539"
+			}`,
+			txJSON: `{
+				"blockHash": null,
+				"blockNumber": null,
+				"from": "0x71562b71999873db5b286df957af199ec94617f7",
+				"gas": "0x7",
+				"gasPrice": "0x6",
+				"hash": "0x806e97f9d712b6cb7e781122001380a2837531b0fc1e5f5d78174ad4cb699873",
+				"input": "0x0001020304",
+				"nonce": "0x5",
+				"to": null,
+				"transactionIndex": null,
+				"value": "0x8",
+				"type": "0x0",
+				"chainId": "0x539",
+				"v": "0xa96",
+				"r": "0x9dc28b267b6ad4e4af6fe9289668f9305c2eb7a3241567860699e478af06835a",
+				"s": "0xa0b51a071aa9bed2cd70aedea859779dff039e3630ea38497d95202e9b1fec7"
+			}`,
+		},
+		{
+			tx: &types.AccessListTx{
+				ChainID:  chainID,
+				Nonce:    5,
+				GasPrice: big.NewInt(6),
+				Gas:      7,
+				To:       &dead,
+				Value:    big.NewInt(8),
+				Data:     []byte{0, 1, 2, 3, 4},
+				AccessList: types.AccessList{
+					types.AccessTuple{
+						Address:     common.Address{0x2},
+						StorageKeys: []common.Hash{types.EmptyRootHash},
+					},
+				},
+				V: big.NewInt(32),
+				R: big.NewInt(10),
+				S: big.NewInt(11),
+			},
+			txArgsJSON: `{
+				"from": "0x71562b71999873db5b286df957af199ec94617f7",
+				"gas": "0x7",
+				"gasPrice": "0x6",
+				"input": "0x0001020304",
+				"nonce": "0x5",
+				"to": "0xdead000000000000000000000000000000000000",
+				"value": "0x8",
+				"accessList": [
+					{
+						"address": "0x0200000000000000000000000000000000000000",
+						"storageKeys": [
+							"0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421"
+						]
+					}
+				],
+				"chainId": "0x539"
+			}`,
+			txJSON: `{
+				"blockHash": null,
+				"blockNumber": null,
+				"from": "0x71562b71999873db5b286df957af199ec94617f7",
+				"gas": "0x7",
+				"gasPrice": "0x6",
+				"hash": "0x121347468ee5fe0a29f02b49b4ffd1c8342bc4255146bb686cd07117f79e7129",
+				"input": "0x0001020304",
+				"nonce": "0x5",
+				"to": "0xdead000000000000000000000000000000000000",
+				"transactionIndex": null,
+				"value": "0x8",
+				"type": "0x1",
+				"accessList": [
+					{
+						"address": "0x0200000000000000000000000000000000000000",
+						"storageKeys": [
+							"0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421"
+						]
+					}
+				],
+				"chainId": "0x539",
+				"v": "0x0",
+				"r": "0xf372ad499239ae11d91d34c559ffc5dab4daffc0069e03afcabdcdf231a0c16b",
+				"s": "0x28573161d1f9472fa0fd4752533609e72f06414f7ab5588699a7141f65d2abf",
+				"yParity": "0x0"
+			}`,
+		},
+		{
+			tx: &types.AccessListTx{
+				ChainID:  chainID,
+				Nonce:    5,
+				GasPrice: big.NewInt(6),
+				Gas:      7,
+				To:       nil,
+				Value:    big.NewInt(8),
+				Data:     []byte{0, 1, 2, 3, 4},
+				AccessList: types.AccessList{
+					types.AccessTuple{
+						Address:     common.Address{0x2},
+						StorageKeys: []common.Hash{types.EmptyRootHash},
+					},
+				},
+				V: big.NewInt(32),
+				R: big.NewInt(10),
+				S: big.NewInt(11),
+			},
+			txArgsJSON: `{
+				"from": "0x71562b71999873db5b286df957af199ec94617f7",
+				"gas": "0x7",
+				"gasPrice": "0x6",
+				"input": "0x0001020304",
+				"nonce": "0x5",
+				"to": null,
+				"value": "0x8",
+				"accessList": [
+					{
+						"address": "0x0200000000000000000000000000000000000000",
+						"storageKeys": [
+							"0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421"
+						]
+					}
+				],
+				"chainId": "0x539"
+			}`,
+			txJSON: `{
+				"blockHash": null,
+				"blockNumber": null,
+				"from": "0x71562b71999873db5b286df957af199ec94617f7",
+				"gas": "0x7",
+				"gasPrice": "0x6",
+				"hash": "0x067c3baebede8027b0f828a9d933be545f7caaec623b00684ac0659726e2055b",
+				"input": "0x0001020304",
+				"nonce": "0x5",
+				"to": null,
+				"transactionIndex": null,
+				"value": "0x8",
+				"type": "0x1",
+				"accessList": [
+					{
+						"address": "0x0200000000000000000000000000000000000000",
+						"storageKeys": [
+							"0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421"
+						]
+					}
+				],
+				"chainId": "0x539",
+				"v": "0x1",
+				"r": "0x542981b5130d4613897fbab144796cb36d3cb3d7807d47d9c7f89ca7745b085c",
+				"s": "0x7425b9dd6c5deaa42e4ede35d0c4570c4624f68c28d812c10d806ffdf86ce63",
+				"yParity": "0x1"
+			}`,
+		},
+		{
+			tx: &types.DynamicFeeTx{
+				ChainID:   chainID,
+				Nonce:     5,
+				GasTipCap: big.NewInt(6),
+				GasFeeCap: big.NewInt(9),
+				Gas:       7,
+				To:        &dead,
+				Value:     big.NewInt(8),
+				Data:      []byte{0, 1, 2, 3, 4},
+				AccessList: types.AccessList{
+					types.AccessTuple{
+						Address:     common.Address{0x2},
+						StorageKeys: []common.Hash{types.EmptyRootHash},
+					},
+				},
+				V: big.NewInt(32),
+				R: big.NewInt(10),
+				S: big.NewInt(11),
+			},
+			txArgsJSON: `{
+				"from": "0x71562b71999873db5b286df957af199ec94617f7",
+				"gas": "0x7",
+				"gasPrice": "0x9",
+				"maxFeePerGas": "0x9",
+				"maxPriorityFeePerGas": "0x6",
+				"input": "0x0001020304",
+				"nonce": "0x5",
+				"to": "0xdead000000000000000000000000000000000000",
+				"value": "0x8",
+				"accessList": [
+					{
+						"address": "0x0200000000000000000000000000000000000000",
+						"storageKeys": [
+							"0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421"
+						]
+					}
+				],
+				"chainId": "0x539"
+			}`,
+			txJSON: `{
+				"blockHash": null,
+				"blockNumber": null,
+				"from": "0x71562b71999873db5b286df957af199ec94617f7",
+				"gas": "0x7",
+				"gasPrice": "0x9",
+				"maxFeePerGas": "0x9",
+				"maxPriorityFeePerGas": "0x6",
+				"hash": "0xb63e0b146b34c3e9cb7fbabb5b3c081254a7ded6f1b65324b5898cc0545d79ff",
+				"input": "0x0001020304",
+				"nonce": "0x5",
+				"to": "0xdead000000000000000000000000000000000000",
+				"transactionIndex": null,
+				"value": "0x8",
+				"type": "0x2",
+				"accessList": [
+					{
+						"address": "0x0200000000000000000000000000000000000000",
+						"storageKeys": [
+							"0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421"
+						]
+					}
+				],
+				"chainId": "0x539",
+				"v": "0x1",
+				"r": "0x3b167e05418a8932cd53d7578711fe1a76b9b96c48642402bb94978b7a107e80",
+				"s": "0x22f98a332d15ea2cc80386c1ebaa31b0afebfa79ebc7d039a1e0074418301fef",
+				"yParity": "0x1"
+			}`,
+		},
+		{
+			tx: &types.DynamicFeeTx{
+				ChainID:    chainID,
+				Nonce:      5,
+				GasTipCap:  big.NewInt(6),
+				GasFeeCap:  big.NewInt(9),
+				Gas:        7,
+				To:         nil,
+				Value:      big.NewInt(8),
+				Data:       []byte{0, 1, 2, 3, 4},
+				AccessList: types.AccessList{},
+				V:          big.NewInt(32),
+				R:          big.NewInt(10),
+				S:          big.NewInt(11),
+			},
+			txArgsJSON: `{
+				"from": "0x71562b71999873db5b286df957af199ec94617f7",
+				"gas": "0x7",
+				"gasPrice": "0x9",
+				"maxFeePerGas": "0x9",
+				"maxPriorityFeePerGas": "0x6",
+				"input": "0x0001020304",
+				"nonce": "0x5",
+				"to": null,
+				"value": "0x8",
+				"accessList": [],
+				"chainId": "0x539"
+			}`,
+			txJSON: `{
+				"blockHash": null,
+				"blockNumber": null,
+				"from": "0x71562b71999873db5b286df957af199ec94617f7",
+				"gas": "0x7",
+				"gasPrice": "0x9",
+				"maxFeePerGas": "0x9",
+				"maxPriorityFeePerGas": "0x6",
+				"hash": "0xcbab17ee031a9d5b5a09dff909f0a28aedb9b295ac0635d8710d11c7b806ec68",
+				"input": "0x0001020304",
+				"nonce": "0x5",
+				"to": null,
+				"transactionIndex": null,
+				"value": "0x8",
+				"type": "0x2",
+				"accessList": [],
+				"chainId": "0x539",
+				"v": "0x0",
+				"r": "0x6446b8a682db7e619fc6b4f6d1f708f6a17351a41c7fbd63665f469bc78b41b9",
+				"s": "0x7626abc15834f391a117c63450047309dbf84c5ce3e8e609b607062641e2de43",
+				"yParity": "0x0"
+			}`,
+		},
+	}
+}
+
+func mustMarshal(t *testing.T, v interface{}) []byte {
+	t.Helper()
+	bz, err := json.Marshal(v)
+	require.NoError(t, err)
+
+	return bz
+}

--- a/e2e/fbproxy/app/middleware_test.go
+++ b/e2e/fbproxy/app/middleware_test.go
@@ -64,7 +64,7 @@ func testSendTxMiddlewareOnce(t *testing.T, tt testTx) {
 	err := json.Unmarshal([]byte(tt.txArgsJSON), &txargs)
 	require.NoError(t, err)
 
-	mw := app.NewSendTxMiddleware(txsigner, chainID)
+	mw := app.NewSendTxMiddleware(txsigner, chainID.Uint64())
 	req := app.JSONRPCMessage{
 		Method:  "eth_sendTransaction",
 		Params:  mustMarshal(t, []app.TransactionArgs{txargs}),

--- a/e2e/fbproxy/app/proxy.go
+++ b/e2e/fbproxy/app/proxy.go
@@ -1,0 +1,162 @@
+package app
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/url"
+	"sync"
+
+	"github.com/omni-network/omni/lib/errors"
+	"github.com/omni-network/omni/lib/log"
+)
+
+// A value of this type can a JSON-RPC request, notification, successful response or
+// error response. Which one it is depends on the fields.
+type JSONRPCMessage struct {
+	Version string          `json:"jsonrpc,omitempty"`
+	ID      json.RawMessage `json:"id,omitempty"`
+	Method  string          `json:"method,omitempty"`
+	Params  json.RawMessage `json:"params,omitempty"`
+	Error   *JSONRPCError   `json:"error,omitempty"`
+	Result  json.RawMessage `json:"result,omitempty"`
+}
+
+type JSONRPCError struct {
+	Code    int    `json:"code"`
+	Message string `json:"message"`
+	Data    any    `json:"data,omitempty"`
+}
+
+type proxy struct {
+	mu     sync.RWMutex
+	target *url.URL
+	mwares []Middleware
+}
+
+type Middleware func(context.Context, JSONRPCMessage) (JSONRPCMessage, error)
+
+func newProxy(target string, mwares ...Middleware) (*proxy, error) {
+	if len(mwares) == 0 {
+		return nil, errors.New("no middlewares provided")
+	}
+
+	resp := new(proxy)
+
+	if err := resp.setTarget(target); err != nil {
+		return nil, err
+	}
+
+	resp.mwares = mwares
+
+	return resp, nil
+}
+
+func (p *proxy) Proxy(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	ctx = log.WithCtx(ctx, "remote_addr", r.RemoteAddr)
+
+	err := p.proxy(ctx, w, r)
+	if err != nil {
+		log.Error(ctx, "Proxy error", err)
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+	}
+}
+
+func (p *proxy) proxy(ctx context.Context, w http.ResponseWriter, r *http.Request) error {
+	reqBody, err := io.ReadAll(r.Body)
+	if err != nil {
+		return errors.Wrap(err, "read body")
+	}
+
+	var reqMsg JSONRPCMessage
+	if err := json.Unmarshal(reqBody, &reqMsg); err != nil {
+		return errors.Wrap(err, "unmarshal request")
+	}
+
+	// apply middlewares
+	for _, mware := range p.getMiddlewares() {
+		reqMsg, err = mware(ctx, reqMsg)
+		if err != nil {
+			return errors.Wrap(err, "middleware")
+		}
+	}
+
+	reqBody, err = json.Marshal(reqMsg)
+	if err != nil {
+		return errors.Wrap(err, "marshal request")
+	}
+
+	nextReq, err := http.NewRequestWithContext(
+		ctx,
+		r.Method,
+		p.getTarget().String(),
+		closeReader{bytes.NewReader(reqBody)},
+	)
+	if err != nil {
+		return errors.Wrap(err, "create next request")
+	}
+	nextReq.Header = r.Header
+
+	resp, err := new(http.Client).Do(nextReq)
+	if err != nil {
+		return errors.Wrap(err, "do request")
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		w.WriteHeader(resp.StatusCode)
+		_, _ = io.Copy(w, resp.Body)
+
+		return nil
+	}
+
+	respBytes, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return errors.Wrap(err, "read response")
+	}
+
+	_, _ = w.Write(respBytes)
+
+	return nil
+}
+
+func (p *proxy) getTarget() *url.URL {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+
+	return p.target
+}
+
+func (p *proxy) getMiddlewares() []Middleware {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+
+	return p.mwares
+}
+
+func (p *proxy) setTarget(target string) error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	u, err := url.Parse(target)
+	if err != nil {
+		return errors.Wrap(err, "parse target url")
+	}
+
+	p.target = u
+
+	return nil
+}
+
+var _ io.ReadCloser = closeReader{}
+
+type closeReader struct {
+	io.Reader
+}
+
+func (closeReader) Close() error {
+	return nil
+}

--- a/e2e/fbproxy/app/txargs.go
+++ b/e2e/fbproxy/app/txargs.go
@@ -1,0 +1,95 @@
+// A copy of the relevant code from go-ethereum/internal/ethapi/transaction_args.go
+
+package app
+
+import (
+	"math/big"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/core/types"
+)
+
+// TransactionArgs represents the arguments to construct a new transaction
+// or a message call.
+type TransactionArgs struct {
+	From                 *common.Address `json:"from"`
+	To                   *common.Address `json:"to"`
+	Gas                  *hexutil.Uint64 `json:"gas"`
+	GasPrice             *hexutil.Big    `json:"gasPrice"`
+	MaxFeePerGas         *hexutil.Big    `json:"maxFeePerGas"`
+	MaxPriorityFeePerGas *hexutil.Big    `json:"maxPriorityFeePerGas"`
+	Value                *hexutil.Big    `json:"value"`
+	Nonce                *hexutil.Uint64 `json:"nonce"`
+
+	// We accept "data" and "input" for backwards-compatibility reasons.
+	// "input" is the newer name and should be preferred by clients.
+	// Issue detail: https://github.com/ethereum/go-ethereum/issues/15628
+	Data  *hexutil.Bytes `json:"data"`
+	Input *hexutil.Bytes `json:"input"`
+
+	// Introduced by AccessListTxType transaction.
+	AccessList *types.AccessList `json:"accessList,omitempty"`
+	ChainID    *hexutil.Big      `json:"chainId,omitempty"`
+}
+
+// ToTransaction converts the arguments to a transaction.
+// This assumes that setDefaults has been called.
+// NOTE: setDefaults omitted in this copy, instead keeping txargs as provided.
+func (args *TransactionArgs) ToTransaction() *types.Transaction {
+	var data types.TxData
+	switch {
+	case args.MaxFeePerGas != nil:
+		al := types.AccessList{}
+		if args.AccessList != nil {
+			al = *args.AccessList
+		}
+		data = &types.DynamicFeeTx{
+			To:         args.To,
+			ChainID:    (*big.Int)(args.ChainID),
+			Nonce:      uint64(*args.Nonce),
+			Gas:        uint64(*args.Gas),
+			GasFeeCap:  (*big.Int)(args.MaxFeePerGas),
+			GasTipCap:  (*big.Int)(args.MaxPriorityFeePerGas),
+			Value:      (*big.Int)(args.Value),
+			Data:       args.data(),
+			AccessList: al,
+		}
+
+	case args.AccessList != nil:
+		data = &types.AccessListTx{
+			To:         args.To,
+			ChainID:    (*big.Int)(args.ChainID),
+			Nonce:      uint64(*args.Nonce),
+			Gas:        uint64(*args.Gas),
+			GasPrice:   (*big.Int)(args.GasPrice),
+			Value:      (*big.Int)(args.Value),
+			Data:       args.data(),
+			AccessList: *args.AccessList,
+		}
+
+	default:
+		data = &types.LegacyTx{
+			To:       args.To,
+			Nonce:    uint64(*args.Nonce),
+			Gas:      uint64(*args.Gas),
+			GasPrice: (*big.Int)(args.GasPrice),
+			Value:    (*big.Int)(args.Value),
+			Data:     args.data(),
+		}
+	}
+
+	return types.NewTx(data)
+}
+
+// data retrieves the transaction calldata. Input field is preferred.
+func (args *TransactionArgs) data() []byte {
+	if args.Input != nil {
+		return *args.Input
+	}
+	if args.Data != nil {
+		return *args.Data
+	}
+
+	return nil
+}

--- a/e2e/fbproxy/cmd/cmd.go
+++ b/e2e/fbproxy/cmd/cmd.go
@@ -1,0 +1,47 @@
+package cmd
+
+import (
+	"github.com/omni-network/omni/e2e/fbproxy/app"
+	libcmd "github.com/omni-network/omni/lib/cmd"
+	"github.com/omni-network/omni/lib/log"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+)
+
+// New returns a new root cobra command that runs the anvilproxy server.
+func New() *cobra.Command {
+	cmd := libcmd.NewRootCmd(
+		"fbproxy",
+		"Fireblocks ETH JSON-RPC proxy server that supports raw signing and transaction broadcasting",
+	)
+
+	cfg := app.DefaultConfig()
+	bindFlags(cmd.Flags(), &cfg)
+
+	logCfg := log.DefaultConfig()
+	log.BindFlags(cmd.Flags(), &logCfg)
+
+	cmd.RunE = func(cmd *cobra.Command, _ []string) error {
+		ctx, err := log.Init(cmd.Context(), logCfg)
+		if err != nil {
+			return err
+		}
+
+		if err := libcmd.LogFlags(ctx, cmd.Flags()); err != nil {
+			return err
+		}
+
+		return app.Run(ctx, cfg)
+	}
+
+	return cmd
+}
+
+func bindFlags(flags *pflag.FlagSet, cfg *app.Config) {
+	flags.StringVar(&cfg.Network, "network", cfg.Network, "Network ID")
+	flags.StringVar(&cfg.ListenAddr, "listen-addr", cfg.ListenAddr, "Address for proxy to listen on")
+	flags.StringVar(&cfg.BaseRPC, "base-rpc", cfg.BaseRPC, "Base RPC URL to forward requests to")
+	flags.StringVar(&cfg.FireAPIKey, "fireblocks-api-key", cfg.FireAPIKey, "FireBlocks api key")
+	flags.StringVar(&cfg.FireKeyPath, "fireblocks-key-path", cfg.FireKeyPath, "FireBlocks RSA private key path")
+}

--- a/e2e/fbproxy/cmd/cmd.go
+++ b/e2e/fbproxy/cmd/cmd.go
@@ -39,9 +39,9 @@ func New() *cobra.Command {
 }
 
 func bindFlags(flags *pflag.FlagSet, cfg *app.Config) {
-	flags.StringVar(&cfg.Network, "network", cfg.Network, "Network ID")
+	flags.StringVar((*string)(&cfg.Network), "network", string(cfg.Network), "Network ID")
 	flags.StringVar(&cfg.ListenAddr, "listen-addr", cfg.ListenAddr, "Address for proxy to listen on")
-	flags.StringVar(&cfg.BaseRPC, "base-rpc", cfg.BaseRPC, "Base RPC URL to forward requests to")
+	flags.StringVar(&cfg.BaseRPC, "base-rpc", cfg.BaseRPC, "Base RPC URL to forward requests to; e.g. http://localhost:8545")
 	flags.StringVar(&cfg.FireAPIKey, "fireblocks-api-key", cfg.FireAPIKey, "FireBlocks api key")
 	flags.StringVar(&cfg.FireKeyPath, "fireblocks-key-path", cfg.FireKeyPath, "FireBlocks RSA private key path")
 }

--- a/e2e/fbproxy/main.go
+++ b/e2e/fbproxy/main.go
@@ -1,0 +1,11 @@
+// The main entry point for the fireblocks proxy command.
+package main
+
+import (
+	proxycmd "github.com/omni-network/omni/e2e/fbproxy/cmd"
+	libcmd "github.com/omni-network/omni/lib/cmd"
+)
+
+func main() {
+	libcmd.Main(proxycmd.New())
+}

--- a/lib/fireblocks/key.go
+++ b/lib/fireblocks/key.go
@@ -12,6 +12,10 @@ import (
 
 // LoadKey loads and returns the RSA256 from disk.
 func LoadKey(path string) (*rsa.PrivateKey, error) {
+	if path == "" {
+		return nil, errors.New("fireblocks key path is empty")
+	}
+
 	bz, err := os.ReadFile(path)
 	if err != nil {
 		return nil, errors.Wrap(err, "load fireblocks key", "path", path)


### PR DESCRIPTION
Add a fireblocks rpc proxy that enables raw signing.

The proxy intercepts `eth_sendTransaction` requests, signs them,
and forwards an `eth_sendRawTransaction` request.

Prerequisite for running admin forge scripts (#1393)

issue: #1393