### PR TITLE
fix(monitor): correctly start fromHeight to start streaming from

### DIFF
--- a/monitor/xmonitor/emitcursorcache.go
+++ b/monitor/xmonitor/emitcursorcache.go
@@ -67,7 +67,10 @@ func startEmitCursorCache(
 			return nil, errors.Wrap(err, "latest height", "chain", chain.Name)
 		}
 
-		fromHeight := latest - cacheStartLag
+		var fromHeight uint64
+		if latest > cacheStartLag {
+			fromHeight = latest - cacheStartLag
+		}
 		req := xchain.ProviderRequest{
 			ChainID:   chain.ID,
 			Height:    fromHeight,


### PR DESCRIPTION
For very new chains (in particular, the omni_evm and omni_consensus chains), the `latest` height is ~0, and we're underflowing.

issue: none