### PR TITLE
chore(ci): remove dependabot labeling

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,4 @@ updates:
   directory: "/"
   schedule:
     interval: "daily"
+  labels: []


### PR DESCRIPTION
removes dependabot labels like `dependencies` and `go`

issue: none