### PR TITLE
fix(relayer): correctly log estimated gas

### DIFF
--- a/relayer/app/sender.go
+++ b/relayer/app/sender.go
@@ -154,7 +154,7 @@ func (s Sender) SendTransaction(ctx context.Context, sub xchain.Submission) erro
 		errAttrs := slices.Concat(receiptAttrs, reqAttrs, []any{
 			"call_resp", hexutil.Encode(resp),
 			"call_err", err,
-			"gas_limit", estimatedGas,
+			"gas_limit", tx.Gas(),
 		})
 
 		revertedSubmissionTotal.WithLabelValues(srcChain, dstChain).Inc()


### PR DESCRIPTION
This log can display (incorrectly) as 0 ([example](https://omniops.grafana.net/goto/OindVflSg?orgId=1)), since we may be relying on the `txMgr` to estimate gas for us. We should log the actual gas limit from the `tx` itself.

issue: none