### PR TITLE
feat(contracts): add pause portal admin script

### DIFF
--- a/contracts/core/script/admin/Admins.sol
+++ b/contracts/core/script/admin/Admins.sol
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: GPL-3.0-only
+pragma solidity 0.8.24;
+
+library Admins {
+    address internal constant devnet = 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266;
+    address internal constant staging = 0x4891925c4f13A34FC26453FD168Db80aF3273014;
+    address internal constant omega = 0xEAD625eB2011394cdD739E91Bf9D51A7169C22F5;
+
+    function forNetwork(string calldata network) internal pure returns (address) {
+        bytes32 hash = keccak256(abi.encodePacked(network));
+
+        if (hash == keccak256(abi.encodePacked("devnet"))) return devnet;
+        if (hash == keccak256(abi.encodePacked("staging"))) return staging;
+        if (hash == keccak256(abi.encodePacked("omega"))) return omega;
+        revert("Admins: invalid network");
+    }
+}

--- a/contracts/core/script/admin/PausePortal.s.sol
+++ b/contracts/core/script/admin/PausePortal.s.sol
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: GPL-3.0-only
+pragma solidity 0.8.24;
+
+import { Script } from "forge-std/Script.sol";
+import { IOmniPortalAdmin } from "src/interfaces/IOmniPortalAdmin.sol";
+import { Admins } from "./Admins.sol";
+
+/**
+ * @title PausePortal
+ * @notice Pause a portal contract.
+ */
+contract PausePortal is Script {
+    function run(string calldata network, address portal) public {
+        vm.startBroadcast(Admins.forNetwork(network));
+        IOmniPortalAdmin(portal).pause();
+        vm.stopBroadcast();
+    }
+}

--- a/contracts/scripts/admin/pauseportal.sh
+++ b/contracts/scripts/admin/pauseportal.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+#
+# Pause a portal on the given chain
+#
+# Usage: RPC=... ADDRESS=... NETWORK=... FIREBLOCKS_API_KEY=... FIREBLOCKS_KEY_PATH=... ./pauseportal.sh
+#
+# Note: This script will only work for persistent networks, not devnet, as devnet uses
+#   anvil accounts as admins.
+
+
+gitroot() {
+  git rev-parse --show-toplevel
+}
+
+usage() {
+  echo "
+  Require environment variables:
+  RPC                 rpc endpoint of the chain
+  ADDRESS             address of the portal contract
+  NETWORK             network name
+  FIREBLOCKS_API_KEY  fireblocks api key
+  FIREBLOCKS_KEY_PATH fireblocks key path
+"
+}
+
+cd $(gitroot)
+source ./contracts/scripts/admin/util.sh
+
+if ! require_env RPC ADDRESS NETWORK FIREBLOCKS_API_KEY FIREBLOCKS_KEY_PATH; then
+  usage
+  exit 1
+fi
+
+echo "Pausing ${NETWORK} portal ${PORTAL} on ${CHAIN}..."
+
+fbproxy_addr="0.0.0.0:7070"
+
+# run fbproxy
+go run ./e2e/fbproxy \
+  --network $NETWORK \
+  --fireblocks-api-key $FIREBLOCKS_API_KEY \
+  --fireblocks-key-path $FIREBLOCKS_KEY_PATH \
+  --listen-addr $fbproxy_addr \
+  --base-rpc $RPC \
+  &
+
+fbproxy_pid=$!
+
+# kill fbproxy on exit
+cleanup() {
+  echo "Cleaning up..."
+  echo "killing fbproxy pid: $fbproxy_pid"
+  pkill -P $fbproxy_pid
+}
+
+trap cleanup EXIT
+
+# wait for a bit, then check if fbproxy is running
+sleep 2
+if ! kill -0 $fbproxy_pid; then
+  echo "fbproxy failed to start"
+  exit 1
+fi
+
+# pause the portal
+forge script PausePortal \
+  --root ./contracts/core \
+  --broadcast \
+  --unlocked \
+  --slow \
+  --rpc-url $fbproxy_addr \
+  --sig $(cast calldata "run(string,address)" $NETWORK $PORTAL)

--- a/contracts/scripts/admin/util.sh
+++ b/contracts/scripts/admin/util.sh
@@ -1,0 +1,12 @@
+# shared admin script utils
+
+# check if required environment variables are set
+# usage: require_env <var1> <var2> ...
+require_env() {
+  for var in $@; do
+    if [ -z "${!var}" ]; then
+      echo "Missing required environment variable: $var"
+      return 1
+    fi
+  done
+}


### PR DESCRIPTION
Add e2e admin pause-portal command.

DRAFT

This is a draft PR that implements the pause portal script outside the e2e runner.

This should be compared to https://github.com/omni-network/omni/pull/1447, which
implements this feature within the e2e runner.

Both offer boilerplate / setup code that will be used for future admin actions.