### PR TITLE
ci(e2e): pin omega version to 1da6143

### DIFF
--- a/e2e/app/definition.go
+++ b/e2e/app/definition.go
@@ -220,6 +220,11 @@ func adaptNode(ctx context.Context, manifest types.Manifest, testnet *e2e.Testne
 		return nil, err
 	}
 
+	// Pinned tag overrides the cli --omni-image-tag flag.
+	if manifest.PinnedHaloTag != "" {
+		tag = manifest.PinnedHaloTag
+	}
+
 	node.Version = "omniops/halo:" + tag
 	node.PrivvalKey = valKey.PrivKey
 	node.NodeKey = nodeKey.PrivKey

--- a/e2e/manifests/omega.toml
+++ b/e2e/manifests/omega.toml
@@ -3,6 +3,7 @@ public_chains = ["holesky","op_sepolia", "base_sepolia","arb_sepolia"]
 
 multi_omni_evms = true
 prometheus = true
+pinned_halo_tag = "1da6143"
 
 [node.validator01]
 [node.validator02]

--- a/e2e/types/manifest.go
+++ b/e2e/types/manifest.go
@@ -97,6 +97,11 @@ type Manifest struct {
 
 	// Perturb defines additional (non-cometBFT) perturbations by service name.
 	Perturb map[string][]Perturb `json:"perturb"`
+
+	// PinnedHaloTag defines the pinned halo docker image tag.
+	// This allows source code defined versions for protected networks.
+	// The --omni-image-tag flag is then only used for non-halo services (relayer, monitor).
+	PinnedHaloTag string `toml:"pinned_halo_tag"`
 }
 
 // Seeds returns a map of seed nodes by name.


### PR DESCRIPTION
Pin omage version to `1da6143` so halo is pinned while other services (relayer/monitor/geth) is upgraded to latest (or whatever versions is defined in upgrade action)

issue: none