### PR TITLE
ci(e2e): bump omega halo

### DIFF
--- a/e2e/manifests/omega.toml
+++ b/e2e/manifests/omega.toml
@@ -3,7 +3,7 @@ public_chains = ["holesky","op_sepolia", "base_sepolia","arb_sepolia"]
 
 multi_omni_evms = true
 prometheus = true
-pinned_halo_tag = "1da6143"
+pinned_halo_tag = "1734918"
 
 [node.validator01]
 [node.validator02]

--- a/e2e/vmcompose/provider.go
+++ b/e2e/vmcompose/provider.go
@@ -145,7 +145,6 @@ func (p *Provider) Upgrade(ctx context.Context, cfg types.UpgradeConfig) error {
 	for _, node := range p.Testnet.Nodes {
 		addFile(node.Name, "config", "halo.toml")
 		addFile(node.Name, "config", "config.toml")
-		addFile(node.Name, "config", "jwtsecret")
 		addFile(node.Name, "config", "priv_validator_key.json")
 		addFile(node.Name, "config", "node_key.json")
 	}
@@ -153,7 +152,6 @@ func (p *Provider) Upgrade(ctx context.Context, cfg types.UpgradeConfig) error {
 	// Include geth config
 	for _, omniEVM := range p.Testnet.OmniEVMs {
 		addFile(omniEVM.InstanceName, "config.toml")
-		addFile(omniEVM.InstanceName, "geth", "jwtsecret")
 		addFile(omniEVM.InstanceName, "geth", "nodekey")
 	}
 


### PR DESCRIPTION
Upgrade omega version by 1 commit to restart the halo instances to fix the stalled chain.

Also, don't upgrade jwtsecret since halo isn't always restarted on upgrade. Which caused the current chain stall.

issue: none
