### PR TITLE
ci(scripts): add custom uint subtract go linter

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -56,6 +56,13 @@ repos:
         entry: .pre-commit/run_go_tests.sh
         types: [ file, go ]
 
+      - id: run-golint
+        name: run-golint
+        language: script
+        require_serial: true # Don't run this in parallel
+        entry: .pre-commit/run_golint.sh
+        types: [ file, go ]
+
       - id: run-forge-tests
         name: run-forge-tests
         language: script

--- a/.pre-commit/run_golint.sh
+++ b/.pre-commit/run_golint.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+# Runs scripts/golint for all touched packages
+MOD=$(go list -m)
+PKGS=$(echo "$@"| xargs -n1 dirname | sort -u | sed -e "s#^#${MOD}/#")
+
+go run github.com/omni-network/omni/scripts/golint $PKGS

--- a/e2e/anvilproxy/app/xmsg.go
+++ b/e2e/anvilproxy/app/xmsg.go
@@ -9,6 +9,7 @@ import (
 	"github.com/omni-network/omni/e2e/types"
 	"github.com/omni-network/omni/lib/errors"
 	"github.com/omni-network/omni/lib/ethclient"
+	"github.com/omni-network/omni/lib/umath"
 
 	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
@@ -174,7 +175,7 @@ func isFuzzyXMsgLogFilter(ctx context.Context, perturb types.Perturb, target str
 
 	const buffer = 2 // Avoid race conditions, require query to be more than 2 ahead of finalized.
 
-	return block-buffer > finalized.Number.Uint64(), block, nil
+	return umath.SubtractOrZero(block, buffer) > finalized.Number.Uint64(), block, nil
 }
 
 // mustGetABI returns the metadata's ABI as an abi.ABI type.

--- a/lib/ethclient/ethbackend/backend.go
+++ b/lib/ethclient/ethbackend/backend.go
@@ -15,6 +15,7 @@ import (
 	"github.com/omni-network/omni/lib/k1util"
 	"github.com/omni-network/omni/lib/log"
 	"github.com/omni-network/omni/lib/txmgr"
+	"github.com/omni-network/omni/lib/umath"
 
 	k1 "github.com/cometbft/cometbft/crypto/secp256k1"
 
@@ -254,7 +255,7 @@ func (b *Backend) EnsureSynced(ctx context.Context) error {
 		return nil // Syncing is nil if node is not syncing.
 	} else if !syncing.Done() {
 		return errors.New("backend not synced",
-			"lag", syncing.HighestBlock-syncing.CurrentBlock,
+			"lag", umath.SubtractOrZero(syncing.HighestBlock, syncing.CurrentBlock),
 			"indexing", syncing.TxIndexRemainingBlocks,
 		)
 	}

--- a/lib/txmgr/txmgr.go
+++ b/lib/txmgr/txmgr.go
@@ -13,6 +13,7 @@ import (
 	"github.com/omni-network/omni/lib/ethclient"
 	"github.com/omni-network/omni/lib/expbackoff"
 	"github.com/omni-network/omni/lib/log"
+	"github.com/omni-network/omni/lib/umath"
 
 	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/common"
@@ -87,7 +88,7 @@ func (m *simple) ReserveNextNonce(ctx context.Context) (uint64, error) {
 			return 0, errors.Wrap(err, "sync progress")
 		} else if syncing != nil && !syncing.Done() { // Note syncing is nil if node is not syncing.
 			return 0, errors.New("backend not synced",
-				"lag", syncing.HighestBlock-syncing.CurrentBlock,
+				"lag", umath.SubtractOrZero(syncing.HighestBlock, syncing.CurrentBlock),
 				"indexing", syncing.TxIndexRemainingBlocks,
 			)
 		}

--- a/lib/umath/umath.go
+++ b/lib/umath/umath.go
@@ -1,0 +1,18 @@
+// Package umath provides some useful unsigned math functions to prevent underflows.
+package umath
+
+// Subtract returns a - b and true if a >= b, otherwise 0 and false.
+func Subtract(a, b uint64) (uint64, bool) {
+	if a < b {
+		return 0, false
+	}
+
+	return a - b, true
+}
+
+// SubtractOrZero returns a - b if a >= b, otherwise 0.
+// This is a convenience function for inline usage.
+func SubtractOrZero(a, b uint64) uint64 {
+	resp, _ := Subtract(a, b)
+	return resp
+}

--- a/lib/xchain/provider/mock.go
+++ b/lib/xchain/provider/mock.go
@@ -12,6 +12,7 @@ import (
 	"github.com/omni-network/omni/lib/errors"
 	"github.com/omni-network/omni/lib/log"
 	"github.com/omni-network/omni/lib/netconf"
+	"github.com/omni-network/omni/lib/umath"
 	"github.com/omni-network/omni/lib/xchain"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -163,9 +164,14 @@ func (m *Mock) parentBlockHash(chainVer xchain.ChainVersion, height uint64) comm
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
+	parentHeight, ok := umath.Subtract(height, 1)
+	if !ok {
+		return common.Hash{} // Height == 0
+	}
+
 	key := blockKey{
 		ChainID:   chainVer.ID,
-		Height:    height - 1,
+		Height:    parentHeight,
 		ConfLevel: chainVer.ConfLevel,
 	}
 

--- a/monitor/xfeemngr/gasprice/buffer_test.go
+++ b/monitor/xfeemngr/gasprice/buffer_test.go
@@ -5,6 +5,7 @@ import (
 	"math/rand"
 	"testing"
 
+	"github.com/omni-network/omni/lib/umath"
 	"github.com/omni-network/omni/monitor/xfeemngr/gasprice"
 	"github.com/omni-network/omni/monitor/xfeemngr/ticker"
 
@@ -43,7 +44,8 @@ func TestBufferStream(t *testing.T) {
 
 	// just increase a little, but not above threshold
 	for chainID, price := range initials {
-		mocks[chainID].SetPrice(price + uint64(float64(price)*thresh) - 1)
+		delta := umath.SubtractOrZero(uint64(float64(price)*thresh), 1)
+		mocks[chainID].SetPrice(price + delta)
 	}
 
 	tick.Tick()

--- a/monitor/xmonitor/emitcache/emitcursorcache.go
+++ b/monitor/xmonitor/emitcache/emitcursorcache.go
@@ -7,6 +7,7 @@ import (
 	"github.com/omni-network/omni/lib/errors"
 	"github.com/omni-network/omni/lib/log"
 	"github.com/omni-network/omni/lib/netconf"
+	"github.com/omni-network/omni/lib/umath"
 	"github.com/omni-network/omni/lib/xchain"
 
 	ormv1alpha1 "cosmossdk.io/api/cosmos/orm/v1alpha1"
@@ -76,7 +77,7 @@ func Start(
 			}
 
 			if block.BlockHeight > cacheTrimLag { // Only trim after cacheTrimLag blocks.
-				if err := cache.trim(ctx, block.BlockHeight-cacheTrimLag); err != nil {
+				if err := cache.trim(ctx, umath.SubtractOrZero(block.BlockHeight, cacheTrimLag)); err != nil {
 					return err
 				}
 			}

--- a/octane/evmengine/keeper/msg_server.go
+++ b/octane/evmengine/keeper/msg_server.go
@@ -6,6 +6,7 @@ import (
 	"github.com/omni-network/omni/lib/errors"
 	"github.com/omni-network/omni/lib/ethclient"
 	"github.com/omni-network/omni/lib/log"
+	"github.com/omni-network/omni/lib/umath"
 	"github.com/omni-network/omni/octane/evmengine/types"
 
 	"github.com/ethereum/go-ethereum/beacon/engine"
@@ -88,8 +89,13 @@ func (s msgServer) ExecutionPayload(ctx context.Context, msg *types.MsgExecution
 		return nil, err
 	}
 
+	parentHeight, ok := umath.Subtract(payload.Number, 1)
+	if !ok { // payload.Number == 0
+		return nil, errors.New("invalid zero payload number")
+	}
+
 	// Deliver all the previous payload log events
-	if err := s.deliverEvents(ctx, payload.Number-1, payload.ParentHash, msg.PrevPayloadEvents); err != nil {
+	if err := s.deliverEvents(ctx, parentHeight, payload.ParentHash, msg.PrevPayloadEvents); err != nil {
 		return nil, errors.Wrap(err, "deliver event logs")
 	}
 

--- a/scripts/golint/main.go
+++ b/scripts/golint/main.go
@@ -1,0 +1,12 @@
+// Command golint is a custom Go linter.
+// It doesn't replace golang-ci-lint which runs all industry standard linters.
+// It merely runs a few custom omni-specific linters.
+package main
+
+import (
+	"golang.org/x/tools/go/analysis/multichecker"
+)
+
+func main() {
+	multichecker.Main(uintSubtractAnalyzer)
+}

--- a/scripts/golint/uintsub.go
+++ b/scripts/golint/uintsub.go
@@ -1,0 +1,109 @@
+package main
+
+import (
+	"go/ast"
+	"go/token"
+	"go/types"
+
+	"github.com/omni-network/omni/lib/errors"
+
+	"golang.org/x/tools/go/analysis"
+	"golang.org/x/tools/go/analysis/passes/inspect"
+	"golang.org/x/tools/go/ast/inspector"
+)
+
+var uintTypes = map[string]bool{
+	"uint":   true,
+	"uint8":  true,
+	"uint16": true,
+	"uint32": true,
+	"uint64": true,
+	"byte":   true,
+}
+
+var uintSubtractAnalyzer = &analysis.Analyzer{
+	Name: "uintsubtract",
+	Doc: "Prevents subtraction of uints, since it may underflow. " +
+		"Use a 'uintsub' function with 'a-b' to bypass linter.",
+	Run: func(p *analysis.Pass) (interface{}, error) {
+		i, ok := p.ResultOf[inspect.Analyzer].(*inspector.Inspector)
+		if !ok {
+			return nil, errors.New("analyzer is not of type *inspector.Inspector")
+		}
+		diags, err := uintstract(i, p.TypesInfo)
+		if err != nil {
+			return nil, errors.Wrap(err, "detect uint subtract")
+		}
+
+		for _, diag := range diags {
+			p.Report(diag)
+		}
+
+		return nil, nil //nolint:nilnil // API requires nil-nil return
+	},
+	Requires: []*analysis.Analyzer{inspect.Analyzer},
+}
+
+func uintstract(i *inspector.Inspector, typeInfo *types.Info) ([]analysis.Diagnostic, error) {
+	var diags []analysis.Diagnostic
+	var err error
+	filter := []ast.Node{new(ast.BinaryExpr)}
+	i.Preorder(filter, func(n ast.Node) {
+		bin, ok := n.(*ast.BinaryExpr)
+		if !ok {
+			err = errors.New("expected *ast.BinaryExpr")
+			return
+		}
+
+		if bin.Op != token.SUB {
+			return // Not a subtraction (-)
+		}
+
+		if isVar(bin.X, "a") && isVar(bin.Y, "b") {
+			return // Ignore 'a-b'
+		}
+
+		leftType := typeInfo.TypeOf(bin.X)
+		if leftType == nil {
+			err = errors.New("left type not found")
+			return
+		}
+
+		if uintTypes[leftType.String()] {
+			diags = append(diags, analysis.Diagnostic{
+				Pos:     bin.OpPos,
+				End:     bin.OpPos,
+				Message: "uint subtraction",
+			})
+
+			return
+		}
+
+		rightType := typeInfo.TypeOf(bin.Y)
+		if rightType == nil {
+			err = errors.New("right type not found")
+			return
+		}
+
+		if uintTypes[rightType.String()] {
+			diags = append(diags, analysis.Diagnostic{
+				Pos:     bin.OpPos,
+				End:     bin.OpPos,
+				Message: "uint subtraction",
+			})
+
+			return
+		}
+	})
+
+	return diags, err
+}
+
+func isVar(exp ast.Expr, name string) bool {
+	ident, ok := exp.(*ast.Ident)
+	if !ok {
+		return false
+	}
+
+	return ident.Name == name
+}

--- a/scripts/golint/uintsub_internal_test.go
+++ b/scripts/golint/uintsub_internal_test.go
@@ -1,0 +1,37 @@
+package main
+
+import (
+	"testing"
+
+	"golang.org/x/tools/go/analysis/analysistest"
+)
+
+func TestUintSub(t *testing.T) {
+	t.Parallel()
+
+	content := `package main
+
+func main() {
+	var a uint64 = 1
+	c := a - b()    // want "uint subtraction"
+	d := c + b()    // This is ok
+	_ = 5 / (d - 3) // want "uint subtraction"
+}
+
+func b() uint64 {
+	return 3
+}
+
+// uintsub bypasses the linter by using 'a-b' variable names.
+func uintsub(a, b uint64) uint64 {
+	return a - b // The linter ignores 'a-b' specifically
+}
+`
+
+	dir, cleanup, err := analysistest.WriteFiles(map[string]string{"main/main.go": content})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cleanup()
+	_ = analysistest.Run(t, dir, uintSubtractAnalyzer, "main")
+}


### PR DESCRIPTION
Adds a custom `scripts/golint` linter that uses the `golang.org/x/tools/go/analysis` framework.

Implement a simple `uintsubtract` linter that detects uint subtractions. Bypass by using `a-b` inside a uintsub function.

Integrate and run this linter using the `pre-commit` framework.

Also fix all occurrences in the repo.

issue: #1431