### PR TITLE
feat(e2e/manifests): add second archive node in Omega manifest

### DIFF
--- a/e2e/manifests/omega.toml
+++ b/e2e/manifests/omega.toml
@@ -28,6 +28,8 @@ mode = "full"
 
 [node.archive01]
 mode = "archive"
+[node.archive02]
+mode = "archive"
 
 
 [keys.validator01]


### PR DESCRIPTION
adds the second archive node to the Omega manifest. Will be picked up on the next Omega release.

issue: #1502