### PR TITLE
chore(relayer): enable pprof on prometheus port

### DIFF
--- a/e2e/docker/compose.yaml.tmpl
+++ b/e2e/docker/compose.yaml.tmpl
@@ -20,12 +20,12 @@ services:
     image: {{ .Version }}
     init: true
     ports:
-    - {{ if $.BindAll }}26656:{{end}}26656
-    - {{ if .ProxyPort }}{{ .ProxyPort }}:{{ end }}26657
+    - {{ if $.BindAll }}26656:{{end}}26656 # Consensus P2P
+    - {{ if .ProxyPort }}{{ .ProxyPort }}:{{ end }}26657 # Consensus RPC
 {{- if .PrometheusProxyPort }}
-    - {{ .PrometheusProxyPort }}:26660
+    - {{ .PrometheusProxyPort }}:26660 # Prometheus
 {{- end }}
-    - 6060
+    - 6060 # Pprof
     volumes:
     - ./{{ .Name }}:/halo
     networks:
@@ -72,11 +72,11 @@ services:
       - --metrics
       {{ if .IsArchive }}- --gcmode=archive{{ end }}
     ports:
-      - {{ if $.BindAll }}8551:{{end}}8551
-      - {{ if .ProxyPort }}{{ .ProxyPort }}:{{ end }}8545
-      - {{ if $.BindAll }}30303:{{end}}30303
-      - 8546
-      - 6060
+      - {{ if $.BindAll }}8551:{{end}}8551 # Auth RPC
+      - {{ if .ProxyPort }}{{ .ProxyPort }}:{{ end }}8545 # HTTP RPC
+      - {{ if $.BindAll }}30303:{{end}}30303 # Execution P2P
+      - 8546 # Websockets RPC
+      - 6060 # Prometheus metrics and pprof
     healthcheck:
       test: "nc -z localhost 8545"
       interval: 1s
@@ -95,6 +95,8 @@ services:
     container_name: relayer
     image: omniops/relayer:{{or .OmniTag "main"}}
     restart: unless-stopped # Restart on crash to mitigate startup race issues
+    ports:
+      - 26660 # Prometheus and pprof
     volumes:
       - ./relayer:/relayer
     networks:
@@ -109,6 +111,8 @@ services:
     container_name: monitor
     image: omniops/monitor:{{or .OmniTag "main"}}
     restart: unless-stopped # Restart on crash to mitigate startup race issues
+    ports:
+      - 26660 # Prometheus and pprof
     volumes:
       - ./monitor:/monitor
     networks:

--- a/e2e/docker/testdata/TestComposeTemplate_commit.golden
+++ b/e2e/docker/testdata/TestComposeTemplate_commit.golden
@@ -17,9 +17,9 @@ services:
     image: omniops/halo:7d1ae53
     init: true
     ports:
-    - 26656
-    - 8584:26657
-    - 6060
+    - 26656 # Consensus P2P
+    - 8584:26657 # Consensus RPC
+    - 6060 # Pprof
     volumes:
     - ./node0:/halo
     networks:
@@ -79,11 +79,11 @@ services:
       - --metrics
       
     ports:
-      - 8551
-      - 8000:8545
-      - 30303
-      - 8546
-      - 6060
+      - 8551 # Auth RPC
+      - 8000:8545 # HTTP RPC
+      - 30303 # Execution P2P
+      - 8546 # Websockets RPC
+      - 6060 # Prometheus metrics and pprof
     healthcheck:
       test: "nc -z localhost 8545"
       interval: 1s
@@ -100,6 +100,8 @@ services:
     container_name: relayer
     image: omniops/relayer:7d1ae53
     restart: unless-stopped # Restart on crash to mitigate startup race issues
+    ports:
+      - 26660 # Prometheus and pprof
     volumes:
       - ./relayer:/relayer
     networks:
@@ -112,6 +114,8 @@ services:
     container_name: monitor
     image: omniops/monitor:7d1ae53
     restart: unless-stopped # Restart on crash to mitigate startup race issues
+    ports:
+      - 26660 # Prometheus and pprof
     volumes:
       - ./monitor:/monitor
     networks:

--- a/e2e/docker/testdata/TestComposeTemplate_empheral_network.golden
+++ b/e2e/docker/testdata/TestComposeTemplate_empheral_network.golden
@@ -17,9 +17,9 @@ services:
     image: omniops/halo:main
     init: true
     ports:
-    - 26656
-    - 8584:26657
-    - 6060
+    - 26656 # Consensus P2P
+    - 8584:26657 # Consensus RPC
+    - 6060 # Pprof
     volumes:
     - ./node0:/halo
     networks:
@@ -79,11 +79,11 @@ services:
       - --metrics
       
     ports:
-      - 8551
-      - 8000:8545
-      - 30303
-      - 8546
-      - 6060
+      - 8551 # Auth RPC
+      - 8000:8545 # HTTP RPC
+      - 30303 # Execution P2P
+      - 8546 # Websockets RPC
+      - 6060 # Prometheus metrics and pprof
     healthcheck:
       test: "nc -z localhost 8545"
       interval: 1s
@@ -100,6 +100,8 @@ services:
     container_name: relayer
     image: omniops/relayer:main
     restart: unless-stopped # Restart on crash to mitigate startup race issues
+    ports:
+      - 26660 # Prometheus and pprof
     volumes:
       - ./relayer:/relayer
     networks:
@@ -112,6 +114,8 @@ services:
     container_name: monitor
     image: omniops/monitor:main
     restart: unless-stopped # Restart on crash to mitigate startup race issues
+    ports:
+      - 26660 # Prometheus and pprof
     volumes:
       - ./monitor:/monitor
     networks:

--- a/e2e/vmcompose/testdata/TestSetup_127-0-0-1-compose.yaml.golden
+++ b/e2e/vmcompose/testdata/TestSetup_127-0-0-1-compose.yaml.golden
@@ -13,9 +13,9 @@ services:
     image: omniops/halo:7d1ae53
     init: true
     ports:
-    - 26656:26656
-    - 26657:26657
-    - 6060
+    - 26656:26656 # Consensus P2P
+    - 26657:26657 # Consensus RPC
+    - 6060 # Pprof
     volumes:
     - ./validator01:/halo
     networks:
@@ -38,11 +38,11 @@ services:
       - --metrics
       
     ports:
-      - 8551:8551
-      - 8545:8545
-      - 30303:30303
-      - 8546
-      - 6060
+      - 8551:8551 # Auth RPC
+      - 8545:8545 # HTTP RPC
+      - 30303:30303 # Execution P2P
+      - 8546 # Websockets RPC
+      - 6060 # Prometheus metrics and pprof
     healthcheck:
       test: "nc -z localhost 8545"
       interval: 1s

--- a/e2e/vmcompose/testdata/TestSetup_127-0-0-2-compose.yaml.golden
+++ b/e2e/vmcompose/testdata/TestSetup_127-0-0-2-compose.yaml.golden
@@ -13,9 +13,9 @@ services:
     image: omniops/halo:7d1ae53
     init: true
     ports:
-    - 26656:26656
-    - 26657:26657
-    - 6060
+    - 26656:26656 # Consensus P2P
+    - 26657:26657 # Consensus RPC
+    - 6060 # Pprof
     volumes:
     - ./validator02:/halo
     networks:
@@ -38,11 +38,11 @@ services:
       - --metrics
       
     ports:
-      - 8551:8551
-      - 8545:8545
-      - 30303:30303
-      - 8546
-      - 6060
+      - 8551:8551 # Auth RPC
+      - 8545:8545 # HTTP RPC
+      - 30303:30303 # Execution P2P
+      - 8546 # Websockets RPC
+      - 6060 # Prometheus metrics and pprof
     healthcheck:
       test: "nc -z localhost 8545"
       interval: 1s

--- a/e2e/vmcompose/testdata/TestSetup_127-0-0-3-compose.yaml.golden
+++ b/e2e/vmcompose/testdata/TestSetup_127-0-0-3-compose.yaml.golden
@@ -34,6 +34,8 @@ services:
     container_name: relayer
     image: omniops/relayer:7d1ae53
     restart: unless-stopped # Restart on crash to mitigate startup race issues
+    ports:
+      - 26660 # Prometheus and pprof
     volumes:
       - ./relayer:/relayer
     networks:

--- a/e2e/vmcompose/testdata/TestSetup_127-0-0-4-compose.yaml.golden
+++ b/e2e/vmcompose/testdata/TestSetup_127-0-0-4-compose.yaml.golden
@@ -13,9 +13,9 @@ services:
     image: omniops/halo:7d1ae53
     init: true
     ports:
-    - 26656:26656
-    - 26657:26657
-    - 6060
+    - 26656:26656 # Consensus P2P
+    - 26657:26657 # Consensus RPC
+    - 6060 # Pprof
     volumes:
     - ./seed01:/halo
     networks:
@@ -38,11 +38,11 @@ services:
       - --metrics
       
     ports:
-      - 8551:8551
-      - 8545:8545
-      - 30303:30303
-      - 8546
-      - 6060
+      - 8551:8551 # Auth RPC
+      - 8545:8545 # HTTP RPC
+      - 30303:30303 # Execution P2P
+      - 8546 # Websockets RPC
+      - 6060 # Prometheus metrics and pprof
     healthcheck:
       test: "nc -z localhost 8545"
       interval: 1s

--- a/e2e/vmcompose/testdata/TestSetup_127-0-0-5-compose.yaml.golden
+++ b/e2e/vmcompose/testdata/TestSetup_127-0-0-5-compose.yaml.golden
@@ -13,9 +13,9 @@ services:
     image: omniops/halo:7d1ae53
     init: true
     ports:
-    - 26656:26656
-    - 26657:26657
-    - 6060
+    - 26656:26656 # Consensus P2P
+    - 26657:26657 # Consensus RPC
+    - 6060 # Pprof
     volumes:
     - ./fullnode01:/halo
     networks:
@@ -38,11 +38,11 @@ services:
       - --metrics
       
     ports:
-      - 8551:8551
-      - 8545:8545
-      - 30303:30303
-      - 8546
-      - 6060
+      - 8551:8551 # Auth RPC
+      - 8545:8545 # HTTP RPC
+      - 30303:30303 # Execution P2P
+      - 8546 # Websockets RPC
+      - 6060 # Prometheus metrics and pprof
     healthcheck:
       test: "nc -z localhost 8545"
       interval: 1s

--- a/monitor/app/app.go
+++ b/monitor/app/app.go
@@ -3,6 +3,7 @@ package monitor
 import (
 	"context"
 	"net/http"
+	"net/http/pprof"
 	"time"
 
 	"github.com/omni-network/omni/contracts/bindings"
@@ -111,6 +112,13 @@ func serveMonitoring(address string) <-chan error {
 	go func() {
 		mux := http.NewServeMux()
 		mux.Handle("/metrics", promhttp.Handler())
+
+		// Copied from net/http/pprof/pprof.go
+		mux.HandleFunc("/debug/pprof/", pprof.Index)
+		mux.HandleFunc("/debug/pprof/cmdline", pprof.Cmdline)
+		mux.HandleFunc("/debug/pprof/profile", pprof.Profile)
+		mux.HandleFunc("/debug/pprof/symbol", pprof.Symbol)
+		mux.HandleFunc("/debug/pprof/trace", pprof.Trace)
 
 		srv := &http.Server{
 			Addr:              address,

--- a/relayer/app/monitor.go
+++ b/relayer/app/monitor.go
@@ -2,6 +2,7 @@ package relayer
 
 import (
 	"net/http"
+	"net/http/pprof"
 	"time"
 
 	"github.com/omni-network/omni/lib/errors"
@@ -16,6 +17,13 @@ func serveMonitoring(address string) <-chan error {
 	go func() {
 		mux := http.NewServeMux()
 		mux.Handle("/metrics", promhttp.Handler())
+
+		// Copied from net/http/pprof/pprof.go
+		mux.HandleFunc("/debug/pprof/", pprof.Index)
+		mux.HandleFunc("/debug/pprof/cmdline", pprof.Cmdline)
+		mux.HandleFunc("/debug/pprof/profile", pprof.Profile)
+		mux.HandleFunc("/debug/pprof/symbol", pprof.Symbol)
+		mux.HandleFunc("/debug/pprof/trace", pprof.Trace)
 
 		srv := &http.Server{
 			Addr:              address,


### PR DESCRIPTION
Enables serving `pprof` on the same server/port as prometheus for `relayer` and `monitor`.

Also clarify ports in docker-compose.

issue: none