### PR TITLE
ci(e2e): configure external advertised P2P IP

### DIFF
--- a/e2e/types/manifest.go
+++ b/e2e/types/manifest.go
@@ -116,19 +116,19 @@ func (m Manifest) Seeds() map[string]bool {
 	return resp
 }
 
-// OmniEVMs returns a map of omni evm instances names by <IsArchive> to deploy.
+// OmniEVMs returns a map of omni evm instances names by mode to deploy.
 // If only a single Omni EVM is to be deployed, the name is "omni_evm".
 // Otherwise, the names are "<node>_evm".
-func (m Manifest) OmniEVMs() map[string]bool {
+func (m Manifest) OmniEVMs() map[string]Mode {
 	if !m.MultiOmniEVMs {
-		return map[string]bool{
-			"omni_evm": false,
+		return map[string]Mode{
+			"omni_evm": ModeValidator,
 		}
 	}
 
-	resp := make(map[string]bool)
+	resp := make(map[string]Mode)
 	for name, node := range m.Nodes {
-		resp[name+"_evm"] = Mode(node.Mode) == ModeArchive
+		resp[name+"_evm"] = Mode(node.Mode)
 	}
 
 	return resp

--- a/e2e/vmcompose/testdata/TestSetup_127-0-0-1-compose.yaml.golden
+++ b/e2e/vmcompose/testdata/TestSetup_127-0-0-1-compose.yaml.golden
@@ -32,7 +32,7 @@ services:
     command:
       - --config=/geth/config.toml
       # Flags not available via config.toml
-      - --nat=extip:<nil>
+      - --nat=extip:127.0.0.1
       - --pprof
       - --pprof.addr=0.0.0.0
       - --metrics

--- a/e2e/vmcompose/testdata/TestSetup_127-0-0-2-compose.yaml.golden
+++ b/e2e/vmcompose/testdata/TestSetup_127-0-0-2-compose.yaml.golden
@@ -32,7 +32,7 @@ services:
     command:
       - --config=/geth/config.toml
       # Flags not available via config.toml
-      - --nat=extip:<nil>
+      - --nat=extip:127.0.0.2
       - --pprof
       - --pprof.addr=0.0.0.0
       - --metrics

--- a/e2e/vmcompose/testdata/TestSetup_127-0-0-4-compose.yaml.golden
+++ b/e2e/vmcompose/testdata/TestSetup_127-0-0-4-compose.yaml.golden
@@ -32,7 +32,7 @@ services:
     command:
       - --config=/geth/config.toml
       # Flags not available via config.toml
-      - --nat=extip:<nil>
+      - --nat=extip:127.0.0.4
       - --pprof
       - --pprof.addr=0.0.0.0
       - --metrics

--- a/e2e/vmcompose/testdata/TestSetup_127-0-0-5-compose.yaml.golden
+++ b/e2e/vmcompose/testdata/TestSetup_127-0-0-5-compose.yaml.golden
@@ -32,7 +32,7 @@ services:
     command:
       - --config=/geth/config.toml
       # Flags not available via config.toml
-      - --nat=extip:<nil>
+      - --nat=extip:127.0.0.5
       - --pprof
       - --pprof.addr=0.0.0.0
       - --metrics


### PR DESCRIPTION
Use externalIP as "advertisingIP" for seeds and fullnodes on protected chains. The rest use internal IPs since they don't support external inbound connections.

issue: none