### PR TITLE
feat(e2e/docker): enable graphql and websockets in geth

### DIFF
--- a/e2e/app/geth/config.go
+++ b/e2e/app/geth/config.go
@@ -120,8 +120,10 @@ func MakeGethConfig(conf Config) FullConfig {
 	// Allow all incoming connections.
 	cfg.Node.HTTPVirtualHosts = []string{"*"}
 	cfg.Node.AuthVirtualHosts = []string{"*"}
+	cfg.Node.GraphQLVirtualHosts = []string{"*"}
 	cfg.Node.WSOrigins = []string{"*"}
 	cfg.Node.HTTPCors = []string{"*"}
+	cfg.Node.GraphQLCors = []string{"*"}
 
 	return cfg
 }

--- a/e2e/app/geth/testdata/TestWriteConfigTOML_archive.golden
+++ b/e2e/app/geth/testdata/TestWriteConfigTOML_archive.golden
@@ -70,7 +70,8 @@ WSHost = "0.0.0.0"
 WSPort = 8546
 WSOrigins = ["*"]
 WSModules = ["net", "web3", "eth", "debug"]
-GraphQLVirtualHosts = ["localhost"]
+GraphQLCors = ["*"]
+GraphQLVirtualHosts = ["*"]
 BatchRequestLimit = 1000
 BatchResponseMaxSize = 25000000
 

--- a/e2e/app/geth/testdata/TestWriteConfigTOML_full.golden
+++ b/e2e/app/geth/testdata/TestWriteConfigTOML_full.golden
@@ -70,7 +70,8 @@ WSHost = "0.0.0.0"
 WSPort = 8546
 WSOrigins = ["*"]
 WSModules = ["net", "web3", "eth"]
-GraphQLVirtualHosts = ["localhost"]
+GraphQLCors = ["*"]
+GraphQLVirtualHosts = ["*"]
 BatchRequestLimit = 1000
 BatchResponseMaxSize = 25000000
 

--- a/e2e/docker/compose.yaml.tmpl
+++ b/e2e/docker/compose.yaml.tmpl
@@ -70,12 +70,13 @@ services:
       - --pprof
       - --pprof.addr=0.0.0.0
       - --metrics
+      - --graphql
       {{ if .IsArchive }}- --gcmode=archive{{ end }}
     ports:
       - {{ if $.BindAll }}8551:{{end}}8551 # Auth RPC
       - {{ if .ProxyPort }}{{ .ProxyPort }}:{{ end }}8545 # HTTP RPC
       - {{ if $.BindAll }}30303:{{end}}30303 # Execution P2P
-      - 8546:8546 # Websockets RPC
+      - {{ if $.BindAll }}8546:{{end}}8546 # Websockets RPC
       - 6060 # Prometheus metrics and pprof
     healthcheck:
       test: "nc -z localhost 8545"

--- a/e2e/docker/compose.yaml.tmpl
+++ b/e2e/docker/compose.yaml.tmpl
@@ -75,7 +75,7 @@ services:
       - {{ if $.BindAll }}8551:{{end}}8551 # Auth RPC
       - {{ if .ProxyPort }}{{ .ProxyPort }}:{{ end }}8545 # HTTP RPC
       - {{ if $.BindAll }}30303:{{end}}30303 # Execution P2P
-      - 8546 # Websockets RPC
+      - 8546:8546 # Websockets RPC
       - 6060 # Prometheus metrics and pprof
     healthcheck:
       test: "nc -z localhost 8545"

--- a/e2e/docker/testdata/TestComposeTemplate_commit.golden
+++ b/e2e/docker/testdata/TestComposeTemplate_commit.golden
@@ -82,7 +82,7 @@ services:
       - 8551 # Auth RPC
       - 8000:8545 # HTTP RPC
       - 30303 # Execution P2P
-      - 8546 # Websockets RPC
+      - 8546:8546 # Websockets RPC
       - 6060 # Prometheus metrics and pprof
     healthcheck:
       test: "nc -z localhost 8545"

--- a/e2e/docker/testdata/TestComposeTemplate_commit.golden
+++ b/e2e/docker/testdata/TestComposeTemplate_commit.golden
@@ -77,12 +77,13 @@ services:
       - --pprof
       - --pprof.addr=0.0.0.0
       - --metrics
+      - --graphql
       
     ports:
       - 8551 # Auth RPC
       - 8000:8545 # HTTP RPC
       - 30303 # Execution P2P
-      - 8546:8546 # Websockets RPC
+      - 8546 # Websockets RPC
       - 6060 # Prometheus metrics and pprof
     healthcheck:
       test: "nc -z localhost 8545"

--- a/e2e/docker/testdata/TestComposeTemplate_empheral_network.golden
+++ b/e2e/docker/testdata/TestComposeTemplate_empheral_network.golden
@@ -82,7 +82,7 @@ services:
       - 8551 # Auth RPC
       - 8000:8545 # HTTP RPC
       - 30303 # Execution P2P
-      - 8546 # Websockets RPC
+      - 8546:8546 # Websockets RPC
       - 6060 # Prometheus metrics and pprof
     healthcheck:
       test: "nc -z localhost 8545"

--- a/e2e/docker/testdata/TestComposeTemplate_empheral_network.golden
+++ b/e2e/docker/testdata/TestComposeTemplate_empheral_network.golden
@@ -77,12 +77,13 @@ services:
       - --pprof
       - --pprof.addr=0.0.0.0
       - --metrics
+      - --graphql
       
     ports:
       - 8551 # Auth RPC
       - 8000:8545 # HTTP RPC
       - 30303 # Execution P2P
-      - 8546:8546 # Websockets RPC
+      - 8546 # Websockets RPC
       - 6060 # Prometheus metrics and pprof
     healthcheck:
       test: "nc -z localhost 8545"

--- a/e2e/vmcompose/testdata/TestSetup_127-0-0-1-compose.yaml.golden
+++ b/e2e/vmcompose/testdata/TestSetup_127-0-0-1-compose.yaml.golden
@@ -41,7 +41,7 @@ services:
       - 8551:8551 # Auth RPC
       - 8545:8545 # HTTP RPC
       - 30303:30303 # Execution P2P
-      - 8546 # Websockets RPC
+      - 8546:8546 # Websockets RPC
       - 6060 # Prometheus metrics and pprof
     healthcheck:
       test: "nc -z localhost 8545"

--- a/e2e/vmcompose/testdata/TestSetup_127-0-0-1-compose.yaml.golden
+++ b/e2e/vmcompose/testdata/TestSetup_127-0-0-1-compose.yaml.golden
@@ -36,6 +36,7 @@ services:
       - --pprof
       - --pprof.addr=0.0.0.0
       - --metrics
+      - --graphql
       
     ports:
       - 8551:8551 # Auth RPC

--- a/e2e/vmcompose/testdata/TestSetup_127-0-0-2-compose.yaml.golden
+++ b/e2e/vmcompose/testdata/TestSetup_127-0-0-2-compose.yaml.golden
@@ -41,7 +41,7 @@ services:
       - 8551:8551 # Auth RPC
       - 8545:8545 # HTTP RPC
       - 30303:30303 # Execution P2P
-      - 8546 # Websockets RPC
+      - 8546:8546 # Websockets RPC
       - 6060 # Prometheus metrics and pprof
     healthcheck:
       test: "nc -z localhost 8545"

--- a/e2e/vmcompose/testdata/TestSetup_127-0-0-2-compose.yaml.golden
+++ b/e2e/vmcompose/testdata/TestSetup_127-0-0-2-compose.yaml.golden
@@ -36,6 +36,7 @@ services:
       - --pprof
       - --pprof.addr=0.0.0.0
       - --metrics
+      - --graphql
       
     ports:
       - 8551:8551 # Auth RPC

--- a/e2e/vmcompose/testdata/TestSetup_127-0-0-4-compose.yaml.golden
+++ b/e2e/vmcompose/testdata/TestSetup_127-0-0-4-compose.yaml.golden
@@ -41,7 +41,7 @@ services:
       - 8551:8551 # Auth RPC
       - 8545:8545 # HTTP RPC
       - 30303:30303 # Execution P2P
-      - 8546 # Websockets RPC
+      - 8546:8546 # Websockets RPC
       - 6060 # Prometheus metrics and pprof
     healthcheck:
       test: "nc -z localhost 8545"

--- a/e2e/vmcompose/testdata/TestSetup_127-0-0-4-compose.yaml.golden
+++ b/e2e/vmcompose/testdata/TestSetup_127-0-0-4-compose.yaml.golden
@@ -36,6 +36,7 @@ services:
       - --pprof
       - --pprof.addr=0.0.0.0
       - --metrics
+      - --graphql
       
     ports:
       - 8551:8551 # Auth RPC

--- a/e2e/vmcompose/testdata/TestSetup_127-0-0-5-compose.yaml.golden
+++ b/e2e/vmcompose/testdata/TestSetup_127-0-0-5-compose.yaml.golden
@@ -41,7 +41,7 @@ services:
       - 8551:8551 # Auth RPC
       - 8545:8545 # HTTP RPC
       - 30303:30303 # Execution P2P
-      - 8546 # Websockets RPC
+      - 8546:8546 # Websockets RPC
       - 6060 # Prometheus metrics and pprof
     healthcheck:
       test: "nc -z localhost 8545"

--- a/e2e/vmcompose/testdata/TestSetup_127-0-0-5-compose.yaml.golden
+++ b/e2e/vmcompose/testdata/TestSetup_127-0-0-5-compose.yaml.golden
@@ -36,6 +36,7 @@ services:
       - --pprof
       - --pprof.addr=0.0.0.0
       - --metrics
+      - --graphql
       
     ports:
       - 8551:8551 # Auth RPC


### PR DESCRIPTION
feat(e2e/docker): adds a mapping for port 8546 so we can use web sockets via our load balancers.

I did go through the code and the "ProxyPort" configuration in the Docker Compose template and tried to make modifications to optionally pass in "WSPort", but this ended up back relating to objects from the CometBFT SDK where there is only a single "Port" field.

Also enabled graphql.

issue: none
