### PR TITLE
chore(e2e): add attest interval golden file

### DIFF
--- a/e2e/types/testdata/TestAttestIntervals.golden
+++ b/e2e/types/testdata/TestAttestIntervals.golden
@@ -1,0 +1,57 @@
+{
+ "arb_sepolia": {
+  "block_period": "300ms",
+  "ephemeral_attest_interval": 2000,
+  "protected_attest_interval": 12000
+ },
+ "base_sepolia": {
+  "block_period": "2s",
+  "ephemeral_attest_interval": 300,
+  "protected_attest_interval": 1800
+ },
+ "ethereum": {
+  "block_period": "12s",
+  "ephemeral_attest_interval": 50,
+  "protected_attest_interval": 300
+ },
+ "holesky": {
+  "block_period": "12s",
+  "ephemeral_attest_interval": 50,
+  "protected_attest_interval": 300
+ },
+ "mock_arb": {
+  "block_period": "1s",
+  "ephemeral_attest_interval": 600,
+  "protected_attest_interval": 3600
+ },
+ "mock_l1": {
+  "block_period": "1s",
+  "ephemeral_attest_interval": 600,
+  "protected_attest_interval": 3600
+ },
+ "mock_l2": {
+  "block_period": "1s",
+  "ephemeral_attest_interval": 600,
+  "protected_attest_interval": 3600
+ },
+ "mock_op": {
+  "block_period": "2s",
+  "ephemeral_attest_interval": 300,
+  "protected_attest_interval": 1800
+ },
+ "omni_evm": {
+  "block_period": "2s",
+  "ephemeral_attest_interval": 300,
+  "protected_attest_interval": 1800
+ },
+ "op_sepolia": {
+  "block_period": "2s",
+  "ephemeral_attest_interval": 300,
+  "protected_attest_interval": 1800
+ },
+ "slow_l1": {
+  "block_period": "12s",
+  "ephemeral_attest_interval": 50,
+  "protected_attest_interval": 300
+ }
+}

--- a/e2e/types/testnet_test.go
+++ b/e2e/types/testnet_test.go
@@ -4,9 +4,35 @@ import (
 	"testing"
 
 	"github.com/omni-network/omni/e2e/types"
+	"github.com/omni-network/omni/lib/evmchain"
+	"github.com/omni-network/omni/lib/netconf"
+	"github.com/omni-network/omni/lib/tutil"
 
 	"github.com/stretchr/testify/require"
 )
+
+//go:generate go test . -clean -golden
+
+func TestAttestIntervals(t *testing.T) {
+	t.Parallel()
+
+	type tuple struct {
+		BlockPeriod             string `json:"block_period"`
+		EphemeralAttestInterval uint64 `json:"ephemeral_attest_interval"`
+		ProtectedAttestInterval uint64 `json:"protected_attest_interval"`
+	}
+
+	resp := make(map[string]tuple)
+	for _, metadata := range evmchain.All() {
+		resp[metadata.Name] = tuple{
+			BlockPeriod:             metadata.BlockPeriod.String(),
+			EphemeralAttestInterval: types.EVMChain{Metadata: metadata}.AttestInterval(netconf.Staging),
+			ProtectedAttestInterval: types.EVMChain{Metadata: metadata}.AttestInterval(netconf.Mainnet),
+		}
+	}
+
+	tutil.RequireGoldenJSON(t, resp)
+}
 
 func TestNextRPCAddress(t *testing.T) {
 	t.Parallel()

--- a/lib/evmchain/evmchain.go
+++ b/lib/evmchain/evmchain.go
@@ -6,6 +6,7 @@
 package evmchain
 
 import (
+	"sort"
 	"time"
 
 	"github.com/omni-network/omni/lib/tokens"
@@ -60,6 +61,20 @@ func MetadataByName(name string) (Metadata, bool) {
 
 func IsOmniEVM(name string) bool {
 	return name == omniEVMName
+}
+
+// All returns all evmchain metadatas ordered by chain ID.
+func All() []Metadata {
+	var resp []Metadata
+	for _, metadata := range static {
+		resp = append(resp, metadata)
+	}
+
+	sort.Slice(resp, func(i, j int) bool {
+		return resp[i].ChainID < resp[j].ChainID
+	})
+
+	return resp
 }
 
 var static = map[uint64]Metadata{


### PR DESCRIPTION
Adds a golden file to make `AttestInterval` for each chain and each network type explicit and easy to lookup or reference.

issue: none