### PR TITLE
chore(lib/cchain): expose cprovider comet rpc client

### DIFF
--- a/lib/cchain/provider.go
+++ b/lib/cchain/provider.go
@@ -6,6 +6,8 @@ import (
 	"github.com/omni-network/omni/lib/errors"
 	"github.com/omni-network/omni/lib/xchain"
 
+	rpcclient "github.com/cometbft/cometbft/rpc/client"
+
 	"github.com/ethereum/go-ethereum/common"
 )
 
@@ -46,6 +48,9 @@ type Provider interface {
 
 	// XBlock returns the validator sync xblock for the given height/offset (or latest) or false if none exist or an error.
 	XBlock(ctx context.Context, heightAndOffset uint64, latest bool) (xchain.Block, bool, error)
+
+	// CometClient returns the underlying cometBFT RPC client.
+	CometClient() rpcclient.Client
 }
 
 // Validator is a consensus chain validator in a validator set.

--- a/lib/cchain/provider/provider.go
+++ b/lib/cchain/provider/provider.go
@@ -18,6 +18,7 @@ import (
 	"github.com/omni-network/omni/lib/tracer"
 	"github.com/omni-network/omni/lib/xchain"
 
+	rpcclient "github.com/cometbft/cometbft/rpc/client"
 	ctypes "github.com/cometbft/cometbft/rpc/core/types"
 
 	"go.opentelemetry.io/otel/attribute"
@@ -44,6 +45,7 @@ type valSetResponse struct {
 
 // Provider implements cchain.Provider.
 type Provider struct {
+	cometCl     rpcclient.Client
 	fetch       fetchFunc
 	latest      latestFunc
 	window      windowFunc
@@ -68,6 +70,10 @@ func NewProviderForT(_ *testing.T, fetch fetchFunc, latest latestFunc, window wi
 		backoffFunc: backoffFunc,
 		chainNamer:  func(xchain.ChainVersion) string { return "" },
 	}
+}
+
+func (p Provider) CometClient() rpcclient.Client {
+	return p.cometCl
 }
 
 func (p Provider) AttestationsFrom(ctx context.Context, chainVer xchain.ChainVersion, xBlockOffset uint64,


### PR DESCRIPTION
Exposes the cprovider underlying comet rpc client. This is mostly for use in xconnector.

issue: none