### PR TITLE
fix(cli): template commit

### DIFF
--- a/cli/cmd/develop.go
+++ b/cli/cmd/develop.go
@@ -13,7 +13,7 @@ import (
 
 const (
 	defaultTemplate       = "hello-world-template"
-	defaultTemplateCommit = "f4002e9" // Commit hash of the template, update as needed
+	defaultTemplateCommit = "main" // Commit hash of the template, update as needed
 )
 
 func newDeveloperCmds() *cobra.Command {


### PR DESCRIPTION
In the `omni developer new` command, which clones the [hello-world-template](https://github.com/omni-network/hello-world-template), just use `main`. It was referencing an old commit, and forcing ourselves to update that commit manually isn't great because it means we have to remember to update it every time we want to change the template

issue: none
