### PR TITLE
chore(docs): update release docs

### DIFF
--- a/docs/release.md
+++ b/docs/release.md
@@ -2,32 +2,25 @@
 
 ## Overview
 
-This document outlines the release process for the Omni monorepo. Currently the process focuses on internal compatibility, simplicity, and rapid iteration.
-
-## Versioning Strategy
-
-- **Semantic Versioning**: A single semantic version is used for the entire repository to ensure intra-compatibility across all components.
-- **No Pre-release Tags**: Versions are released without `-alpha`, `-beta`, or similar tags. Bugs are addressed by swiftly releasing a new patch version.
-- **Release Schedule**: New versions are released by discussion and published Wednesdays, following a two-week sprint cycle or as needed for urgent features or fixes.
+This document outlines the release process for the Omni monorepo.
 
 ## Components Covered
+
+Note that a single semantic version is used for the entire repository to ensure compatibility across all components:
 
 - Halo
 - Relayer
 - Monitor
 - Contracts
+- CLI
 
 ## Release Process
 
-1. **Internal Testing**: Perform a preliminary check on the release.
-2. **Version Bump**: Update the version in `lib/buildinfo/buildinfo.go` to the desired `vX.Y.Z`, then push the branch and open a pull request.
-3. **Draft Release Notes**: After tagging the version with a `git tag`, the CI pipeline drafts the release and publishes Docker containers on DockerHub.
-4. **Discussion and Publishing**: Release draft is discussed internally for review before publication.
+- Releases are cut from release branches, named `release/v{X.Y.Z}` (not the main branch).
+- Then push a version upgrade commit to update `lib/buildinfo/buildinfo.go`.
+- Versions are released without `-alpha`, `-beta`, or similar tags. Bugs are addressed by swiftly releasing a new patch version.
+- After tagging the version with a `git tag`, the CI pipeline drafts the release and publishes Docker containers on DockerHub.
 
 ## Release Notes Format
 
 Release notes provide a comprehensive overview of updates, including new features, bug fixes, and breaking changes for each component.
-
-### CI for Release Notes
-
-The release notes generation process is semi-automated through the CI, see [.goreleaser.yaml](../.goreleaser.yaml).


### PR DESCRIPTION
Update `release.md` after latest discussion about the release process, specifically introduce cutting from release branches and change the semantic versioning standard for releases `release/X`

issue: none