### PR TITLE
fix(e2e): avoid using delayed nodes for monitor

### DIFF
--- a/e2e/app/monitor.go
+++ b/e2e/app/monitor.go
@@ -21,7 +21,7 @@ func LogMetrics(ctx context.Context, def Definition) error {
 	extNetwork := networkFromDef(def)
 
 	// Pick a random node to monitor.
-	if err := MonitorCProvider(ctx, random(def.Testnet.Nodes), extNetwork); err != nil {
+	if err := MonitorCProvider(ctx, def.Testnet.BroadcastNode(), extNetwork); err != nil {
 		return errors.Wrap(err, "monitoring cchain provider")
 	}
 


### PR DESCRIPTION
Using the delayed node for the monitor can cause unexpected failures (eg. [here](https://github.com/omni-network/omni/actions/runs/10010990361/attempts/1)).

issue: none
