### PR TITLE
ci(lib/anvil): swap anvil for anvilproxy

### DIFF
--- a/e2e/docker/compose.yaml.tmpl
+++ b/e2e/docker/compose.yaml.tmpl
@@ -44,7 +44,7 @@ services:
       - ANVILPROXY_CHAIN_ID={{ .Chain.ChainID }}
       - ANVILPROXY_BLOCK_TIME={{.Chain.BlockPeriod.Seconds}}
       - ANVILPROXY_SLOTS_IN_AN_EPOCH=4 # Finality in 4*2*BlockPeriod
-      {{ if .LoadState }}- FORKPROXY_LOAD_STATE=/anvil/state.json{{ end }}
+      {{ if .LoadState }}- ANVILPROXY_LOAD_STATE=/anvil/state.json{{ end }}
     ports:
       - {{ if .ProxyPort }}{{ .ProxyPort }}:{{ end }}8545
     networks:

--- a/e2e/docker/testdata/TestComposeTemplate_commit.golden
+++ b/e2e/docker/testdata/TestComposeTemplate_commit.golden
@@ -53,7 +53,7 @@ services:
       - ANVILPROXY_CHAIN_ID=1
       - ANVILPROXY_BLOCK_TIME=3600
       - ANVILPROXY_SLOTS_IN_AN_EPOCH=4 # Finality in 4*2*BlockPeriod
-      - FORKPROXY_LOAD_STATE=/anvil/state.json
+      - ANVILPROXY_LOAD_STATE=/anvil/state.json
     ports:
       - 9000:8545
     networks:

--- a/e2e/docker/testdata/TestComposeTemplate_empheral_network.golden
+++ b/e2e/docker/testdata/TestComposeTemplate_empheral_network.golden
@@ -53,7 +53,7 @@ services:
       - ANVILPROXY_CHAIN_ID=1
       - ANVILPROXY_BLOCK_TIME=3600
       - ANVILPROXY_SLOTS_IN_AN_EPOCH=4 # Finality in 4*2*BlockPeriod
-      - FORKPROXY_LOAD_STATE=/anvil/state.json
+      - ANVILPROXY_LOAD_STATE=/anvil/state.json
     ports:
       - 9000:8545
     networks:

--- a/e2e/vmcompose/testdata/TestSetup_127-0-0-3-compose.yaml.golden
+++ b/e2e/vmcompose/testdata/TestSetup_127-0-0-3-compose.yaml.golden
@@ -16,7 +16,7 @@ services:
       - ANVILPROXY_CHAIN_ID=1652
       - ANVILPROXY_BLOCK_TIME=1
       - ANVILPROXY_SLOTS_IN_AN_EPOCH=4 # Finality in 4*2*BlockPeriod
-      - FORKPROXY_LOAD_STATE=/anvil/state.json
+      - ANVILPROXY_LOAD_STATE=/anvil/state.json
     ports:
       - 8545:8545
     networks:

--- a/lib/anvil/compose.yaml.tmpl
+++ b/lib/anvil/compose.yaml.tmpl
@@ -4,14 +4,11 @@ services:
   anvil:
     labels:
       anvil: true
-    image: ghcr.io/foundry-rs/foundry:latest
+    image: omniops/anvilproxy:main
     platform: linux/amd64
-    entrypoint:
-      - anvil
-      - --host=0.0.0.0
-      - --chain-id={{ .ChainID }}
-      - --silent
-      - --load-state=/anvil/state.json
+    environment:
+      - ANVILPROXY_CHAIN_ID={{ .ChainID }}
+      - ANVILPROXY_LOAD_STATE=/anvil/state.json
     ports:
       - {{ .Port }}:8545
     volumes:

--- a/lib/anvil/utils_test.go
+++ b/lib/anvil/utils_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"math/big"
 	"testing"
-	"time"
 
 	"github.com/omni-network/omni/lib/anvil"
 	"github.com/omni-network/omni/lib/tutil"
@@ -15,9 +14,7 @@ import (
 )
 
 const (
-	chainName   = "test"
-	chainID     = 99
-	blockPeriod = time.Second
+	chainID = 99
 )
 
 func TestFundAccounts(t *testing.T) {

--- a/scripts/fix_golden_tests.sh
+++ b/scripts/fix_golden_tests.sh
@@ -3,7 +3,8 @@
 # fix_golden_tests.sh fixes all golden test fixtures in the repo.
 
 # Find all unique directories with _test.go files with tutil.RequireGolden* calls.
-DIRS=$(grep -rl 'tutil.RequireGolden' . | xargs dirname | uniq)
+
+DIRS=$(find . -type f -iname "*.go" -exec grep -rl "RequireGolden" '{}' + | xargs dirname | uniq)
 
 # Run `go:generate` for each directory.
 for DIR in $DIRS; do


### PR DESCRIPTION
Instead of using `anvil:latest` use our own `anvilproxy:main` that we know if working and should be faster to pull 🤞 .

This aims to fix failing CI which is timing out downloading `anvil:latest`.

issue: none