### PR TITLE
ci(e2e): populate p2p with advertised addrs

### DIFF
--- a/e2e/app/definition.go
+++ b/e2e/app/definition.go
@@ -342,7 +342,9 @@ func TestnetFromManifest(ctx context.Context, manifest types.Manifest, infd type
 			return types.Testnet{}, err
 		}
 
-		en := enode.NewV4(&nodeKey.PublicKey, inst.IPAddress, 30303, 30303)
+		ip := advertisedIP(manifest.Network, mode, inst.IPAddress, inst.ExtIPAddress)
+
+		en := enode.NewV4(&nodeKey.PublicKey, ip, 30303, 30303)
 
 		internalIP := inst.IPAddress.String()
 		if infd.Provider == docker.ProviderName {
@@ -352,7 +354,7 @@ func TestnetFromManifest(ctx context.Context, manifest types.Manifest, infd type
 		omniEVMS = append(omniEVMS, types.OmniEVM{
 			Chain:        types.OmniEVMByNetwork(manifest.Network),
 			InstanceName: name,
-			AdvertisedIP: advertisedIP(manifest.Network, mode, inst.IPAddress, inst.ExtIPAddress),
+			AdvertisedIP: ip,
 			ProxyPort:    inst.Port,
 			InternalRPC:  fmt.Sprintf("http://%s:8545", internalIP),
 			ExternalRPC:  fmt.Sprintf("http://%s:%d", inst.ExtIPAddress.String(), inst.Port),

--- a/halo/cmd/cometconfig.go
+++ b/halo/cmd/cometconfig.go
@@ -42,6 +42,8 @@ func DefaultCometConfig(homeDir string) cfg.Config {
 	conf.StateSync.DiscoveryTime = time.Second * 10    // Increase discovery time
 	conf.StateSync.ChunkRequestTimeout = time.Minute   // Increase timeout
 	conf.Mempool.Type = cfg.MempoolTypeNop             // Disable cometBFT mempool
+	conf.ProxyApp = ""                                 // Only support built-in ABCI app supported.
+	conf.ABCI = ""                                     // Only support built-in ABCI app supported.
 
 	return *conf
 }

--- a/halo/cmd/testdata/TestRunCmd_defaults.golden
+++ b/halo/cmd/testdata/TestRunCmd_defaults.golden
@@ -18,7 +18,7 @@
  "Comet": {
   "Version": "0.38.10",
   "RootDir": "./halo",
-  "ProxyApp": "tcp://127.0.0.1:26658",
+  "ProxyApp": "",
   "Moniker": "testmoniker",
   "DBBackend": "goleveldb",
   "DBPath": "data",
@@ -29,7 +29,7 @@
   "PrivValidatorState": "data/priv_validator_state.json",
   "PrivValidatorListenAddr": "",
   "NodeKey": "config/node_key.json",
-  "ABCI": "socket",
+  "ABCI": "",
   "FilterPeers": false,
   "RPC": {
    "RootDir": "./halo",

--- a/halo/cmd/testdata/TestRunCmd_flags.golden
+++ b/halo/cmd/testdata/TestRunCmd_flags.golden
@@ -18,7 +18,7 @@
  "Comet": {
   "Version": "0.38.10",
   "RootDir": "foo",
-  "ProxyApp": "tcp://127.0.0.1:26658",
+  "ProxyApp": "",
   "Moniker": "testmoniker",
   "DBBackend": "goleveldb",
   "DBPath": "data",
@@ -29,7 +29,7 @@
   "PrivValidatorState": "data/priv_validator_state.json",
   "PrivValidatorListenAddr": "",
   "NodeKey": "config/node_key.json",
-  "ABCI": "socket",
+  "ABCI": "",
   "FilterPeers": false,
   "RPC": {
    "RootDir": "foo",

--- a/halo/cmd/testdata/TestRunCmd_json_files.golden
+++ b/halo/cmd/testdata/TestRunCmd_json_files.golden
@@ -18,7 +18,7 @@
  "Comet": {
   "Version": "0.38.10",
   "RootDir": "testinput/input2",
-  "ProxyApp": "tcp://127.0.0.1:26658",
+  "ProxyApp": "",
   "Moniker": "testmoniker",
   "DBBackend": "goleveldb",
   "DBPath": "data",
@@ -29,7 +29,7 @@
   "PrivValidatorState": "data/priv_validator_state.json",
   "PrivValidatorListenAddr": "",
   "NodeKey": "config/node_key.json",
-  "ABCI": "socket",
+  "ABCI": "",
   "FilterPeers": false,
   "RPC": {
    "RootDir": "testinput/input2",

--- a/halo/cmd/testdata/TestRunCmd_toml_files.golden
+++ b/halo/cmd/testdata/TestRunCmd_toml_files.golden
@@ -21,7 +21,7 @@
  "Comet": {
   "Version": "0.38.10",
   "RootDir": "testinput/input1",
-  "ProxyApp": "tcp://127.0.0.1:26658",
+  "ProxyApp": "",
   "Moniker": "config.toml",
   "DBBackend": "goleveldb",
   "DBPath": "data",
@@ -32,7 +32,7 @@
   "PrivValidatorState": "data/priv_validator_state.json",
   "PrivValidatorListenAddr": "",
   "NodeKey": "config/node_key.json",
-  "ABCI": "socket",
+  "ABCI": "",
   "FilterPeers": false,
   "RPC": {
    "RootDir": "testinput/input1",


### PR DESCRIPTION
When attempting to join omega using `omni operator init-nodes` and the local node fetches peer addresses from the bootstrapped peers, debug logs show that private IPs are returned, this causes P2P networking to fail.

This attempt to address the problem by using "advertised" IPs consistently (not only in advertised IP context).
This means that our internal nodes will also connect to seed/fullnodes using their external IPs.
When asked for peers, they would then hopefully return those external IPs and not internal IPs like previously.

issue: none