### PR TITLE
ci(github): label release branch PRs

### DIFF
--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -1,10 +1,11 @@
 name: ci main
-# continuous integration on push to main
+# continuous integration on push to main and release branches
 
 on:
   push:
     branches:
       - main
+      - release*
 
 permissions:
   contents: read

--- a/.github/workflows/ci-notify.yml
+++ b/.github/workflows/ci-notify.yml
@@ -4,7 +4,7 @@ name: ci notify
 on:
   workflow_run:
     workflows: ["*"]
-    branches: [main]
+    branches: [main,release*]
     types: [completed]
 
 jobs:

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -1,10 +1,11 @@
 name: ci pr
-# continuous integration on pull requests to main
+# continuous integration on pull requests to main and release branches
 
 on:
   pull_request:
     branches:
       - main
+      - release*
 
 permissions:
   contents: read

--- a/.github/workflows/pr-label.yml
+++ b/.github/workflows/pr-label.yml
@@ -1,0 +1,43 @@
+name: Label PR
+
+on:
+  workflow_call:
+
+jobs:
+  label_pr:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Calculate branch label
+        id: branch-label
+        run: |
+
+          # Short name for current branch. For PRs, use target branch (base ref)
+          # Reference: https://stackoverflow.com/questions/60300169/how-to-get-branch-name-on-github-action
+          GIT_BRANCH=${GITHUB_BASE_REF:-${GITHUB_REF#refs/heads/}}
+          echo "GIT_BRANCH=$GIT_BRANCH"
+
+          LABEL=""
+          if [[ $GIT_BRANCH = main ]]; then
+            # Do not label main branch PRs
+            LABEL="skip"
+          elif [[ $GIT_BRANCH = release* ]]; then
+            # Label release branches
+            LABEL="$GIT_BRANCH"
+          else
+            # Label all other branches as invalid
+            LABEL="branch-invalid"
+          fi
+          echo "label=$LABEL" >> $GITHUB_OUTPUT
+
+      - uses: actions/github-script@v6
+        if: steps.branch-label.outputs.label != 'skip'
+        with:
+          script: |
+            github.rest.issues.addLabels({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              labels: ["${{steps.branch-label.outputs.label}}"]
+            })


### PR DESCRIPTION
Adds the `release/v0.X` label to PRs to any release branch.

Also ensures github actions run on release branches.

issue: #1552