### PR TITLE
fix(cchain): correctly find earliest store height

### DIFF
--- a/lib/cchain/provider/abci.go
+++ b/lib/cchain/provider/abci.go
@@ -435,17 +435,15 @@ func getEarliestStoreHeight(ctx context.Context, cl atypes.QueryClient, chainVer
 	// However, as far as I can tell, Cosmos doesn't ever set this value, it's stubbed out with a TODO: https://github.com/cosmos/cosmos-sdk/blob/main/client/grpc/node/service.go#L58
 	// For now, we just very inefficiently walk forwards in time hoping to find the earliest commit info
 
-	var i uint64
-	for i = 0; ; i++ {
-		_, _, err := queryEarliestAttestation(ctx, cl, chainVer, startPoint+i)
+	for height := startPoint; ; height++ {
+		_, _, err := queryEarliestAttestation(ctx, cl, chainVer, height)
 		if IsErrHistoryPruned(err) {
 			continue
-		}
-		if err != nil {
+		} else if err != nil {
 			return 0, errors.Wrap(err, "querying earliest attestation")
 		}
 
-		return startPoint + i, nil
+		return height, nil
 	}
 }
 

--- a/lib/cchain/provider/abci.go
+++ b/lib/cchain/provider/abci.go
@@ -445,7 +445,7 @@ func getEarliestStoreHeight(ctx context.Context, cl atypes.QueryClient, chainVer
 			return 0, errors.Wrap(err, "querying earliest attestation")
 		}
 
-		return startPoint, nil
+		return startPoint + i, nil
 	}
 }
 


### PR DESCRIPTION
Actually find the earliest store height, don't just return `startPoint` always.

issue: none
