### PR TITLE
ci(lib/anvil): increase anvil pull timeout

### DIFF
--- a/.github/workflows/gotest.yml
+++ b/.github/workflows/gotest.yml
@@ -15,4 +15,6 @@ jobs:
         with:
           go-version: 'stable'
       # TODO(corver): add coverage
+      - name: Pull anvil # This can be slow and cause timeouts
+        run: docker pull ghcr.io/foundry-rs/foundry:latest
       - run: go test -timeout=5m -race -tags=verify_logs ./...


### PR DESCRIPTION
CI is failing due to docker pull anvil timeouts. So do explicit pull before running tests.

issue: none