### PR TITLE
ci(github): fix release branch matching

### DIFF
--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -5,7 +5,7 @@ on:
   push:
     branches:
       - main
-      - release*
+      - release/**
 
 permissions:
   contents: read

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -5,7 +5,7 @@ on:
   pull_request:
     branches:
       - main
-      - release*
+      - release/**
 
 permissions:
   contents: read


### PR DESCRIPTION
Fix github action release branch matching.

As per docs:
`*: Matches zero or more characters, but does not match the / character. For example, Octo* matches Octocat.`

issue: none