### PR TITLE
feat(attest): reject votes for unsupported conf levels

### DIFF
--- a/halo/app/app.go
+++ b/halo/app/app.go
@@ -7,6 +7,7 @@ import (
 	"github.com/omni-network/omni/halo/evmslashing"
 	"github.com/omni-network/omni/halo/evmstaking"
 	registrykeeper "github.com/omni-network/omni/halo/registry/keeper"
+	rtypes "github.com/omni-network/omni/halo/registry/types"
 	valsynckeeper "github.com/omni-network/omni/halo/valsync/keeper"
 	"github.com/omni-network/omni/lib/errors"
 	"github.com/omni-network/omni/lib/ethclient"
@@ -74,7 +75,8 @@ func newApp(
 	db dbm.DB,
 	engineCl ethclient.EngineClient,
 	voter atypes.Voter,
-	namer atypes.ChainVerNameFunc,
+	chainVerNamer atypes.ChainVerNameFunc,
+	chainNamer rtypes.ChainNameFunc,
 	feeRecProvider etypes.FeeRecipientProvider,
 	baseAppOpts ...func(*baseapp.BaseApp),
 ) (*App, error) {
@@ -83,7 +85,8 @@ func newApp(
 		depinject.Supply(
 			logger,
 			engineCl,
-			namer,
+			chainVerNamer,
+			chainNamer,
 			voter,
 			feeRecProvider,
 		),

--- a/halo/app/rollback.go
+++ b/halo/app/rollback.go
@@ -58,6 +58,7 @@ func Rollback(ctx context.Context, cfg Config, rCfg RollbackConfig) error {
 		engineCl,
 		voter,
 		netconf.ChainVersionNamer(cfg.Network),
+		netconf.ChainNamer(cfg.Network),
 		burnEVMFees{},
 		baseAppOpts...,
 	)

--- a/halo/app/start.go
+++ b/halo/app/start.go
@@ -134,6 +134,7 @@ func Start(ctx context.Context, cfg Config) (<-chan error, func(context.Context)
 		engineCl,
 		voter,
 		netconf.ChainVersionNamer(cfg.Network),
+		netconf.ChainNamer(cfg.Network),
 		burnEVMFees{},
 		baseAppOpts...,
 	)

--- a/halo/attest/keeper/keeper.go
+++ b/halo/attest/keeper/keeper.go
@@ -641,7 +641,7 @@ func (k *Keeper) ExtendVote(ctx sdk.Context, _ *abci.RequestExtendVote) (*abci.R
 	duplicate := make(map[types.VoteSource]bool)
 	var filtered []*types.Vote
 	for _, vote := range votes {
-		if err := checkSupportedChainAndConfLevel(ctx, k.portalRegistry, vote.BlockHeader.ChainId, vote.BlockHeader.ConfLevel); err != nil {
+		if err := checkSupportedChainAndConfLevel(ctx, k.portalRegistry, vote.BlockHeader.SourceChainId, vote.BlockHeader.ConfLevel); err != nil {
 			return nil, errors.Wrap(err, "check supported chain")
 		}
 
@@ -766,7 +766,7 @@ func (k *Keeper) VerifyVoteExtension(ctx sdk.Context, req *abci.RequestVerifyVot
 			return respReject, nil
 		}
 
-		if err := checkSupportedChainAndConfLevel(ctx, k.portalRegistry, vote.BlockHeader.ChainId, vote.BlockHeader.ConfLevel); err != nil {
+		if err := checkSupportedChainAndConfLevel(ctx, k.portalRegistry, vote.BlockHeader.SourceChainId, vote.BlockHeader.ConfLevel); err != nil {
 			log.Warn(ctx, "Rejecting vote for unsupported chain", err, "chain", k.namer(vote.BlockHeader.XChainVersion()))
 			return respReject, nil
 		}
@@ -860,7 +860,7 @@ func (k *Keeper) verifyAggVotes(ctx context.Context, valset ValSet, aggs []*type
 		}
 		errAttrs := []any{"chain", k.namer(agg.BlockHeader.XChainVersion()), "offset", agg.BlockHeader.Offset}
 
-		if err := checkSupportedChainAndConfLevel(ctx, k.portalRegistry, agg.BlockHeader.ChainId, agg.BlockHeader.ConfLevel); err != nil {
+		if err := checkSupportedChainAndConfLevel(ctx, k.portalRegistry, agg.BlockHeader.SourceChainId, agg.BlockHeader.ConfLevel); err != nil {
 			return errors.Wrap(err, "check supported chain")
 		}
 

--- a/halo/attest/keeper/keeper.go
+++ b/halo/attest/keeper/keeper.go
@@ -1021,7 +1021,7 @@ func checkSupportedChainAndConfLevel(ctx context.Context, registry rtypes.Portal
 	}
 
 	if !supportedChain {
-		return errors.New("unsupported chain", "chainID", chainID)
+		return errors.New("unsupported chain", "chain", chainID)
 	}
 
 	confLevelsMap, err := registry.ConfLevels(ctx)
@@ -1031,7 +1031,7 @@ func checkSupportedChainAndConfLevel(ctx context.Context, registry rtypes.Portal
 
 	supportedConfLevels, ok := confLevelsMap[chainID]
 	if !ok {
-		return errors.New("missing conf levels", "chainID", chainID)
+		return errors.New("missing conf levels", "chain", chainID)
 	}
 
 	for _, supportedConfLevel := range supportedConfLevels {
@@ -1040,7 +1040,7 @@ func checkSupportedChainAndConfLevel(ctx context.Context, registry rtypes.Portal
 		}
 	}
 
-	return errors.New("unsupported conf level", "chainID", chainID, "confLevel", confLevel)
+	return errors.New("unsupported conf level", "chain", chainID, "conf", xchain.ConfLevel(confLevel).String())
 }
 
 // windowCompare returns -1 if x < mid-voteWindow, 1 if x > mid+voteWindow, else 0.

--- a/halo/registry/keeper/helper.go
+++ b/halo/registry/keeper/helper.go
@@ -2,6 +2,7 @@ package keeper
 
 import (
 	"github.com/omni-network/omni/lib/errors"
+	"github.com/omni-network/omni/lib/xchain"
 
 	"github.com/ethereum/go-ethereum/common"
 )
@@ -28,4 +29,13 @@ func (p *Portal) Verify() error {
 	}
 
 	return nil
+}
+
+func shardLabels(shardIDs []uint64) []string {
+	var labels []string
+	for _, shardID := range shardIDs {
+		labels = append(labels, xchain.ShardID(shardID).Label())
+	}
+
+	return labels
 }

--- a/halo/registry/keeper/keeper.go
+++ b/halo/registry/keeper/keeper.go
@@ -6,6 +6,7 @@ import (
 	"github.com/omni-network/omni/contracts/bindings"
 	"github.com/omni-network/omni/halo/genutil/evm/predeploys"
 	ptypes "github.com/omni-network/omni/halo/portal/types"
+	"github.com/omni-network/omni/halo/registry/types"
 	"github.com/omni-network/omni/lib/errors"
 	"github.com/omni-network/omni/lib/ethclient"
 	"github.com/omni-network/omni/lib/xchain"
@@ -24,11 +25,17 @@ type Keeper struct {
 	ethCl           ethclient.Client
 	portalRegAdress common.Address
 	portalRegistry  *bindings.PortalRegistryFilterer
+	chainNamer      types.ChainNameFunc
 
 	latestCache *cache
 }
 
-func NewKeeper(emilPortal ptypes.EmitPortal, storeService store.KVStoreService, ethCl ethclient.Client) (Keeper, error) {
+func NewKeeper(
+	emilPortal ptypes.EmitPortal,
+	storeService store.KVStoreService,
+	ethCl ethclient.Client,
+	namer types.ChainNameFunc,
+) (Keeper, error) {
 	schema := &ormv1alpha1.ModuleSchemaDescriptor{SchemaFile: []*ormv1alpha1.ModuleSchemaDescriptor_FileEntry{
 		{Id: 1, ProtoFileName: File_halo_registry_keeper_registry_proto.Path()},
 	}}
@@ -55,6 +62,7 @@ func NewKeeper(emilPortal ptypes.EmitPortal, storeService store.KVStoreService, 
 		ethCl:           ethCl,
 		portalRegAdress: address,
 		portalRegistry:  protalReg,
+		chainNamer:      namer,
 		latestCache:     new(cache),
 	}, nil
 }

--- a/halo/registry/keeper/logeventproc.go
+++ b/halo/registry/keeper/logeventproc.go
@@ -107,8 +107,8 @@ func (k Keeper) addPortal(ctx context.Context, portal *Portal) error {
 
 	log.Info(ctx, "🔭 Added network portal",
 		"network_id", network.GetId(),
-		"chain_id", portal.GetChainId(),
-		"shards", portal.GetShardIds(),
+		"chain", k.chainNamer(portal.GetChainId()),
+		"shards", shardLabels(portal.GetShardIds()),
 		"height", sdk.UnwrapSDKContext(ctx).BlockHeight(),
 	)
 

--- a/halo/registry/keeper/logeventproc_internal_test.go
+++ b/halo/registry/keeper/logeventproc_internal_test.go
@@ -122,7 +122,7 @@ func setupKeeper(t *testing.T) (sdk.Context, Keeper, *testEmitPortal) {
 	ctx = ctx.WithChainID(netconf.Simnet.Static().OmniConsensusChainIDStr())
 
 	emitPortal := new(testEmitPortal)
-	k, err := NewKeeper(emitPortal, storeSvc, nil)
+	k, err := NewKeeper(emitPortal, storeSvc, nil, netconf.ChainNamer(netconf.Simnet))
 	require.NoError(t, err, "new keeper")
 
 	return ctx, k, emitPortal

--- a/halo/registry/module/module.go
+++ b/halo/registry/module/module.go
@@ -103,6 +103,7 @@ type ModuleInputs struct {
 	EmitPortal   ptypes.EmitPortal
 	StoreService store.KVStoreService
 	EthCl        ethclient.Client
+	ChainNamer   types.ChainNameFunc
 	Config       *Module
 }
 
@@ -118,6 +119,7 @@ func ProvideModule(in ModuleInputs) (ModuleOutputs, error) {
 		in.EmitPortal,
 		in.StoreService,
 		in.EthCl,
+		in.ChainNamer,
 	)
 	if err != nil {
 		return ModuleOutputs{}, err

--- a/halo/registry/types/interface.go
+++ b/halo/registry/types/interface.go
@@ -10,6 +10,6 @@ type PortalRegistry interface {
 	// SupportedChain returns true if the chain is included in the registry.
 	SupportedChain(ctx context.Context, chainID uint64) (bool, error)
 
-	// ConfLevels returns the all confirmation levels supported by all chains.
+	// ConfLevels returns all confirmation levels supported by all chains.
 	ConfLevels(ctx context.Context) (map[uint64][]xchain.ConfLevel, error)
 }

--- a/halo/registry/types/interface.go
+++ b/halo/registry/types/interface.go
@@ -13,3 +13,6 @@ type PortalRegistry interface {
 	// ConfLevels returns all confirmation levels supported by all chains.
 	ConfLevels(ctx context.Context) (map[uint64][]xchain.ConfLevel, error)
 }
+
+// ChainNameFunc returns the name of the chain.
+type ChainNameFunc func(chainID uint64) string

--- a/lib/netconf/netconf.go
+++ b/lib/netconf/netconf.go
@@ -111,26 +111,15 @@ func (n Network) OmniConsensusChain() (Chain, bool) {
 // EthereumChain returns the ethereum Layer1 chain config or false if it does not exist.
 func (n Network) EthereumChain() (Chain, bool) {
 	for _, chain := range n.Chains {
-		switch n.ID {
-		case Mainnet:
-			if chain.ID == evmchain.IDEthereum {
-				return chain, true
-			}
-		case Omega:
-			if chain.ID == evmchain.IDHolesky {
-				return chain, true
-			}
-		default:
-			if chain.ID == evmchain.IDMockL1Fast || chain.ID == evmchain.IDMockL1Slow {
-				return chain, true
-			}
+		if IsEthereumChain(n.ID, chain.ID) {
+			return chain, true
 		}
 	}
 
 	return Chain{}, false
 }
 
-// IsEthereumChainID returns true if the chainID is the EthereumChainID for the given network.
+// IsEthereumChain returns true if the chainID is the EthereumChainID for the given network.
 func IsEthereumChain(network ID, chainID uint64) bool {
 	switch network {
 	case Mainnet:
@@ -279,9 +268,7 @@ type Chain struct {
 // ConfLevels returns the uniq set of confirmation levels
 // supported by the chain. This is inferred from the supported shards.
 func (c Chain) ConfLevels() []xchain.ConfLevel {
-	dedup := map[xchain.ConfLevel]struct{}{
-		xchain.ConfFinalized: {}, // All chains require ConfFinalized.
-	}
+	dedup := make(map[xchain.ConfLevel]struct{})
 
 	for _, shard := range c.Shards {
 		conf := shard.ConfLevel()

--- a/lib/netconf/netconf_test.go
+++ b/lib/netconf/netconf_test.go
@@ -182,9 +182,8 @@ func TestExecutionSeeds(t *testing.T) {
 func TestConfLevels(t *testing.T) {
 	t.Parallel()
 
-	// Latest finalization start results in 1 shard and 2 conf levels.
 	chain := netconf.Chain{
-		Shards: []xchain.ShardID{xchain.ShardLatest0},
+		Shards: []xchain.ShardID{xchain.ShardBroadcast0, xchain.ShardLatest0},
 	}
 	require.Len(t, chain.ConfLevels(), 2)
 	require.EqualValues(t, []xchain.ConfLevel{xchain.ConfLatest, xchain.ConfFinalized}, chain.ConfLevels())

--- a/lib/netconf/static.go
+++ b/lib/netconf/static.go
@@ -222,14 +222,14 @@ func SimnetNetwork() Network {
 		ID: Simnet,
 		Chains: []Chain{
 			mustSimnetChain(Simnet.Static().OmniExecutionChainID, xchain.ShardFinalized0),
-			mustSimnetChain(evmchain.IDMockL1Fast, xchain.ShardLatest0),
-			mustSimnetChain(evmchain.IDMockL2, xchain.ShardLatest0),
+			mustSimnetChain(evmchain.IDMockL1Fast, xchain.ShardFinalized0, xchain.ShardLatest0),
+			mustSimnetChain(evmchain.IDMockL2, xchain.ShardFinalized0),
 			Simnet.Static().OmniConsensusChain(),
 		},
 	}
 }
 
-func mustSimnetChain(id uint64, shard xchain.ShardID) Chain {
+func mustSimnetChain(id uint64, shards ...xchain.ShardID) Chain {
 	meta, ok := evmchain.MetadataByID(id)
 	if !ok {
 		panic("missing chain metadata")
@@ -239,7 +239,7 @@ func mustSimnetChain(id uint64, shard xchain.ShardID) Chain {
 		ID:          meta.ChainID,
 		Name:        meta.Name,
 		BlockPeriod: time.Millisecond * 500, // Speed up block times for testing
-		Shards:      []xchain.ShardID{shard},
+		Shards:      shards,
 	}
 }
 


### PR DESCRIPTION
This ensures that we never create or verify votes for unsupported Conf levels.

issue: #1579