### PR TITLE
test(halo): harden flapping tests

### DIFF
--- a/halo/app/start_test.go
+++ b/halo/app/start_test.go
@@ -42,7 +42,7 @@ func TestSmoke(t *testing.T) {
 	}()
 
 	// Connect to the server.
-	cl, err := rpchttp.New("http://localhost:26657", "/websocket")
+	cl, err := rpchttp.New(cfg.Comet.RPC.ListenAddress, "/websocket")
 	require.NoError(t, err)
 
 	cprov := cprovider.NewABCIProvider(cl, netconf.Simnet, netconf.ChainVersionNamer(netconf.Simnet))
@@ -96,8 +96,8 @@ func TestSmoke(t *testing.T) {
 
 	<-ctx.Done()
 
-	// Stop the server.
-	require.NoError(t, stopfunc(ctx))
+	// Stop the server, with a fresh context
+	require.NoError(t, stopfunc(context.Background()))
 }
 
 func testCProvider(t *testing.T, ctx context.Context, cprov cprovider.Provider) {
@@ -140,6 +140,9 @@ func setupSimnet(t *testing.T) haloapp.Config {
 
 	cmtCfg := halocmd.DefaultCometConfig(homeDir)
 	cmtCfg.BaseConfig.DBBackend = string(db.MemDBBackend)
+	cmtCfg.P2P.ListenAddress = tutil.RandomListenAddress(t) // Avoid port clashes
+	cmtCfg.RPC.ListenAddress = tutil.RandomListenAddress(t) // Avoid port clashes
+	cmtCfg.Instrumentation.Prometheus = false
 
 	haloCfg := halocfg.DefaultConfig()
 	haloCfg.HomeDir = homeDir

--- a/lib/tutil/random.go
+++ b/lib/tutil/random.go
@@ -2,6 +2,10 @@ package tutil
 
 import (
 	"crypto/rand"
+	"fmt"
+	mrand2 "math/rand/v2"
+	"net"
+	"testing"
 
 	"github.com/ethereum/go-ethereum/common"
 )
@@ -28,4 +32,37 @@ func RandomAddress() common.Address {
 	_, _ = rand.Read(resp[:])
 
 	return resp
+}
+
+func RandomListenAddress(t *testing.T) string {
+	t.Helper()
+	return fmt.Sprintf("tcp://127.0.0.1:%d", RandomAvailablePort(t))
+}
+
+func RandomAvailablePort(t *testing.T) int {
+	t.Helper()
+
+	// randPort returns between base and base + spread
+	randPort := func() int {
+		base, spread := 20000, 20000
+		return base + mrand2.IntN(spread)
+	}
+
+	// Pick a random port, since we can't "reserve" it.
+	for i := 0; i < 5; i++ {
+		port := randPort()
+		l, err := net.Listen("tcp", fmt.Sprintf("127.0.0.1:%d", port))
+		if err != nil {
+			continue
+		}
+		if err := l.Close(); err != nil {
+			continue
+		}
+
+		return port
+	}
+
+	t.Fatalf("failed to find available port")
+
+	return 0
 }


### PR DESCRIPTION
Attempts to fix the flapping tests in CI:
- Pick random bind ports to avoid `bind address already in use`.
- Harden PruneHistoryTest:
  - Pick chain without fuzzy dependent attestations.
  - First wait for att=0 to be eligible for deletion
  - Then wait for it to be deleted 
  - Speeds up test from 30s to 12s. 

issue: none