### PR TITLE
ci(e2e): use external IP for staging fullnode1

### DIFF
--- a/cli/cmd/compose.yml.tpl
+++ b/cli/cmd/compose.yml.tpl
@@ -21,11 +21,12 @@ services:
       # Flags not available via config.toml
       #- --nat=extip:<my-external-ip>
       #- --metrics
+      #- --verbosity=4 # Log level (4=debug)
     ports:
       - 8551         # Auth-RPC (used by halo)
       - 8545:8545    # JSON-RCP
       - 8546:8546    # Websocket-RPC
       - 30303:30303  # Execution P2P
-      # - 6060:6060         # Prometheus metrics
+      #- 6060:6060   # Prometheus metrics
     volumes:
       - ./geth:/geth

--- a/e2e/app/geth/config.go
+++ b/e2e/app/geth/config.go
@@ -95,7 +95,7 @@ func MakeGethConfig(conf Config) FullConfig {
 	cfg.Eth.Miner.Recommit = 500 * time.Millisecond
 
 	// Set the bootnodes and trusted nodes.
-	cfg.Node.P2P.Name = conf.Moniker
+	cfg.Node.UserIdent = conf.Moniker
 	cfg.Node.P2P.DiscoveryV4 = true // TODO(corver): Switch to v5.
 	cfg.Node.P2P.BootstrapNodesV5 = conf.BootNodes
 	cfg.Node.P2P.BootstrapNodes = conf.BootNodes

--- a/e2e/app/geth/testdata/TestWriteConfigTOML_archive.golden
+++ b/e2e/app/geth/testdata/TestWriteConfigTOML_archive.golden
@@ -56,6 +56,7 @@ MaxPrice = 500000000000
 IgnorePrice = 2
 
 [Node]
+UserIdent = "archive"
 DataDir = "/geth"
 IPCPath = "/geth/geth.ipc"
 HTTPHost = "0.0.0.0"

--- a/e2e/app/geth/testdata/TestWriteConfigTOML_full.golden
+++ b/e2e/app/geth/testdata/TestWriteConfigTOML_full.golden
@@ -56,6 +56,7 @@ MaxPrice = 500000000000
 IgnorePrice = 2
 
 [Node]
+UserIdent = "full"
 DataDir = "/geth"
 IPCPath = "/geth/geth.ipc"
 HTTPHost = "0.0.0.0"

--- a/e2e/app/setup.go
+++ b/e2e/app/setup.go
@@ -325,6 +325,12 @@ func advertisedIP(network netconf.ID, mode types.Mode, internal, external net.IP
 		// Only seeds and fullnodes allow external peers to connect to them.
 		return external
 	}
+
+	if network == netconf.Staging && mode == types.ModeArchive {
+		// Staging fullnode1 is an archive node, but we need to connect to it.
+		return external
+	}
+
 	// Validators and archive nodes are "secured" and only allow internal peers to connect to them.
 
 	return internal

--- a/halo/app/cmtlog.go
+++ b/halo/app/cmtlog.go
@@ -49,7 +49,7 @@ type cmtLogger struct {
 	level int
 }
 
-func newCmtLogger(ctx context.Context, levelStr string) (cmtlog.Logger, error) {
+func NewCmtLogger(ctx context.Context, levelStr string) (cmtlog.Logger, error) {
 	level, ok := levels[strings.ToLower(levelStr)]
 	if !ok {
 		return cmtLogger{}, errors.New("invalid comet log level", "level", levelStr)

--- a/halo/app/start.go
+++ b/halo/app/start.go
@@ -211,7 +211,7 @@ func newCometNode(ctx context.Context, cfg *cmtcfg.Config, app *App, privVal cmt
 		return nil, errors.Wrap(err, "load or gen node key", "key_file", cfg.NodeKeyFile())
 	}
 
-	cmtLog, err := newCmtLogger(ctx, cfg.LogLevel)
+	cmtLog, err := NewCmtLogger(ctx, cfg.LogLevel)
 	if err != nil {
 		return nil, err
 	}

--- a/halo/attest/voter/voter.go
+++ b/halo/attest/voter/voter.go
@@ -513,7 +513,7 @@ func (v *Voter) saveUnsafe() error {
 		Committed: v.committed,
 		Latest:    latestToJSON(v.latest),
 	}
-	bz, err := json.Marshal(s)
+	bz, err := json.MarshalIndent(s, "", " ")
 	if err != nil {
 		return errors.Wrap(err, "marshal state path")
 	}

--- a/lib/netconf/static.go
+++ b/lib/netconf/static.go
@@ -140,6 +140,12 @@ var (
 
 	//go:embed omega/execution-seeds.txt
 	omegaExecutionSeedsTXT []byte
+
+	//go:embed staging/consensus-seeds.txt
+	stagingConsensusSeedsTXT []byte
+
+	//go:embed staging/execution-seeds.txt
+	stagingExecutionSeedsTXT []byte
 )
 
 //nolint:gochecknoglobals // Static mappings.
@@ -161,6 +167,8 @@ var statics = map[ID]Static{
 		Version:              runid,
 		OmniExecutionChainID: evmchain.IDOmniEphemeral,
 		MaxValidators:        maxValidators,
+		ConsensusSeedTXT:     stagingConsensusSeedsTXT,
+		ExecutionSeedTXT:     stagingExecutionSeedsTXT,
 	},
 	Omega: {
 		Network:              Omega,

--- a/lib/p2putil/pex.go
+++ b/lib/p2putil/pex.go
@@ -1,0 +1,135 @@
+package p2putil
+
+import (
+	"context"
+	"fmt"
+
+	haloapp "github.com/omni-network/omni/halo/app"
+	"github.com/omni-network/omni/lib/errors"
+	"github.com/omni-network/omni/lib/log"
+	"github.com/omni-network/omni/lib/netconf"
+
+	cmtconfig "github.com/cometbft/cometbft/config"
+	"github.com/cometbft/cometbft/crypto/ed25519"
+	"github.com/cometbft/cometbft/p2p"
+	"github.com/cometbft/cometbft/p2p/conn"
+	"github.com/cometbft/cometbft/p2p/pex"
+	tmp2p "github.com/cometbft/cometbft/proto/tendermint/p2p"
+	"github.com/cometbft/cometbft/version"
+)
+
+// FetchPexAddrs fetches a list of cometBFT P2P peers from the provided peer using the PEX protocol.
+func FetchPexAddrs(ctx context.Context, network netconf.ID, peer *p2p.NetAddress) ([]*p2p.NetAddress, error) {
+	sw, err := makeSwitch(ctx, network)
+	if err != nil {
+		return nil, err
+	}
+
+	receive := make(chan p2p.Envelope, 1)
+	sw.AddReactor("pex", pexReactor{receive: receive})
+
+	if err := sw.Start(); err != nil {
+		return nil, errors.Wrap(err, "start switch")
+	}
+	defer sw.Stop() //nolint:errcheck // Not critical.
+
+	if err := sw.DialPeerWithAddress(peer); err != nil {
+		return nil, errors.Wrap(err, "dial peer", "peer", peer)
+	}
+
+	for {
+		select {
+		case <-ctx.Done():
+			return nil, errors.Wrap(ctx.Err(), "canceled")
+		case e := <-receive:
+			msg, ok := e.Message.(*tmp2p.PexAddrs)
+			if !ok {
+				log.Debug(ctx, "Ignoring message", "msg", fmt.Sprintf("%T", e.Message))
+				continue
+			}
+
+			addrs, err := p2p.NetAddressesFromProto(msg.Addrs)
+			if err != nil {
+				return nil, errors.Wrap(err, "parse addresses")
+			}
+
+			return addrs, nil
+		}
+	}
+}
+
+// makeSwitch creates a new cometBFT p2p switch.
+// This was copied from cometbft/p2p/test_util.go.
+func makeSwitch(ctx context.Context, network netconf.ID) (*p2p.Switch, error) {
+	cfg := cmtconfig.DefaultP2PConfig()
+	nodeKey := p2p.NodeKey{PrivKey: ed25519.GenPrivKey()}
+	nodeInfo := p2p.DefaultNodeInfo{
+		ProtocolVersion: p2p.NewProtocolVersion(
+			version.P2PProtocol,
+			version.BlockProtocol,
+			0,
+		),
+		DefaultNodeID: nodeKey.ID(),
+		ListenAddr:    "127.0.0.1:0",
+		Network:       network.Static().OmniConsensusChainIDStr(),
+		Version:       "1.2.3",
+		Channels:      []byte{pex.PexChannel},
+		Moniker:       "omni/p2putil/fetch/pex",
+	}
+
+	tranport := p2p.NewMultiplexTransport(nodeInfo, nodeKey, p2p.MConnConfig(cfg))
+
+	cmtlog, err := haloapp.NewCmtLogger(ctx, "debug")
+	if err != nil {
+		return nil, err
+	}
+
+	sw := p2p.NewSwitch(cfg, tranport)
+	sw.SetNodeKey(&nodeKey)
+	sw.SetNodeInfo(nodeInfo)
+	sw.SetLogger(cmtlog)
+
+	return sw, nil
+}
+
+// pexReactor is a very simple reactor that sends a PEX request
+// to a peer and forwards to response on the receive channel.
+type pexReactor struct {
+	p2p.Reactor
+	receive chan p2p.Envelope
+}
+
+func (pexReactor) AddPeer(peer p2p.Peer) {
+	// Immediately send a PEX request to the peer.
+	peer.Send(p2p.Envelope{
+		ChannelID: pex.PexChannel,
+		Message:   &tmp2p.PexRequest{},
+	})
+}
+
+func (p pexReactor) Receive(e p2p.Envelope) {
+	select {
+	case p.receive <- e:
+	default:
+	}
+}
+
+func (pexReactor) GetChannels() []*conn.ChannelDescriptor {
+	return []*conn.ChannelDescriptor{
+		{
+			ID:                  pex.PexChannel,
+			Priority:            1,
+			SendQueueCapacity:   10,
+			RecvMessageCapacity: 256 * 256,
+			MessageType:         &tmp2p.Message{},
+		},
+	}
+}
+
+func (pexReactor) RemovePeer(p2p.Peer, any)        {}
+func (pexReactor) SetSwitch(*p2p.Switch)           {}
+func (pexReactor) InitPeer(peer p2p.Peer) p2p.Peer { return peer }
+func (pexReactor) OnStart() error                  { return nil }
+func (pexReactor) Start() error                    { return nil }
+func (pexReactor) OnStop()                         {}
+func (pexReactor) Stop() error                     { return nil }

--- a/lib/p2putil/pex_test.go
+++ b/lib/p2putil/pex_test.go
@@ -1,0 +1,52 @@
+package p2putil_test
+
+import (
+	"context"
+	"flag"
+	"testing"
+
+	"github.com/omni-network/omni/lib/log"
+	"github.com/omni-network/omni/lib/netconf"
+	"github.com/omni-network/omni/lib/p2putil"
+
+	"github.com/cometbft/cometbft/p2p"
+
+	"github.com/stretchr/testify/require"
+)
+
+var integration = flag.Bool("integration", false, "Include integration tests")
+
+//nolint:tparallel // Concurrent output is hard to read, so do it sequentially.
+func TestSeedPeers(t *testing.T) {
+	t.Parallel()
+	if !*integration {
+		t.Skip("skipping integration test")
+	}
+
+	ctx := context.Background()
+	ctx, err := log.Init(ctx, log.Config{
+		Level:  "debug",
+		Color:  "force",
+		Format: "console",
+	})
+	require.NoError(t, err)
+
+	for _, network := range []netconf.ID{netconf.Staging, netconf.Omega} {
+		t.Run(network.String(), func(t *testing.T) {
+			for _, seedNode := range network.Static().ConsensusSeeds() {
+				t.Logf("Fetching peers from %s", seedNode)
+
+				seedAddr, err := p2p.NewNetAddressString(seedNode)
+				require.NoError(t, err)
+
+				peers, err := p2putil.FetchPexAddrs(ctx, network, seedAddr)
+				require.NoError(t, err)
+
+				t.Logf("Fetched %d peers", len(peers))
+				for i, peer := range peers {
+					t.Logf("Peer %d: %s", i, peer)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
Staging only has a single fullnode, it is also an archive node, use an externalIP in order to join to it.

Also some general cleanups:
 - Improve docker compose comments
 - Set geth moniker correctly
 - Indent voter json for easier human readability
 - Wire missing staging seed embeds
 - Add `p2putil.FetchPexPeers` to debug p2p issues.

issue: #1541 