### PR TITLE
ci(e2e): improve p2p config

### DIFF
--- a/e2e/app/definition.go
+++ b/e2e/app/definition.go
@@ -237,6 +237,13 @@ func adaptNode(ctx context.Context, manifest types.Manifest, testnet *e2e.Testne
 		}
 		node.Seeds = append(node.Seeds, testnet.LookupNode(seed))
 	}
+
+	if node.Mode == types.ModeSeed {
+		// Seed nodes should wait for incoming connections; so no persistent peers.
+		node.PersistentPeers = nil
+		return node, nil
+	}
+
 	// Remove seeds from persisted peers (cometBFT adds all nodes as peers by default).
 	var persisted []*e2e.Node
 	for _, peer := range node.PersistentPeers {


### PR DESCRIPTION
Improve P2P config:
 - Remove all seed node persistent peers. It seems like seed nodes don't add persistent peers to address book. They should only wait for incoming connections. 
 - Enable strict routing for public nodes (seeds and fullnodes)
 - Set private peer IDs (validators and archive nodes)

issue: #1541 