### PR TITLE
ci(e2e): improve seed node p2p config

### DIFF
--- a/e2e/app/definition.go
+++ b/e2e/app/definition.go
@@ -238,12 +238,6 @@ func adaptNode(ctx context.Context, manifest types.Manifest, testnet *e2e.Testne
 		node.Seeds = append(node.Seeds, testnet.LookupNode(seed))
 	}
 
-	if node.Mode == types.ModeSeed {
-		// Seed nodes should wait for incoming connections; so no persistent peers.
-		node.PersistentPeers = nil
-		return node, nil
-	}
-
 	// Remove seeds from persisted peers (cometBFT adds all nodes as peers by default).
 	var persisted []*e2e.Node
 	for _, peer := range node.PersistentPeers {

--- a/e2e/app/setup.go
+++ b/e2e/app/setup.go
@@ -375,7 +375,7 @@ func isPublicNode(network netconf.ID, mode types.Mode) bool {
 // All persisted peers are added. This aids seed nodes that don't seem
 // to add persisted peer consistently.
 func writeHaloAddressBook(network netconf.ID, path string, node *e2e.Node) error {
-	addrBook := pex.NewAddrBook(path, true)
+	addrBook := pex.NewAddrBook(path, false)
 	for _, peer := range node.PersistentPeers {
 		addr := advertisedP2PAddr(network, peer)
 		netAddr, err := p2p.NewNetAddressString(addr)

--- a/e2e/app/setup.go
+++ b/e2e/app/setup.go
@@ -33,6 +33,7 @@ import (
 	"github.com/cometbft/cometbft/config"
 	"github.com/cometbft/cometbft/crypto"
 	"github.com/cometbft/cometbft/p2p"
+	"github.com/cometbft/cometbft/p2p/pex"
 	"github.com/cometbft/cometbft/privval"
 	e2e "github.com/cometbft/cometbft/test/e2e/pkg"
 
@@ -131,6 +132,10 @@ func Setup(ctx context.Context, def Definition, depCfg DeployConfig) error {
 			return err
 		}
 		config.WriteConfigFile(filepath.Join(nodeDir, "config", "config.toml"), cfg) // panics
+
+		if err := writeHaloAddressBook(def.Testnet.Network, filepath.Join(nodeDir, "config", "addrbook.json"), node); err != nil {
+			return err
+		}
 
 		endpoints := internalEndpoints(def, node.Name)
 		omniEVM := omniEVMByPrefix(def.Testnet, node.Name)
@@ -364,6 +369,26 @@ func isPublicNode(network netconf.ID, mode types.Mode) bool {
 	// Validators and archive nodes are "secured" and only allow internal peers to connect to them.
 
 	return false
+}
+
+// writeHaloAddressBook pre-populates the halo address book for a node.
+// All persisted peers are added. This aids seed nodes that don't seem
+// to add persisted peer consistently.
+func writeHaloAddressBook(network netconf.ID, path string, node *e2e.Node) error {
+	addrBook := pex.NewAddrBook(path, true)
+	for _, peer := range node.PersistentPeers {
+		addr := advertisedP2PAddr(network, peer)
+		netAddr, err := p2p.NewNetAddressString(addr)
+		if err != nil {
+			return errors.Wrap(err, "parse net address")
+		}
+		if err := addrBook.AddAddress(netAddr, netAddr); err != nil {
+			return errors.Wrap(err, "add address")
+		}
+	}
+	addrBook.Save()
+
+	return nil
 }
 
 // writeHaloConfig generates an halo application config for a node and writes it to disk.


### PR DESCRIPTION
Improve seed node p2p again:
 - Add normal persisted peers (since staging had a blip where seednode didn't have any nodes)
 - Prepopulate addressbook with persisted peers.

issue: #1541
