### PR TITLE
fix(lib): cancel worker context on Stream shutdown

### DIFF
--- a/lib/stream/stream.go
+++ b/lib/stream/stream.go
@@ -146,6 +146,10 @@ func Stream[E any](ctx context.Context, deps Deps[E], srcChainID uint64, startHe
 	// Sorting buffer connects the concurrent fetch workers to the callback
 	sorter := newSortingBuffer(startHeight, deps, callbackFunc)
 
+	// Ensure that fetch workers are stopped when streaming / processing is done.
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
 	// Start fetching workers
 	startFetchWorkers(ctx, deps, fetchFunc, sorter, startHeight)
 


### PR DESCRIPTION
Cancel the context for all workers on shutdown, this avoids leaking goroutines as we observed in #1464. 

issue: #1602 
