### PR TITLE
ci(e2e): dont configure seed nodes

### DIFF
--- a/e2e/app/definition.go
+++ b/e2e/app/definition.go
@@ -200,7 +200,7 @@ func adaptCometTestnet(ctx context.Context, manifest types.Manifest, testnet *e2
 
 	for i := range testnet.Nodes {
 		var err error
-		testnet.Nodes[i], err = adaptNode(ctx, manifest, testnet, testnet.Nodes[i], imgTag)
+		testnet.Nodes[i], err = adaptNode(ctx, manifest, testnet.Nodes[i], imgTag)
 		if err != nil {
 			return nil, err
 		}
@@ -210,7 +210,7 @@ func adaptCometTestnet(ctx context.Context, manifest types.Manifest, testnet *e2
 }
 
 // adaptNode adapts the default comet node for omni specific changes and custom config.
-func adaptNode(ctx context.Context, manifest types.Manifest, testnet *e2e.Testnet, node *e2e.Node, tag string) (*e2e.Node, error) {
+func adaptNode(ctx context.Context, manifest types.Manifest, node *e2e.Node, tag string) (*e2e.Node, error) {
 	valKey, err := getOrGenKey(ctx, manifest, node.Name, key.Validator)
 	if err != nil {
 		return nil, err
@@ -229,24 +229,9 @@ func adaptNode(ctx context.Context, manifest types.Manifest, testnet *e2e.Testne
 	node.PrivvalKey = valKey.PrivKey
 	node.NodeKey = nodeKey.PrivKey
 
-	// Add seeds (cometBFT only adds seeds defined explicitly per node, we auto-add all seeds).
-	seeds := manifest.Seeds()
-	for seed := range seeds {
-		if seed == node.Name {
-			continue // Skip self
-		}
-		node.Seeds = append(node.Seeds, testnet.LookupNode(seed))
-	}
-
-	// Remove seeds from persisted peers (cometBFT adds all nodes as peers by default).
-	var persisted []*e2e.Node
-	for _, peer := range node.PersistentPeers {
-		if seeds[peer.Name] {
-			continue
-		}
-		persisted = append(persisted, peer)
-	}
-	node.PersistentPeers = persisted
+	// Note cometBFT adds all nodes as persisted peers (and only adds explicit per-node configured seeds).
+	// This is fine since we want to fully mesh all our nodes.
+	// Only external peers should use seed-nodes.
 
 	return node, nil
 }


### PR DESCRIPTION
Remove seed nodes config, connect all peers simply as persisted peers. This aims to address issue with staging seed node still not having any peers in its address book.

issue: #1541