### PR TITLE
chore(halo): monitor comet syncing

### DIFF
--- a/cli/cmd/operator.go
+++ b/cli/cmd/operator.go
@@ -19,6 +19,7 @@ import (
 	"github.com/omni-network/omni/lib/netconf"
 	"github.com/omni-network/omni/lib/xchain"
 
+	cmtconfig "github.com/cometbft/cometbft/config"
 	k1 "github.com/cometbft/cometbft/crypto/secp256k1"
 	rpchttp "github.com/cometbft/cometbft/rpc/client/http"
 
@@ -118,6 +119,10 @@ func initNodes(ctx context.Context, cfg initConfig) error {
 		HaloCfgFunc: func(cfg *halocfg.Config) {
 			cfg.EngineEndpoint = "http://omni_evm:8551"
 			cfg.EngineJWTFile = "/geth/jwtsecret"
+			cfg.RPCEndpoints = xchain.RPCEndpoints{cfg.Network.Static().OmniExecutionChainName(): "http://omni_evm:8545"}
+		},
+		CometCfgFunc: func(cfg *cmtconfig.Config) {
+			cfg.LogLevel = "info"
 		},
 	})
 	if err != nil {

--- a/halo/app/metrics.go
+++ b/halo/app/metrics.go
@@ -26,4 +26,11 @@ var (
 		Name:      "peers",
 		Help:      "Number of execution P2P peers of the attached omni_evm",
 	})
+
+	cometSynced = promauto.NewGauge(prometheus.GaugeOpts{
+		Namespace: "halo",
+		Subsystem: "comet",
+		Name:      "synced",
+		Help:      "Constant gauge of 1 if attached the cometBFT is synced, 0 if syncing.",
+	})
 )

--- a/halo/app/monitor.go
+++ b/halo/app/monitor.go
@@ -7,7 +7,59 @@ import (
 	"github.com/omni-network/omni/lib/errors"
 	"github.com/omni-network/omni/lib/ethclient"
 	"github.com/omni-network/omni/lib/log"
+
+	rpcclient "github.com/cometbft/cometbft/rpc/client"
 )
+
+// monitorCometForever blocks until the context is canceled.
+// It periodically calls monitorCometOnce.
+func monitorCometForever(ctx context.Context, rpcClient rpcclient.Client, isSyncing func() bool) {
+	ticker := time.NewTicker(time.Second * 30)
+	defer ticker.Stop()
+
+	// Run initial monitoring immediately.
+	lastHeight, _ := monitorCometOnce(ctx, rpcClient, isSyncing, 0)
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			height, err := monitorCometOnce(ctx, rpcClient, isSyncing, lastHeight)
+			if err != nil {
+				log.Warn(ctx, "Failed monitoring cometBFT (will retry)", err)
+				// Don't reset lastHeight to zero.
+			} else {
+				lastHeight = height
+			}
+		}
+	}
+}
+
+// monitorCometOnce monitors the cometBFT peers, and sync status.
+func monitorCometOnce(ctx context.Context, rpcClient rpcclient.Client, isSyncing func() bool, lastHeight int64) (int64, error) {
+	if netInfo, err := rpcClient.NetInfo(ctx); err != nil {
+		return 0, errors.Wrap(err, "net info")
+	} else if netInfo.NPeers == 0 {
+		log.Error(ctx, "Halo has 0 consensus p2p peers", nil)
+	}
+
+	synced := 1
+	if isSyncing() {
+		synced = 0
+		log.Warn(ctx, "Halo is syncing", nil)
+	}
+	cometSynced.Set(float64(synced))
+
+	abciInfo, err := rpcClient.ABCIInfo(ctx)
+	if err != nil {
+		return 0, errors.Wrap(err, "abci info")
+	} else if !isSyncing() && abciInfo.Response.LastBlockHeight <= lastHeight {
+		log.Warn(ctx, "Halo height is not increasing, evm syncing?", nil)
+	}
+
+	return abciInfo.Response.LastBlockHeight, nil
+}
 
 // monitorEVMForever blocks until the contract is canceled.
 // It periodically calls monitorEVMOnce.
@@ -17,7 +69,7 @@ func monitorEVMForever(ctx context.Context, cfg Config, ethCl ethclient.Client) 
 
 	// Geth Auth API (EngineClient) doesn't enable net module, so we can't monitor peer count with it.
 	// If a HTTP API also configured in RPCEndpoints, use it instead.
-	const omniEVM = "omni_evm"
+	omniEVM := cfg.Network.Static().OmniExecutionChainName()
 	omniEVMRPC, err := cfg.RPCEndpoints.ByNameOrID(omniEVM, cfg.Network.Static().OmniExecutionChainID)
 	if err == nil {
 		newEthCl, err := ethclient.Dial(omniEVM, omniEVMRPC)
@@ -26,6 +78,9 @@ func monitorEVMForever(ctx context.Context, cfg Config, ethCl ethclient.Client) 
 			log.Info(ctx, "Using rpc endpoint to monitor attached omni evm", "rpc", omniEVMRPC)
 		}
 	}
+
+	// Run initial monitoring immediately.
+	_ = monitorEVMOnce(ctx, ethCl)
 
 	for {
 		select {
@@ -49,7 +104,7 @@ func monitorEVMOnce(ctx context.Context, ethCl ethclient.Client) error {
 	} else if err != nil {
 		return errors.Wrap(err, "peer count")
 	} else if peers == 0 {
-		log.Warn(ctx, "Attached omni evm has 0 peers", nil)
+		log.Error(ctx, "Attached omni evm has 0 peers", nil)
 		evmPeers.Set(0)
 	} else {
 		evmPeers.Set(float64(peers))

--- a/halo/app/start.go
+++ b/halo/app/start.go
@@ -183,6 +183,7 @@ func Start(ctx context.Context, cfg Config) (<-chan error, func(context.Context)
 		return nil, nil, errors.Wrap(err, "start comet node")
 	}
 
+	go monitorCometForever(ctx, rpcClient, cmtNode.ConsensusReactor().WaitSync)
 	go monitorEVMForever(ctx, cfg, engineCl)
 
 	// Return async and stop functions.

--- a/lib/ethclient/enginemock.go
+++ b/lib/ethclient/enginemock.go
@@ -200,6 +200,14 @@ func (m *engineMock) maybeErr(ctx context.Context) error {
 	return nil
 }
 
+func (*engineMock) PeerCount(context.Context) (uint64, error) {
+	return 1, nil
+}
+
+func (*engineMock) SyncProgress(context.Context) (*ethereum.SyncProgress, error) {
+	return nil, nil //nolint:nilnil // nil-nil return means not syncing.
+}
+
 func (m *engineMock) FilterLogs(_ context.Context, q ethereum.FilterQuery) ([]types.Log, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()

--- a/lib/netconf/static.go
+++ b/lib/netconf/static.go
@@ -49,6 +49,12 @@ func (s Static) OmniConsensusChainIDStr() string {
 	return fmt.Sprintf("%s%d", consensusIDPrefix, s.OmniConsensusChainIDUint64())
 }
 
+// OmniExecutionChainName returns the name of the Omni execution chain.
+func (s Static) OmniExecutionChainName() string {
+	meta, _ := evmchain.MetadataByID(s.OmniExecutionChainID)
+	return meta.Name
+}
+
 // OmniConsensusChainIDUint64 returns the chain ID uint64 for the Omni consensus chain.
 // It is calculated as 1_000_000 + OmniExecutionChainID.
 func (s Static) OmniConsensusChainIDUint64() uint64 {


### PR DESCRIPTION
Adds logs and metrics for halo/geth syncing, also geth peers. 

Don't initialise voter until the node is a validator. This avoid issues with partial rpc endpoint config in non-validators.

issue: #1526