### PR TITLE
fix(e2e): relayer should use an archive node

### DIFF
--- a/e2e/docker/docker.go
+++ b/e2e/docker/docker.go
@@ -271,10 +271,7 @@ func additionalServices(testnet types.Testnet) []string {
 		resp = append(resp, "prometheus")
 	}
 
-	// Monitor must connect to an archive node.
-	if testnet.HasArchiveNode() {
-		resp = append(resp, "monitor")
-	}
+	resp = append(resp, "monitor")
 
 	// In monitor only mode, we only start monitor and prometheus.
 	if testnet.OnlyMonitor {

--- a/e2e/manifests/devnet0.toml
+++ b/e2e/manifests/devnet0.toml
@@ -1,7 +1,10 @@
-# Devnet0 is a tiny devnet. Only a single validator and two anvils.
+# Devnet0 is a tiny devnet. Only a single validator, an archive node (for the relayer), and two anvils.
 # This is aimed at local dev environments.
 
 network = "devnet"
 anvil_chains = ["mock_op", "mock_arb"]
 
 [node.validator01]
+
+[node.fullnode01]
+mode="archive"

--- a/e2e/types/testnet.go
+++ b/e2e/types/testnet.go
@@ -107,17 +107,6 @@ func (t Testnet) BroadcastNode() *e2e.Node {
 	return t.Nodes[0]
 }
 
-// HasArchiveNode returns whether the Testnet has any nodes running in ModeArchive.
-func (t Testnet) HasArchiveNode() bool {
-	for _, node := range t.Nodes {
-		if node.Mode == ModeArchive {
-			return true
-		}
-	}
-
-	return false
-}
-
 // ArchiveNode returns the first node running in ModeArchive.
 // Note that this is different from the CometBFT Testnet.ArchiveNodes() method.
 func (t Testnet) ArchiveNode() (*e2e.Node, bool) {


### PR DESCRIPTION
The relayer has to use an archive node after #1612, else it might not be able to fetch necessary attestations.

issue: none
