### PR TITLE
chore(monitor/emitcache): fallback to archive node

### DIFF
--- a/e2e/app/cleanup.go
+++ b/e2e/app/cleanup.go
@@ -7,10 +7,9 @@ import (
 	"path/filepath"
 	"runtime"
 
+	"github.com/omni-network/omni/e2e/docker"
 	"github.com/omni-network/omni/lib/errors"
 	"github.com/omni-network/omni/lib/log"
-
-	"github.com/cometbft/cometbft/test/e2e/pkg/infra/docker"
 )
 
 // CleanInfra stops and removes the infra containers.

--- a/e2e/app/perturb.go
+++ b/e2e/app/perturb.go
@@ -4,13 +4,13 @@ import (
 	"context"
 	"time"
 
+	"github.com/omni-network/omni/e2e/docker"
 	"github.com/omni-network/omni/e2e/types"
 	"github.com/omni-network/omni/lib/errors"
 	"github.com/omni-network/omni/lib/log"
 
 	rpctypes "github.com/cometbft/cometbft/rpc/core/types"
 	e2e "github.com/cometbft/cometbft/test/e2e/pkg"
-	"github.com/cometbft/cometbft/test/e2e/pkg/infra/docker"
 )
 
 // perturb the running testnet.

--- a/e2e/cmd/cmd.go
+++ b/e2e/cmd/cmd.go
@@ -8,13 +8,12 @@ import (
 	"github.com/omni-network/omni/e2e/app"
 	"github.com/omni-network/omni/e2e/app/eoa"
 	"github.com/omni-network/omni/e2e/app/key"
+	"github.com/omni-network/omni/e2e/docker"
 	"github.com/omni-network/omni/e2e/types"
 	libcmd "github.com/omni-network/omni/lib/cmd"
 	"github.com/omni-network/omni/lib/errors"
 	"github.com/omni-network/omni/lib/log"
 	"github.com/omni-network/omni/lib/netconf"
-
-	cmtdocker "github.com/cometbft/cometbft/test/e2e/pkg/infra/docker"
 
 	"github.com/ethereum/go-ethereum/common"
 
@@ -117,7 +116,7 @@ func newLogsCmd(def *app.Definition) *cobra.Command {
 		Use:   "logs",
 		Short: "Prints the infrastructure logs (of a previously preserved network)",
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			err := cmtdocker.ExecComposeVerbose(cmd.Context(), def.Testnet.Dir, "logs")
+			err := docker.ExecComposeVerbose(cmd.Context(), def.Testnet.Dir, "logs")
 			if err != nil {
 				return errors.Wrap(err, "executing docker-compose logs")
 			}

--- a/lib/xchain/provider.go
+++ b/lib/xchain/provider.go
@@ -78,6 +78,13 @@ func ConfEmitRef(level ConfLevel) EmitRef {
 	}
 }
 
+// HeightEmitRef returns a EmitRef with the provided confirmation level.
+func HeightEmitRef(height uint64) EmitRef {
+	return EmitRef{
+		Height: &height,
+	}
+}
+
 // LatestEmitRef returns a EmitRef with the latest confirmation level.
 func LatestEmitRef() EmitRef {
 	return ConfEmitRef(ConfLatest)

--- a/monitor/xmonitor/emitcache/metrics.go
+++ b/monitor/xmonitor/emitcache/metrics.go
@@ -1,0 +1,22 @@
+package emitcache
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+var (
+	hitCounter = promauto.NewCounterVec(prometheus.CounterOpts{
+		Namespace: "monitor",
+		Subsystem: "emitcache",
+		Name:      "hit_total",
+		Help:      "Total number of emitcache hits per stream",
+	}, []string{"stream"})
+
+	missCounter = promauto.NewCounterVec(prometheus.CounterOpts{
+		Namespace: "monitor",
+		Subsystem: "emitcache",
+		Name:      "miss_total",
+		Help:      "Total number of emitcache misses per stream",
+	}, []string{"stream"})
+)


### PR DESCRIPTION
Workaround cache not populated errors by falling back to querying (archive) nodes. Also add metrics with the aim of debugging and fixing the emitcache issues in the long run.

Also refactor docker to use `docker compose` instead of `docker-compose` which isn't supported on github runners anymore it seems.

issue: #1591 