### PR TITLE
feat(e2e): add support for relayer and monitor pinning

### DIFF
--- a/e2e/docker/compose.yaml.tmpl
+++ b/e2e/docker/compose.yaml.tmpl
@@ -94,7 +94,7 @@ services:
     labels:
       e2e: true
     container_name: relayer
-    image: omniops/relayer:{{or .OmniTag "main"}}
+    image: omniops/relayer:{{or .RelayerTag "main"}}
     restart: unless-stopped # Restart on crash to mitigate startup race issues
     ports:
       - 26660 # Prometheus and pprof
@@ -110,7 +110,7 @@ services:
     labels:
       e2e: true
     container_name: monitor
-    image: omniops/monitor:{{or .OmniTag "main"}}
+    image: omniops/monitor:{{or .MonitorTag "main"}}
     restart: unless-stopped # Restart on crash to mitigate startup race issues
     ports:
       - 26660 # Prometheus and pprof

--- a/e2e/docker/docker.go
+++ b/e2e/docker/docker.go
@@ -43,7 +43,6 @@ type Provider struct {
 	*cmtdocker.Provider
 	servicesOnce sync.Once
 	testnet      types.Testnet
-	omniTag      string
 }
 
 func (*Provider) Clean(ctx context.Context) error {
@@ -60,7 +59,7 @@ func (*Provider) Clean(ctx context.Context) error {
 }
 
 // NewProvider returns a new Provider.
-func NewProvider(testnet types.Testnet, infd types.InfrastructureData, imgTag string) *Provider {
+func NewProvider(testnet types.Testnet, infd types.InfrastructureData) *Provider {
 	return &Provider{
 		Provider: &cmtdocker.Provider{
 			ProviderData: infra.ProviderData{
@@ -69,7 +68,6 @@ func NewProvider(testnet types.Testnet, infd types.InfrastructureData, imgTag st
 			},
 		},
 		testnet: testnet,
-		omniTag: imgTag,
 	}
 }
 
@@ -87,7 +85,9 @@ func (p *Provider) Setup() error {
 		Relayer:     true,
 		Prometheus:  p.testnet.Prometheus,
 		Monitor:     true,
-		OmniTag:     p.omniTag,
+		OmniTag:     p.testnet.OmniImgTag,
+		RelayerTag:  p.testnet.RelayerImgTag,
+		MonitorTag:  p.testnet.MonitorImgTag,
 	}
 
 	bz, err := GenerateComposeFile(def)
@@ -177,6 +177,8 @@ type ComposeDef struct {
 
 	Monitor    bool
 	OmniTag    string
+	RelayerTag string
+	MonitorTag string
 	Relayer    bool
 	Prometheus bool
 }

--- a/e2e/docker/docker_test.go
+++ b/e2e/docker/docker_test.go
@@ -28,17 +28,23 @@ func TestComposeTemplate(t *testing.T) {
 
 	tests := []struct {
 		name       string
-		tag        string
+		omniTag    string
+		relayerTag string
+		monitorTag string
 		isEmpheral bool
 	}{
 		{
 			name:       "commit",
-			tag:        "7d1ae53",
+			omniTag:    "7d1ae53",
+			relayerTag: "9fecc1a",
+			monitorTag: "555ede3",
 			isEmpheral: false,
 		},
 		{
 			name:       "empheral_network",
-			tag:        "main",
+			omniTag:    "main",
+			relayerTag: "main",
+			monitorTag: "main",
 			isEmpheral: true,
 		},
 	}
@@ -62,7 +68,7 @@ func TestComposeTemplate(t *testing.T) {
 					Prometheus: true,
 					Nodes: []*e2e.Node{{
 						Name:       "node0",
-						Version:    "omniops/halo:" + test.tag,
+						Version:    "omniops/halo:" + test.omniTag,
 						InternalIP: ipNet.IP,
 						ProxyPort:  8584,
 					}},
@@ -99,6 +105,9 @@ func TestComposeTemplate(t *testing.T) {
 						LoadState:  "path/to/anvil/state.json",
 					},
 				},
+				OmniImgTag:    test.omniTag,
+				RelayerImgTag: test.relayerTag,
+				MonitorImgTag: test.monitorTag,
 			}
 
 			// If the network is empheral, we use the devnet configuration.
@@ -106,7 +115,7 @@ func TestComposeTemplate(t *testing.T) {
 				testnet.Network = netconf.Devnet
 			}
 
-			p := docker.NewProvider(testnet, types.InfrastructureData{}, test.tag)
+			p := docker.NewProvider(testnet, types.InfrastructureData{})
 			require.NoError(t, err)
 
 			require.NoError(t, p.Setup())

--- a/e2e/docker/testdata/TestComposeTemplate_commit.golden
+++ b/e2e/docker/testdata/TestComposeTemplate_commit.golden
@@ -99,7 +99,7 @@ services:
     labels:
       e2e: true
     container_name: relayer
-    image: omniops/relayer:7d1ae53
+    image: omniops/relayer:9fecc1a
     restart: unless-stopped # Restart on crash to mitigate startup race issues
     ports:
       - 26660 # Prometheus and pprof
@@ -113,7 +113,7 @@ services:
     labels:
       e2e: true
     container_name: monitor
-    image: omniops/monitor:7d1ae53
+    image: omniops/monitor:555ede3
     restart: unless-stopped # Restart on crash to mitigate startup race issues
     ports:
       - 26660 # Prometheus and pprof

--- a/e2e/types/manifest.go
+++ b/e2e/types/manifest.go
@@ -102,6 +102,14 @@ type Manifest struct {
 	// This allows source code defined versions for protected networks.
 	// The --omni-image-tag flag is then only used for non-halo services (relayer, monitor).
 	PinnedHaloTag string `toml:"pinned_halo_tag"`
+
+	// PinnedMonitorTag defines the pinned monitor docker image tag.
+	// The --omni-image-tag flag is then only used for halo and relayer services, unless also pinned.
+	PinnedMonitorTag string `toml:"pinned_monitor_tag"`
+
+	// PinnedRelayerTag defines the pinned relayer docker image tag.
+	// The --omni-image-tag flag is then only used for halo and monitor services, unless also pinned.
+	PinnedRelayerTag string `toml:"pinned_relayer_tag"`
 }
 
 // Seeds returns a map of seed nodes by name.

--- a/e2e/types/testnet.go
+++ b/e2e/types/testnet.go
@@ -22,12 +22,15 @@ import (
 // Testnet wraps e2e.Omega with additional omni-specific fields.
 type Testnet struct {
 	*e2e.Testnet
-	Network      netconf.ID
-	OmniEVMs     []OmniEVM
-	AnvilChains  []AnvilChain
-	PublicChains []PublicChain
-	OnlyMonitor  bool
-	Perturb      map[string][]Perturb
+	Network       netconf.ID
+	OmniEVMs      []OmniEVM
+	AnvilChains   []AnvilChain
+	PublicChains  []PublicChain
+	OnlyMonitor   bool
+	Perturb       map[string][]Perturb
+	OmniImgTag    string
+	RelayerImgTag string
+	MonitorImgTag string
 }
 
 // RandomHaloAddr returns a random halo address for cprovider and cometBFT rpc clients.

--- a/e2e/vmcompose/provider.go
+++ b/e2e/vmcompose/provider.go
@@ -31,14 +31,12 @@ type Provider struct {
 	Testnet types.Testnet
 	Data    types.InfrastructureData
 	once    sync.Once
-	omniTag string
 }
 
-func NewProvider(testnet types.Testnet, data types.InfrastructureData, imgTag string) *Provider {
+func NewProvider(testnet types.Testnet, data types.InfrastructureData) *Provider {
 	return &Provider{
 		Testnet: testnet,
 		Data:    data,
-		omniTag: imgTag,
 	}
 }
 
@@ -90,7 +88,9 @@ func (p *Provider) Setup() error {
 			Relayer:     services["relayer"],
 			Monitor:     services["monitor"],
 			Prometheus:  p.Testnet.Prometheus,
-			OmniTag:     p.omniTag,
+			OmniTag:     p.Testnet.OmniImgTag,
+			RelayerTag:  p.Testnet.RelayerImgTag,
+			MonitorTag:  p.Testnet.MonitorImgTag,
 		}
 		compose, err := docker.GenerateComposeFile(def)
 		if err != nil {


### PR DESCRIPTION
Adds support for the pinning of relayer and monitor containers.

This is my second attempt at this and it's probably 70% the same as the last version. I Worked backwards from the rendered template where container image tags were being determined.

- Didn't want to put logic in the template to determine tags as I felt this should be done in the code prior

- On that basis we need fields/properties to map those tags at some point to pass them into the Docker compose template. We can either pass these around as variables, or as properties of other types (imo)

- We have to load the manifest to actually determine any pinning, so any pinning logic has to come after that

- I wanted to remove the existing pinning code out of the adaptNode() function (definition.go) as I didn't want the same logic happening in multiple places, so moved this out to its own function

- It felt tidier making the omni tag, and the other tags, part of the testnet struct, rather than passing 3 tags around various functions, so moved those as well

issue: #1629 