### PR TITLE
ci(e2e): pin monitor and relayer images

### DIFF
--- a/e2e/app/definition.go
+++ b/e2e/app/definition.go
@@ -266,6 +266,7 @@ func NoNodesTestnet(manifest types.Manifest, infd types.InfrastructureData, cfg 
 	}
 
 	return types.Testnet{
+		Manifest:     manifest,
 		Network:      manifest.Network,
 		Testnet:      cmtTestnet,
 		PublicChains: publics,
@@ -396,6 +397,7 @@ func TestnetFromManifest(ctx context.Context, manifest types.Manifest, infd type
 	}
 
 	return types.Testnet{
+		Manifest:     manifest,
 		Network:      manifest.Network,
 		Testnet:      cmtTestnet,
 		OmniEVMs:     omniEVMS,

--- a/e2e/docker/compose.yaml.tmpl
+++ b/e2e/docker/compose.yaml.tmpl
@@ -39,7 +39,7 @@ services:
       e2e: true
     container_name: {{ .Chain.Name }}
     platform: linux/amd64
-    image: omniops/anvilproxy:{{or $.OmniTag "main"}}
+    image: omniops/anvilproxy:{{or $.AnvilProxyTag "main"}}
     environment:
       - ANVILPROXY_CHAIN_ID={{ .Chain.ChainID }}
       - ANVILPROXY_BLOCK_TIME={{.Chain.BlockPeriod.Seconds}}
@@ -94,7 +94,7 @@ services:
     labels:
       e2e: true
     container_name: relayer
-    image: omniops/relayer:{{or .OmniTag "main"}}
+    image: omniops/relayer:{{or .RelayerTag "main"}}
     restart: unless-stopped # Restart on crash to mitigate startup race issues
     ports:
       - 26660 # Prometheus and pprof
@@ -110,7 +110,7 @@ services:
     labels:
       e2e: true
     container_name: monitor
-    image: omniops/monitor:{{or .OmniTag "main"}}
+    image: omniops/monitor:{{or .MonitorTag "main"}}
     restart: unless-stopped # Restart on crash to mitigate startup race issues
     ports:
       - 26660 # Prometheus and pprof

--- a/e2e/docker/docker.go
+++ b/e2e/docker/docker.go
@@ -87,8 +87,8 @@ func (p *Provider) Setup() error {
 		Relayer:     true,
 		Prometheus:  p.testnet.Prometheus,
 		Monitor:     true,
-		OmniTag:     p.omniTag,
 	}
+	def = SetImageTags(def, p.testnet.Manifest, p.omniTag)
 
 	bz, err := GenerateComposeFile(def)
 	if err != nil {
@@ -175,10 +175,12 @@ type ComposeDef struct {
 	OmniEVMs []types.OmniEVM
 	Anvils   []types.AnvilChain
 
-	Monitor    bool
-	OmniTag    string
-	Relayer    bool
-	Prometheus bool
+	Monitor       bool
+	AnvilProxyTag string
+	RelayerTag    string
+	MonitorTag    string
+	Relayer       bool
+	Prometheus    bool
 }
 
 func (ComposeDef) GethTag() string {
@@ -197,6 +199,28 @@ func (c ComposeDef) NodeOmniEVMs() map[string]string {
 	}
 
 	return resp
+}
+
+// SetImageTags returns a new ComposeDef with the image tags set.
+// This is a convenience function to avoid setting the tags manually.
+func SetImageTags(def ComposeDef, manifest types.Manifest, omniImgTag string) ComposeDef {
+	anvilProxyTag := omniImgTag
+
+	monitorTag := omniImgTag
+	if manifest.PinnedMonitorTag != "" {
+		monitorTag = manifest.PinnedMonitorTag
+	}
+
+	relayerTag := omniImgTag
+	if manifest.PinnedRelayerTag != "" {
+		relayerTag = manifest.PinnedRelayerTag
+	}
+
+	def.AnvilProxyTag = anvilProxyTag
+	def.MonitorTag = monitorTag
+	def.RelayerTag = relayerTag
+
+	return def
 }
 
 func GenerateComposeFile(def ComposeDef) ([]byte, error) {

--- a/e2e/docker/docker_test.go
+++ b/e2e/docker/docker_test.go
@@ -55,6 +55,10 @@ func TestComposeTemplate(t *testing.T) {
 
 			dir := t.TempDir()
 			testnet := types.Testnet{
+				Manifest: types.Manifest{
+					PinnedRelayerTag: "v2",
+					PinnedMonitorTag: "v3",
+				},
 				Testnet: &e2e.Testnet{
 					Name:       "test",
 					IP:         ipNet,

--- a/e2e/docker/testdata/TestComposeTemplate_commit.golden
+++ b/e2e/docker/testdata/TestComposeTemplate_commit.golden
@@ -99,7 +99,7 @@ services:
     labels:
       e2e: true
     container_name: relayer
-    image: omniops/relayer:7d1ae53
+    image: omniops/relayer:v2
     restart: unless-stopped # Restart on crash to mitigate startup race issues
     ports:
       - 26660 # Prometheus and pprof
@@ -113,7 +113,7 @@ services:
     labels:
       e2e: true
     container_name: monitor
-    image: omniops/monitor:7d1ae53
+    image: omniops/monitor:v3
     restart: unless-stopped # Restart on crash to mitigate startup race issues
     ports:
       - 26660 # Prometheus and pprof

--- a/e2e/docker/testdata/TestComposeTemplate_empheral_network.golden
+++ b/e2e/docker/testdata/TestComposeTemplate_empheral_network.golden
@@ -99,7 +99,7 @@ services:
     labels:
       e2e: true
     container_name: relayer
-    image: omniops/relayer:main
+    image: omniops/relayer:v2
     restart: unless-stopped # Restart on crash to mitigate startup race issues
     ports:
       - 26660 # Prometheus and pprof
@@ -113,7 +113,7 @@ services:
     labels:
       e2e: true
     container_name: monitor
-    image: omniops/monitor:main
+    image: omniops/monitor:v3
     restart: unless-stopped # Restart on crash to mitigate startup race issues
     ports:
       - 26660 # Prometheus and pprof

--- a/e2e/types/manifest.go
+++ b/e2e/types/manifest.go
@@ -100,8 +100,18 @@ type Manifest struct {
 
 	// PinnedHaloTag defines the pinned halo docker image tag.
 	// This allows source code defined versions for protected networks.
-	// The --omni-image-tag flag is then only used for non-halo services (relayer, monitor).
+	// This overrides the --omni-image-tag if non-empty.
 	PinnedHaloTag string `toml:"pinned_halo_tag"`
+
+	// PinnedMonitorTag defines the pinned monitor docker image tag.
+	// This allows source code defined versions for protected networks.
+	// This overrides the --omni-image-tag if non-empty.
+	PinnedMonitorTag string `toml:"pinned_monitor_tag"`
+
+	// PinnedRelayerTag defines the pinned relayer docker image tag.
+	// This allows source code defined versions for protected networks.
+	// This overrides the --omni-image-tag if non-empty.
+	PinnedRelayerTag string `toml:"pinned_relayer_tag"`
 }
 
 // Seeds returns a map of seed nodes by name.

--- a/e2e/types/testnet.go
+++ b/e2e/types/testnet.go
@@ -22,6 +22,7 @@ import (
 // Testnet wraps e2e.Omega with additional omni-specific fields.
 type Testnet struct {
 	*e2e.Testnet
+	Manifest     Manifest
 	Network      netconf.ID
 	OmniEVMs     []OmniEVM
 	AnvilChains  []AnvilChain

--- a/e2e/vmcompose/provider.go
+++ b/e2e/vmcompose/provider.go
@@ -90,8 +90,9 @@ func (p *Provider) Setup() error {
 			Relayer:     services["relayer"],
 			Monitor:     services["monitor"],
 			Prometheus:  p.Testnet.Prometheus,
-			OmniTag:     p.omniTag,
 		}
+		def = docker.SetImageTags(def, p.Testnet.Manifest, p.omniTag)
+
 		compose, err := docker.GenerateComposeFile(def)
 		if err != nil {
 			return errors.Wrap(err, "generate compose file")


### PR DESCRIPTION
Support pinning of monitor and relayer images.

issue: https://github.com/omni-network/omni/issues/1629
