### PR TITLE
chore(halo): instrument validator status

### DIFF
--- a/halo/app/lazyvoter.go
+++ b/halo/app/lazyvoter.go
@@ -251,6 +251,12 @@ func (l *voterLoader) TrimBehind(minsByChain map[xchain.ChainVersion]uint64) int
 }
 
 func (l *voterLoader) UpdateValidatorSet(valset *vtypes.ValidatorSetResponse) error {
+	isVal, err := valset.IsValidator(l.localAddr)
+	if err != nil {
+		return err
+	}
+	setConstantGauge(cometValidator, isVal)
+
 	if v, ok := l.getVoter(); ok {
 		return v.UpdateValidatorSet(valset)
 	}
@@ -258,12 +264,7 @@ func (l *voterLoader) UpdateValidatorSet(valset *vtypes.ValidatorSetResponse) er
 	l.mu.Lock()
 	defer l.mu.Unlock()
 
-	var err error
-	l.isVal, err = valset.IsValidator(l.localAddr)
-	if err != nil {
-		return err
-	}
-
+	l.isVal = isVal
 	l.lastValSet = valset
 
 	return nil

--- a/halo/app/metrics.go
+++ b/halo/app/metrics.go
@@ -34,6 +34,13 @@ var (
 		Help:      "Constant gauge of 1 if attached the cometBFT is synced, 0 if syncing.",
 	})
 
+	cometValidator = promauto.NewGauge(prometheus.GaugeOpts{
+		Namespace: "halo",
+		Subsystem: "comet",
+		Name:      "validator",
+		Help:      "Constant gauge of 1 if local halo node is a cometBFT validator, 0 if not a validator.",
+	})
+
 	dbSize = promauto.NewGauge(prometheus.GaugeOpts{
 		Namespace: "halo",
 		Subsystem: "db",
@@ -41,3 +48,12 @@ var (
 		Help:      "Current size of the database directory in bytes.",
 	})
 )
+
+// setConstantGauge sets the value of a gauge to 1 if b is true, 0 otherwise.
+func setConstantGauge(gauge prometheus.Gauge, b bool) {
+	var val float64
+	if b {
+		val = 1
+	}
+	gauge.Set(val)
+}


### PR DESCRIPTION
Adds the `halo_comet_validator` constant gauge metric that tracks whether the local halo node is a cometBFT validator (1) or not (0). Se should add an alert if any `validator` halo instance is not a validator.

issue: #1526