### PR TITLE
chore(github): remove pushing e2e logs to loki

### DIFF
--- a/.github/workflows/e2etest.yml
+++ b/.github/workflows/e2etest.yml
@@ -13,8 +13,10 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: 'stable'
+
       - name: Run e2e tests
         run: make e2e-ci
+
       - name: Upload failed logs
         uses: actions/upload-artifact@v4
         if: failure()
@@ -22,12 +24,3 @@ jobs:
           name: failed-logs
           path: e2e/failed-logs.txt
           retention-days: 3
-
-      - name: e2e-logs
-        if: failure()
-        uses: metrico/loki-action@V3.1
-        with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-          endpoint: ${{ secrets.LOGQL_ENDPOINT }}
-          username: ${{ secrets.LOGQL_USER }}
-          password: ${{ secrets.LOGQL_PASS }}


### PR DESCRIPTION
Remove github action step that pushes e2e logs to loki since it has never worked for a long time.

issue: #1626