### PR TITLE
chore(monitor): implement historical baseline tracking

### DIFF
--- a/halo/app/start_test.go
+++ b/halo/app/start_test.go
@@ -78,7 +78,7 @@ func TestSmoke(t *testing.T) {
 	chainVer := xchain.ChainVersion{ID: srcChain, ConfLevel: xchain.ConfFinalized}
 
 	// Ensure all blocks are attested and approved.
-	cprov.Subscribe(ctx, chainVer, 1, "test", func(ctx context.Context, approved xchain.Attestation) error {
+	cprov.StreamAsync(ctx, chainVer, 1, "test", func(ctx context.Context, approved xchain.Attestation) error {
 		// Sanity check we can fetch latest directly as well.
 		att, ok, err := cprov.LatestAttestation(ctx, chainVer)
 		tutil.RequireNoError(t, err)

--- a/lib/cchain/provider/provider_test.go
+++ b/lib/cchain/provider/provider_test.go
@@ -44,7 +44,7 @@ func TestProvider(t *testing.T) {
 	wg.Add(1)
 
 	chainVer := xchain.ChainVersion{ID: chainID, ConfLevel: conf}
-	p.Subscribe(ctx, chainVer, fromHeight, "test", func(ctx context.Context, approved xchain.Attestation) error {
+	p.StreamAsync(ctx, chainVer, fromHeight, "test", func(ctx context.Context, approved xchain.Attestation) error {
 		actual = append(actual, approved)
 		if len(actual) == total {
 			cancel()  // Cancel the context to stop further fetch operations

--- a/lib/stream/stream.go
+++ b/lib/stream/stream.go
@@ -30,6 +30,7 @@ type Deps[E any] struct {
 	// Config
 	FetchWorkers  uint64
 	ElemLabel     string
+	HeightLabel   string
 	RetryCallback bool
 
 	// Metrics
@@ -70,7 +71,7 @@ func Stream[E any](ctx context.Context, deps Deps[E], srcChainID uint64, startHe
 			if ctx.Err() != nil {
 				return nil
 			} else if err != nil {
-				log.Warn(ctx, "Failed fetching "+deps.ElemLabel+" (will retry)", err, "height", height)
+				log.Warn(ctx, "Failed fetching "+deps.ElemLabel+" (will retry)", err, deps.HeightLabel, height)
 				deps.IncFetchErr()
 				backoff()
 
@@ -85,7 +86,7 @@ func Stream[E any](ctx context.Context, deps Deps[E], srcChainID uint64, startHe
 			heightsOK := true
 			for i, elem := range elems {
 				if h := deps.Height(elem); h != height+uint64(i) {
-					log.Error(ctx, "Invalid "+deps.ElemLabel+" height [BUG]", nil,
+					log.Error(ctx, "Invalid "+deps.ElemLabel+" "+deps.HeightLabel+" [BUG]", nil,
 						"expect", height,
 						"actual", h,
 					)
@@ -107,7 +108,7 @@ func Stream[E any](ctx context.Context, deps Deps[E], srcChainID uint64, startHe
 		height := deps.Height(elem)
 		ctx, span := deps.StartTrace(ctx, height, "callback")
 		defer span.End()
-		ctx = log.WithCtx(ctx, "height", height)
+		ctx = log.WithCtx(ctx, deps.HeightLabel, height)
 
 		backoff := deps.Backoff(ctx)
 

--- a/lib/xchain/provider/provider.go
+++ b/lib/xchain/provider/provider.go
@@ -169,6 +169,7 @@ func (p *Provider) stream(
 		},
 		Backoff:       p.backoffFunc,
 		ElemLabel:     "block",
+		HeightLabel:   "height",
 		RetryCallback: retryCallback,
 		Height: func(block xchain.Block) uint64 {
 			return block.BlockHeight

--- a/monitor/app/historical.go
+++ b/monitor/app/historical.go
@@ -1,0 +1,111 @@
+package monitor
+
+import (
+	"context"
+	"strconv"
+	"time"
+
+	"github.com/omni-network/omni/lib/cchain"
+	"github.com/omni-network/omni/lib/errors"
+	"github.com/omni-network/omni/lib/log"
+	"github.com/omni-network/omni/lib/netconf"
+	"github.com/omni-network/omni/lib/umath"
+	"github.com/omni-network/omni/lib/xchain"
+)
+
+// runHistoricalBaselineForever blocks forever, periodically running historical baselines for all chains in the network.
+// Historical baseline is the time it takes to stream a certain number of historical attestations from the cprovider.
+// This is used to track the performance of the cprovider historical query logic.
+func runHistoricalBaselineForever(ctx context.Context, network netconf.Network, cprov cchain.Provider) {
+	chainVers := keys(network.ChainVersionNames())
+	sizes := []uint64{100, 1000, 10000}
+
+	const period = time.Minute
+	timer := time.NewTimer(period)
+	defer timer.Stop()
+
+	for i := 0; ; i++ {
+		select {
+		case <-ctx.Done():
+			return
+		case <-timer.C:
+			chainVer := pick(chainVers, i)
+			chainVerName := network.ChainVersionName(chainVer)
+			size := pick(sizes, i)
+			t0 := time.Now()
+
+			log.Info(ctx, "Running historical baseline", "chain", chainVerName, "size", size)
+
+			measure, err := runHistoricalBaselineOnce(ctx, cprov, chainVer, size)
+			if ctx.Err() != nil {
+				return
+			} else if err != nil {
+				log.Warn(ctx, "Failed running historical baseline (will retry)", err,
+					"chain", chainVerName, "size", size)
+			} else if measure {
+				duration := time.Since(t0)
+				log.Info(ctx, "Ran historical baseline", "chain", chainVerName, "size", size, "duration", duration)
+				histBaseline.WithLabelValues(chainVerName, strconv.FormatUint(size, 10)).Observe(duration.Seconds())
+			}
+			timer.Reset(period)
+		}
+	}
+}
+
+func runHistoricalBaselineOnce(
+	ctx context.Context,
+	cprov cchain.Provider,
+	chainVer xchain.ChainVersion,
+	size uint64,
+) (bool, error) {
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	latest, ok, err := cprov.LatestAttestation(ctx, chainVer)
+	if err != nil {
+		return false, err
+	} else if !ok {
+		return false, nil
+	}
+
+	from := umath.SubtractOrZero(latest.AttestOffset, size)
+	if from == 0 {
+		return false, nil // Not enough attestations to run historical baseline
+	}
+
+	var last uint64
+	err = cprov.StreamAttestations(ctx, chainVer, from, "hist_baseline",
+		func(_ context.Context, att xchain.Attestation) error {
+			last = att.AttestOffset
+			if last >= latest.AttestOffset {
+				cancel()
+			}
+
+			return nil
+		})
+	if ctx.Err() != nil {
+		return true, nil
+	} else if err != nil {
+		return false, errors.Wrap(err, "stream attestations", "last", last, "from", from)
+	}
+
+	return false, errors.New("unexpected stream end [BUG]")
+}
+
+func keys[K comparable, V any](m map[K]V) []K {
+	var keys []K
+	for k := range m {
+		keys = append(keys, k)
+	}
+
+	return keys
+}
+
+func pick[V any](arr []V, i int) V {
+	if len(arr) == 0 {
+		var zero V
+		return zero
+	}
+
+	return arr[i%len(arr)]
+}

--- a/monitor/app/metrics.go
+++ b/monitor/app/metrics.go
@@ -1,6 +1,8 @@
 package monitor
 
 import (
+	"time"
+
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 )
@@ -12,4 +14,12 @@ var (
 		Name:      "sync_diff",
 		Help:      "Maximum sync difference (concurrent latest heights) per chain",
 	}, []string{"chain"})
+
+	histBaseline = promauto.NewHistogramVec(prometheus.HistogramOpts{
+		Namespace: "monitor",
+		Subsystem: "cprovider",
+		Name:      "historical_baseline_seconds",
+		Help:      "Baseline time (in seconds) to stream historical approved attestation",
+		Buckets:   prometheus.ExponentialBucketsRange(time.Second.Seconds(), time.Hour.Seconds(), 8),
+	}, []string{"chain", "size"})
 )

--- a/monitor/app/sync.go
+++ b/monitor/app/sync.go
@@ -13,7 +13,11 @@ import (
 // startMonitoringSyncDiff starts a goroutine per chain that periodically calculates the rpc-sync-diff
 // which indicates the difference in latest heights (sync) of possible HA upstream RPC servers.
 // A rpc-sync-diff of 2 or more can indicate the upstreams are not 100% consistently synced.
-func startMonitoringSyncDiff(ctx context.Context, network netconf.Network, ethClients map[uint64]ethclient.Client) {
+func startMonitoringSyncDiff(
+	ctx context.Context,
+	network netconf.Network,
+	ethClients map[uint64]ethclient.Client,
+) {
 	for chainID, ethCl := range ethClients {
 		go func(chainID uint64, ethCl ethclient.Client) {
 			ticker := time.NewTicker(time.Second * 20)

--- a/relayer/app/cursors_internal_test.go
+++ b/relayer/app/cursors_internal_test.go
@@ -136,7 +136,7 @@ type mockProvider struct {
 	SubscribeFn func(ctx context.Context, chainVer xchain.ChainVersion, xBlockOffset uint64, callback cchain.ProviderCallback)
 }
 
-func (m *mockProvider) Subscribe(ctx context.Context, chainVer xchain.ChainVersion, xBlockOffset uint64,
+func (m *mockProvider) StreamAsync(ctx context.Context, chainVer xchain.ChainVersion, xBlockOffset uint64,
 	_ string, callback cchain.ProviderCallback,
 ) {
 	m.SubscribeFn(ctx, chainVer, xBlockOffset, callback)

--- a/relayer/app/worker.go
+++ b/relayer/app/worker.go
@@ -107,7 +107,7 @@ func (w *Worker) runOnce(ctx context.Context) error {
 
 		callback := w.newCallback(msgFilter, buf.AddInput, newMsgStreamMapper(w.network))
 
-		w.cProvider.Subscribe(ctx, chainVer, fromOffset, w.destChain.Name, callback)
+		w.cProvider.StreamAsync(ctx, chainVer, fromOffset, w.destChain.Name, callback)
 
 		logAttrs = append(logAttrs, w.network.ChainVersionName(chainVer), fromOffset)
 	}


### PR DESCRIPTION
Implements a periodic cprovider historical baseline tracking. Results in `monitor_cprovider_historical_baseline_seconds` histogram. 

Also refactor `cprovder` to align with `xprovider` sync vs async API. 
Improve `stream` package log labels.

issue: #1623 