### PR TITLE
ci(e2e): build and use halovisor

### DIFF
--- a/.github/workflows/clicommand.yml
+++ b/.github/workflows/clicommand.yml
@@ -58,6 +58,9 @@ jobs:
         cd dist/anvilproxy_linux_amd64_v1
         docker build -f "../../e2e/anvilproxy/Dockerfile" . -t "omniops/anvilproxy:${GITHUB_SHA::7}"
 
+    - name: Build halovisor image
+      run: scripts/halovisor/build.sh "${GITHUB_SHA::7}"
+
     - name: Install CLI from Source
       run: go install ./cli/cmd/omni
       shell: bash

--- a/.github/workflows/pr-e2etest.yml
+++ b/.github/workflows/pr-e2etest.yml
@@ -42,6 +42,9 @@ jobs:
           cd dist/anvilproxy_linux_amd64_v1
           docker build -f "../../e2e/anvilproxy/Dockerfile" . -t "omniops/anvilproxy:${GITHUB_SHA::7}"
 
+      - name: Build halovisor image
+        run: scripts/halovisor/build.sh "${GITHUB_SHA::7}"
+
       - name: Run devnet1 e2e test
         run: |
           go install github.com/omni-network/omni/e2e

--- a/.github/workflows/release-snapshot.yml
+++ b/.github/workflows/release-snapshot.yml
@@ -30,6 +30,12 @@ jobs:
         id: git_ref
         run: echo "short_sha=`echo ${GITHUB_SHA::7}`" >> "$GITHUB_OUTPUT"
 
+      - name: Build and push halovisor
+        run: |
+          scripts/halovisor/build.sh ${GITHUB_SHA::7}
+          docker push omniops/halovisor:${GITHUB_SHA::7}
+          docker push omniops/halovisor:main
+
       - name: Push Halo to Dockerhub
         run: |
           docker push omniops/halo:${GITHUB_SHA::7}

--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,7 @@ help:  ## Display this help message
 .PHONY: build-docker
 build-docker: ensure-go-releaser ## Builds the docker images.
 	@goreleaser release --snapshot --clean
+	@scripts/halovisor/build.sh
 
 .PHONY: build-halo-relayer
 build-halo-relayer: ensure-go-releaser ## Builds the halo and relayer docker images only (slightly faster than above).
@@ -15,6 +16,7 @@ build-halo-relayer: ensure-go-releaser ## Builds the halo and relayer docker ima
 	@scripts/build_docker.sh relayer
 	@scripts/build_docker.sh monitor
 	@scripts/build_docker.sh anvilproxy 'e2e' '' 'amd64'
+	@scripts/halovisor/build.sh
 
 ###############################################################################
 ###                                Contracts                                 ###

--- a/e2e/app/definition.go
+++ b/e2e/app/definition.go
@@ -225,7 +225,7 @@ func adaptNode(ctx context.Context, manifest types.Manifest, node *e2e.Node, tag
 		tag = manifest.PinnedHaloTag
 	}
 
-	node.Version = "omniops/halo:" + tag
+	node.Version = "omniops/halovisor:" + tag
 	node.PrivvalKey = valKey.PrivKey
 	node.NodeKey = nodeKey.PrivKey
 

--- a/e2e/docker/compose.yaml.tmpl
+++ b/e2e/docker/compose.yaml.tmpl
@@ -18,6 +18,7 @@ services:
       e2e: true
     container_name: {{ .Name }}
     image: {{ .Version }}
+    restart: unless-stopped
     init: true
     ports:
     - {{ if $.BindAll }}26656:{{end}}26656 # Consensus P2P
@@ -27,7 +28,8 @@ services:
 {{- end }}
     - 6060 # Pprof
     volumes:
-    - ./{{ .Name }}:/halo
+    - ./{{ .Name }}/config:/halo/config
+    - ./{{ .Name }}/data:/halo/data
     networks:
       {{ $.NetworkName }}:
         {{ if $.Network }}ipv4_address: {{ .InternalIP }}{{ end }}
@@ -63,6 +65,7 @@ services:
       e2e: true
     container_name: {{ .InstanceName }}
     image: "ethereum/client-go:{{ $.GethTag }}"
+    restart: unless-stopped
     command:
       - --config=/geth/config.toml
       # Flags not available via config.toml
@@ -95,7 +98,7 @@ services:
       e2e: true
     container_name: relayer
     image: omniops/relayer:{{or .RelayerTag "main"}}
-    restart: unless-stopped # Restart on crash to mitigate startup race issues
+    restart: unless-stopped
     ports:
       - 26660 # Prometheus and pprof
     volumes:
@@ -111,7 +114,7 @@ services:
       e2e: true
     container_name: monitor
     image: omniops/monitor:{{or .MonitorTag "main"}}
-    restart: unless-stopped # Restart on crash to mitigate startup race issues
+    restart: unless-stopped
     ports:
       - 26660 # Prometheus and pprof
     volumes:

--- a/e2e/docker/testdata/TestComposeTemplate_commit.golden
+++ b/e2e/docker/testdata/TestComposeTemplate_commit.golden
@@ -15,13 +15,15 @@ services:
       e2e: true
     container_name: node0
     image: omniops/halo:7d1ae53
+    restart: unless-stopped
     init: true
     ports:
     - 26656 # Consensus P2P
     - 8584:26657 # Consensus RPC
     - 6060 # Pprof
     volumes:
-    - ./node0:/halo
+    - ./node0/config:/halo/config
+    - ./node0/data:/halo/data
     networks:
       test:
         ipv4_address: 10.186.73.0
@@ -70,6 +72,7 @@ services:
       e2e: true
     container_name: omni_evm_0
     image: "ethereum/client-go:v1.14.7"
+    restart: unless-stopped
     command:
       - --config=/geth/config.toml
       # Flags not available via config.toml
@@ -100,7 +103,7 @@ services:
       e2e: true
     container_name: relayer
     image: omniops/relayer:v2
-    restart: unless-stopped # Restart on crash to mitigate startup race issues
+    restart: unless-stopped
     ports:
       - 26660 # Prometheus and pprof
     volumes:
@@ -114,7 +117,7 @@ services:
       e2e: true
     container_name: monitor
     image: omniops/monitor:v3
-    restart: unless-stopped # Restart on crash to mitigate startup race issues
+    restart: unless-stopped
     ports:
       - 26660 # Prometheus and pprof
     volumes:

--- a/e2e/docker/testdata/TestComposeTemplate_empheral_network.golden
+++ b/e2e/docker/testdata/TestComposeTemplate_empheral_network.golden
@@ -15,13 +15,15 @@ services:
       e2e: true
     container_name: node0
     image: omniops/halo:main
+    restart: unless-stopped
     init: true
     ports:
     - 26656 # Consensus P2P
     - 8584:26657 # Consensus RPC
     - 6060 # Pprof
     volumes:
-    - ./node0:/halo
+    - ./node0/config:/halo/config
+    - ./node0/data:/halo/data
     networks:
       test:
         ipv4_address: 10.186.73.0
@@ -70,6 +72,7 @@ services:
       e2e: true
     container_name: omni_evm_0
     image: "ethereum/client-go:v1.14.7"
+    restart: unless-stopped
     command:
       - --config=/geth/config.toml
       # Flags not available via config.toml
@@ -100,7 +103,7 @@ services:
       e2e: true
     container_name: relayer
     image: omniops/relayer:v2
-    restart: unless-stopped # Restart on crash to mitigate startup race issues
+    restart: unless-stopped
     ports:
       - 26660 # Prometheus and pprof
     volumes:
@@ -114,7 +117,7 @@ services:
       e2e: true
     container_name: monitor
     image: omniops/monitor:v3
-    restart: unless-stopped # Restart on crash to mitigate startup race issues
+    restart: unless-stopped
     ports:
       - 26660 # Prometheus and pprof
     volumes:

--- a/e2e/vmcompose/testdata/TestSetup_127-0-0-1-compose.yaml.golden
+++ b/e2e/vmcompose/testdata/TestSetup_127-0-0-1-compose.yaml.golden
@@ -10,14 +10,16 @@ services:
     labels:
       e2e: true
     container_name: validator01
-    image: omniops/halo:7d1ae53
+    image: omniops/halovisor:7d1ae53
+    restart: unless-stopped
     init: true
     ports:
     - 26656:26656 # Consensus P2P
     - 26657:26657 # Consensus RPC
     - 6060 # Pprof
     volumes:
-    - ./validator01:/halo
+    - ./validator01/config:/halo/config
+    - ./validator01/data:/halo/data
     networks:
       test:
         
@@ -29,6 +31,7 @@ services:
       e2e: true
     container_name: validator01_evm
     image: "ethereum/client-go:v1.14.7"
+    restart: unless-stopped
     command:
       - --config=/geth/config.toml
       # Flags not available via config.toml

--- a/e2e/vmcompose/testdata/TestSetup_127-0-0-2-compose.yaml.golden
+++ b/e2e/vmcompose/testdata/TestSetup_127-0-0-2-compose.yaml.golden
@@ -10,14 +10,16 @@ services:
     labels:
       e2e: true
     container_name: validator02
-    image: omniops/halo:7d1ae53
+    image: omniops/halovisor:7d1ae53
+    restart: unless-stopped
     init: true
     ports:
     - 26656:26656 # Consensus P2P
     - 26657:26657 # Consensus RPC
     - 6060 # Pprof
     volumes:
-    - ./validator02:/halo
+    - ./validator02/config:/halo/config
+    - ./validator02/data:/halo/data
     networks:
       test:
         
@@ -29,6 +31,7 @@ services:
       e2e: true
     container_name: validator02_evm
     image: "ethereum/client-go:v1.14.7"
+    restart: unless-stopped
     command:
       - --config=/geth/config.toml
       # Flags not available via config.toml

--- a/e2e/vmcompose/testdata/TestSetup_127-0-0-3-compose.yaml.golden
+++ b/e2e/vmcompose/testdata/TestSetup_127-0-0-3-compose.yaml.golden
@@ -33,7 +33,7 @@ services:
       e2e: true
     container_name: relayer
     image: omniops/relayer:7d1ae53
-    restart: unless-stopped # Restart on crash to mitigate startup race issues
+    restart: unless-stopped
     ports:
       - 26660 # Prometheus and pprof
     volumes:

--- a/e2e/vmcompose/testdata/TestSetup_127-0-0-4-compose.yaml.golden
+++ b/e2e/vmcompose/testdata/TestSetup_127-0-0-4-compose.yaml.golden
@@ -10,14 +10,16 @@ services:
     labels:
       e2e: true
     container_name: seed01
-    image: omniops/halo:7d1ae53
+    image: omniops/halovisor:7d1ae53
+    restart: unless-stopped
     init: true
     ports:
     - 26656:26656 # Consensus P2P
     - 26657:26657 # Consensus RPC
     - 6060 # Pprof
     volumes:
-    - ./seed01:/halo
+    - ./seed01/config:/halo/config
+    - ./seed01/data:/halo/data
     networks:
       test:
         
@@ -29,6 +31,7 @@ services:
       e2e: true
     container_name: seed01_evm
     image: "ethereum/client-go:v1.14.7"
+    restart: unless-stopped
     command:
       - --config=/geth/config.toml
       # Flags not available via config.toml

--- a/e2e/vmcompose/testdata/TestSetup_127-0-0-5-compose.yaml.golden
+++ b/e2e/vmcompose/testdata/TestSetup_127-0-0-5-compose.yaml.golden
@@ -10,14 +10,16 @@ services:
     labels:
       e2e: true
     container_name: fullnode01
-    image: omniops/halo:7d1ae53
+    image: omniops/halovisor:7d1ae53
+    restart: unless-stopped
     init: true
     ports:
     - 26656:26656 # Consensus P2P
     - 26657:26657 # Consensus RPC
     - 6060 # Pprof
     volumes:
-    - ./fullnode01:/halo
+    - ./fullnode01/config:/halo/config
+    - ./fullnode01/data:/halo/data
     networks:
       test:
         
@@ -29,6 +31,7 @@ services:
       e2e: true
     container_name: fullnode01_evm
     image: "ethereum/client-go:v1.14.7"
+    restart: unless-stopped
     command:
       - --config=/geth/config.toml
       # Flags not available via config.toml

--- a/scripts/halovisor/Dockerfile
+++ b/scripts/halovisor/Dockerfile
@@ -1,0 +1,40 @@
+# Docker build args
+# TODO: Pin halo genesis to public omega release
+ARG HALO_VERSION_GENESIS=main
+
+# Build stages
+FROM golang:alpine AS build-cosmovisor
+ENV COSMOVISOR_VERSION=v1.5.0
+RUN go install cosmossdk.io/tools/cosmovisor/cmd/cosmovisor@${COSMOVISOR_VERSION}
+
+FROM omniops/halo:${HALO_VERSION_GENESIS} AS build-genesis
+
+# TODO: Add post-genesis network-upgrade versions here.
+
+# Runtime stage
+FROM scratch AS runtime
+
+# Install ca-certificates (for https to rollups)
+COPY --from=alpine:latest /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
+
+# Create /tmp directory (default cometBFT --temp-dir)
+COPY --from=alpine:latest /tmp /tmp
+
+# Cosmovisor environment variables
+ENV DAEMON_HOME=/halo
+ENV DAEMON_NAME=halo
+ENV DAEMON_ALLOW_DOWNLOAD_BINARIES=false
+ENV DAEMON_RESTART_AFTER_UPGRADE=true
+
+# Define mounted volumes
+VOLUME /halo/config
+VOLUME /halo/data
+
+# Copy binaries from build stages.
+COPY --from=build-cosmovisor /go/bin/cosmovisor /usr/local/bin/cosmovisor
+COPY --from=build-genesis /app $DAEMON_HOME/cosmovisor/genesis/bin/halo
+
+# Cosmovisor is the entrypoint
+ENTRYPOINT [ "cosmovisor" ]
+# First 'run' is cosmovisor command, second 'run' is halo command.
+CMD [ "run", "run" ]

--- a/scripts/halovisor/build.sh
+++ b/scripts/halovisor/build.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+
+# ./build.sh <halo_genesis_version>
+# This scripts builds the halovisor docker image
+# Halovisor wraps cosmovisor and multiple halo versions into a single docker image.
+# It allows for docker based deployments that support halo network upgrades.
+
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+
+HALO_GENESIS_VERSION="${1}"
+if [ -z "$HALO_GENESIS_VERSION" ]; then
+  HALO_GENESIS_VERSION=$(git rev-parse --short=7 HEAD)
+  echo "Using head as HALO_GENESIS_VERSION: ${HALO_GENESIS_VERSION}"
+fi
+
+IMAGEREF="omniops/halovisor:${HALO_GENESIS_VERSION}"
+IMAGEMAIN="omniops/halovisor:main"
+
+docker build \
+  --build-arg HALO_GENESIS_VERSION="${HALO_GENESIS_VERSION}" \
+  -t "${IMAGEREF}" \
+  -t "${IMAGEMAIN}" \
+  "${SCRIPT_DIR}"
+
+echo "Built docker image: ${IMAGEREF}"
+echo "Built docker image: ${IMAGEMAIN}"
+
+# TODOs:
+# - Add support for multiple halo versions/upgrades
+# - Add support for official releases
+# - Support multiple architectures


### PR DESCRIPTION
Introduce the `halovisor` docker image:
 - It is a drop-in replacement for `halo` image.
 - It wraps cosmovisor and the all halo versions from genesis to latest.
 - The aim is to support default cosmosSDK-cosmovisor-based network upgrades from within docker. 
 
 Inspired by [this](https://tutorials.cosmos.network/hands-on-exercise/4-run-in-prod/5-migration-prod.html) blog

issue: none