### PR TITLE
chore(e2e/manifests): removes slow l1 on staging and introduces holesky

### DIFF
--- a/e2e/app/testdata/TestManifestServiceReference.golden
+++ b/e2e/app/testdata/TestManifestServiceReference.golden
@@ -36,7 +36,6 @@
   "relayer",
   "seed01",
   "seed01_evm",
-  "slow_l1",
   "validator01",
   "validator01_evm",
   "validator02",

--- a/e2e/manifests/staging.toml
+++ b/e2e/manifests/staging.toml
@@ -1,6 +1,5 @@
 network = "staging"
-public_chains = ["op_sepolia","base_sepolia","arb_sepolia"]
-anvil_chains = ["slow_l1"]
+public_chains = ["op_sepolia","base_sepolia","arb_sepolia","holesky"]
 multi_omni_evms = true
 prometheus = true
 


### PR DESCRIPTION
Changes staging manifest to remove Slow L1 and adds Holesky to the public chains

Incorrect link below. Issue is the same number, but in the ops repo.

issue: #348
