### PR TITLE
chore(cli): allow easy metrics

### DIFF
--- a/cli/cmd/compose.yml.tpl
+++ b/cli/cmd/compose.yml.tpl
@@ -19,9 +19,11 @@ services:
     command:
       - --config=/geth/config.toml
       # Flags not available via config.toml
-      #- --nat=extip:<my-external-ip>
-      #- --metrics
-      #- --verbosity=4 # Log level (4=debug)
+      #- --nat=extip:<my-external-ip> # External IP for P2P via NAT
+      #- --metrics                    # Enable prometheus metrics
+      #- --pprof                      # Enable prometheus metrics
+      #- --pprof.addr=0.0.0.0         # Enable prometheus metrics
+      #- --verbosity=4                # Log level (4=debug)
     ports:
       - 8551         # Auth-RPC (used by halo)
       - 8545:8545    # JSON-RCP

--- a/cli/cmd/operator.go
+++ b/cli/cmd/operator.go
@@ -123,6 +123,10 @@ func initNodes(ctx context.Context, cfg initConfig) error {
 		},
 		CometCfgFunc: func(cfg *cmtconfig.Config) {
 			cfg.LogLevel = "info"
+			cfg.Instrumentation.Prometheus = true
+		},
+		LogCfgFunc: func(cfg *log.Config) {
+			cfg.Color = log.ColorForce
 		},
 	})
 	if err != nil {

--- a/halo/cmd/init.go
+++ b/halo/cmd/init.go
@@ -38,6 +38,7 @@ type InitConfig struct {
 	Network       netconf.ID
 	TrustedSync   bool
 	AddrBook      bool
+	LogCfgFunc    func(*log.Config)
 	HaloCfgFunc   func(*halocfg.Config)
 	CometCfgFunc  func(*cmtconfig.Config)
 	Force         bool
@@ -59,6 +60,15 @@ func (c InitConfig) CometCfg(cfg *cmtconfig.Config) {
 	if c.CometCfgFunc != nil {
 		c.CometCfgFunc(cfg)
 	}
+}
+
+func (c InitConfig) LogCfg() log.Config {
+	cfg := log.DefaultConfig()
+	if c.LogCfgFunc != nil {
+		c.LogCfgFunc(&cfg)
+	}
+
+	return cfg
 }
 
 // newInitCmd returns a new cobra command that initializes the files and folders required by halo.
@@ -253,7 +263,7 @@ func InitFiles(ctx context.Context, initCfg InitConfig) error {
 	haloConfigFile := cfg.ConfigFile()
 	if cmtos.FileExists(haloConfigFile) {
 		log.Info(ctx, "Found halo config file", "path", haloConfigFile)
-	} else if err := halocfg.WriteConfigTOML(cfg, log.DefaultConfig()); err != nil {
+	} else if err := halocfg.WriteConfigTOML(cfg, initCfg.LogCfg()); err != nil {
 		return err
 	} else {
 		log.Info(ctx, "Generated default halo config file", "path", haloConfigFile)


### PR DESCRIPTION
For `locally joined` omni full nodes, allow enabling metrics of geth/halo by binding ports only.

Enable colorized halo logs by default.

issue: none