### PR TITLE
chore(halo): fix plan upgrade authority

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -143,6 +143,7 @@ linters:
     - gofumpt              # Not compatible with gci, see https://github.com/golangci/golangci-lint/issues/1490.
     - gomnd                # Too many false positives
     - gomoddirectives      # We have a replace directive
+    - interfacebloat       # This isn't a big problem
     - intrange             # Intrange just result in other lint warns in many cases.
     - ireturn              # Too many false positives
     - mnd                  # Too many false positives

--- a/halo/app/app.go
+++ b/halo/app/app.go
@@ -84,6 +84,7 @@ func newApp(
 	chainVerNamer atypes.ChainVerNameFunc,
 	chainNamer rtypes.ChainNameFunc,
 	feeRecProvider etypes.FeeRecipientProvider,
+	appOpts servertypes.AppOptions,
 	baseAppOpts ...func(*baseapp.BaseApp),
 ) (*App, error) {
 	depCfg := depinject.Configs(
@@ -95,6 +96,7 @@ func newApp(
 			chainNamer,
 			voter,
 			feeRecProvider,
+			appOpts,
 		),
 	)
 

--- a/halo/app/app_config.go
+++ b/halo/app/app_config.go
@@ -4,6 +4,7 @@ import (
 	attestmodule "github.com/omni-network/omni/halo/attest/module"
 	attesttypes "github.com/omni-network/omni/halo/attest/types"
 	"github.com/omni-network/omni/halo/evmstaking"
+	"github.com/omni-network/omni/halo/evmupgrade"
 	portalmodule "github.com/omni-network/omni/halo/portal/module"
 	portaltypes "github.com/omni-network/omni/halo/portal/types"
 	registrymodule "github.com/omni-network/omni/halo/registry/module"
@@ -185,8 +186,10 @@ var (
 				Config: appconfig.WrapAny(&evidencemodulev1.Module{}),
 			},
 			{
-				Name:   upgradetypes.ModuleName,
-				Config: appconfig.WrapAny(&upgrademodulev1.Module{}),
+				Name: upgradetypes.ModuleName,
+				Config: appconfig.WrapAny(&upgrademodulev1.Module{
+					Authority: evmupgrade.ModuleName,
+				}),
 			},
 			{
 				Name:   engevmtypes.ModuleName,

--- a/halo/app/pruning_test.go
+++ b/halo/app/pruning_test.go
@@ -29,9 +29,10 @@ func TestPruningHistory(t *testing.T) {
 
 	cfg := setupSimnet(t)
 
-	// Prune everything > 3 blocks old
+	// Prune everything > 2 blocks old (every interval=10 blocks)
 	cfg.PruningOption = pruningtypes.PruningOptionEverything
-	cfg.MinRetainBlocks = 3
+	cfg.MinRetainBlocks = 2
+	// Note the pruneInterval is 10, so we only prune at height 20
 
 	// Start the server async
 	async, stopfunc, err := haloapp.Start(ctx, cfg)
@@ -104,8 +105,9 @@ func TestPruningHistory(t *testing.T) {
 		return true
 	}, time.Minute, time.Millisecond*300)
 
+	const pruneInterval = uint64(10)
 	minPrunedHeight := eligibleHeight + cfg.MinRetainBlocks
-	maxPrunedHeight := eligibleHeight + (2 * cfg.MinRetainBlocks) // Allow some wiggle room
+	maxPrunedHeight := eligibleHeight/pruneInterval + (2 * pruneInterval) // Allow pruning up to the next interval
 	t.Logf("prunedHeight=%d, createdHeight=%d, minRetainBlocks=%d", prunedHeight, eligibleHeight, cfg.MinRetainBlocks)
 
 	require.GreaterOrEqual(t, prunedHeight, minPrunedHeight, "prunedHeight=%d too low (eligibleHeight=%d)", prunedHeight, eligibleHeight)

--- a/halo/app/rollback.go
+++ b/halo/app/rollback.go
@@ -60,6 +60,7 @@ func Rollback(ctx context.Context, cfg Config, rCfg RollbackConfig) error {
 		netconf.ChainVersionNamer(cfg.Network),
 		netconf.ChainNamer(cfg.Network),
 		burnEVMFees{},
+		serverAppOptsFromCfg(cfg),
 		baseAppOpts...,
 	)
 	if err != nil {

--- a/halo/app/start.go
+++ b/halo/app/start.go
@@ -34,7 +34,9 @@ import (
 	storetypes "cosmossdk.io/store/types"
 	dbm "github.com/cosmos/cosmos-db"
 	"github.com/cosmos/cosmos-sdk/baseapp"
-	"github.com/cosmos/cosmos-sdk/server"
+	sdkflags "github.com/cosmos/cosmos-sdk/client/flags"
+	sdkserver "github.com/cosmos/cosmos-sdk/server"
+	sdkservertypes "github.com/cosmos/cosmos-sdk/server/types"
 	sdktelemetry "github.com/cosmos/cosmos-sdk/telemetry"
 	"github.com/cosmos/cosmos-sdk/types/mempool"
 	grpc1 "github.com/cosmos/gogoproto/grpc"
@@ -136,6 +138,7 @@ func Start(ctx context.Context, cfg Config) (<-chan error, func(context.Context)
 		netconf.ChainVersionNamer(cfg.Network),
 		netconf.ChainNamer(cfg.Network),
 		burnEVMFees{},
+		serverAppOptsFromCfg(cfg),
 		baseAppOpts...,
 	)
 	if err != nil {
@@ -220,7 +223,7 @@ func newCometNode(ctx context.Context, cfg *cmtcfg.Config, app *App, privVal cmt
 	}
 
 	wrapper := newABCIWrapper(
-		server.NewCometABCIWrapper(app),
+		sdkserver.NewCometABCIWrapper(app),
 		app.EVMEngKeeper.PostFinalize,
 		func() storetypes.CacheMultiStore {
 			return app.CommitMultiStore().CacheMultiStore()
@@ -300,8 +303,9 @@ func chainIDFromGenesis(cfg Config) (string, error) {
 func newEngineClient(ctx context.Context, cfg Config, network netconf.ID, pubkey crypto.PubKey) (ethclient.EngineClient, error) {
 	if network == netconf.Simnet {
 		return ethclient.NewEngineMock(
-			ethclient.WithMockSelfDelegation(pubkey, 1),
 			ethclient.WithPortalRegister(netconf.SimnetNetwork()),
+			ethclient.WithFarFutureUpgradePlan(),
+			ethclient.WithMockSelfDelegation(pubkey, 1),
 		)
 	}
 
@@ -385,4 +389,22 @@ func registerGenesisServer(ctx context.Context, s grpc1.Server, cfg Config) erro
 	genserve.Register(s, execution, consensus)
 
 	return nil
+}
+
+var _ sdkservertypes.AppOptions = serverAppOpts{}
+
+// serverAppOpts implements the cosmos-sdk server app options interface.
+type serverAppOpts map[string]any
+
+func (o serverAppOpts) Get(key string) any {
+	return o[key]
+}
+
+// serverAppOptsFromCfg returns the cosmos-sdk server app options from the given config.
+// This is required by the upgrade module.
+func serverAppOptsFromCfg(cfg Config) serverAppOpts {
+	return serverAppOpts{
+		sdkflags.FlagHome:                cfg.HomeDir,
+		sdkserver.FlagUnsafeSkipUpgrades: cfg.UnsafeSkipUpgrades,
+	}
 }

--- a/halo/app/start_test.go
+++ b/halo/app/start_test.go
@@ -72,7 +72,7 @@ func TestSmoke(t *testing.T) {
 		setHash := types.NewValidatorSet(set.Validators).Hash()
 
 		return !bytes.Equal(getSetHash, setHash)
-	}, time.Second*time.Duration(target*2), time.Millisecond*100)
+	}, time.Second*time.Duration(target*4), time.Millisecond*100)
 
 	srcChain := netconf.Simnet.Static().OmniExecutionChainID
 	chainVer := xchain.ChainVersion{ID: srcChain, ConfLevel: xchain.ConfFinalized}
@@ -131,6 +131,13 @@ func testCProvider(t *testing.T, ctx context.Context, cprov cprovider.Provider) 
 	require.NoError(t, err)
 	require.Nil(t, exec)
 	require.NotNil(t, cons)
+
+	require.Eventually(t, func() bool {
+		_, ok, err := cprov.CurrentUpgradePlan(ctx)
+		require.NoError(t, err)
+
+		return ok
+	}, time.Second*5, time.Millisecond*100)
 }
 
 func setupSimnet(t *testing.T) haloapp.Config {
@@ -150,7 +157,7 @@ func setupSimnet(t *testing.T) haloapp.Config {
 	haloCfg.EVMBuildDelay = time.Millisecond
 	haloCfg.EngineEndpoint = "dummy"
 	haloCfg.EngineJWTFile = "dummy"
-	haloCfg.RPCEndpoints = map[string]string{"dummy": "dummy"}
+	haloCfg.RPCEndpoints = map[string]string{"omni_evm": "dummy"}
 
 	cfg := haloapp.Config{
 		Config: haloCfg,

--- a/halo/attest/module/module.go
+++ b/halo/attest/module/module.go
@@ -18,6 +18,8 @@ import (
 	"github.com/grpc-ecosystem/grpc-gateway/runtime"
 )
 
+const ConsensusVersion = 1
+
 var (
 	_ module.AppModuleBasic     = (*AppModule)(nil)
 	_ appmodule.AppModule       = (*AppModule)(nil)
@@ -42,6 +44,10 @@ func NewAppModuleBasic(cdc codec.BinaryCodec) AppModuleBasic {
 // Name returns the name of the module as a string.
 func (AppModuleBasic) Name() string {
 	return types.ModuleName
+}
+
+func (AppModuleBasic) ConsensusVersion() uint64 {
+	return ConsensusVersion
 }
 
 // RegisterLegacyAminoCodec registers the amino codec for the module, which is used

--- a/halo/cmd/flags.go
+++ b/halo/cmd/flags.go
@@ -8,6 +8,7 @@ import (
 	"github.com/omni-network/omni/lib/tracer"
 	"github.com/omni-network/omni/lib/xchain"
 
+	sdkserver "github.com/cosmos/cosmos-sdk/server"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 )
@@ -28,6 +29,7 @@ func bindRunFlags(cmd *cobra.Command, cfg *halocfg.Config) {
 	flags.StringVar(&cfg.PruningOption, "pruning", cfg.PruningOption, "Pruning strategy (default|nothing|everything)")
 	flags.DurationVar(&cfg.EVMBuildDelay, "evm-build-delay", cfg.EVMBuildDelay, "Minimum delay between triggering and fetching a EVM payload build")
 	flags.BoolVar(&cfg.EVMBuildOptimistic, "evm-build-optimistic", cfg.EVMBuildOptimistic, "Enables optimistic building of EVM payloads on previous block finalize")
+	flags.IntSliceVar(&cfg.UnsafeSkipUpgrades, sdkserver.FlagUnsafeSkipUpgrades, cfg.UnsafeSkipUpgrades, "Skip a set of upgrade heights to continue the old binary")
 }
 
 func bindRollbackFlags(flags *pflag.FlagSet, cfg *app.RollbackConfig) {

--- a/halo/cmd/testdata/TestCLIReference_rollback.golden
+++ b/halo/cmd/testdata/TestCLIReference_rollback.golden
@@ -29,4 +29,5 @@ Flags:
       --snapshot-keep-recent uint                 State sync snapshot to keep (default 2)
       --tracing-endpoint string                   Tracing OTLP endpoint
       --tracing-headers string                    Tracing OTLP headers
+      --unsafe-skip-upgrades ints                 Skip a set of upgrade heights to continue the old binary
       --xchain-evm-rpc-endpoints stringToString   Cross-chain EVM RPC endpoints. e.g. "ethereum=http://geth:8545,optimism=https://optimism.io" (default [])

--- a/halo/cmd/testdata/TestCLIReference_run.golden
+++ b/halo/cmd/testdata/TestCLIReference_run.golden
@@ -21,4 +21,5 @@ Flags:
       --snapshot-keep-recent uint                 State sync snapshot to keep (default 2)
       --tracing-endpoint string                   Tracing OTLP endpoint
       --tracing-headers string                    Tracing OTLP headers
+      --unsafe-skip-upgrades ints                 Skip a set of upgrade heights to continue the old binary
       --xchain-evm-rpc-endpoints stringToString   Cross-chain EVM RPC endpoints. e.g. "ethereum=http://geth:8545,optimism=https://optimism.io" (default [])

--- a/halo/cmd/testdata/TestRunCmd_defaults.golden
+++ b/halo/cmd/testdata/TestRunCmd_defaults.golden
@@ -15,6 +15,7 @@
   "Endpoint": "",
   "Headers": ""
  },
+ "UnsafeSkipUpgrades": null,
  "Comet": {
   "Version": "0.38.10",
   "RootDir": "./halo",

--- a/halo/cmd/testdata/TestRunCmd_flags.golden
+++ b/halo/cmd/testdata/TestRunCmd_flags.golden
@@ -15,6 +15,7 @@
   "Endpoint": "",
   "Headers": ""
  },
+ "UnsafeSkipUpgrades": null,
  "Comet": {
   "Version": "0.38.10",
   "RootDir": "foo",

--- a/halo/cmd/testdata/TestRunCmd_json_files.golden
+++ b/halo/cmd/testdata/TestRunCmd_json_files.golden
@@ -15,6 +15,7 @@
   "Endpoint": "",
   "Headers": ""
  },
+ "UnsafeSkipUpgrades": null,
  "Comet": {
   "Version": "0.38.10",
   "RootDir": "testinput/input2",

--- a/halo/cmd/testdata/TestRunCmd_toml_files.golden
+++ b/halo/cmd/testdata/TestRunCmd_toml_files.golden
@@ -18,6 +18,7 @@
   "Endpoint": "http://tracing.com",
   "Headers": "Authorization=Basic 123456"
  },
+ "UnsafeSkipUpgrades": null,
  "Comet": {
   "Version": "0.38.10",
   "RootDir": "testinput/input1",

--- a/halo/config/config.toml.tmpl
+++ b/halo/config/config.toml.tmpl
@@ -9,7 +9,7 @@ version = "{{ .Version }}"
 network = "{{ .Network }}"
 
 #######################################################################
-###                          Halo Options                           ###
+###                       Halo Octane Options                       ###
 #######################################################################
 
 # Omni execution client Engine API http endpoint.
@@ -17,6 +17,20 @@ engine-endpoint = "{{ .EngineEndpoint }}"
 
 # Omni execution client JWT file used for authentication.
 engine-jwt-file = "{{ .EngineJWTFile }}"
+
+# EVMBuildDelay defines the minimum delay between triggering a EVM payload build and fetching the result.
+# This is a tradeoff between "high value blocks" and "fast consensus".
+# It should be slightly higher than geth's --miner.recommit value.
+evm-build-delay = "{{.EVMBuildDelay}}"
+
+# EVMBuildOptimistic defines whether to trigger optimistic EVM payload building.
+# If true, the EVM payload will be triggered on previous finalisation. This allows
+# more time for block building while ensuring faster consensus blocks.
+evm-build-optimistic = {{.EVMBuildOptimistic}}
+
+#######################################################################
+###                          Cosmos SDK                             ###
+#######################################################################
 
 # SnapshotInterval specifies the height interval at which halo
 # will take state sync snapshots. Defaults to 1000 (roughly once an hour), setting this to
@@ -42,9 +56,9 @@ snapshot-keep-recent = {{ .SnapshotKeepRecent }}
 # ResponseCommit.RetainHeight.
 min-retain-blocks = {{ .MinRetainBlocks }}
 
-# default: the last 362880 states are kept, pruning at 10 block intervals
-# nothing: all historic states will be saved, nothing will be deleted (i.e. archiving node)
+# default: 'default' is the same as 'everything'; reducing disk usage for normal full nodes.
 # everything: 2 latest states will be kept; pruning at 10 block intervals.
+# nothing: all historic states will be saved, nothing will be deleted (i.e. archiving node)
 pruning = "{{ .PruningOption }}"
 
 # AppDBBackend defines the database backend type to use for the application and snapshots DBs.
@@ -52,15 +66,8 @@ pruning = "{{ .PruningOption }}"
 # The fallback is the db_backend value set in CometBFT's config.toml.
 app-db-backend = "{{ .BackendType }}"
 
-# EVMBuildDelay defines the minimum delay between triggering a EVM payload build and fetching the result.
-# This is a tradeoff between "high value blocks" and "fast consensus".
-# It should be slightly higher than geth's --miner.recommit value.
-evm-build-delay = "{{.EVMBuildDelay}}"
-
-# EVMBuildOptimistic defines whether to trigger optimistic EVM payload building.
-# If true, the EVM payload will be triggered on previous finalisation. This allows
-# more time for block building while ensuring faster consensus blocks.
-evm-build-optimistic = {{.EVMBuildOptimistic}}
+# Skip a set of upgrade heights to continue the old binary
+unsafe-skip-upgrades = {{ FmtIntSlice .UnsafeSkipUpgrades }}
 
 #######################################################################
 ###                             X-Chain                             ###

--- a/halo/config/config_test.go
+++ b/halo/config/config_test.go
@@ -23,6 +23,7 @@ func TestDefaultConfigReference(t *testing.T) {
 	cfg.RPCEndpoints = map[string]string{
 		"ethereum": "http://127.0.0.1:8545",
 	}
+	cfg.UnsafeSkipUpgrades = []int{1, 2, 3}
 
 	require.NoError(t, os.MkdirAll(filepath.Join(tempDir, "config"), 0o755))
 	require.NoError(t, halocfg.WriteConfigTOML(cfg, log.DefaultConfig()))

--- a/halo/config/testdata/default_halo.toml
+++ b/halo/config/testdata/default_halo.toml
@@ -9,7 +9,7 @@ version = "v0.1.10"
 network = ""
 
 #######################################################################
-###                          Halo Options                           ###
+###                       Halo Octane Options                       ###
 #######################################################################
 
 # Omni execution client Engine API http endpoint.
@@ -17,6 +17,20 @@ engine-endpoint = ""
 
 # Omni execution client JWT file used for authentication.
 engine-jwt-file = ""
+
+# EVMBuildDelay defines the minimum delay between triggering a EVM payload build and fetching the result.
+# This is a tradeoff between "high value blocks" and "fast consensus".
+# It should be slightly higher than geth's --miner.recommit value.
+evm-build-delay = "600ms"
+
+# EVMBuildOptimistic defines whether to trigger optimistic EVM payload building.
+# If true, the EVM payload will be triggered on previous finalisation. This allows
+# more time for block building while ensuring faster consensus blocks.
+evm-build-optimistic = true
+
+#######################################################################
+###                          Cosmos SDK                             ###
+#######################################################################
 
 # SnapshotInterval specifies the height interval at which halo
 # will take state sync snapshots. Defaults to 1000 (roughly once an hour), setting this to
@@ -42,9 +56,9 @@ snapshot-keep-recent = 2
 # ResponseCommit.RetainHeight.
 min-retain-blocks = 1
 
-# default: the last 362880 states are kept, pruning at 10 block intervals
-# nothing: all historic states will be saved, nothing will be deleted (i.e. archiving node)
+# default: 'default' is the same as 'everything'; reducing disk usage for normal full nodes.
 # everything: 2 latest states will be kept; pruning at 10 block intervals.
+# nothing: all historic states will be saved, nothing will be deleted (i.e. archiving node)
 pruning = "default"
 
 # AppDBBackend defines the database backend type to use for the application and snapshots DBs.
@@ -52,15 +66,8 @@ pruning = "default"
 # The fallback is the db_backend value set in CometBFT's config.toml.
 app-db-backend = "goleveldb"
 
-# EVMBuildDelay defines the minimum delay between triggering a EVM payload build and fetching the result.
-# This is a tradeoff between "high value blocks" and "fast consensus".
-# It should be slightly higher than geth's --miner.recommit value.
-evm-build-delay = "600ms"
-
-# EVMBuildOptimistic defines whether to trigger optimistic EVM payload building.
-# If true, the EVM payload will be triggered on previous finalisation. This allows
-# more time for block building while ensuring faster consensus blocks.
-evm-build-optimistic = true
+# Skip a set of upgrade heights to continue the old binary
+unsafe-skip-upgrades = [1,2,3]
 
 #######################################################################
 ###                             X-Chain                             ###

--- a/halo/evmupgrade/evmupgrade.go
+++ b/halo/evmupgrade/evmupgrade.go
@@ -19,6 +19,7 @@ import (
 
 	ukeeper "cosmossdk.io/x/upgrade/keeper"
 	utypes "cosmossdk.io/x/upgrade/types"
+	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 )
 
 const ModuleName = "evmupgrade"
@@ -120,7 +121,11 @@ func (p EventProcessor) Deliver(ctx context.Context, _ common.Hash, elog *evmeng
 func (p EventProcessor) deliverCancelUpgrade(ctx context.Context, _ *bindings.UpgradeCancelUpgrade) error {
 	log.Info(ctx, "EVM cancel upgrade detected")
 
-	_, err := ukeeper.NewMsgServerImpl(p.uKeeper).CancelUpgrade(ctx, &utypes.MsgCancelUpgrade{})
+	msg := utypes.MsgCancelUpgrade{
+		Authority: authtypes.NewModuleAddress(ModuleName).String(),
+	}
+
+	_, err := ukeeper.NewMsgServerImpl(p.uKeeper).CancelUpgrade(ctx, &msg)
 	if err != nil {
 		return errors.Wrap(err, "cancel software upgrade")
 	}
@@ -138,6 +143,7 @@ func (p EventProcessor) deliverPlanUpgrade(ctx context.Context, plan *bindings.U
 	}
 
 	msg := utypes.MsgSoftwareUpgrade{
+		Authority: authtypes.NewModuleAddress(ModuleName).String(),
 		Plan: utypes.Plan{
 			Name:   plan.Name,
 			Height: height,

--- a/halo/genutil/genutil.go
+++ b/halo/genutil/genutil.go
@@ -21,6 +21,7 @@ import (
 	"cosmossdk.io/math"
 	etypes "cosmossdk.io/x/evidence/types"
 	"cosmossdk.io/x/tx/signing"
+	utypes "cosmossdk.io/x/upgrade/types"
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/codec"
 	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
@@ -247,7 +248,9 @@ func defaultAppState(
 		dtypes.ModuleName:   marshal(dtypes.DefaultGenesisState()),
 		etypes.ModuleName:   marshal(etypes.DefaultGenesisState()),
 		vtypes.ModuleName:   marshal(vtypes.DefaultGenesisState()),
+		gtypes.ModuleName:   marshal(gtypes.DefaultGenesisState()),
 		evmtypes.ModuleName: marshal(evmengGenesis),
+		utypes.ModuleName:   []byte("{}"), // See cosmossdk.io/x/upgrade@v0.1.4/module.go#DefaultGenesis
 	}
 }
 

--- a/halo/genutil/testdata/TestMakeGenesis.golden
+++ b/halo/genutil/testdata/TestMakeGenesis.golden
@@ -216,6 +216,7 @@
    "redelegations": [],
    "exported": false
   },
+  "upgrade": {},
   "valsync": {}
  },
  "consensus": {

--- a/halo/portal/module/module.go
+++ b/halo/portal/module/module.go
@@ -14,6 +14,8 @@ import (
 	"github.com/grpc-ecosystem/grpc-gateway/runtime"
 )
 
+const ConsensusVersion = 1
+
 var (
 	_ module.AppModuleBasic = (*AppModule)(nil)
 	_ appmodule.AppModule   = (*AppModule)(nil)
@@ -36,6 +38,10 @@ func NewAppModuleBasic(cdc codec.BinaryCodec) AppModuleBasic {
 // Name returns the name of the module as a string.
 func (AppModuleBasic) Name() string {
 	return types.ModuleName
+}
+
+func (AppModuleBasic) ConsensusVersion() uint64 {
+	return ConsensusVersion
 }
 
 // RegisterLegacyAminoCodec registers the amino codec for the module, which is used

--- a/halo/registry/module/module.go
+++ b/halo/registry/module/module.go
@@ -16,6 +16,8 @@ import (
 	"github.com/grpc-ecosystem/grpc-gateway/runtime"
 )
 
+const ConsensusVersion = 1
+
 var (
 	_ module.AppModuleBasic = (*AppModule)(nil)
 	_ appmodule.AppModule   = (*AppModule)(nil)
@@ -38,6 +40,10 @@ func NewAppModuleBasic(cdc codec.BinaryCodec) AppModuleBasic {
 // Name returns the name of the module as a string.
 func (AppModuleBasic) Name() string {
 	return types.ModuleName
+}
+
+func (AppModuleBasic) ConsensusVersion() uint64 {
+	return ConsensusVersion
 }
 
 // RegisterLegacyAminoCodec registers the amino codec for the module, which is used

--- a/halo/valsync/module/module.go
+++ b/halo/valsync/module/module.go
@@ -24,6 +24,10 @@ import (
 	"github.com/grpc-ecosystem/grpc-gateway/runtime"
 )
 
+const (
+	ConsensusVersion = 1
+)
+
 var (
 	_ module.AppModuleBasic  = (*AppModule)(nil)
 	_ module.HasGenesis      = (*AppModule)(nil)
@@ -48,6 +52,10 @@ func NewAppModuleBasic(cdc codec.BinaryCodec) AppModuleBasic {
 // Name returns the name of the module as a string.
 func (AppModuleBasic) Name() string {
 	return types.ModuleName
+}
+
+func (AppModuleBasic) ConsensusVersion() uint64 {
+	return ConsensusVersion
 }
 
 // RegisterLegacyAminoCodec registers the amino codec for the module, which is used

--- a/lib/cchain/provider.go
+++ b/lib/cchain/provider.go
@@ -10,6 +10,8 @@ import (
 	rpcclient "github.com/cometbft/cometbft/rpc/client"
 
 	"github.com/ethereum/go-ethereum/common"
+
+	utypes "cosmossdk.io/x/upgrade/types"
 )
 
 // ProviderCallback is the callback function signature that will be called with each approved attestation per
@@ -65,6 +67,9 @@ type Provider interface {
 
 	// Portals returns the portals registered in the registry module.
 	Portals(ctx context.Context) ([]*rtypes.Portal, bool, error)
+
+	// CurrentUpgradePlan returns the current (non-activated) upgrade plan.
+	CurrentUpgradePlan(ctx context.Context) (utypes.Plan, bool, error)
 }
 
 // Validator is a consensus chain validator in a validator set.

--- a/lib/cmd/flags.go
+++ b/lib/cmd/flags.go
@@ -7,10 +7,11 @@ import (
 
 	"github.com/omni-network/omni/lib/log"
 
+	sdkflags "github.com/cosmos/cosmos-sdk/client/flags"
 	"github.com/spf13/pflag"
 )
 
-const homeFlag = "home"
+const homeFlag = sdkflags.FlagHome
 
 // BindHomeFlag binds the home flag to the given flag set.
 // This is generally only required for apps that require multiple config files or persist data to disk.

--- a/lib/netconf/provider.go
+++ b/lib/netconf/provider.go
@@ -68,10 +68,6 @@ func AwaitOnExecutionChain(ctx context.Context, netID ID, portalRegistry *bindin
 
 // AwaitOnConsensusChain blocks and returns network configuration as soon as it can be loaded from the Consensus Chain's registry.
 func AwaitOnConsensusChain(ctx context.Context, netID ID, cprov cchain.Provider, expected []string) (Network, error) {
-	if netID == Simnet {
-		return SimnetNetwork(), nil
-	}
-
 	cfg := expbackoff.DefaultConfig
 	cfg.MaxDelay = 5 * time.Second
 	backoff := expbackoff.New(ctx, expbackoff.With(cfg))

--- a/octane/evmengine/keeper/db.go
+++ b/octane/evmengine/keeper/db.go
@@ -22,6 +22,8 @@ const executionHeadID = 1
 func (k *Keeper) InsertGenesisHead(ctx context.Context, executionBlockHash []byte) error {
 	if len(executionBlockHash) != common.HashLength {
 		return errors.New("invalid execution block hash length", "length", len(executionBlockHash))
+	} else if common.BytesToHash(executionBlockHash) == (common.Hash{}) {
+		return errors.New("invalid zero execution block hash")
 	}
 
 	const genesisHeight = 0 // Genesis block height is 0.

--- a/octane/evmengine/module/module.go
+++ b/octane/evmengine/module/module.go
@@ -22,6 +22,8 @@ import (
 	"github.com/grpc-ecosystem/grpc-gateway/runtime"
 )
 
+const ConsensusVersion = 1
+
 var (
 	_ module.AppModuleBasic = (*AppModule)(nil)
 	_ appmodule.AppModule   = (*AppModule)(nil)
@@ -45,6 +47,10 @@ func NewAppModuleBasic(cdc codec.BinaryCodec) AppModuleBasic {
 // Name returns the name of the module as a string.
 func (AppModuleBasic) Name() string {
 	return types.ModuleName
+}
+
+func (AppModuleBasic) ConsensusVersion() uint64 {
+	return ConsensusVersion
 }
 
 // RegisterLegacyAminoCodec registers the amino codec for the module, which is used


### PR DESCRIPTION
Fixes the `authority` field of `PlanUpgrade` messages enforced by `Upgrade` module.

Also add submitting `PlanUpgrade` evm logs to smoke test and assert it is created succesfully.

Swap simnet to use `AwaitOnConsensusChain` since it can do this. This makes voter in simnet start slightly later.

Increase `Pruning` history test allowed delay since now things are a bit slower.

Also wire `upgrade` module flag via `serverAppOpts`. Had to add support for slice flags to cobra/viper setup.

issue:  #1673 