### PR TITLE
refactor(halo): wire evmeventprocs using depinject

### DIFF
--- a/halo/app/app_config.go
+++ b/halo/app/app_config.go
@@ -3,6 +3,7 @@ package app
 import (
 	attestmodule "github.com/omni-network/omni/halo/attest/module"
 	attesttypes "github.com/omni-network/omni/halo/attest/types"
+	"github.com/omni-network/omni/halo/evmslashing"
 	"github.com/omni-network/omni/halo/evmstaking"
 	"github.com/omni-network/omni/halo/evmupgrade"
 	portalmodule "github.com/omni-network/omni/halo/portal/module"
@@ -218,4 +219,12 @@ var (
 			},
 		},
 	})
+
+	// diProviders defines a list of depinject provider functions.
+	// These are non-cosmos module constructors used in halo's app wiring.
+	diProviders = []any{
+		evmslashing.DIProvide,
+		evmstaking.DIProvide,
+		evmupgrade.DIProvide,
+	}
 )

--- a/halo/evmslashing/depinject.go
+++ b/halo/evmslashing/depinject.go
@@ -1,0 +1,37 @@
+package evmslashing
+
+import (
+	"github.com/omni-network/omni/lib/errors"
+	"github.com/omni-network/omni/lib/ethclient"
+	evmenginetypes "github.com/omni-network/omni/octane/evmengine/types"
+
+	"cosmossdk.io/depinject"
+	slashingkeeper "github.com/cosmos/cosmos-sdk/x/slashing/keeper"
+)
+
+type DIInputs struct {
+	depinject.In
+	EthCl          ethclient.Client
+	SlashingKeeper slashingkeeper.Keeper
+}
+
+type DIOutputs struct {
+	depinject.Out
+	EventProc         EventProcessor
+	InjectedEventProc evmenginetypes.InjectedEventProc
+}
+
+func DIProvide(input DIInputs) (DIOutputs, error) {
+	proc, err := New(
+		input.EthCl,
+		input.SlashingKeeper,
+	)
+	if err != nil {
+		return DIOutputs{}, errors.Wrap(err, "new")
+	}
+
+	return DIOutputs{
+		EventProc:         proc,
+		InjectedEventProc: evmenginetypes.InjectEventProc(proc),
+	}, nil
+}

--- a/halo/evmstaking/depinject.go
+++ b/halo/evmstaking/depinject.go
@@ -1,0 +1,43 @@
+package evmstaking
+
+import (
+	"github.com/omni-network/omni/lib/errors"
+	"github.com/omni-network/omni/lib/ethclient"
+	evmenginetypes "github.com/omni-network/omni/octane/evmengine/types"
+
+	"cosmossdk.io/depinject"
+	accountkeeper "github.com/cosmos/cosmos-sdk/x/auth/keeper"
+	bankkeeper "github.com/cosmos/cosmos-sdk/x/bank/keeper"
+	stakingkeeper "github.com/cosmos/cosmos-sdk/x/staking/keeper"
+)
+
+type DIInputs struct {
+	depinject.In
+	EthCl         ethclient.Client
+	StakingKeeper *stakingkeeper.Keeper
+	BankKeeper    bankkeeper.Keeper
+	AccountKeeper accountkeeper.AccountKeeper
+}
+
+type DIOutputs struct {
+	depinject.Out
+	EventProc         EventProcessor
+	InjectedEventProc evmenginetypes.InjectedEventProc
+}
+
+func DIProvide(input DIInputs) (DIOutputs, error) {
+	proc, err := New(
+		input.EthCl,
+		input.StakingKeeper,
+		input.BankKeeper,
+		input.AccountKeeper,
+	)
+	if err != nil {
+		return DIOutputs{}, errors.Wrap(err, "new")
+	}
+
+	return DIOutputs{
+		EventProc:         proc,
+		InjectedEventProc: evmenginetypes.InjectEventProc(proc),
+	}, nil
+}

--- a/halo/evmupgrade/depinject.go
+++ b/halo/evmupgrade/depinject.go
@@ -1,0 +1,37 @@
+package evmupgrade
+
+import (
+	"github.com/omni-network/omni/lib/errors"
+	"github.com/omni-network/omni/lib/ethclient"
+	evmenginetypes "github.com/omni-network/omni/octane/evmengine/types"
+
+	"cosmossdk.io/depinject"
+	updatekeeper "cosmossdk.io/x/upgrade/keeper"
+)
+
+type DIInputs struct {
+	depinject.In
+	EthCl        ethclient.Client
+	UpdateKeeper *updatekeeper.Keeper
+}
+
+type DIOutputs struct {
+	depinject.Out
+	EventProc         EventProcessor
+	InjectedEventProc evmenginetypes.InjectedEventProc
+}
+
+func DIProvide(input DIInputs) (DIOutputs, error) {
+	proc, err := New(
+		input.EthCl,
+		input.UpdateKeeper,
+	)
+	if err != nil {
+		return DIOutputs{}, errors.Wrap(err, "new")
+	}
+
+	return DIOutputs{
+		EventProc:         proc,
+		InjectedEventProc: evmenginetypes.InjectEventProc(proc),
+	}, nil
+}

--- a/halo/registry/module/module.go
+++ b/halo/registry/module/module.go
@@ -5,6 +5,7 @@ import (
 	"github.com/omni-network/omni/halo/registry/keeper"
 	"github.com/omni-network/omni/halo/registry/types"
 	"github.com/omni-network/omni/lib/ethclient"
+	evmenginetypes "github.com/omni-network/omni/octane/evmengine/types"
 
 	"cosmossdk.io/core/appmodule"
 	"cosmossdk.io/core/store"
@@ -116,8 +117,9 @@ type ModuleInputs struct {
 type ModuleOutputs struct {
 	depinject.Out
 
-	Keeper keeper.Keeper
-	Module appmodule.AppModule
+	Keeper       keeper.Keeper
+	Module       appmodule.AppModule
+	EVMEventProc evmenginetypes.InjectedEventProc
 }
 
 func ProvideModule(in ModuleInputs) (ModuleOutputs, error) {
@@ -137,7 +139,8 @@ func ProvideModule(in ModuleInputs) (ModuleOutputs, error) {
 	)
 
 	return ModuleOutputs{
-		Keeper: k,
-		Module: m,
+		Keeper:       k,
+		Module:       m,
+		EVMEventProc: evmenginetypes.InjectEventProc(k),
 	}, nil
 }

--- a/octane/evmengine/keeper/abci_internal_test.go
+++ b/octane/evmengine/keeper/abci_internal_test.go
@@ -156,10 +156,9 @@ func TestKeeper_PrepareProposal(t *testing.T) {
 			address: common.BytesToAddress([]byte("test")),
 		}
 		frp := newRandomFeeRecipientProvider()
-		keeper, err := NewKeeper(cdc, storeService, &mockEngine, txConfig, ap, frp)
+		keeper, err := NewKeeper(cdc, storeService, &mockEngine, txConfig, ap, frp, mockLogProvider{})
 		require.NoError(t, err)
 		keeper.SetVoteProvider(mockVEProvider{})
-		keeper.AddEventProcessor(mockLogProvider{})
 		populateGenesisHead(ctx, t, keeper)
 
 		// get the genesis block to build on top of
@@ -220,9 +219,8 @@ func TestKeeper_PrepareProposal(t *testing.T) {
 			address: common.BytesToAddress([]byte("test")),
 		}
 		frp := newRandomFeeRecipientProvider()
-		keeper, err := NewKeeper(cdc, storeService, &mockEngine, txConfig, ap, frp)
+		keeper, err := NewKeeper(cdc, storeService, &mockEngine, txConfig, ap, frp, mockLogProvider{})
 		require.NoError(t, err)
-		keeper.AddEventProcessor(mockLogProvider{})
 		keeper.SetVoteProvider(mockVEProvider{})
 		populateGenesisHead(ctx, t, keeper)
 
@@ -288,10 +286,9 @@ func TestOptimistic(t *testing.T) {
 		address: val1,
 	}
 	frp := newRandomFeeRecipientProvider()
-	keeper, err := NewKeeper(cdc, storeService, &mockEngine, txConfig, ap, frp)
+	keeper, err := NewKeeper(cdc, storeService, &mockEngine, txConfig, ap, frp, mockLogProvider{})
 	require.NoError(t, err)
 	keeper.SetVoteProvider(mockVEProvider{})
-	keeper.AddEventProcessor(mockLogProvider{})
 	keeper.SetCometAPI(cmtAPI)
 	keeper.SetBuildOptimistic(true)
 	populateGenesisHead(ctx, t, keeper)

--- a/octane/evmengine/keeper/keeper.go
+++ b/octane/evmengine/keeper/keeper.go
@@ -55,6 +55,7 @@ func NewKeeper(
 	txConfig client.TxConfig,
 	addrProvider types.AddressProvider,
 	feeRecProvider types.FeeRecipientProvider,
+	eventProcs ...types.EvmEventProcessor,
 ) (*Keeper, error) {
 	schema := &ormv1alpha1.ModuleSchemaDescriptor{SchemaFile: []*ormv1alpha1.ModuleSchemaDescriptor_FileEntry{
 		{Id: 1, ProtoFileName: File_octane_evmengine_keeper_evmengine_proto.Path()},
@@ -78,12 +79,8 @@ func NewKeeper(
 		txConfig:       txConfig,
 		addrProvider:   addrProvider,
 		feeRecProvider: feeRecProvider,
+		eventProcs:     eventProcs,
 	}, nil
-}
-
-// TODO(corver): Figure out how to use depinject for this.
-func (k *Keeper) AddEventProcessor(p types.EvmEventProcessor) {
-	k.eventProcs = append(k.eventProcs, p)
 }
 
 func (k *Keeper) SetVoteProvider(p types.VoteExtensionProvider) {

--- a/octane/evmengine/keeper/msg_server_internal_test.go
+++ b/octane/evmengine/keeper/msg_server_internal_test.go
@@ -49,10 +49,9 @@ func Test_msgServer_ExecutionPayload(t *testing.T) {
 	}
 	frp := newRandomFeeRecipientProvider()
 	evmLogProc := mockLogProvider{deliverErr: errors.New("test error")}
-	keeper, err := NewKeeper(cdc, storeService, &mockEngine, txConfig, ap, frp)
+	keeper, err := NewKeeper(cdc, storeService, &mockEngine, txConfig, ap, frp, evmLogProc)
 	require.NoError(t, err)
 	keeper.SetCometAPI(cmtAPI)
-	keeper.AddEventProcessor(evmLogProc)
 	populateGenesisHead(ctx, t, keeper)
 	msgSrv := NewMsgServerImpl(keeper)
 

--- a/octane/evmengine/module/module.go
+++ b/octane/evmengine/module/module.go
@@ -150,6 +150,7 @@ type ModuleInputs struct {
 	EngineCl       ethclient.EngineClient
 	AddrProvider   types.AddressProvider
 	FeeRecProvider types.FeeRecipientProvider
+	EventProcs     []types.InjectedEventProc
 }
 
 type ModuleOutputs struct {
@@ -161,6 +162,12 @@ type ModuleOutputs struct {
 }
 
 func ProvideModule(in ModuleInputs) (ModuleOutputs, error) {
+	// Unwrap the depinject event processors
+	var eventProcs []types.EvmEventProcessor
+	for _, proc := range in.EventProcs {
+		eventProcs = append(eventProcs, proc)
+	}
+
 	k, err := keeper.NewKeeper(
 		in.Cdc,
 		in.StoreService,
@@ -168,6 +175,7 @@ func ProvideModule(in ModuleInputs) (ModuleOutputs, error) {
 		in.TXConfig,
 		in.AddrProvider,
 		in.FeeRecProvider,
+		eventProcs...,
 	)
 	if err != nil {
 		return ModuleOutputs{}, err

--- a/octane/evmengine/types/cpayload.go
+++ b/octane/evmengine/types/cpayload.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 
+	"cosmossdk.io/depinject"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
@@ -31,3 +32,18 @@ type EvmEventProcessor interface {
 	Addresses() []common.Address
 	Deliver(ctx context.Context, blockHash common.Hash, log *EVMEvent) error
 }
+
+var _ depinject.ManyPerContainerType = InjectedEventProc{}
+
+// InjectedEventProc wraps an EvmEventProcessor such that
+// many instances can be injected during app wiring.
+type InjectedEventProc struct {
+	EvmEventProcessor
+}
+
+// InjectEventProc returns an InjectedEventProc that wraps the given EvmEventProcessor.
+func InjectEventProc(proc EvmEventProcessor) InjectedEventProc {
+	return InjectedEventProc{EvmEventProcessor: proc}
+}
+
+func (InjectedEventProc) IsManyPerContainerType() {}


### PR DESCRIPTION
Refactor halo app wiring to use `depinject` for `EvmEventProcessors`.

issue: none