### PR TITLE
ci(e2e): address relayer funds issue

### DIFF
--- a/e2e/app/eoa/fund.go
+++ b/e2e/app/eoa/fund.go
@@ -34,8 +34,8 @@ var (
 	// thresholdLarge is used by EOAs that constantly perform actions and need enough balance
 	// to last a weekend without topping up even if fees are spiking.
 	thresholdLarge = FundThresholds{
-		minEther:    5,
-		targetEther: 20, // TODO(corver): Increase along with e2e/app#saneMaxEther
+		minEther:    10,
+		targetEther: 50,
 	}
 
 	defaultThresholdsByRole = map[Role]FundThresholds{

--- a/e2e/app/fund.go
+++ b/e2e/app/fund.go
@@ -17,7 +17,7 @@ import (
 	"github.com/ethereum/go-ethereum/params"
 )
 
-const saneMaxEther = 20 // Maximum amount to fund in ether. // TODO(corver): Increase this.
+const saneMaxEther = 50 // Maximum amount to fund in ether.
 
 // noAnvilDev returns a list of accounts that are not dev anvil accounts.
 func noAnvilDev(accounts []common.Address) []common.Address {

--- a/e2e/app/run.go
+++ b/e2e/app/run.go
@@ -20,8 +20,8 @@ import (
 const (
 	// defaultPingPongN defines a few days of ping pong hops after each deploy.
 	defaultPingPongN = 100_000
-	// defaultPingPongP defines 10 parallel ping pongs per edge.
-	defaultPingPongP = 10
+	// defaultPingPongP defines 3 parallel ping pongs per edge.
+	defaultPingPongP = 3
 	// defaultPingPongL defines a single parallel ping pongs to use Latest confirmation level. This decreases on-chain costs.
 	defaultPingPongL = 1
 )

--- a/monitor/loadgen/loadgen.go
+++ b/monitor/loadgen/loadgen.go
@@ -69,7 +69,7 @@ func Start(ctx context.Context, network netconf.Network, ethClients map[uint64]e
 		return errors.Wrap(err, "new omni stake")
 	}
 
-	var period = time.Hour
+	var period = time.Hour * 6
 	if network.ID == netconf.Devnet {
 		period = time.Second * 5
 	}


### PR DESCRIPTION
Relayer on staging is running out of 20ETH balance fast: 
 - Increase relayer funding from 20 to 50
 - Decrease parallel ping pongs from 10 to 3
 - Increase self-delegation period from 1H to 6H (allowing more relayer downtime before `old valset` issue is triggered).

issue: #1701