### PR TITLE
ci(golant): add log attrs snake case lint

### DIFF
--- a/halo/app/monitor.go
+++ b/halo/app/monitor.go
@@ -145,6 +145,10 @@ func monitorEVMOnce(ctx context.Context, ethCl ethclient.Client) error {
 	return nil
 }
 
+func New() error {
+	return nil
+}
+
 // dirSize returns the total size of the directory at path.
 func dirSize(path string) (int64, error) {
 	var size int64

--- a/halo/app/monitor.go
+++ b/halo/app/monitor.go
@@ -145,10 +145,6 @@ func monitorEVMOnce(ctx context.Context, ethCl ethclient.Client) error {
 	return nil
 }
 
-func New() error {
-	return nil
-}
-
 // dirSize returns the total size of the directory at path.
 func dirSize(path string) (int64, error) {
 	var size int64

--- a/halo/attest/voter/voter.go
+++ b/halo/attest/voter/voter.go
@@ -559,7 +559,7 @@ func detectReorg(chainVer xchain.ChainVersion, prevBlock *xchain.Block, block xc
 	for _, xmsg := range block.Msgs {
 		offset, ok := streamOffsets[xmsg.StreamID]
 		if ok && xmsg.StreamOffset != offset+1 {
-			return errors.New("non-consecutive message offsets", "streamID", xmsg.StreamID, "prev_offset", offset, "new_offset", xmsg.StreamOffset)
+			return errors.New("non-consecutive message offsets", "stream", xmsg.StreamID, "prev_offset", offset, "new_offset", xmsg.StreamOffset)
 		}
 
 		// Update the cursor

--- a/lib/cchain/provider/abci.go
+++ b/lib/cchain/provider/abci.go
@@ -173,7 +173,7 @@ func newABCIFetchFunc(cl atypes.QueryClient, client rpcclient.Client, chainNamer
 			return []xchain.Attestation{}, nil
 		}
 
-		log.Debug(ctx, "Offset not found in latest state", "chain", chainName, "offset", fromOffset, "earliestAttestationAtLatestHeight", earliestAttestationAtLatestHeight.AttestOffset)
+		log.Debug(ctx, "Offset not found in latest state", "chain", chainName, "offset", fromOffset, "earliest", earliestAttestationAtLatestHeight.AttestOffset)
 
 		offsetHeight, err := searchOffsetInHistory(ctx, client, cl, chainVer, chainName, fromOffset)
 		if err != nil {
@@ -386,7 +386,7 @@ func searchOffsetInHistory(ctx context.Context, client rpcclient.Client, cl atyp
 		}
 
 		if queryHeight == 0 || queryHeight >= uint64(info.Response.LastBlockHeight) {
-			return 0, errors.New("unexpected query height [BUG]", "queryHeight", queryHeight) // This should never happen
+			return 0, errors.New("unexpected query height [BUG]", "height", queryHeight) // This should never happen
 		}
 		earliestAtt, ok, err := queryEarliestAttestation(ctx, cl, chainVer, queryHeight)
 		if IsErrHistoryPruned(err) {
@@ -456,7 +456,7 @@ func searchOffsetInHistory(ctx context.Context, client rpcclient.Client, cl atyp
 		}
 
 		if fromOffset >= earliestAtt.AttestOffset && fromOffset <= latestAtt.AttestOffset {
-			log.Debug(ctx, "Fetching offset from history", "chain", chainName, "fromOffset", fromOffset, "latestHeight", info.Response.LastBlockHeight, "foundHeight", midHeightIndex, "lookbackSteps", lookbackStepsCounter, "binarySearchSteps", binarySearchStepsCounter)
+			log.Debug(ctx, "Fetching offset from history", "chain", chainName, "from", fromOffset, "latest", info.Response.LastBlockHeight, "found", midHeightIndex, "lookback", lookbackStepsCounter, "search", binarySearchStepsCounter)
 			fetchStepsMetrics(chainName, lookbackStepsCounter, binarySearchStepsCounter)
 
 			return midHeightIndex, nil

--- a/lib/cchain/provider/provider.go
+++ b/lib/cchain/provider/provider.go
@@ -142,7 +142,7 @@ func (p Provider) stream(
 	retryCallback bool,
 ) error {
 	if attestOffset == 0 {
-		return errors.New("invalid zero attest offset [BUG]", "workerName", workerName)
+		return errors.New("invalid zero attest offset [BUG]", "worker", workerName)
 	}
 
 	srcChain := p.chainNamer(chainVer)

--- a/lib/fireblocks/jsonhttp.go
+++ b/lib/fireblocks/jsonhttp.go
@@ -81,12 +81,12 @@ func (c jsonHTTP) Send(ctx context.Context, uri string, httpMethod string, reque
 			if resp.Header.Get("Content-Type") != "application/json" {
 				errResponse.Code = resp.StatusCode
 
-				return false, errors.New("non-JSON error response", "status code", resp.StatusCode, "body", string(respBytes))
+				return false, errors.New("non-JSON error response", "status_code", resp.StatusCode, "body", string(respBytes))
 			}
 
 			err = json.Unmarshal(respBytes, errResponse)
 			if err != nil {
-				return false, errors.Wrap(err, "unmarshal error response", "status code", resp.StatusCode, "body", string(respBytes))
+				return false, errors.Wrap(err, "unmarshal error response", "status_code", resp.StatusCode, "body", string(respBytes))
 			}
 		}
 

--- a/monitor/xfeemngr/oracle.go
+++ b/monitor/xfeemngr/oracle.go
@@ -72,12 +72,12 @@ func (o feeOracle) syncOnce(ctx context.Context) {
 	for _, dest := range append(o.dests, o.chain) {
 		err := o.syncGasPrice(ctx, dest)
 		if err != nil {
-			log.Error(ctx, "Failed to sync gas price", err, "destChainID", dest.ChainID)
+			log.Error(ctx, "Failed to sync gas price", err, "dest_chain", dest.ChainID)
 		}
 
 		err = o.syncToNativeRate(ctx, dest)
 		if err != nil {
-			log.Error(ctx, "Failed to sync conversion rate", err, "destChainID", dest.ChainID)
+			log.Error(ctx, "Failed to sync conversion rate", err, "dest_chain", dest.ChainID)
 		}
 	}
 }
@@ -93,7 +93,7 @@ func (o feeOracle) syncGasPrice(ctx context.Context, dest evmchain.Metadata) err
 	}
 
 	if buffered > maxSaneGasPrice {
-		log.Warn(ctx, "Buffered gas price exceeds sane max", errors.New("unexpected gas price"), "buffered", buffered, "maxSane", maxSaneGasPrice)
+		log.Warn(ctx, "Buffered gas price exceeds sane max", errors.New("unexpected gas price"), "buffered", buffered, "max_sane", maxSaneGasPrice)
 		buffered = maxSaneGasPrice
 	}
 
@@ -143,12 +143,12 @@ func (o feeOracle) syncToNativeRate(ctx context.Context, dest evmchain.Metadata)
 	bufferedRate := destPrice / srcPrice
 
 	if o.chain.NativeToken == tokens.OMNI && dest.NativeToken == tokens.ETH && bufferedRate > maxSaneOmniPerEth {
-		log.Warn(ctx, "Buffered omni-per-eth exceeds sane max", errors.New("unexpected conversion rate"), "buffered", bufferedRate, "maxSane", maxSaneOmniPerEth)
+		log.Warn(ctx, "Buffered omni-per-eth exceeds sane max", errors.New("unexpected conversion rate"), "buffered", bufferedRate, "max_sane", maxSaneOmniPerEth)
 		bufferedRate = maxSaneOmniPerEth
 	}
 
 	if o.chain.NativeToken == tokens.ETH && dest.NativeToken == tokens.OMNI && bufferedRate > maxSaneEthPerOmni {
-		log.Warn(ctx, "Buffered eth-per-omni exceeds sane max", errors.New("unexpected conversion rate"), "buffered", bufferedRate, "maxSane", maxSaneEthPerOmni)
+		log.Warn(ctx, "Buffered eth-per-omni exceeds sane max", errors.New("unexpected conversion rate"), "buffered", bufferedRate, "max_sane", maxSaneEthPerOmni)
 		bufferedRate = maxSaneEthPerOmni
 	}
 

--- a/scripts/golint/logattrs.go
+++ b/scripts/golint/logattrs.go
@@ -1,0 +1,117 @@
+package main
+
+import (
+	"go/ast"
+	"go/token"
+	"regexp"
+
+	"github.com/omni-network/omni/lib/errors"
+
+	"golang.org/x/tools/go/analysis"
+	"golang.org/x/tools/go/analysis/passes/inspect"
+	"golang.org/x/tools/go/ast/inspector"
+)
+
+var logAttrsAnalyzer = &analysis.Analyzer{
+	Name: "logattrs",
+	Doc:  "Ensures snake_case log and error attribute keys",
+	Run: func(p *analysis.Pass) (interface{}, error) {
+		i, ok := p.ResultOf[inspect.Analyzer].(*inspector.Inspector)
+		if !ok {
+			return nil, errors.New("analyzer is not of type *inspector.Inspector")
+		}
+		diags, err := logAttrs(i)
+		if err != nil {
+			return nil, errors.Wrap(err, "detect uint subtract")
+		}
+
+		for _, diag := range diags {
+			p.Report(diag)
+		}
+
+		return nil, nil //nolint:nilnil // API requires nil-nil return
+	},
+	Requires: []*analysis.Analyzer{inspect.Analyzer},
+}
+
+func logAttrs(i *inspector.Inspector) ([]analysis.Diagnostic, error) {
+	var diags []analysis.Diagnostic
+	var err error
+	filter := []ast.Node{new(ast.CallExpr)}
+	i.Preorder(filter, func(n ast.Node) {
+		call, ok := n.(*ast.CallExpr)
+		if !ok {
+			err = errors.New("expected *ast.CallExpr")
+			return
+		}
+
+		selct, ok := call.Fun.(*ast.SelectorExpr)
+		if !ok {
+			return
+		}
+
+		index, ok := attrIndex(selct, attrFuncs)
+		if !ok {
+			return
+		}
+
+		for i := index; i < len(call.Args); i++ {
+			arg := call.Args[i]
+
+			strLiteral, ok := arg.(*ast.BasicLit)
+			if !ok {
+				continue
+			}
+			if strLiteral.Kind != token.STRING {
+				return // Unexpected
+			}
+
+			// Skip next value
+			i++
+
+			if !isSnakeCase(strLiteral.Value) {
+				diags = append(diags, analysis.Diagnostic{
+					Pos:     strLiteral.Pos(),
+					Message: "log/error attribute key must be snake_case; not " + strLiteral.Value,
+				})
+			}
+		}
+	})
+
+	return diags, err
+}
+
+var snakeRegex = regexp.MustCompile(`"[a-z][a-z0-9_]+"`)
+
+func isSnakeCase(value string) bool {
+	return snakeRegex.MatchString(value)
+}
+
+func attrIndex(selct *ast.SelectorExpr, selectors map[string]map[string]int) (int, bool) {
+	funIdent, ok := selct.X.(*ast.Ident)
+	if !ok {
+		return 0, false
+	}
+
+	funcs, ok := selectors[funIdent.Name]
+	if !ok {
+		return 0, false
+	}
+
+	index, ok := funcs[selct.Sel.Name]
+
+	return index, ok
+}
+
+var attrFuncs = map[string]map[string]int{
+	"log": {
+		"Debug": 2,
+		"Info":  2,
+		"Warn":  3,
+		"Error": 3,
+	},
+	"errors": {
+		"Wrap": 2,
+		"New":  1,
+	},
+}

--- a/scripts/golint/logattrs.go
+++ b/scripts/golint/logattrs.go
@@ -81,7 +81,7 @@ func logAttrs(i *inspector.Inspector) ([]analysis.Diagnostic, error) {
 	return diags, err
 }
 
-var snakeRegex = regexp.MustCompile(`"[a-z][a-z0-9_]+"`)
+var snakeRegex = regexp.MustCompile(`"[a-z0-9_]+"`)
 
 func isSnakeCase(value string) bool {
 	return snakeRegex.MatchString(value)

--- a/scripts/golint/logattrs_internal_test.go
+++ b/scripts/golint/logattrs_internal_test.go
@@ -1,0 +1,63 @@
+package main
+
+import (
+	"testing"
+
+	"golang.org/x/tools/go/analysis/analysistest"
+)
+
+func TestLogAttrs(t *testing.T) {
+	t.Parallel()
+
+	pkgMain := `package main
+
+import (
+	"context"
+	"main/log"
+	"main/errors"
+)
+
+func main() {
+	ctx := context.Background()
+	log.Debug(ctx, "Good, no attrs")
+	log.Debug(ctx, "Good, valid attrs", "foo", "bar", "snake_case", "qux")
+	log.Debug(ctx, "Bad, invalid attrs", "foo", "bar", "camelCase", "qux") // want "log/error attribute key must be snake_case"
+
+	err := errors.New("fine", "foo", "bar", "snake_case", "qux")
+	err = errors.Wrap(err, "bad", "foo",
+		"bar", "camelCase", "qux") // want "log/error attribute key must be snake_case"
+	log.Warn(ctx, "no extra attrs", err)
+	log.Warn(ctx, "good attrs", err, "foo", "bar", "snake_case", "Values don't matter'")
+	log.Error(ctx, "bad attrs", err, "camelCase", "qux") // want "log/error attribute key must be snake_case"
+}
+`
+
+	pkgLog := `package log
+
+import (
+	"context"
+)
+
+func Debug(context.Context, string, ...any) {}
+func Info(context.Context, string, ...any) {}
+func Warn(context.Context, string, error, ...any) {}
+func Error(context.Context, string, error, ...any) {}
+`
+
+	pkgError := `package errors
+
+func Wrap(err error, _ string, _ ...any) error { return err }
+func New(string, ...any) error { return nil }
+`
+
+	dir, cleanup, err := analysistest.WriteFiles(map[string]string{
+		"main/main.go":          pkgMain,
+		"main/log/log.go":       pkgLog,
+		"main/errors/errors.go": pkgError,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cleanup()
+	_ = analysistest.Run(t, dir, logAttrsAnalyzer, "main")
+}

--- a/scripts/golint/main.go
+++ b/scripts/golint/main.go
@@ -8,5 +8,8 @@ import (
 )
 
 func main() {
-	multichecker.Main(uintSubtractAnalyzer)
+	multichecker.Main(
+		uintSubtractAnalyzer,
+		logAttrsAnalyzer,
+	)
 }


### PR DESCRIPTION
Add a custom `golint` linter to ensure our log attributes are consistently `snake_case`.

issue: none