### PR TITLE
feat(monitor/xfeemngr): manage fee params for chain not in network

### DIFF
--- a/e2e/types/testdata/TestAttestIntervals.golden
+++ b/e2e/types/testdata/TestAttestIntervals.golden
@@ -49,7 +49,7 @@
   "ephemeral_attest_interval": 300,
   "protected_attest_interval": 1800
  },
- "slow_l1": {
+ "sepolia": {
   "block_period": "12s",
   "ephemeral_attest_interval": 50,
   "protected_attest_interval": 300

--- a/lib/contracts/feeoraclev1/deploy.go
+++ b/lib/contracts/feeoraclev1/deploy.go
@@ -68,7 +68,7 @@ func Deploy(ctx context.Context, network netconf.ID, chainID uint64, destChainID
 		return common.Address{}, nil, errors.Wrap(err, "bind opts")
 	}
 
-	feeparams, err := feeParams(ctx, network, chainID, destChainIDs, backends, coingecko.New())
+	feeparams, err := feeParams(ctx, chainID, destChainIDs, backends, coingecko.New())
 	if err != nil {
 		return common.Address{}, nil, errors.Wrap(err, "fee params")
 	}

--- a/lib/evmchain/evmchain.go
+++ b/lib/evmchain/evmchain.go
@@ -20,14 +20,14 @@ const (
 	// Testnets.
 	IDOmniOmega   uint64 = 164
 	IDHolesky     uint64 = 17000
+	IDSepolia     uint64 = 11155111
 	IDArbSepolia  uint64 = 421614
 	IDOpSepolia   uint64 = 11155420
 	IDBaseSepolia uint64 = 84532
 
 	// Ephemeral.
 	IDOmniEphemeral uint64 = 1651
-	IDMockL1Fast    uint64 = 1652
-	IDMockL1Slow    uint64 = 1653
+	IDMockL1        uint64 = 1652
 	IDMockL2        uint64 = 1654
 	IDMockOp        uint64 = 1655
 	IDMockArb       uint64 = 1656
@@ -38,7 +38,7 @@ const (
 
 type Metadata struct {
 	ChainID     uint64
-	IsL2        bool
+	PostsTo     uint64 // chain id to which tx data is posted
 	Name        string
 	BlockPeriod time.Duration
 	NativeToken tokens.Token
@@ -102,26 +102,32 @@ var static = map[uint64]Metadata{
 		BlockPeriod: 12 * time.Second,
 		NativeToken: tokens.ETH,
 	},
+	IDSepolia: {
+		ChainID:     IDSepolia,
+		Name:        "sepolia",
+		BlockPeriod: 12 * time.Second,
+		NativeToken: tokens.ETH,
+	},
 	IDArbSepolia: {
 		ChainID:     IDArbSepolia,
 		Name:        "arb_sepolia",
 		BlockPeriod: 300 * time.Millisecond,
 		NativeToken: tokens.ETH,
-		IsL2:        true,
+		PostsTo:     IDSepolia,
 	},
 	IDOpSepolia: {
 		ChainID:     IDOpSepolia,
 		Name:        "op_sepolia",
 		BlockPeriod: 2 * time.Second,
 		NativeToken: tokens.ETH,
-		IsL2:        true,
+		PostsTo:     IDSepolia,
 	},
 	IDBaseSepolia: {
 		ChainID:     IDBaseSepolia,
 		Name:        "base_sepolia",
 		BlockPeriod: 2 * time.Second,
 		NativeToken: tokens.ETH,
-		IsL2:        true,
+		PostsTo:     IDSepolia,
 	},
 	IDOmniEphemeral: {
 		ChainID:     IDOmniEphemeral,
@@ -129,16 +135,10 @@ var static = map[uint64]Metadata{
 		BlockPeriod: omniEVMBlockPeriod,
 		NativeToken: tokens.OMNI,
 	},
-	IDMockL1Fast: {
-		ChainID:     IDMockL1Fast,
+	IDMockL1: {
+		ChainID:     IDMockL1,
 		Name:        "mock_l1",
 		BlockPeriod: time.Second,
-		NativeToken: tokens.ETH,
-	},
-	IDMockL1Slow: {
-		ChainID:     IDMockL1Slow,
-		Name:        "slow_l1",
-		BlockPeriod: time.Second * 12,
 		NativeToken: tokens.ETH,
 	},
 	IDMockL2: {
@@ -146,20 +146,17 @@ var static = map[uint64]Metadata{
 		Name:        "mock_l2",
 		BlockPeriod: time.Second,
 		NativeToken: tokens.ETH,
-		IsL2:        true,
 	},
 	IDMockOp: {
 		ChainID:     IDMockOp,
 		Name:        "mock_op",
 		BlockPeriod: time.Second * 2,
 		NativeToken: tokens.ETH,
-		IsL2:        true,
 	},
 	IDMockArb: {
 		ChainID:     IDMockArb,
 		Name:        "mock_arb",
 		BlockPeriod: time.Second,
 		NativeToken: tokens.ETH,
-		IsL2:        true,
 	},
 }

--- a/lib/netconf/netconf.go
+++ b/lib/netconf/netconf.go
@@ -127,7 +127,7 @@ func IsEthereumChain(network ID, chainID uint64) bool {
 	case Omega:
 		return chainID == evmchain.IDHolesky
 	default:
-		return chainID == evmchain.IDMockL1Fast || chainID == evmchain.IDMockL1Slow
+		return chainID == evmchain.IDMockL1
 	}
 }
 

--- a/lib/netconf/static.go
+++ b/lib/netconf/static.go
@@ -236,7 +236,7 @@ func SimnetNetwork() Network {
 		ID: Simnet,
 		Chains: []Chain{
 			mustSimnetChain(Simnet.Static().OmniExecutionChainID, xchain.ShardFinalized0),
-			mustSimnetChain(evmchain.IDMockL1Fast, xchain.ShardFinalized0, xchain.ShardLatest0),
+			mustSimnetChain(evmchain.IDMockL1, xchain.ShardFinalized0, xchain.ShardLatest0),
 			mustSimnetChain(evmchain.IDMockL2, xchain.ShardFinalized0),
 			Simnet.Static().OmniConsensusChain(),
 		},

--- a/monitor/app/app.go
+++ b/monitor/app/app.go
@@ -85,7 +85,7 @@ func Run(ctx context.Context, cfg Config) error {
 		return errors.Wrap(err, "start xchain monitor")
 	}
 
-	if err := xfeemngr.Start(ctx, network, ethClients, cfg.PrivateKey); err != nil {
+	if err := xfeemngr.Start(ctx, network, cfg.RPCEndpoints, cfg.PrivateKey); err != nil {
 		return errors.Wrap(err, "start xfee manager")
 	}
 

--- a/monitor/xfeemngr/contract/bound.go
+++ b/monitor/xfeemngr/contract/bound.go
@@ -112,6 +112,30 @@ func (c BoundFeeOracleV1) txOptsWithCtx(ctx context.Context) (*bind.TransactOpts
 	return c.backend.BindOpts(ctx, c.owner)
 }
 
+// PostsTo returns the postsTo value on the FeeOracleV1 contract for the destination chain.
+func (c BoundFeeOracleV1) PostsTo(ctx context.Context, destChainID uint64) (uint64, error) {
+	return c.bound.PostsTo(callOpts(ctx), destChainID)
+}
+
+func (c BoundFeeOracleV1) BulkSetFeeParams(ctx context.Context, params []bindings.IFeeOracleV1ChainFeeParams) error {
+	txOpts, err := c.txOptsWithCtx(ctx)
+	if err != nil {
+		return errors.Wrap(err, "tx opts")
+	}
+
+	tx, err := c.bound.BulkSetFeeParams(txOpts, params)
+	if err != nil {
+		return errors.Wrap(err, "bulk set fee params")
+	}
+
+	_, err = c.backend.WaitMined(ctx, tx)
+	if err != nil {
+		return errors.Wrap(err, "wait mined", "tx", tx.Hash().Hex())
+	}
+
+	return nil
+}
+
 // callOpts returns a new call opts with the given context.
 func callOpts(ctx context.Context) *bind.CallOpts {
 	return &bind.CallOpts{Context: ctx}

--- a/monitor/xfeemngr/contract/contract.go
+++ b/monitor/xfeemngr/contract/contract.go
@@ -3,6 +3,8 @@ package contract
 import (
 	"context"
 	"math/big"
+
+	"github.com/omni-network/omni/contracts/bindings"
 )
 
 type FeeOracleV1 interface {
@@ -11,4 +13,7 @@ type FeeOracleV1 interface {
 
 	SetToNativeRate(ctx context.Context, destChainID uint64, rate *big.Int) error
 	ToNativeRate(ctx context.Context, destChainID uint64) (*big.Int, error)
+
+	PostsTo(ctx context.Context, destChainID uint64) (uint64, error)
+	BulkSetFeeParams(ctx context.Context, params []bindings.IFeeOracleV1ChainFeeParams) error
 }

--- a/monitor/xfeemngr/oracle.go
+++ b/monitor/xfeemngr/oracle.go
@@ -5,6 +5,7 @@ import (
 	"crypto/ecdsa"
 	"math/big"
 
+	"github.com/omni-network/omni/contracts/bindings"
 	"github.com/omni-network/omni/lib/errors"
 	"github.com/omni-network/omni/lib/ethclient"
 	"github.com/omni-network/omni/lib/evmchain"
@@ -20,26 +21,16 @@ import (
 type feeOracle struct {
 	contract contract.FeeOracleV1
 	chain    evmchain.Metadata   // source chain
-	dests    []evmchain.Metadata // destination chains
+	toSync   []evmchain.Metadata // chains to sync on fee oracle
 	gprice   *gasprice.Buffer    // gas price buffer
 	tprice   *tokenprice.Buffer  // token price buffer
 }
 
-func makeOracle(ctx context.Context, chain netconf.Chain, network netconf.Network, ethClients map[uint64]ethclient.Client,
+func makeOracle(ctx context.Context, chain netconf.Chain, toSync []evmchain.Metadata, ethCl ethclient.Client,
 	pk *ecdsa.PrivateKey, gprice *gasprice.Buffer, tprice *tokenprice.Buffer) (feeOracle, error) {
 	chainmeta, ok := evmchain.MetadataByID(chain.ID)
 	if !ok {
 		return feeOracle{}, errors.New("chain metadata not found", "chain", chain.ID)
-	}
-
-	destChains, err := makeDestChains(chain.ID, network)
-	if err != nil {
-		return feeOracle{}, errors.Wrap(err, "make dest chains")
-	}
-
-	ethCl, ok := ethClients[chain.ID]
-	if !ok {
-		return feeOracle{}, errors.New("eth client not found", "chain", chain.ID)
 	}
 
 	bound, err := contract.New(ctx, chain, ethCl, pk)
@@ -49,7 +40,7 @@ func makeOracle(ctx context.Context, chain netconf.Chain, network netconf.Networ
 
 	return feeOracle{
 		chain:    chainmeta,
-		dests:    destChains,
+		toSync:   toSync,
 		contract: bound,
 		gprice:   gprice,
 		tprice:   tprice,
@@ -65,11 +56,9 @@ func (o feeOracle) syncForever(ctx context.Context, tick ticker.Ticker) {
 
 // syncOnce syncs the on-chain gas price and token conversion rates with their respective buffers, once.
 func (o feeOracle) syncOnce(ctx context.Context) {
-	ctx = log.WithCtx(ctx, "srcChainID", o.chain.ChainID, "srcToken", o.chain.NativeToken)
+	ctx = log.WithCtx(ctx, "src_token", o.chain.NativeToken)
 
-	// sync for all destination chains and source chain
-	// we include source chain, to allow calculation of xcall callbacks
-	for _, dest := range append(o.dests, o.chain) {
+	for _, dest := range o.toSync {
 		err := o.syncGasPrice(ctx, dest)
 		if err != nil {
 			log.Error(ctx, "Failed to sync gas price", err, "dest_chain", dest.ChainID)
@@ -79,12 +68,17 @@ func (o feeOracle) syncOnce(ctx context.Context) {
 		if err != nil {
 			log.Error(ctx, "Failed to sync conversion rate", err, "dest_chain", dest.ChainID)
 		}
+
+		err = o.correctPostsTo(ctx, dest)
+		if err != nil {
+			log.Error(ctx, "Failed to correct postsTo chain", err, "dest_chain", dest.ChainID)
+		}
 	}
 }
 
 // syncGasPrice sets the on-chain gas price to the buffered gas price, if they differ.
 func (o feeOracle) syncGasPrice(ctx context.Context, dest evmchain.Metadata) error {
-	ctx = log.WithCtx(ctx, "destChainID", dest.ChainID)
+	ctx = log.WithCtx(ctx, "chainId", dest.ChainID)
 
 	buffered := o.gprice.GasPrice(dest.ChainID)
 
@@ -123,6 +117,49 @@ func (o feeOracle) syncGasPrice(ctx context.Context, dest evmchain.Metadata) err
 	return nil
 }
 
+func (o feeOracle) correctPostsTo(ctx context.Context, dest evmchain.Metadata) error {
+	postsTo, err := o.contract.PostsTo(ctx, dest.ChainID)
+	if err != nil {
+		return errors.Wrap(err, "postsTo")
+	}
+
+	// if postsTo is correct, do nothing
+	if postsTo == dest.PostsTo {
+		return nil
+	}
+
+	// if not correct, correct via BulkSetFeeParams (there is not a single setter for postsTo)
+	// use current onchain gas price and conversion rate
+
+	gasPrice, err := o.contract.GasPriceOn(ctx, dest.ChainID)
+	if err != nil {
+		return errors.Wrap(err, "gas price on")
+	}
+
+	rate, err := o.contract.ToNativeRate(ctx, dest.ChainID)
+	if err != nil {
+		return errors.Wrap(err, "conversion rate on")
+	}
+
+	params := []bindings.IFeeOracleV1ChainFeeParams{
+		{
+			ChainId:      dest.ChainID,
+			GasPrice:     gasPrice,
+			ToNativeRate: rate,
+			PostsTo:      dest.PostsTo,
+		},
+	}
+
+	err = o.contract.BulkSetFeeParams(ctx, params)
+	if err != nil {
+		return errors.Wrap(err, "bulk set fee params")
+	}
+
+	log.Info(ctx, "Corrected postsTo", "dest_chain", dest.Name, "correct", dest.PostsTo, "actual", postsTo)
+
+	return nil
+}
+
 // guageGasPrice updates the gas price gauge for the given chain.
 func guageGasPrice(src, dest evmchain.Metadata, price uint64) {
 	onChainGasPrice.WithLabelValues(src.Name, dest.Name).Set(float64(price))
@@ -130,7 +167,7 @@ func guageGasPrice(src, dest evmchain.Metadata, price uint64) {
 
 // syncToNativeRate sets the on-chain conversion rate to the buffered conversion rate, if they differ.
 func (o feeOracle) syncToNativeRate(ctx context.Context, dest evmchain.Metadata) error {
-	ctx = log.WithCtx(ctx, "destChainID", dest.ChainID, "destToken", dest.NativeToken)
+	ctx = log.WithCtx(ctx, "dest_chain", dest.Name, "dest_token", dest.NativeToken)
 
 	srcPrice := o.tprice.Price(o.chain.NativeToken)
 	destPrice := o.tprice.Price(dest.NativeToken)
@@ -188,33 +225,6 @@ func (o feeOracle) syncToNativeRate(ctx context.Context, dest evmchain.Metadata)
 // guageRate updates the conversion rate gauge for the given source and destination chains.
 func guageRate(src, dest evmchain.Metadata, rate float64) {
 	onChainConversionRate.WithLabelValues(src.Name, dest.Name, src.NativeToken.String(), dest.NativeToken.String()).Set(rate)
-}
-
-// makeDestChains generates a list of destination chains, excluding the source chain.
-func makeDestChains(srcChainID uint64, network netconf.Network) ([]evmchain.Metadata, error) {
-	chains := network.EVMChains()
-	destChains := make([]evmchain.Metadata, 0, len(chains)-1)
-
-	var foundSrc bool
-	for _, chain := range chains {
-		if chain.ID == srcChainID {
-			foundSrc = true
-			continue
-		}
-
-		meta, ok := evmchain.MetadataByID(chain.ID)
-		if !ok {
-			return nil, errors.New("chain metadata not found", "chain", chain.ID)
-		}
-
-		destChains = append(destChains, meta)
-	}
-
-	if !foundSrc {
-		return nil, errors.New("source chain not in network", "chain", srcChainID)
-	}
-
-	return destChains, nil
 }
 
 // rateDenom matches FeeOracleV1.CONVERSION_RATE_DENOM

--- a/monitor/xfeemngr/xfeemngr.go
+++ b/monitor/xfeemngr/xfeemngr.go
@@ -7,10 +7,12 @@ import (
 
 	"github.com/omni-network/omni/lib/errors"
 	"github.com/omni-network/omni/lib/ethclient"
+	"github.com/omni-network/omni/lib/evmchain"
 	"github.com/omni-network/omni/lib/log"
 	"github.com/omni-network/omni/lib/netconf"
 	"github.com/omni-network/omni/lib/tokens"
 	"github.com/omni-network/omni/lib/tokens/coingecko"
+	"github.com/omni-network/omni/lib/xchain"
 	"github.com/omni-network/omni/monitor/xfeemngr/gasprice"
 	"github.com/omni-network/omni/monitor/xfeemngr/ticker"
 	"github.com/omni-network/omni/monitor/xfeemngr/tokenprice"
@@ -50,16 +52,26 @@ const (
 	maxSaneEthPerOmni = float64(1)
 )
 
-func Start(ctx context.Context, network netconf.Network, ethClients map[uint64]ethclient.Client, privKeyPath string) error {
+func Start(ctx context.Context, network netconf.Network, rpcs xchain.RPCEndpoints, privKeyPath string) error {
 	privKey, err := crypto.LoadECDSA(privKeyPath)
 	if err != nil {
 		return errors.Wrap(err, "load private key")
 	}
 
+	toSync, err := chainsToSync(network)
+	if err != nil {
+		return err
+	}
+
+	ethClients, err := makeEthClients(toSync, rpcs)
+	if err != nil {
+		return err
+	}
+
 	gprice := gasprice.NewBuffer(makeGasPricers(ethClients), gasprice.WithThresholdPct(gasPriceBufferThreshold))
 	tprice := tokenprice.NewBuffer(coingecko.New(), tokens.OMNI, tokens.ETH, tokenprice.WithThresholdPct(tokenPriceBufferThreshold))
 
-	oracles, err := makeOracles(ctx, network, ethClients, privKey, gprice, tprice)
+	oracles, err := makeOracles(ctx, network, toSync, ethClients, privKey, gprice, tprice)
 	if err != nil {
 		return err
 	}
@@ -103,12 +115,17 @@ func makeGasPricers(ethClients map[uint64]ethclient.Client) map[uint64]ethereum.
 }
 
 // makeOracles makes a map chainID to feeOracle for each chain in the network.
-func makeOracles(ctx context.Context, network netconf.Network, ethClients map[uint64]ethclient.Client,
+func makeOracles(ctx context.Context, network netconf.Network, toSync []evmchain.Metadata, ethClients map[uint64]ethclient.Client,
 	pk *ecdsa.PrivateKey, gprice *gasprice.Buffer, tprice *tokenprice.Buffer) (map[uint64]feeOracle, error) {
 	oracles := make(map[uint64]feeOracle)
 
 	for _, chain := range network.EVMChains() {
-		oracle, err := makeOracle(ctx, chain, network, ethClients, pk, gprice, tprice)
+		ethCl, ok := ethClients[chain.ID]
+		if !ok {
+			return nil, errors.New("eth client not found", "chain", chain.ID)
+		}
+
+		oracle, err := makeOracle(ctx, chain, toSync, ethCl, pk, gprice, tprice)
 		if err != nil {
 			return nil, errors.Wrap(err, "make oracle", "chain", chain.Name)
 		}
@@ -117,4 +134,61 @@ func makeOracles(ctx context.Context, network netconf.Network, ethClients map[ui
 	}
 
 	return oracles, nil
+}
+
+// chainsToSync returns a list of evmchain.Metadata to sync on each fee oracle.
+// This includes all evm chains in the network, and their "postsTo" chains.
+func chainsToSync(network netconf.Network) ([]evmchain.Metadata, error) {
+	var toSync []evmchain.Metadata
+
+	// avoid dups - some chains have same postsTo, and they may be in the network
+	set := make(map[uint64]bool)
+
+	// add all chains in network
+	for _, chain := range network.EVMChains() {
+		meta, ok := evmchain.MetadataByID(chain.ID)
+		if !ok {
+			return nil, errors.New("chain metadata not found", "chain", chain.ID)
+		}
+
+		toSync = append(toSync, meta)
+		set[meta.ChainID] = true
+	}
+
+	// add all "postsTo" chains
+	for _, chain := range toSync {
+		if chain.PostsTo == 0 || set[chain.PostsTo] {
+			continue
+		}
+
+		meta, ok := evmchain.MetadataByID(chain.PostsTo)
+		if !ok {
+			return nil, errors.New("chain metadata not found", "chain", meta.ChainID)
+		}
+
+		toSync = append(toSync, meta)
+		set[meta.ChainID] = true
+	}
+
+	return toSync, nil
+}
+
+func makeEthClients(chains []evmchain.Metadata, rpcs xchain.RPCEndpoints) (map[uint64]ethclient.Client, error) {
+	clients := make(map[uint64]ethclient.Client)
+
+	for _, chain := range chains {
+		rpc, err := rpcs.ByNameOrID(chain.Name, chain.ChainID)
+		if err != nil {
+			return nil, err
+		}
+
+		c, err := ethclient.Dial(chain.Name, rpc)
+		if err != nil {
+			return nil, errors.Wrap(err, "dial rpc", "chain_name", chain.Name, "chain_id", chain.ChainID, "rpc_url", rpc)
+		}
+
+		clients[chain.ChainID] = c
+	}
+
+	return clients, nil
 }


### PR DESCRIPTION
Support management of onchain fee params for a chain not in the network.

Testnet sepolia chains post tx data to sepolia. Their xcall fees should therefore 
be calculated using sepolia gas prices. Sepolia is not in the omega network, but we
need to manage it's fee params on chain.

Requires https://github.com/omni-network/ops/pull/385

issue: none
