### PR TITLE
fix(e2e): reduce admin script timeout risk

### DIFF
--- a/e2e/fbproxy/app/app.go
+++ b/e2e/fbproxy/app/app.go
@@ -117,7 +117,7 @@ func newHTTPServer(ctx context.Context, cfg Config) (*http.Server, error) {
 	return &http.Server{
 		ReadHeaderTimeout: 30 * time.Second,
 		IdleTimeout:       30 * time.Second,
-		WriteTimeout:      30 * time.Second,
+		WriteTimeout:      5 * time.Minute, // large timeout, to allow for fb tx mpc signing.
 		Handler:           http.HandlerFunc(proxy.Proxy),
 	}, nil
 }


### PR DESCRIPTION
Reduce timeout risk in admin forge scripts

- Increase fbproxy write timeout to allow for mpc fireblocks signing.
- Run admin scripts in sequence, not parallet

issue: none