### PR TITLE
chore(buildinfo): update omni version

### DIFF
--- a/halo/config/testdata/default_halo.toml
+++ b/halo/config/testdata/default_halo.toml
@@ -3,7 +3,7 @@
 
 # The version of the Halo binary that created or
 # last modified the config file. Do not modify this.
-version = "v0.1.10"
+version = "v0.4-dev"
 
 # Omni network to participate in: mainnet, testnet, or devnet.
 network = ""

--- a/halo/genutil/testdata/TestMakeGenesis.golden
+++ b/halo/genutil/testdata/TestMakeGenesis.golden
@@ -1,6 +1,6 @@
 {
  "app_name": "halo",
- "app_version": "v0.1.10",
+ "app_version": "v0.4-dev",
  "genesis_time": "1970-01-01T00:00:01Z",
  "chain_id": "omni-1001651",
  "initial_height": 1,

--- a/lib/buildinfo/buildinfo.go
+++ b/lib/buildinfo/buildinfo.go
@@ -13,7 +13,7 @@ import (
 
 // version of the whole omni-monorepo and all binaries built from this git commit.
 // This value is set by goreleaser at build-time and should be the git tag for official releases.
-var version = "v0.1.10"
+var version = "v0.4-dev"
 
 // unknown is the default value for the git commit hash and timestamp.
 const unknown = "unknown"

--- a/monitor/app/testdata/default_monitor.toml
+++ b/monitor/app/testdata/default_monitor.toml
@@ -3,7 +3,7 @@
 
 # The version of the Halo binary that created or
 # last modified the config file. Do not modify this.
-version = "v0.1.10"
+version = "v0.4-dev"
 
 # Omni network to participate in: mainnet, testnet, or devnet.
 network = ""

--- a/relayer/app/testdata/default_relayer.toml
+++ b/relayer/app/testdata/default_relayer.toml
@@ -3,7 +3,7 @@
 
 # The version of the Halo binary that created or
 # last modified the config file. Do not modify this.
-version = "v0.1.10"
+version = "v0.4-dev"
 
 # Omni network to participate in: mainnet, testnet, or devnet.
 network = ""


### PR DESCRIPTION
Updates the omni version on main to `v0.4-dev` to indicate we are building on top of v0.4.0

issue: none