### PR TITLE
chore(ci): lock go minor version in ci

### DIFF
--- a/.github/workflows/check-sol-artifacts.yml
+++ b/.github/workflows/check-sol-artifacts.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v5
         with:
-          go-version: 'stable'
+          go-version: '1.22'
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
       - name: Install pnpm

--- a/.github/workflows/ci-verifypr.yml
+++ b/.github/workflows/ci-verifypr.yml
@@ -12,6 +12,6 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: 'stable'
+          go-version: '1.22'
       - name: "Verify PR"
         run: go run github.com/omni-network/omni/scripts/verifypr

--- a/.github/workflows/clicommand.yml
+++ b/.github/workflows/clicommand.yml
@@ -28,7 +28,7 @@ jobs:
     - name: Install Go
       uses: actions/setup-go@v5
       with:
-        go-version: 'stable'
+        go-version: '1.22'
 
     - name: Build binaries
       uses: goreleaser/goreleaser-action@v5
@@ -109,7 +109,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v5
         with:
-          go-version: 'stable'
+          go-version: '1.22'
 
       - name: Configure Git
         run: |

--- a/.github/workflows/e2etest.yml
+++ b/.github/workflows/e2etest.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v5
         with:
-          go-version: 'stable'
+          go-version: '1.22'
 
       - name: Run e2e tests
         run: make e2e-ci

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v5
         with:
-          go-version: 'stable'
+          go-version: '1.22'
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:

--- a/.github/workflows/gotest.yml
+++ b/.github/workflows/gotest.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v5
         with:
-          go-version: 'stable'
+          go-version: '1.22'
       # TODO(corver): add coverage
       - name: Pull anvil # This can be slow and cause timeouts
         run: docker pull ghcr.io/foundry-rs/foundry:latest

--- a/.github/workflows/pr-e2etest.yml
+++ b/.github/workflows/pr-e2etest.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v5
         with:
-          go-version: 'stable'
+          go-version: '1.22'
 
       - name: Build binaries
         uses: goreleaser/goreleaser-action@v5

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -17,6 +17,6 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v5
         with:
-          go-version: 'stable'
+          go-version: '1.22'
       - name: Run pre-commit hooks
         uses: pre-commit/action@v3.0.1


### PR DESCRIPTION
Lock go minor version in ci

Locking goversion to 1.22 in ci until we can upgrade to 1.23. Upgrade to 1.23 
is blocked by https://github.com/ethereum/go-ethereum/issues/30100

issue: none