### PR TITLE
chore(ci): lock go minor version

### DIFF
--- a/.github/workflows/release-official.yml
+++ b/.github/workflows/release-official.yml
@@ -12,7 +12,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: stable
+          go-version: '1.22'
 
       - name: Login to Dockerhub container registry
         uses: docker/login-action@v3

--- a/.github/workflows/release-snapshot.yml
+++ b/.github/workflows/release-snapshot.yml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: stable
+          go-version: '1.22'
       - name: Login to Dockerhub container registry
         uses: docker/login-action@v3
         with:


### PR DESCRIPTION
Lock go minor version in ci

Locking goversion to 1.22 in ci until we can upgrade to 1.23. Upgrade to 1.23
is blocked by https://github.com/ethereum/go-ethereum/issues/30100

Adds version locks missed in https://github.com/omni-network/omni/pull/1721


issue: none