### PR TITLE
fix(halo/attest): fix duplicate agg vote logic

### DIFF
--- a/halo/attest/keeper/cpayload.go
+++ b/halo/attest/keeper/cpayload.go
@@ -14,6 +14,8 @@ import (
 	abci "github.com/cometbft/cometbft/abci/types"
 	cmtproto "github.com/cometbft/cometbft/proto/tendermint/types"
 
+	"github.com/ethereum/go-ethereum/common"
+
 	"github.com/cosmos/cosmos-sdk/baseapp"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
@@ -123,7 +125,7 @@ func votesFromLastCommit(
 
 // aggregateVotes aggregates the provided attestations by block header.
 func aggregateVotes(votes []*types.Vote) ([]*types.AggVote, error) {
-	uniqueAggs := make(map[[32]byte]*types.AggVote)
+	uniqueAggs := make(map[common.Hash]*types.AggVote)
 	for _, vote := range votes {
 		attRoot, err := vote.AttestationRoot()
 		if err != nil {
@@ -146,9 +148,9 @@ func aggregateVotes(votes []*types.Vote) ([]*types.AggVote, error) {
 }
 
 // flattenAggs returns the values of the provided map.
-func flattenAggs(aggsByHeader map[[32]byte]*types.AggVote) []*types.AggVote {
-	aggs := make([]*types.AggVote, 0, len(aggsByHeader))
-	for _, agg := range aggsByHeader {
+func flattenAggs(aggsByRoot map[common.Hash]*types.AggVote) []*types.AggVote {
+	aggs := make([]*types.AggVote, 0, len(aggsByRoot))
+	for _, agg := range aggsByRoot {
 		aggs = append(aggs, agg)
 	}
 

--- a/halo/attest/keeper/keeper_internal_test.go
+++ b/halo/attest/keeper/keeper_internal_test.go
@@ -1,8 +1,22 @@
 package keeper
 
 import (
+	"bytes"
+	"context"
+	"crypto/ecdsa"
 	"fmt"
 	"testing"
+
+	"github.com/omni-network/omni/halo/attest/types"
+	"github.com/omni-network/omni/lib/k1util"
+	"github.com/omni-network/omni/lib/netconf"
+	"github.com/omni-network/omni/lib/tutil"
+	"github.com/omni-network/omni/lib/xchain"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/crypto"
+
+	"github.com/stretchr/testify/require"
 )
 
 // AttestTable returns the attestations ORM table.
@@ -50,4 +64,184 @@ func TestWindowCompose(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestVerifyAggVotes(t *testing.T) {
+	t.Parallel()
+	const (
+		voteExtLimit = 4
+		cChainID     = 999
+		windowOffset = 64
+		power        = 10
+		srcChain1    = 1
+	)
+	val1 := genPrivKey(t)
+	val2 := genPrivKey(t)
+	val3 := genPrivKey(t)
+	valX := genPrivKey(t) // Not in set
+	vals := []*ecdsa.PrivateKey{val1, val2, val3, valX}
+	portalReg := testPortalRegistry{srcChain1: []xchain.ConfLevel{xchain.ConfFinalized}}
+
+	valset := ValSet{Vals: map[common.Address]int64{
+		addr(val1): power,
+		addr(val2): power,
+		addr(val3): power,
+	}}
+
+	att1 := &types.AttestHeader{
+		ConsensusChainId: cChainID,
+		SourceChainId:    srcChain1,
+		ConfLevel:        uint32(xchain.ConfFinalized),
+		AttestOffset:     1,
+	}
+
+	block1A := &types.BlockHeader{
+		ChainId:     srcChain1,
+		BlockHeight: 1,
+		BlockHash:   tutil.RandomHash().Bytes(),
+	}
+
+	block1B := &types.BlockHeader{
+		ChainId:     srcChain1,
+		BlockHeight: 1,
+		BlockHash:   tutil.RandomHash().Bytes(),
+	}
+	msgRootA := tutil.RandomHash().Bytes()
+	msgRootB := tutil.RandomHash().Bytes()
+
+	windowCompareFunc := func(ctx context.Context, chainVersion xchain.ChainVersion, attestOffset uint64) (int, error) {
+		if attestOffset > windowOffset {
+			return 1, nil
+		}
+
+		return 0, nil
+	}
+
+	tests := []struct {
+		name   string
+		aggs   []*types.AggVote
+		errStr string
+	}{
+		{
+			name: "no votes",
+		},
+		{
+			name: "same att header, different blocks",
+			aggs: []*types.AggVote{
+				{
+					AttestHeader: att1,
+					BlockHeader:  block1A,
+					MsgRoot:      msgRootA,
+					Signatures:   toSign(val1, val2),
+				},
+				{
+					AttestHeader: att1,
+					BlockHeader:  block1B,
+					MsgRoot:      msgRootB,
+					Signatures:   toSign(val3),
+				},
+			},
+		},
+		{
+			name:   "same att header, same blocks",
+			errStr: "invalid duplicate aggregate vote",
+			aggs: []*types.AggVote{
+				{
+					AttestHeader: att1,
+					BlockHeader:  block1A,
+					MsgRoot:      msgRootA,
+					Signatures:   toSign(val1, val2),
+				},
+				{
+					AttestHeader: att1,
+					BlockHeader:  block1A,
+					MsgRoot:      msgRootA,
+					Signatures:   toSign(val3),
+				},
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			ctx := context.Background()
+			keeper := Keeper{
+				portalRegistry: portalReg,
+				namer:          netconf.SimnetNetwork().ChainVersionName,
+				voter:          nil,
+				voteWindow:     0,
+				voteExtLimit:   voteExtLimit,
+			}
+
+			for i := 0; i < len(test.aggs); i++ {
+				test.aggs[i].Signatures = sign(t, test.aggs[i], vals)
+			}
+
+			err := keeper.verifyAggVotes(ctx, cChainID, valset, test.aggs, windowCompareFunc)
+			if test.errStr == "" {
+				require.NoError(t, err)
+			} else {
+				require.ErrorContains(t, err, test.errStr)
+			}
+		})
+	}
+}
+
+func sign(t *testing.T, vote *types.AggVote, vals []*ecdsa.PrivateKey) []*types.SigTuple {
+	t.Helper()
+	attRoot, err := vote.AttestationRoot()
+	require.NoError(t, err)
+
+	for i := 0; i < len(vote.Signatures); i++ {
+		sig := vote.Signatures[i]
+		var found bool
+		for _, val := range vals {
+			if bytes.Equal(sig.ValidatorAddress, addr(val).Bytes()) {
+				pk, err := k1util.StdPrivKeyToComet(val)
+				require.NoError(t, err)
+
+				s, err := k1util.Sign(pk, attRoot)
+				require.NoError(t, err)
+
+				vote.Signatures[i].Signature = s[:]
+				found = true
+
+				break
+			}
+		}
+
+		require.True(t, found, "signature not found")
+	}
+
+	return vote.Signatures
+}
+
+func addr(val *ecdsa.PrivateKey) common.Address {
+	return crypto.PubkeyToAddress(val.PublicKey)
+}
+
+func toSign(vals ...*ecdsa.PrivateKey) []*types.SigTuple {
+	var resp []*types.SigTuple
+	for _, val := range vals {
+		resp = append(resp, &types.SigTuple{
+			ValidatorAddress: addr(val).Bytes(),
+		})
+	}
+
+	return resp
+}
+
+func genPrivKey(t *testing.T) *ecdsa.PrivateKey {
+	t.Helper()
+
+	privKey, err := crypto.GenerateKey()
+	require.NoError(t, err)
+
+	return privKey
+}
+
+type testPortalRegistry map[uint64][]xchain.ConfLevel
+
+func (t testPortalRegistry) ConfLevels(context.Context) (map[uint64][]xchain.ConfLevel, error) {
+	return t, nil
 }

--- a/halo/attest/keeper/proposal_server.go
+++ b/halo/attest/keeper/proposal_server.go
@@ -28,7 +28,7 @@ func (s proposalServer) AddVotes(ctx context.Context, msg *types.MsgAddVotes,
 	valset, err := s.prevBlockValSet(ctx)
 	if err != nil {
 		return nil, errors.Wrap(err, "fetch validators")
-	} else if err := s.verifyAggVotes(ctx, consensusID, valset, msg.Votes); err != nil {
+	} else if err := s.verifyAggVotes(ctx, consensusID, valset, msg.Votes, s.windowCompare); err != nil {
 		return nil, errors.Wrap(err, "verify votes")
 	}
 


### PR DESCRIPTION
Fixes attest module `verifyAggVotes` dedup logic to align with `aggregateVotes` logic that uses `attestation root` as dedup key. 

issue: #1731