### PR TITLE
chore(e2e): allow ephemeral network upgrades

### DIFF
--- a/e2e/app/run.go
+++ b/e2e/app/run.go
@@ -259,14 +259,6 @@ func E2ETest(ctx context.Context, def Definition, cfg E2ETestConfig) error {
 // Upgrade generates all local artifacts, but only copies the dynamic artifacts (excl genesis) to the VMs.
 // It then calls docker-compose up.
 func Upgrade(ctx context.Context, def Definition, cfg DeployConfig, upgradeCfg types.ServiceConfig) error {
-	if def.Testnet.Network.IsEphemeral() {
-		// TODO(corver): Staging could support upgrades.
-		//  Currently, validator private keys are rotated,
-		//  so they stop being validators,
-		//  resulting in the chain stalling.
-		return errors.New("cannot upgrade ephemeral network", "network", def.Testnet.Network)
-	}
-
 	if err := Setup(ctx, def, cfg); err != nil {
 		return err
 	}


### PR DESCRIPTION
Allow ephemeral network upgrades.

issue: none