### PR TITLE
feat(e2e): pass all rpc overrides to xfeemnger

### DIFF
--- a/monitor/app/app.go
+++ b/monitor/app/app.go
@@ -88,7 +88,7 @@ func Run(ctx context.Context, cfg Config) error {
 		return errors.Wrap(err, "start xchain monitor")
 	}
 
-	if err := xfeemngr.Start(ctx, network, cfg.RPCEndpoints, cfg.PrivateKey); err != nil {
+	if err := xfeemngr.Start(ctx, network, cfg.XFeeMngr, cfg.PrivateKey); err != nil {
 		return errors.Wrap(err, "start xfee manager")
 	}
 

--- a/monitor/app/config.go
+++ b/monitor/app/config.go
@@ -10,6 +10,7 @@ import (
 	"github.com/omni-network/omni/lib/netconf"
 	"github.com/omni-network/omni/lib/xchain"
 	"github.com/omni-network/omni/monitor/loadgen"
+	"github.com/omni-network/omni/monitor/xfeemngr"
 
 	cmtos "github.com/cometbft/cometbft/libs/os"
 
@@ -23,6 +24,7 @@ type Config struct {
 	PrivateKey     string
 	HaloURL        string
 	LoadGen        loadgen.Config
+	XFeeMngr       xfeemngr.Config
 	DBDir          string
 }
 

--- a/monitor/app/config.toml.tpl
+++ b/monitor/app/config.toml.tpl
@@ -39,6 +39,23 @@ halo-url = "{{ .HaloURL }}"
 {{ end }}
 
 #######################################################################
+###                             X-FeeMngr                           ###
+#######################################################################
+
+[xfeemngr]
+
+# EVM RPC endpoints to use in xfeemngr. This may include out-of-network rpcs.
+[xfeemngr.rpc-endpoints]
+{{- if not .XFeeMngr.RPCEndpoints }}
+# ethereum = "http://my-ethreum-node:8545"
+# optimism = "https://my-op-node.com"
+{{ end -}}
+{{- range $key, $value := .XFeeMngr.RPCEndpoints }}
+{{ $key }} = "{{ $value }}"
+{{ end }}
+
+
+#######################################################################
 ###                         Logging Options                         ###
 #######################################################################
 

--- a/monitor/app/testdata/default_monitor.toml
+++ b/monitor/app/testdata/default_monitor.toml
@@ -35,6 +35,19 @@ halo-url = ""
 
 
 #######################################################################
+###                             X-FeeMngr                           ###
+#######################################################################
+
+[xfeemngr]
+
+# EVM RPC endpoints to use in xfeemngr. This may include out-of-network rpcs.
+[xfeemngr.rpc-endpoints]
+# ethereum = "http://my-ethreum-node:8545"
+# optimism = "https://my-op-node.com"
+
+
+
+#######################################################################
 ###                         Logging Options                         ###
 #######################################################################
 

--- a/monitor/cmd/cmd.go
+++ b/monitor/cmd/cmd.go
@@ -19,6 +19,7 @@ func New() *cobra.Command {
 	cfg := monitor.DefaultConfig()
 	bindRunFlags(cmd.Flags(), &cfg)
 	bindLoadGenFlags(cmd.Flags(), &cfg.LoadGen)
+	bindXFeeMngrFlags(cmd.Flags(), &cfg.XFeeMngr)
 
 	logCfg := log.DefaultConfig()
 	log.BindFlags(cmd.Flags(), &logCfg)

--- a/monitor/cmd/flags.go
+++ b/monitor/cmd/flags.go
@@ -5,6 +5,7 @@ import (
 	"github.com/omni-network/omni/lib/xchain"
 	monitor "github.com/omni-network/omni/monitor/app"
 	"github.com/omni-network/omni/monitor/loadgen"
+	"github.com/omni-network/omni/monitor/xfeemngr"
 
 	"github.com/spf13/pflag"
 )
@@ -20,4 +21,8 @@ func bindRunFlags(flags *pflag.FlagSet, cfg *monitor.Config) {
 
 func bindLoadGenFlags(flags *pflag.FlagSet, cfg *loadgen.Config) {
 	flags.StringVar(&cfg.ValidatorKeysGlob, "loadgen-validator-keys-glob", cfg.ValidatorKeysGlob, "Glob path to the validator keys used for self-delegation load generation. Only applicable to devnet and staging")
+}
+
+func bindXFeeMngrFlags(flags *pflag.FlagSet, cfg *xfeemngr.Config) {
+	flags.StringToStringVar((*map[string]string)(&cfg.RPCEndpoints), "xfeemngr-rpc-endpoints", cfg.RPCEndpoints, "Cross-chain EVM RPC endpoints. e.g. \"ethereum=http://geth:8545,optimism=https://optimism.io\"")
 }

--- a/monitor/xfeemngr/xfeemngr.go
+++ b/monitor/xfeemngr/xfeemngr.go
@@ -28,6 +28,10 @@ type Manager struct {
 	ticker  ticker.Ticker
 }
 
+type Config struct {
+	RPCEndpoints xchain.RPCEndpoints
+}
+
 const (
 	// feeOracleSyncInterval is the interval at which fee oracles syncs buffered gas and token prices with FeeOracle deployments.
 	feeOracleSyncInterval = 5 * time.Minute
@@ -52,7 +56,9 @@ const (
 	maxSaneEthPerOmni = float64(1)
 )
 
-func Start(ctx context.Context, network netconf.Network, rpcs xchain.RPCEndpoints, privKeyPath string) error {
+func Start(ctx context.Context, network netconf.Network, cfg Config, privKeyPath string) error {
+	log.Info(ctx, "Starting fee manager", "endpoint", cfg.RPCEndpoints)
+
 	privKey, err := crypto.LoadECDSA(privKeyPath)
 	if err != nil {
 		return errors.Wrap(err, "load private key")
@@ -63,7 +69,7 @@ func Start(ctx context.Context, network netconf.Network, rpcs xchain.RPCEndpoint
 		return err
 	}
 
-	ethClients, err := makeEthClients(toSync, rpcs)
+	ethClients, err := makeEthClients(toSync, cfg.RPCEndpoints)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Pass all rpc overrides to the xfeemngr.

This allows us to pass in rpcs for chains that are not in-network. 
We pass to xfeemngr explicitly, because other processes assume all
endpoints are in-network.

issue: none
