### PR TITLE
chore(monitor): improve routescan recon

### DIFF
--- a/lib/netconf/netconf.go
+++ b/lib/netconf/netconf.go
@@ -177,6 +177,16 @@ func (n Network) ChainVersionsTo(dstChainID uint64) []xchain.ChainVersion {
 	return resp
 }
 
+// EVMStreams returns the all streams between EVM chains.
+func (n Network) EVMStreams() []xchain.StreamID {
+	var resp []xchain.StreamID
+	for _, srcChain := range n.EVMChains() {
+		resp = append(resp, n.StreamsFrom(srcChain.ID)...)
+	}
+
+	return resp
+}
+
 // StreamsTo returns the all streams to the provided destination chain.
 func (n Network) StreamsTo(dstChainID uint64) []xchain.StreamID {
 	if dstChainID == n.ID.Static().OmniConsensusChainIDUint64() {

--- a/monitor/routerecon/metrics.go
+++ b/monitor/routerecon/metrics.go
@@ -19,4 +19,11 @@ var (
 		Name:      "failure_total",
 		Help:      "Total count of failed route recons",
 	})
+
+	reconCompletedOffset = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: "monitor",
+		Subsystem: "routerecon",
+		Name:      "completed_offset",
+		Help:      "Latest completed attest offset per stream",
+	}, []string{"stream"})
 )

--- a/monitor/routerecon/recon_internal_test.go
+++ b/monitor/routerecon/recon_internal_test.go
@@ -5,8 +5,8 @@ import (
 	"testing"
 
 	"github.com/omni-network/omni/e2e/types"
+	"github.com/omni-network/omni/lib/log"
 	"github.com/omni-network/omni/lib/netconf"
-	"github.com/omni-network/omni/lib/tutil"
 	"github.com/omni-network/omni/lib/xchain"
 	xconnect "github.com/omni-network/omni/lib/xchain/connect"
 
@@ -32,9 +32,12 @@ func TestReconOnce(t *testing.T) {
 	conn, err := xconnect.New(ctx, netconf.Omega, endpoints)
 	require.NoError(t, err)
 
-	crossTx, err := paginateLatestCrossTx(ctx)
-	require.NoError(t, err)
-
-	err = reconOnce(ctx, conn.Network, conn.XProvider, conn.EthClients, crossTx)
-	tutil.RequireNoError(t, err)
+	for _, stream := range conn.Network.EVMStreams() {
+		err := reconStreamOnce(ctx, conn.Network, conn.XProvider, conn.EthClients, stream)
+		if err != nil {
+			log.Warn(ctx, "RouteRecon failed", err, "stream", conn.Network.StreamName(stream))
+		} else {
+			log.Info(ctx, "RouteRecon success", "stream", conn.Network.StreamName(stream))
+		}
+	}
 }

--- a/monitor/routerecon/routescan_internal_test.go
+++ b/monitor/routerecon/routescan_internal_test.go
@@ -18,12 +18,19 @@ func TestQueryLatestXChain(t *testing.T) {
 	if !*integration {
 		t.Skip("skipping integration test")
 	}
-	t.Parallel()
+
 	ctx := context.Background()
-	resp, err := paginateLatestCrossTx(ctx)
+	resp, err := paginateLatestCrossTx(ctx, queryFilter{})
 	require.NoError(t, err)
 	require.NotEmpty(t, resp.ID)
+
 	bz, err := json.MarshalIndent(resp, "", "  ")
 	require.NoError(t, err)
 	t.Log(string(bz))
+}
+
+// TestIntegrationFalse ensures the integration flag defaults to false.
+func TestIntegrationFalse(t *testing.T) {
+	t.Parallel()
+	require.False(t, *integration)
 }

--- a/monitor/routerecon/types.go
+++ b/monitor/routerecon/types.go
@@ -1,0 +1,150 @@
+package routerecon
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/omni-network/omni/lib/errors"
+	"github.com/omni-network/omni/lib/xchain"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+)
+
+type chainID string
+
+func (c chainID) ID() (uint64, error) {
+	if strings.Contains(string(c), "_") {
+		var resp, dummy uint64
+		_, err := fmt.Sscanf(string(c), "%d_%d", &resp, &dummy)
+		if err != nil {
+			return 0, errors.Wrap(err, "parse chain id")
+		}
+
+		return resp, nil
+	}
+
+	resp, err := strconv.ParseUint(string(c), 10, 64)
+	if err != nil {
+		return 0, errors.Wrap(err, "parse chain id")
+	}
+
+	return resp, nil
+}
+
+func (c *chainID) UnmarshalJSON(bz []byte) error {
+	var str string
+	if err := json.Unmarshal(bz, &str); err == nil {
+		*c = chainID(str)
+		return nil
+	}
+
+	var i uint64
+	if err := json.Unmarshal(bz, &i); err != nil {
+		return errors.Wrap(err, "unmarshal chain id")
+	}
+
+	*c = chainID(strconv.FormatUint(i, 10))
+
+	return nil
+}
+
+type crossTxJSON struct {
+	ID             string         `json:"id"` // sha256("omni#{srcChainId}#{dstChainId}#{shardId}#{offset}")
+	Type           string         `json:"type"`
+	Status         string         `json:"status"`
+	SrcChainID     chainID        `json:"srcChainId"`
+	SrcTimestamp   time.Time      `json:"srcTimestamp"`
+	SrcTxHash      common.Hash    `json:"srcTxHash"`
+	SrcBlockNumber uint64         `json:"srcBlockNumber"`
+	SrcBlockHash   common.Hash    `json:"srcBlockHash"`
+	SrcGasLimit    uint64         `json:"srcGasLimit,string"`
+	DstChainID     chainID        `json:"dstChainId"`
+	DstTimestamp   time.Time      `json:"dstTimestamp"`
+	DstTxHash      common.Hash    `json:"dstTxHash"`
+	DstBlockNumber uint64         `json:"dstBlockNumber"`
+	DstBlockHash   common.Hash    `json:"dstBlockHash"`
+	DstGasLimit    uint64         `json:"dstGasLimit,string"`
+	From           common.Address `json:"from"`
+	To             common.Address `json:"to"`
+	Data           struct {
+		Relayer   common.Address `json:"relayer"`
+		GasUsed   uint64         `json:"gasUsed,string"`
+		Error     hexutil.Bytes  `json:"error"`
+		Offset    uint64         `json:"offset,string"`
+		ShardID   xchain.ShardID `json:"shardId,string"`
+		ConfLevel string         `json:"confirmationLevel"` // ConfLevel of ShardID
+		GasLimit  uint64         `json:"gasLimit,string"`
+		Fees      string         `json:"fees"`
+	} `json:"data"`
+}
+
+// ExpectedID calculates the expected ID of the cross transaction from its fields.
+func (c crossTxJSON) ExpectedID() string {
+	s := fmt.Sprintf("omni#%s#%s#%d#%d", c.SrcChainID, c.DstChainID, c.Data.ShardID, c.Data.Offset)
+	bz := sha256.Sum256([]byte(s))
+
+	return hex.EncodeToString(bz[:])
+}
+
+// ConfLevel returns the confirmation level of the cross transaction. This matches the ShardID's ConfLevel.
+func (c crossTxJSON) ConfLevel() (xchain.ConfLevel, error) {
+	switch strings.ToLower(c.Data.ConfLevel) {
+	case "finalized":
+		return xchain.ConfFinalized, nil
+	case "latest":
+		return xchain.ConfLatest, nil
+	default:
+		return 0, errors.New("invalid conf level", "got", c.Data.ConfLevel)
+	}
+}
+
+func (c crossTxJSON) Success() bool {
+	return len(c.Data.Error) == 0
+}
+
+func (c crossTxJSON) MsgID() (xchain.MsgID, error) {
+	srcChainID, err := c.SrcChainID.ID()
+	if err != nil {
+		return xchain.MsgID{}, errors.Wrap(err, "parse src chain id")
+	}
+
+	dstChainID, err := c.DstChainID.ID()
+	if err != nil {
+		return xchain.MsgID{}, errors.Wrap(err, "parse dst chain id")
+	}
+
+	return xchain.MsgID{
+		StreamID: xchain.StreamID{
+			SourceChainID: srcChainID,
+			DestChainID:   dstChainID,
+			ShardID:       c.Data.ShardID,
+		},
+		StreamOffset: c.Data.Offset,
+	}, nil
+}
+
+type crossTxResponse struct {
+	Items []crossTxJSON `json:"items"`
+	Links links         `json:"link"`
+}
+
+type links struct {
+	Next      string `json:"next"`
+	NextToken string `json:"nextToken"`
+}
+
+// queryFilter defines the cross transactions to query.
+type queryFilter struct {
+	Stream  xchain.StreamID // Defaults to any stream if zero
+	Pending bool            // Default to Completed if false
+}
+
+func (f queryFilter) HasStream() bool {
+	return f.Stream != (xchain.StreamID{})
+}


### PR DESCRIPTION
Improve routescan recon:
 - Fix issue with receipt.ConfLevel
 - Recon each stream explicitly (except arb_sepolia which isn't supported currently).
 - Track completed offset to compare against our submitted offset
 - Verify crossTX.ID against expected value
 - Improve types.

issue: #1714 