### PR TITLE
ci(e2e): add backwards compatibility test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -83,7 +83,7 @@ devnet-clean: ## Deletes devnet1 containers
 .PHONY: e2e-ci
 e2e-ci: ## Runs all e2e CI tests
 	@go install github.com/omni-network/omni/e2e
-	@cd e2e && ./run-multiple.sh manifests/devnet1.toml manifests/fuzzyhead.toml manifests/ci.toml
+	@cd e2e && ./run-multiple.sh manifests/devnet1.toml manifests/fuzzyhead.toml manifests/ci.toml manifests/backwards.toml
 
 .PHONY: e2e-run
 e2e-run: ## Run specific e2e manifest (MANIFEST=single, MANIFEST=devnet1, etc). Note container remain running after the test.

--- a/e2e/app/definition.go
+++ b/e2e/app/definition.go
@@ -196,7 +196,7 @@ func newBackends(ctx context.Context, cfg DefinitionConfig, testnet types.Testne
 func adaptCometTestnet(ctx context.Context, manifest types.Manifest, testnet *e2e.Testnet, imgTag string) (*e2e.Testnet, error) {
 	testnet.Dir = runsDir(testnet.File)
 	testnet.VoteExtensionsEnableHeight = 1
-	testnet.UpgradeVersion = "omniops/halo:" + imgTag
+	testnet.UpgradeVersion = "omniops/halovisor:" + imgTag // Currently only support upgrading to "latest" version
 
 	for i := range testnet.Nodes {
 		var err error
@@ -225,7 +225,12 @@ func adaptNode(ctx context.Context, manifest types.Manifest, node *e2e.Node, tag
 		tag = manifest.PinnedHaloTag
 	}
 
-	node.Version = "omniops/halovisor:" + tag
+	// Override default comet version with our own, see github.com/cometbft/cometbft@v0.38.11/test/e2e/pkg/testnet.go:36
+	const cometLocalVersion = "cometbft/e2e-node:local-version"
+	if node.Version == cometLocalVersion {
+		node.Version = "omniops/halovisor:" + tag
+	}
+
 	node.PrivvalKey = valKey.PrivKey
 	node.NodeKey = nodeKey.PrivKey
 

--- a/e2e/docker/compose.yaml.tmpl
+++ b/e2e/docker/compose.yaml.tmpl
@@ -17,7 +17,7 @@ services:
     labels:
       e2e: true
     container_name: {{ .Name }}
-    image: {{ .Version }}
+    image: {{ .Version }}{{if ne .Version $.UpgradeVersion}} # Upgrade {{ .Name }}:{{ $.UpgradeVersion }}{{end}}
     restart: unless-stopped
     init: true
     ports:

--- a/e2e/docker/testdata/TestComposeTemplate_empheral_network_upgrade.golden
+++ b/e2e/docker/testdata/TestComposeTemplate_empheral_network_upgrade.golden
@@ -14,7 +14,7 @@ services:
     labels:
       e2e: true
     container_name: node0
-    image: omniops/halo:main # Upgrade node0:omniops/halo:v1.0
+    image: omniops/halo:v1.0
     restart: unless-stopped
     init: true
     ports:

--- a/e2e/manifests/backwards.toml
+++ b/e2e/manifests/backwards.toml
@@ -1,0 +1,17 @@
+# Backwards ensures backwards-compatibility with v0.4.0.
+network = "devnet"
+anvil_chains = ["mock_l1", "mock_l2"]
+
+multi_omni_evms = true
+
+[node.validator01]
+[node.validator02]
+mode = "archive"
+
+[node.validator03]
+version="omniops/halovisor:v0.4.0"
+perturb = ["upgrade"]
+
+[node.validator04]
+version="omniops/halovisor:v0.4.0"
+perturb = ["upgrade"]

--- a/e2e/types/manifest.go
+++ b/e2e/types/manifest.go
@@ -58,6 +58,8 @@ const (
 	PerturbStopStart Perturb = "stopstart"
 	// PerturbRollback defines a perturbation that stops a halo node, performs a rollback, then starts it again.
 	PerturbRollback Perturb = "rollback"
+	// PerturbUpgrade defines a perturbation that upgrades a halo node to the latest image tag.
+	PerturbUpgrade Perturb = "upgrade"
 
 	// PerturbFuzzyHeadDropBlocks defines a perturbation that enables fuzzyhead dropping xblock for a while.
 	PerturbFuzzyHeadDropBlocks Perturb = "fuzzyhead_dropblocks"

--- a/e2e/vmcompose/provider.go
+++ b/e2e/vmcompose/provider.go
@@ -50,6 +50,10 @@ func (p *Provider) Setup() error {
 		var nodes []*e2e.Node
 		var halos []string
 		for _, node := range p.Testnet.Nodes {
+			if node.Version != p.Testnet.UpgradeVersion {
+				return errors.New("upgrades not supported for vmcompose")
+			}
+
 			if services[node.Name] {
 				nodes = append(nodes, node)
 				halos = append(halos, node.Name)
@@ -80,16 +84,17 @@ func (p *Provider) Setup() error {
 		}
 
 		def := docker.ComposeDef{
-			Network:     false,
-			BindAll:     true,
-			NetworkName: p.Testnet.Name,
-			NetworkCIDR: p.Testnet.IP.String(),
-			Nodes:       nodes,
-			OmniEVMs:    omniEVMs,
-			Anvils:      anvilChains,
-			Relayer:     services["relayer"],
-			Monitor:     services["monitor"],
-			Prometheus:  p.Testnet.Prometheus,
+			UpgradeVersion: p.Testnet.UpgradeVersion,
+			Network:        false,
+			BindAll:        true,
+			NetworkName:    p.Testnet.Name,
+			NetworkCIDR:    p.Testnet.IP.String(),
+			Nodes:          nodes,
+			OmniEVMs:       omniEVMs,
+			Anvils:         anvilChains,
+			Relayer:        services["relayer"],
+			Monitor:        services["monitor"],
+			Prometheus:     p.Testnet.Prometheus,
 		}
 		def = docker.SetImageTags(def, p.Testnet.Manifest, p.omniTag)
 


### PR DESCRIPTION
Adds a `backwards.toml` that ensures backwards compatibility of `main` with `v0.4.0` our first omega LTS version. 

issue: #1537 
