### PR TITLE
chore(github): build and push halovisor on release

### DIFF
--- a/.github/workflows/release-official.yml
+++ b/.github/workflows/release-official.yml
@@ -27,3 +27,8 @@ jobs:
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push halovisor
+        run: |
+          scripts/halovisor/build.sh ${{ github.ref_name }}
+          docker push omniops/halovisor:${{ github.ref_name }}


### PR DESCRIPTION
Build halovisor image on official release. Note this still doesn't build multi-arch (darwin) images yet.

issue: #1735 
