### PR TITLE
feat(cli): add operator commands

### DIFF
--- a/cli/cmd/cmd.go
+++ b/cli/cmd/cmd.go
@@ -30,6 +30,8 @@ func newOperatorCmds() *cobra.Command {
 	cmd.AddCommand(
 		newRegisterCmd(),
 		newInitCmd(),
+		newCreateValCmd(),
+		newCreateKeyCmd(),
 	)
 
 	return cmd

--- a/cli/cmd/compose.yml.tpl
+++ b/cli/cmd/compose.yml.tpl
@@ -2,7 +2,7 @@ services:
 
   halo:
     container_name: halo
-    image: omniops/halo:{{.HaloTag}}
+    image: omniops/halovisor:{{.HaloTag}}
     restart: unless-stopped
     ports:
       - 26656:26656 # Consensus P2P

--- a/cli/cmd/flags.go
+++ b/cli/cmd/flags.go
@@ -51,3 +51,27 @@ func bindRPCURL(cmd *cobra.Command, rpcURL *string) {
 	cmd.Flags().StringVar(rpcURL, flagRPCURL, *rpcURL, "URL of the eth-json RPC server")
 	_ = cmd.MarkFlagRequired(flagRPCURL)
 }
+
+func bindCreateValConfig(cmd *cobra.Command, cfg *createValConfig) {
+	netconf.BindFlag(cmd.Flags(), &cfg.Network)
+
+	const (
+		flagPrivateKeyFile = "private-key-file"
+		flagConsPubKeyHex  = "consensus-pubkey-hex"
+		flagSelfDelegation = "self-delegation"
+	)
+	cmd.Flags().StringVar(&cfg.PrivateKeyFile, flagPrivateKeyFile, cfg.PrivateKeyFile, "Path to the insecure operator private key file")
+	cmd.Flags().StringVar(&cfg.ConsensusPubKeyHex, flagConsPubKeyHex, cfg.ConsensusPubKeyHex, "Hex-encoded validator consensus public key")
+	cmd.Flags().Uint64Var(&cfg.SelfDelegation, flagSelfDelegation, cfg.SelfDelegation, "Self-delegation amount in OMNI (minimum 100 OMNI)")
+
+	_ = cmd.MarkFlagRequired(flagPrivateKeyFile)
+	_ = cmd.MarkFlagRequired(flagConsPubKeyHex)
+	_ = cmd.MarkFlagRequired(flagSelfDelegation)
+	_ = cmd.MarkFlagRequired("network")
+}
+
+func bindCreateKeyConfig(cmd *cobra.Command, cfg *createKeyConfig) {
+	const flagType = "type"
+	cmd.Flags().StringVar((*string)(&cfg.Type), flagType, string(cfg.Type), "Type of key to create")
+	cmd.Flags().StringVar(&cfg.PrivateKeyFile, "output-file", cfg.PrivateKeyFile, "Path to output private key file")
+}

--- a/cli/cmd/key.go
+++ b/cli/cmd/key.go
@@ -1,0 +1,87 @@
+package cmd
+
+import (
+	"encoding/hex"
+
+	"github.com/omni-network/omni/lib/errors"
+	"github.com/omni-network/omni/lib/log"
+
+	"github.com/ethereum/go-ethereum/crypto"
+
+	"github.com/spf13/cobra"
+)
+
+func newCreateKeyCmd() *cobra.Command {
+	cfg := defaultCreateKeyConfig()
+	cmd := &cobra.Command{
+		Use:   "create-operator-key",
+		Short: "Create new operator key",
+		Long:  `Create new operator EOA private key used to fund and sign operator staking transactions`,
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			if err := cfg.Verify(); err != nil {
+				return errors.Wrap(err, "verify flags")
+			}
+
+			privKey, err := crypto.GenerateKey()
+			if err != nil {
+				return errors.Wrap(err, "generate key")
+			}
+			if err := crypto.SaveECDSA(cfg.PrivateKeyFile, privKey); err != nil {
+				return errors.Wrap(err, "save key")
+			}
+
+			log.Info(cmd.Context(), "🎉 Created operator private key",
+				"type", cfg.Type,
+				"file", cfg.PrivateKeyFile,
+				"address", crypto.PubkeyToAddress(privKey.PublicKey).Hex(),
+				"pubkey", hex.EncodeToString(crypto.CompressPubkey(&privKey.PublicKey)),
+			)
+			log.Info(cmd.Context(), "🚧 Remember to backup this key 🚧")
+
+			return nil
+		},
+	}
+
+	bindCreateKeyConfig(cmd, &cfg)
+
+	return cmd
+}
+
+type keyType string
+
+const (
+	KeyTypeInsecure keyType = "insecure"
+)
+
+func (t keyType) Verify() error {
+	if t != KeyTypeInsecure {
+		return errors.New("invalid key type")
+	}
+
+	return nil
+}
+
+type createKeyConfig struct {
+	Type           keyType
+	PrivateKeyFile string
+}
+
+func (c createKeyConfig) Verify() error {
+	if err := c.Type.Verify(); err != nil {
+		return errors.Wrap(err, "verify --type")
+	}
+
+	if c.PrivateKeyFile == "" {
+		return errors.New("required flag --output-file not set")
+	}
+
+	return nil
+}
+
+func defaultCreateKeyConfig() createKeyConfig {
+	return createKeyConfig{
+		Type:           KeyTypeInsecure,
+		PrivateKeyFile: "./operator-private-key",
+	}
+}

--- a/cli/cmd/staking.go
+++ b/cli/cmd/staking.go
@@ -1,0 +1,177 @@
+package cmd
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"encoding/hex"
+	"fmt"
+	"math/big"
+	"strings"
+
+	"github.com/omni-network/omni/contracts/bindings"
+	"github.com/omni-network/omni/halo/genutil/evm/predeploys"
+	"github.com/omni-network/omni/lib/errors"
+	"github.com/omni-network/omni/lib/ethclient"
+	"github.com/omni-network/omni/lib/ethclient/ethbackend"
+	"github.com/omni-network/omni/lib/evmchain"
+	"github.com/omni-network/omni/lib/log"
+	"github.com/omni-network/omni/lib/netconf"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/params"
+
+	"github.com/spf13/cobra"
+)
+
+const minSelfDelegation = uint64(100)
+
+func newCreateValCmd() *cobra.Command {
+	var cfg createValConfig
+
+	cmd := &cobra.Command{
+		Use:   "create-validator",
+		Short: "Create new validator initialized with a self-delegation",
+		Long:  `Sign and broadcast a create-validator transaction that registers a new validator on the omni consensus chain initialized with a self-delegation`,
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			if err := cfg.Verify(); err != nil {
+				return errors.Wrap(err, "verify flags")
+			}
+
+			err := createValidator(cmd.Context(), cfg)
+			if err != nil {
+				return errors.Wrap(err, "create-validator")
+			}
+
+			return nil
+		},
+	}
+
+	bindCreateValConfig(cmd, &cfg)
+
+	return cmd
+}
+
+type createValConfig struct {
+	Network            netconf.ID
+	PrivateKeyFile     string
+	ConsensusPubKeyHex string
+	SelfDelegation     uint64
+}
+
+func (c createValConfig) ConsensusPubKey() (*ecdsa.PublicKey, error) {
+	if strings.HasPrefix(c.ConsensusPubKeyHex, "0x") {
+		return nil, errors.New("consensus pubkey hex should not have 0x prefix")
+	}
+
+	bz, err := hex.DecodeString(c.ConsensusPubKeyHex)
+	if err != nil {
+		return nil, errors.Wrap(err, "decode consensus pubkey hex")
+	}
+
+	resp, err := crypto.DecompressPubkey(bz)
+	if err != nil {
+		return nil, errors.Wrap(err, "decompress consensus pubkey")
+	}
+
+	return resp, nil
+}
+
+func (c createValConfig) Verify() error {
+	if c.PrivateKeyFile == "" {
+		return errors.New("required flag --private-key-file not set")
+	}
+
+	if err := c.Network.Verify(); err != nil {
+		return errors.Wrap(err, "verify --network flag")
+	}
+
+	if _, err := c.ConsensusPubKey(); err != nil {
+		return errors.Wrap(err, "verify --consensus-pubkey-hex flag")
+	}
+
+	if c.SelfDelegation < minSelfDelegation {
+		return errors.New("insufficient --self-delegation", "minimum", minSelfDelegation, "self_delegation", c.SelfDelegation)
+	}
+
+	if c.SelfDelegation > 1e3*minSelfDelegation {
+		return errors.New("excessive --self-delegation", "maximum", 1e3*minSelfDelegation, "self_delegation", c.SelfDelegation)
+	}
+
+	return nil
+}
+
+func createValidator(ctx context.Context, cfg createValConfig) error {
+	opPrivKey, err := crypto.LoadECDSA(cfg.PrivateKeyFile)
+	if err != nil {
+		return errors.Wrap(err, "load private key")
+	}
+	opAddr := crypto.PubkeyToAddress(opPrivKey.PublicKey)
+
+	chainID := cfg.Network.Static().OmniExecutionChainID
+	chainMeta, ok := evmchain.MetadataByID(chainID)
+	if !ok {
+		return errors.New("chain metadata not found")
+	}
+
+	ethCl, err := ethclient.Dial(chainMeta.Name, cfg.Network.Static().ExecutionRPC())
+	if err != nil {
+		return err
+	}
+
+	backend, err := ethbackend.NewBackend(chainMeta.Name, chainID, chainMeta.BlockPeriod, ethCl, opPrivKey)
+	if err != nil {
+		return err
+	}
+
+	contract, err := bindings.NewStaking(common.HexToAddress(predeploys.Staking), backend)
+	if err != nil {
+		return err
+	}
+
+	if ok, err := contract.IsAllowedValidator(nil, opAddr); err != nil {
+		return err
+	} else if !ok {
+		return &CliError{
+			Msg:     "Operator address not allowed to create validator: " + opAddr.Hex(),
+			Suggest: "Contact Omni team to be included in validator allow list",
+		}
+	}
+
+	bal, err := ethCl.EtherBalanceAt(ctx, opAddr)
+	if err != nil {
+		return err
+	} else if bal <= float64(cfg.SelfDelegation) {
+		return &CliError{
+			Msg:     fmt.Sprintf("Operator address has insufficient balance=%.2f OMNI, address=%s", bal, opAddr),
+			Suggest: "Fund the operator address with sufficient OMNI for self-delegation and gas",
+		}
+	}
+
+	txOpts, err := backend.BindOpts(ctx, opAddr)
+	if err != nil {
+		return err
+	}
+	txOpts.Value = new(big.Int).Mul(big.NewInt(int64(cfg.SelfDelegation)), big.NewInt(params.Ether)) // Send self-delegation
+
+	consPubkey, err := cfg.ConsensusPubKey()
+	if err != nil {
+		return err
+	}
+
+	tx, err := contract.CreateValidator(txOpts, crypto.CompressPubkey(consPubkey))
+	if err != nil {
+		return errors.Wrap(err, "create validator")
+	}
+
+	_, err = backend.WaitMined(ctx, tx)
+	if err != nil {
+		return errors.Wrap(err, "wait mined")
+	}
+
+	link := fmt.Sprintf("https://%s.omniscan.network/tx/%s", cfg.Network, tx.Hash().Hex())
+	log.Info(ctx, "🎉 Create-validator transaction created and included on-chain", "link", link)
+
+	return nil
+}

--- a/e2e/app/run.go
+++ b/e2e/app/run.go
@@ -105,6 +105,10 @@ func Deploy(ctx context.Context, def Definition, cfg DeployConfig) (*pingpong.XD
 		return nil, err
 	}
 
+	if err := allowStagingValidators(ctx, def); err != nil {
+		return nil, err
+	}
+
 	if err := setupTokenBridge(ctx, def); err != nil {
 		return nil, errors.Wrap(err, "setup token bridge")
 	}

--- a/halo/app/privkey.go
+++ b/halo/app/privkey.go
@@ -19,7 +19,7 @@ func loadPrivVal(cfg Config) (*privval.FilePV, error) {
 		return nil, errors.New("cometBFT priv validator key file is required", "comet_file", cmtFile)
 	}
 
-	key, err := loadCometFilePV(cmtFile)
+	key, err := LoadCometFilePV(cmtFile)
 	if err != nil {
 		return nil, err
 	}
@@ -42,8 +42,8 @@ func loadPrivVal(cfg Config) (*privval.FilePV, error) {
 	return resp, nil
 }
 
-// loadCometFilePV loads a CometBFT privval file and returns the private key.
-func loadCometFilePV(file string) (crypto.PrivKey, error) {
+// LoadCometFilePV loads a CometBFT privval file and returns the private key.
+func LoadCometFilePV(file string) (crypto.PrivKey, error) {
 	bz, err := os.ReadFile(file)
 	if err != nil {
 		return nil, errors.Wrap(err, "read comet privval", "path", file)

--- a/halo/cmd/testdata/TestCLIReference_halo.golden
+++ b/halo/cmd/testdata/TestCLIReference_halo.golden
@@ -4,12 +4,13 @@ Usage:
   halo [command]
 
 Available Commands:
-  completion  Generate the autocompletion script for the specified shell
-  help        Help about any command
-  init        Initializes required halo files and directories
-  rollback    Rollback Cosmos SDK and CometBFT state by one height
-  run         Runs the halo consensus client
-  version     Print the version information of this binary
+  completion       Generate the autocompletion script for the specified shell
+  consensus-pubkey Print the consensus public key
+  help             Help about any command
+  init             Initializes required halo files and directories
+  rollback         Rollback Cosmos SDK and CometBFT state by one height
+  run              Runs the halo consensus client
+  version          Print the version information of this binary
 
 Flags:
   -h, --help   help for halo

--- a/halo/cmd/testdata/TestCLIReference_init.golden
+++ b/halo/cmd/testdata/TestCLIReference_init.golden
@@ -24,5 +24,5 @@ Flags:
       --force            Force initialization (overwrite existing files)
   -h, --help             help for init
       --home string      The application home directory containing config and data (default "./halo")
-      --network string   Omni network to participate in: mainnet, testnet, devnet
+      --network string   Omni network to participate in: mainnet, omega, devnet
       --trusted-sync     Initialize trusted state-sync height and hash by querying the Omni RPC

--- a/halo/cmd/testdata/TestCLIReference_rollback.golden
+++ b/halo/cmd/testdata/TestCLIReference_rollback.golden
@@ -23,7 +23,7 @@ Flags:
       --log-format string                         Log format; console, json (default "console")
       --log-level string                          Log level; debug, info, warn, error (default "info")
       --min-retain-blocks uint                    Minimum block height offset during ABCI commit to prune CometBFT blocks (default 1)
-      --network string                            Omni network to participate in: mainnet, testnet, devnet
+      --network string                            Omni network to participate in: mainnet, omega, devnet
       --pruning string                            Pruning strategy (default|nothing|everything) (default "default")
       --snapshot-interval uint                    State sync snapshot interval (default 1000)
       --snapshot-keep-recent uint                 State sync snapshot to keep (default 2)

--- a/halo/cmd/testdata/TestCLIReference_run.golden
+++ b/halo/cmd/testdata/TestCLIReference_run.golden
@@ -15,7 +15,7 @@ Flags:
       --log-format string                         Log format; console, json (default "console")
       --log-level string                          Log level; debug, info, warn, error (default "info")
       --min-retain-blocks uint                    Minimum block height offset during ABCI commit to prune CometBFT blocks (default 1)
-      --network string                            Omni network to participate in: mainnet, testnet, devnet
+      --network string                            Omni network to participate in: mainnet, omega, devnet
       --pruning string                            Pruning strategy (default|nothing|everything) (default "default")
       --snapshot-interval uint                    State sync snapshot interval (default 1000)
       --snapshot-keep-recent uint                 State sync snapshot to keep (default 2)

--- a/lib/netconf/flag.go
+++ b/lib/netconf/flag.go
@@ -4,5 +4,5 @@ import "github.com/spf13/pflag"
 
 // BindFlag binds the network identifier flag.
 func BindFlag(flags *pflag.FlagSet, network *ID) {
-	flags.StringVar((*string)(network), "network", string(*network), "Omni network to participate in: mainnet, testnet, devnet")
+	flags.StringVar((*string)(network), "network", string(*network), "Omni network to participate in: mainnet, omega, devnet")
 }


### PR DESCRIPTION
Adds the following `omni` cli commands:
 - `omni operator create-operator-key`: creates a insecure operator private key
 - `omni operator create-validator`: sign and broadcasts `create-validator` transaction.
 
Adds the following `halo` binary command:
 - `halo consensus-pubkey`: Prints the halo consensus pubkey for use in `create-validator` above. 

issue: #1757 