### PR TITLE
chore(halo/attest): instrument validator votes

### DIFF
--- a/halo/attest/keeper/common_test.go
+++ b/halo/attest/keeper/common_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/omni-network/omni/halo/attest/keeper"
 	"github.com/omni-network/omni/halo/attest/testutil"
 	"github.com/omni-network/omni/halo/attest/types"
+	vtypes "github.com/omni-network/omni/halo/valsync/types"
 	"github.com/omni-network/omni/lib/netconf"
 	"github.com/omni-network/omni/lib/xchain"
 
@@ -50,6 +51,13 @@ func fuzzyDeps(times int) expectation {
 		m.registry.EXPECT().ConfLevels(gomock.Any()).Return(map[uint64][]xchain.ConfLevel{
 			defaultChainID: {xchain.ConfFinalized, xchain.ConfLatest},
 		}, nil).Times(times)
+	}
+}
+
+func valsetCalled() expectation {
+	return func(_ sdk.Context, m mocks) {
+		m.valProvider.EXPECT().ValidatorSet(gomock.Any(), gomock.Any()).
+			Return(&vtypes.ValidatorSetResponse{}, nil).AnyTimes()
 	}
 }
 

--- a/halo/attest/keeper/keeper_test.go
+++ b/halo/attest/keeper/keeper_test.go
@@ -497,6 +497,7 @@ func TestKeeper_Approve(t *testing.T) {
 				activeSetQueried(17),
 				activeSetQueried(18),
 				trimBehindCalled(),
+				valsetCalled(),
 				noFuzzyDeps(),
 			},
 			prerequisites: []prerequisite{
@@ -554,6 +555,7 @@ func TestKeeper_Approve(t *testing.T) {
 				activeSetQueried(9),
 				activeSetQueried(10),
 				trimBehindCalled(),
+				valsetCalled(),
 				noFuzzyDeps(),
 			},
 			prerequisites: []prerequisite{
@@ -667,6 +669,7 @@ func TestKeeper_Approve(t *testing.T) {
 				activeSetQueried(11),
 				activeSetQueried(12),
 				trimBehindCalled(),
+				valsetCalled(),
 				fuzzyDeps(1),
 			},
 			prerequisites: []prerequisite{
@@ -740,6 +743,7 @@ func TestKeeper_Approve(t *testing.T) {
 				activeSetQueried(11),
 				activeSetQueried(12),
 				trimBehindCalled(),
+				valsetCalled(),
 				fuzzyDeps(2),
 			},
 			prerequisites: []prerequisite{
@@ -875,6 +879,7 @@ func TestKeeper_Approve(t *testing.T) {
 				activeSetQueried(9),
 				activeSetQueried(10),
 				trimBehindCalled(),
+				valsetCalled(),
 				noFuzzyDeps(),
 			},
 			prerequisites: []prerequisite{

--- a/halo/attest/keeper/metrics.go
+++ b/halo/attest/keeper/metrics.go
@@ -52,6 +52,32 @@ var (
 		Name:      "double_sign_total",
 		Help:      "Total number of double sign votes detected per validator",
 	}, []string{"validator"})
+
+	approvedVotesCounter = promauto.NewCounterVec(prometheus.CounterOpts{
+		Namespace: "halo",
+		Subsystem: "attest",
+		Name:      "votes_approved_total",
+		Help: "Total number of votes included in approved attestations per validator per stream. " +
+			"Approved votes were present in approved attestations at time of deletion. They count towards rewards",
+	}, []string{"validator", "stream"})
+
+	discardedVotesCounter = promauto.NewCounterVec(prometheus.CounterOpts{
+		Namespace: "halo",
+		Subsystem: "attest",
+		Name:      "votes_discarded_total",
+		Help: "Total number of votes included in discarded attestations per validator per stream. " +
+			"Discarded votes were included on-chain but were either for previously approved attestations (late) or " +
+			"for non-quorum attestations (wrong). They don't count towards rewards",
+	}, []string{"validator", "stream"})
+
+	missingVotesCounter = promauto.NewCounterVec(prometheus.CounterOpts{
+		Namespace: "halo",
+		Subsystem: "attest",
+		Name:      "votes_missing_total",
+		Help: "Total number of votes missing from approved attestations per validator per stream. " +
+			"Missing votes were missing from approved attestations at time of deletion. " +
+			"They may be late or never included on-chain. missing-discarded==not-voting",
+	}, []string{"validator", "stream"})
 )
 
 func latency(method string) func() {

--- a/halo/attest/testutil/mock_interfaces.go
+++ b/halo/attest/testutil/mock_interfaces.go
@@ -205,6 +205,21 @@ func (mr *MockValProviderMockRecorder) ActiveSetByHeight(ctx, height any) *gomoc
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ActiveSetByHeight", reflect.TypeOf((*MockValProvider)(nil).ActiveSetByHeight), ctx, height)
 }
 
+// ValidatorSet mocks base method.
+func (m *MockValProvider) ValidatorSet(ctx context.Context, req *types1.ValidatorSetRequest) (*types1.ValidatorSetResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ValidatorSet", ctx, req)
+	ret0, _ := ret[0].(*types1.ValidatorSetResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ValidatorSet indicates an expected call of ValidatorSet.
+func (mr *MockValProviderMockRecorder) ValidatorSet(ctx, req any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ValidatorSet", reflect.TypeOf((*MockValProvider)(nil).ValidatorSet), ctx, req)
+}
+
 // MockChainNamer is a mock of ChainNamer interface.
 type MockChainNamer struct {
 	ctrl     *gomock.Controller

--- a/halo/valsync/types/types.go
+++ b/halo/valsync/types/types.go
@@ -9,6 +9,7 @@ import (
 // ValidatorProvider is the interface that provides the active set of validators at a given height.
 type ValidatorProvider interface {
 	ActiveSetByHeight(ctx context.Context, height uint64) (*ValidatorSetResponse, error)
+	ValidatorSet(ctx context.Context, req *ValidatorSetRequest) (*ValidatorSetResponse, error)
 }
 
 type RegisterPortalRequest struct {


### PR DESCRIPTION
Adds three counters that track validator xchain attestation performance:
- `halo_attest_votes_approved_total`: Total number of votes included in approved attestations per validator per stream. Approved votes were present in approved attestations at time of deletion. They count towards rewards
- `halo_attest_votes_discarded_total`: Total number of votes included in discarded attestations per validator per stream. Discarded votes were included on-chain but were either for previously approved attestations (late) or for non-quorum attestations (wrong). They don't count towards rewards".
- `halo_attest_votes_missing_total`: Total number of votes missing from approved attestations per validator per stream. Missing votes were missing from approved attestations at time of deletion. They may be late or never included on-chain. missing-discarded==not-voting

This allows tracking which validators are voting, vs not voting vs voting late. 

issue: none