### PR TITLE
ci(e2e): enable geth trace logs on staging

### DIFF
--- a/e2e/docker/compose.yaml.tmpl
+++ b/e2e/docker/compose.yaml.tmpl
@@ -74,6 +74,7 @@ services:
       - --pprof.addr=0.0.0.0
       - --metrics
       - --graphql
+      - --verbosity={{$.GethVerbosity}} # Log level (1=error,2=warn,3=info,4=debug)
       {{ if .IsArchive }}- --gcmode=archive{{ end }}
     ports:
       - {{ if $.BindAll }}8551:{{end}}8551 # Auth RPC

--- a/e2e/docker/testdata/TestComposeTemplate_commit.golden
+++ b/e2e/docker/testdata/TestComposeTemplate_commit.golden
@@ -81,6 +81,7 @@ services:
       - --pprof.addr=0.0.0.0
       - --metrics
       - --graphql
+      - --verbosity=3 # Log level (1=error,2=warn,3=info,4=debug)
       
     ports:
       - 8551 # Auth RPC

--- a/e2e/docker/testdata/TestComposeTemplate_empheral_network.golden
+++ b/e2e/docker/testdata/TestComposeTemplate_empheral_network.golden
@@ -81,6 +81,7 @@ services:
       - --pprof.addr=0.0.0.0
       - --metrics
       - --graphql
+      - --verbosity=3 # Log level (1=error,2=warn,3=info,4=debug)
       
     ports:
       - 8551 # Auth RPC

--- a/e2e/docker/testdata/TestComposeTemplate_empheral_network_upgrade.golden
+++ b/e2e/docker/testdata/TestComposeTemplate_empheral_network_upgrade.golden
@@ -81,6 +81,7 @@ services:
       - --pprof.addr=0.0.0.0
       - --metrics
       - --graphql
+      - --verbosity=3 # Log level (1=error,2=warn,3=info,4=debug)
       
     ports:
       - 8551 # Auth RPC

--- a/e2e/vmcompose/testdata/TestSetup_127-0-0-1-compose.yaml.golden
+++ b/e2e/vmcompose/testdata/TestSetup_127-0-0-1-compose.yaml.golden
@@ -40,6 +40,7 @@ services:
       - --pprof.addr=0.0.0.0
       - --metrics
       - --graphql
+      - --verbosity=3 # Log level (1=error,2=warn,3=info,4=debug)
       
     ports:
       - 8551:8551 # Auth RPC

--- a/e2e/vmcompose/testdata/TestSetup_127-0-0-2-compose.yaml.golden
+++ b/e2e/vmcompose/testdata/TestSetup_127-0-0-2-compose.yaml.golden
@@ -40,6 +40,7 @@ services:
       - --pprof.addr=0.0.0.0
       - --metrics
       - --graphql
+      - --verbosity=3 # Log level (1=error,2=warn,3=info,4=debug)
       
     ports:
       - 8551:8551 # Auth RPC

--- a/e2e/vmcompose/testdata/TestSetup_127-0-0-4-compose.yaml.golden
+++ b/e2e/vmcompose/testdata/TestSetup_127-0-0-4-compose.yaml.golden
@@ -40,6 +40,7 @@ services:
       - --pprof.addr=0.0.0.0
       - --metrics
       - --graphql
+      - --verbosity=3 # Log level (1=error,2=warn,3=info,4=debug)
       
     ports:
       - 8551:8551 # Auth RPC

--- a/e2e/vmcompose/testdata/TestSetup_127-0-0-5-compose.yaml.golden
+++ b/e2e/vmcompose/testdata/TestSetup_127-0-0-5-compose.yaml.golden
@@ -40,6 +40,7 @@ services:
       - --pprof.addr=0.0.0.0
       - --metrics
       - --graphql
+      - --verbosity=3 # Log level (1=error,2=warn,3=info,4=debug)
       
     ports:
       - 8551:8551 # Auth RPC


### PR DESCRIPTION
Temporary debug snapsync issues on staging by setting trace level geth logs.

issue: none