### PR TITLE
feat(cli): support archive in init-nodes

### DIFF
--- a/cli/cmd/compose.yml.tpl
+++ b/cli/cmd/compose.yml.tpl
@@ -20,6 +20,7 @@ services:
     command:
       - --config=/geth/config.toml
       - --verbosity={{.GethVerbosity}}                 # Log level (1=error,2=warn,3=info,4=debug)
+      {{ if .GethArchive }}- --gcmode=archive{{ end }}
       # Flags not available via config.toml
       #- --nat=extip:<my-external-ip> # External IP for P2P via NAT
       #- --metrics                    # Enable prometheus metrics

--- a/cli/cmd/flags.go
+++ b/cli/cmd/flags.go
@@ -19,6 +19,8 @@ func bindInitConfig(cmd *cobra.Command, cfg *initConfig) {
 	cmd.Flags().StringVar(&cfg.Moniker, "moniker", "", "Human-readable node name used in p2p networking")
 	cmd.Flags().StringVar(&cfg.Home, "home", "", "Home directory. If empty, defaults to: $HOME/.omni/<network>/")
 	cmd.Flags().BoolVar(&cfg.Clean, "clean", cfg.Clean, "Delete contents of home directory")
+	cmd.Flags().BoolVar(&cfg.Archive, "archive", cfg.Archive, "Enable archive mode. Note this requires more disk space")
+	cmd.Flags().BoolVar(&cfg.Debug, "debug", cfg.Debug, "Configure nodes with debug log level")
 }
 
 func bindAVSAddress(cmd *cobra.Command, addr *string) {

--- a/e2e/app/setup.go
+++ b/e2e/app/setup.go
@@ -357,17 +357,12 @@ func isPublicNode(network netconf.ID, mode types.Mode) bool {
 		return false
 	}
 
-	if mode == types.ModeSeed || mode == types.ModeFull {
-		// Only seeds and fullnodes allow external peers to connect to them.
+	if mode == types.ModeSeed || mode == types.ModeFull || mode == types.ModeArchive {
+		// Only seeds and fullnodes and archives allow external peers to connect to them.
 		return true
 	}
 
-	if network == netconf.Staging && mode == types.ModeArchive {
-		// Staging fullnode1 is an archive node, but we need to connect to it.
-		return true
-	}
-
-	// Validators and archive nodes are "secured" and only allow internal peers to connect to them.
+	// Validators nodes are "secured" and only allow internal peers to connect to them.
 
 	return false
 }
@@ -405,14 +400,10 @@ func writeHaloConfig(
 ) error {
 	cfg := halocfg.DefaultConfig()
 
-	switch mode {
-	case types.ModeArchive:
+	if mode == types.ModeArchive {
 		cfg.PruningOption = "nothing"
 		// Setting this to 0 retains all blocks
 		cfg.MinRetainBlocks = 0
-	default:
-		cfg.PruningOption = "default"
-		cfg.MinRetainBlocks = 1
 	}
 
 	cfg.Network = network

--- a/lib/log/config.go
+++ b/lib/log/config.go
@@ -23,12 +23,12 @@ const (
 
 //nolint:gochecknoglobals // Static mapping.
 var (
-	levelDebug = strings.ToLower(slog.LevelDebug.String())
-	levelInfo  = strings.ToLower(slog.LevelInfo.String())
+	LevelDebug = strings.ToLower(slog.LevelDebug.String())
+	LevelInfo  = strings.ToLower(slog.LevelInfo.String())
 	levelWarn  = strings.ToLower(slog.LevelWarn.String())
 	levelError = strings.ToLower(slog.LevelError.String())
 
-	levels = []string{levelDebug, levelInfo, levelWarn, levelError}
+	levels = []string{LevelDebug, LevelInfo, levelWarn, levelError}
 )
 
 //nolint:gochecknoglobals // Static mapping.
@@ -49,7 +49,7 @@ var colors = map[string]termenv.Profile{
 // DefaultConfig returns a default config.
 func DefaultConfig() Config {
 	return Config{
-		Level:  levelInfo,
+		Level:  LevelInfo,
 		Color:  ColorAuto,
 		Format: FormatConsole,
 	}


### PR DESCRIPTION
Adds a `--archive` flag to `omni operator init-nodes` to join a network as an archive node.

This is currently blocked on the fact that our archive nodes are not publicly accessible via P2P so the local archive node can't find blocks to download.

issue: none