### PR TITLE
ci(e2e): fix verbose geth logs on staging

### DIFF
--- a/e2e/docker/docker.go
+++ b/e2e/docker/docker.go
@@ -16,7 +16,6 @@ import (
 	"github.com/omni-network/omni/e2e/types"
 	"github.com/omni-network/omni/lib/errors"
 	"github.com/omni-network/omni/lib/log"
-	"github.com/omni-network/omni/lib/netconf"
 
 	e2e "github.com/cometbft/cometbft/test/e2e/pkg"
 	"github.com/cometbft/cometbft/test/e2e/pkg/exec"
@@ -27,8 +26,6 @@ import (
 )
 
 const ProviderName = "docker"
-
-const defaultGethVerbosity = 3
 
 // composeTmpl is our own custom docker compose template. This differs from cometBFT's.
 //
@@ -92,11 +89,8 @@ func (p *Provider) Setup() error {
 		Relayer:        true,
 		Prometheus:     p.testnet.Prometheus,
 		Monitor:        true,
+		GethVerbosity:  3, // Info
 	}
-	if p.testnet.Network == netconf.Staging {
-		def.gethVerbosity = 5 // TODO(corver): Revert to info logs after debugging snapsync issues.
-	}
-
 	def = SetImageTags(def, p.testnet.Manifest, p.omniTag)
 
 	bz, err := GenerateComposeFile(def)
@@ -180,7 +174,7 @@ type ComposeDef struct {
 	NetworkCIDR    string
 	BindAll        bool
 	UpgradeVersion string
-	gethVerbosity  int // # Geth log level (1=error,2=warn,3=info(default),4=debug,5=trace)
+	GethVerbosity  int // # Geth log level (1=error,2=warn,3=info(default),4=debug,5=trace)
 
 	Nodes    []*e2e.Node
 	OmniEVMs []types.OmniEVM
@@ -196,14 +190,6 @@ type ComposeDef struct {
 
 func (ComposeDef) GethTag() string {
 	return geth.Version
-}
-
-func (c ComposeDef) GethVerbosity() int {
-	if c.gethVerbosity == 0 {
-		return defaultGethVerbosity // InfoLevel
-	}
-
-	return c.gethVerbosity
 }
 
 // NodeOmniEVMs returns a map of node name to OmniEVM instance name; map[node_name]omni_evm.

--- a/e2e/vmcompose/provider.go
+++ b/e2e/vmcompose/provider.go
@@ -17,6 +17,7 @@ import (
 	"github.com/omni-network/omni/e2e/types"
 	"github.com/omni-network/omni/lib/errors"
 	"github.com/omni-network/omni/lib/log"
+	"github.com/omni-network/omni/lib/netconf"
 
 	e2e "github.com/cometbft/cometbft/test/e2e/pkg"
 
@@ -83,6 +84,11 @@ func (p *Provider) Setup() error {
 			}
 		}
 
+		gethVerbosity := 3 // Info level
+		if p.Testnet.Network == netconf.Staging {
+			gethVerbosity = 5 // TODO(corver): Revert to info logs after debugging snapsync issues.
+		}
+
 		def := docker.ComposeDef{
 			UpgradeVersion: p.Testnet.UpgradeVersion,
 			Network:        false,
@@ -95,6 +101,7 @@ func (p *Provider) Setup() error {
 			Relayer:        services["relayer"],
 			Monitor:        services["monitor"],
 			Prometheus:     p.Testnet.Prometheus,
+			GethVerbosity:  gethVerbosity,
 		}
 		def = docker.SetImageTags(def, p.Testnet.Manifest, p.omniTag)
 


### PR DESCRIPTION
Move log level to vmcompose since that is what staging uses.

issue: none