### PR TITLE
chore(docs): update docs ci

### DIFF
--- a/.github/workflows/ci-docs.yml
+++ b/.github/workflows/ci-docs.yml
@@ -8,7 +8,7 @@ on:
     branches:
       - main
     paths:
-      - 'docs/website/**'
+      - 'docs/**'
 jobs:
   deploy:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Docs did not redeploy when [this PR](https://github.com/omni-network/omni/pull/1798) was merged, need to include the full docs directory

issue: none