### PR TITLE
chore(monitor/indexer): track number of fuzzy overrides per stream

### DIFF
--- a/lib/xchain/types.go
+++ b/lib/xchain/types.go
@@ -41,7 +41,12 @@ func (c ConfLevel) Valid() bool {
 
 // IsFuzzy returns true if this confirmation level is not ConfFinalized.
 func (c ConfLevel) IsFuzzy() bool {
-	return c == ConfLatest
+	return !c.IsFinalized()
+}
+
+// IsFinalized returns true if this confirmation level is ConfFinalized.
+func (c ConfLevel) IsFinalized() bool {
+	return c == ConfFinalized
 }
 
 // Label returns a short label for the confirmation level.

--- a/lib/xchain/types_internal_test.go
+++ b/lib/xchain/types_internal_test.go
@@ -10,7 +10,7 @@ func TestConfLevelFuzzy(t *testing.T) {
 	t.Parallel()
 	var fuzzies []ConfLevel
 	for conf := ConfUnknown; conf < confSentinel; conf++ {
-		if conf.IsFuzzy() {
+		if conf.Valid() && conf.IsFuzzy() {
 			fuzzies = append(fuzzies, conf)
 		}
 	}

--- a/monitor/xmonitor/indexer/indexer_internal_test.go
+++ b/monitor/xmonitor/indexer/indexer_internal_test.go
@@ -9,6 +9,8 @@ import (
 	"github.com/omni-network/omni/lib/umath"
 	"github.com/omni-network/omni/lib/xchain"
 
+	"github.com/ethereum/go-ethereum/common"
+
 	dbm "github.com/cosmos/cosmos-db"
 	fuzz "github.com/google/gofuzz"
 	"github.com/stretchr/testify/require"
@@ -24,7 +26,7 @@ func TestIndexer(t *testing.T) {
 
 	streamNamer := func(s xchain.StreamID) string { return fmt.Sprint(s) }
 
-	indexer, err := newIndexer(db, streamNamer)
+	indexer, err := newIndexer(db, mockXProvider{}, streamNamer)
 	require.NoError(t, err)
 	var samples []sample
 	indexer.sampleFunc = func(s sample) {
@@ -110,12 +112,21 @@ func TestIndexer(t *testing.T) {
 
 func makeSample(blocks []xchain.Block, receipts []xchain.Receipt, msgs []xchain.Msg, idx int) sample {
 	return sample{
-		Stream:    fmt.Sprint(receipts[idx].StreamID),
-		XDApp:     "unknown",
-		Latency:   getReceiptBlock(blocks, receipts[idx].MsgID).Timestamp.Sub(getMsgBlock(blocks, msgs[idx].MsgID).Timestamp),
-		ExcessGas: umath.SubtractOrZero(msgs[idx].DestGasLimit, receipts[idx].GasUsed),
-		Success:   receipts[idx].Success,
+		Stream:        fmt.Sprint(receipts[idx].StreamID),
+		XDApp:         "unknown",
+		Latency:       getReceiptBlock(blocks, receipts[idx].MsgID).Timestamp.Sub(getMsgBlock(blocks, msgs[idx].MsgID).Timestamp),
+		ExcessGas:     umath.SubtractOrZero(msgs[idx].DestGasLimit, receipts[idx].GasUsed),
+		Success:       receipts[idx].Success,
+		FuzzyOverride: expectFuzzyOverride(receipts[idx]),
 	}
+}
+
+func expectFuzzyOverride(receipt xchain.Receipt) bool {
+	if !receipt.ConfLevel().IsFuzzy() {
+		return false
+	}
+
+	return !mockConfLevel(receipt.TxHash).IsFuzzy()
 }
 
 func getReceiptBlock(blocks []xchain.Block, msgID xchain.MsgID) xchain.Block {
@@ -147,4 +158,28 @@ func fuzzBlock(f *fuzz.Fuzzer, msgs []xchain.Msg, receipts []xchain.Receipt) xch
 	resp.Receipts = receipts
 
 	return resp
+}
+
+type mockXProvider struct {
+	xchain.Provider
+}
+
+func (m mockXProvider) GetSubmission(_ context.Context, chainID uint64, txHash common.Hash) (xchain.Submission, error) {
+	return xchain.Submission{
+		AttHeader: xchain.AttestHeader{
+			ChainVersion: xchain.ChainVersion{
+				ID:        chainID,
+				ConfLevel: mockConfLevel(txHash),
+			},
+		},
+	}, nil
+}
+
+func mockConfLevel(txHash common.Hash) xchain.ConfLevel {
+	confLevel = xchain.ConfFinalized
+	if txHash[0]%2 == 0 {
+		confLevel = xchain.ConfLatest
+	}
+
+	return confLevel
 }


### PR DESCRIPTION
Adds tracking of the number of fuzzy overrides per stream to monitor indexer.

issue: #1627 