### PR TITLE
ci(e2e): enable constant snapshots in staging

### DIFF
--- a/e2e/app/setup.go
+++ b/e2e/app/setup.go
@@ -417,6 +417,10 @@ func writeHaloConfig(
 	if testCfg {
 		cfg.SnapshotInterval = 1   // Write snapshots each block in e2e tests
 		cfg.SnapshotKeepRecent = 0 // Keep all snapshots in e2e tests
+	} else if network == netconf.Staging {
+		// TODO(corver): Remove this once debugging staging snapsync issues are solved.
+		cfg.SnapshotInterval = 1     // Write snapshots each block in staging
+		cfg.SnapshotKeepRecent = 500 // Keep a lot of snapshots in staging
 	}
 
 	return halocfg.WriteConfigTOML(cfg, logCfg)

--- a/monitor/xmonitor/indexer/indexer_internal_test.go
+++ b/monitor/xmonitor/indexer/indexer_internal_test.go
@@ -17,6 +17,7 @@ import (
 )
 
 //go:generate go test . -count=1000 -race
+
 func TestIndexer(t *testing.T) {
 	t.Parallel()
 
@@ -176,10 +177,10 @@ func (m mockXProvider) GetSubmission(_ context.Context, chainID uint64, txHash c
 }
 
 func mockConfLevel(txHash common.Hash) xchain.ConfLevel {
-	confLevel = xchain.ConfFinalized
+	resp := xchain.ConfFinalized
 	if txHash[0]%2 == 0 {
-		confLevel = xchain.ConfLatest
+		resp = xchain.ConfLatest
 	}
 
-	return confLevel
+	return resp
 }


### PR DESCRIPTION
Enables snapshots each block on staging. This aims to debug snapsync issues.

issue: none