### PR TITLE
feat(cometbft): mitigate slow blocks due to inactive validators

### DIFF
--- a/halo/cmd/cometconfig.go
+++ b/halo/cmd/cometconfig.go
@@ -44,6 +44,7 @@ func DefaultCometConfig(homeDir string) cfg.Config {
 	conf.Mempool.Type = cfg.MempoolTypeNop             // Disable cometBFT mempool
 	conf.ProxyApp = ""                                 // Only support built-in ABCI app supported.
 	conf.ABCI = ""                                     // Only support built-in ABCI app supported.
+	conf.Consensus.TimeoutPropose = time.Second        // Mitigate slow blocks when proposer inactive (default=3s).
 
 	return *conf
 }

--- a/halo/cmd/testdata/TestRunCmd_defaults.golden
+++ b/halo/cmd/testdata/TestRunCmd_defaults.golden
@@ -130,7 +130,7 @@
   "Consensus": {
    "RootDir": "./halo",
    "WalPath": "data/cs.wal/wal",
-   "TimeoutPropose": 3000000000,
+   "TimeoutPropose": 1000000000,
    "TimeoutProposeDelta": 500000000,
    "TimeoutPrevote": 1000000000,
    "TimeoutPrevoteDelta": 500000000,

--- a/halo/cmd/testdata/TestRunCmd_flags.golden
+++ b/halo/cmd/testdata/TestRunCmd_flags.golden
@@ -130,7 +130,7 @@
   "Consensus": {
    "RootDir": "foo",
    "WalPath": "data/cs.wal/wal",
-   "TimeoutPropose": 3000000000,
+   "TimeoutPropose": 1000000000,
    "TimeoutProposeDelta": 500000000,
    "TimeoutPrevote": 1000000000,
    "TimeoutPrevoteDelta": 500000000,

--- a/halo/cmd/testdata/TestRunCmd_json_files.golden
+++ b/halo/cmd/testdata/TestRunCmd_json_files.golden
@@ -130,7 +130,7 @@
   "Consensus": {
    "RootDir": "testinput/input2",
    "WalPath": "data/cs.wal/wal",
-   "TimeoutPropose": 3000000000,
+   "TimeoutPropose": 1000000000,
    "TimeoutProposeDelta": 500000000,
    "TimeoutPrevote": 1000000000,
    "TimeoutPrevoteDelta": 500000000,

--- a/halo/cmd/testdata/TestRunCmd_toml_files.golden
+++ b/halo/cmd/testdata/TestRunCmd_toml_files.golden
@@ -133,7 +133,7 @@
   "Consensus": {
    "RootDir": "testinput/input1",
    "WalPath": "data/cs.wal/wal",
-   "TimeoutPropose": 3000000000,
+   "TimeoutPropose": 1000000000,
    "TimeoutProposeDelta": 500000000,
    "TimeoutPrevote": 1000000000,
    "TimeoutPrevoteDelta": 500000000,


### PR DESCRIPTION
Decreases default cometBFT consensus config param `timeout_propose` from 3s to 1s.

This aim to mitigate slow blocks when the proposing validator is offline/inactive. Currently, when 1 of 3 validators are offline, the block times on staging decreases from 1s to 4s.

I had a look at some other cosmos chains and aligning timeout_commit and timeout_propose seems to be common practice:
 - [Sei](https://github.com/sei-protocol/sei-chain/blob/main/app/params/config.go#L98-L103): `timeout_commit=200ms, timeout_propose=300s`
 - [Moonbridge](https://services.moonbridge.team/testnet/kopi/install/) and [kopi](https://docs.kopi.money/nodes.html#setting-up-a-node): `timeout_commit=1s, timeout_propose=1s`

This change aims to mitigate the affect of offline validators on block times.

issue: none or #12345

<!--
  PR title and body follows conventional commit; https://www.conventionalcommits.org/en/v1.0.0
  Title template: `type(app/pkg): concise description`
  See allowed types: https://github.com/conventional-changelog/commitlint/tree/master/%40commitlint/config-conventional#type-enum
  Description must be concise: lower case, no punctuation, no more than 50 characters.
  Scope must be concise: only a one or two folders; e.g. 'halo/cmd' or 'github' or '*'
-->
