### PR TITLE
chore(lib/buildinfo): simplify version

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -10,7 +10,7 @@ builds:
     goos: [linux, darwin]
     goarch: [amd64, arm64]
     ldflags:
-      - -s -w -X github.com/omni-network/omni/lib/buildinfo.version={{.Tag}}
+      - -s -w -X github.com/omni-network/omni/lib/buildinfo.version={{ if .IsSnapshot }}main{{ else }}{{.Tag}}{{ end }}
 
   - id: relayer
     main: ./relayer
@@ -19,7 +19,7 @@ builds:
     goos: [linux, darwin]
     goarch: [amd64, arm64]
     ldflags:
-      - -s -w -X github.com/omni-network/omni/lib/buildinfo.version={{.Tag}}
+      - -s -w -X github.com/omni-network/omni/lib/buildinfo.version={{ if .IsSnapshot }}main{{ else }}{{.Tag}}{{ end }}
 
   - id: monitor
     main: ./monitor
@@ -35,7 +35,7 @@ builds:
     goos: [ linux, darwin ]
     goarch: [ amd64, arm64 ]
     ldflags:
-      - -s -w -X github.com/omni-network/omni/lib/buildinfo.version={{.Tag}}
+      - -s -w -X github.com/omni-network/omni/lib/buildinfo.version={{ if .IsSnapshot }}main{{ else }}{{.Tag}}{{ end }}
 
   - id: anvilproxy
     main: ./e2e/anvilproxy

--- a/halo/config/testdata/default_halo.toml
+++ b/halo/config/testdata/default_halo.toml
@@ -3,7 +3,7 @@
 
 # The version of the Halo binary that created or
 # last modified the config file. Do not modify this.
-version = "v0.4-dev"
+version = "main"
 
 # Omni network to participate in: mainnet, testnet, or devnet.
 network = ""

--- a/halo/genutil/testdata/TestMakeGenesis.golden
+++ b/halo/genutil/testdata/TestMakeGenesis.golden
@@ -1,6 +1,6 @@
 {
  "app_name": "halo",
- "app_version": "v0.4-dev",
+ "app_version": "main",
  "genesis_time": "1970-01-01T00:00:01Z",
  "chain_id": "omni-1001651",
  "initial_height": 1,

--- a/lib/buildinfo/buildinfo.go
+++ b/lib/buildinfo/buildinfo.go
@@ -13,7 +13,7 @@ import (
 
 // version of the whole omni-monorepo and all binaries built from this git commit.
 // This value is set by goreleaser at build-time and should be the git tag for official releases.
-var version = "v0.4-dev"
+var version = "main"
 
 // unknown is the default value for the git commit hash and timestamp.
 const unknown = "unknown"

--- a/monitor/app/testdata/default_monitor.toml
+++ b/monitor/app/testdata/default_monitor.toml
@@ -3,7 +3,7 @@
 
 # The version of the Halo binary that created or
 # last modified the config file. Do not modify this.
-version = "v0.4-dev"
+version = "main"
 
 # Omni network to participate in: mainnet, testnet, or devnet.
 network = ""

--- a/relayer/app/testdata/default_relayer.toml
+++ b/relayer/app/testdata/default_relayer.toml
@@ -3,7 +3,7 @@
 
 # The version of the Halo binary that created or
 # last modified the config file. Do not modify this.
-version = "v0.4-dev"
+version = "main"
 
 # Omni network to participate in: mainnet, testnet, or devnet.
 network = ""


### PR DESCRIPTION
Set `lib/buildinfo.version=main` forever, no need to update this when doing a new release.

This version field will be set by goreleaser.

issue: none