### PR TITLE
chore(e2e/vmcompose): run docker compose down during upgrade

### DIFF
--- a/e2e/vmcompose/provider.go
+++ b/e2e/vmcompose/provider.go
@@ -278,6 +278,7 @@ func (p *Provider) Upgrade(ctx context.Context, cfg types.ServiceConfig) error {
 
 			startCmd := fmt.Sprintf("cd /omni/%s && "+
 				"sudo mv %s docker-compose.yaml && "+
+				"sudo docker compose down && "+
 				"sudo docker compose up -d",
 				p.Testnet.Name, composeFile)
 


### PR DESCRIPTION
Only running `docker compose up -d` doesn't always result in all changes reflecting in services since docker only restarts the container if the docker-compose file itself changed. If only artefacts changed, the container isn't restarted.

This ensures that we always restart the containers.

issue: none