### PR TITLE
chore(cli): init archives as persisted peer

### DIFF
--- a/cli/cmd/initnodes.go
+++ b/cli/cmd/initnodes.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"text/template"
 
 	"github.com/omni-network/omni/e2e/app/geth"
@@ -141,6 +142,12 @@ func initNodes(ctx context.Context, cfg initConfig) error {
 		CometCfgFunc: func(cmtCfg *cmtconfig.Config) {
 			cmtCfg.LogLevel = logLevel
 			cmtCfg.Instrumentation.Prometheus = true
+			if cfg.Archive {
+				if cmtCfg.P2P.PersistentPeers != "" {
+					cmtCfg.P2P.PersistentPeers += ","
+				}
+				cmtCfg.P2P.PersistentPeers += strings.Join(cfg.Network.Static().ConsensusArchives(), ",")
+			}
 		},
 		LogCfgFunc: func(logCfg *log.Config) {
 			logCfg.Color = log.ColorForce

--- a/halo/cmd/init.go
+++ b/halo/cmd/init.go
@@ -190,7 +190,10 @@ func InitFiles(ctx context.Context, initCfg InitConfig) error {
 
 	// Add P2P seeds to comet config (persisted peers works better than seeds)
 	if seeds := network.Static().ConsensusSeeds(); len(seeds) > 0 {
-		comet.P2P.PersistentPeers = strings.Join(seeds, ",")
+		if comet.P2P.PersistentPeers != "" {
+			comet.P2P.PersistentPeers += ","
+		}
+		comet.P2P.PersistentPeers += strings.Join(seeds, ",")
 	}
 
 	// Setup node key

--- a/lib/netconf/omega/consensus-archives.txt
+++ b/lib/netconf/omega/consensus-archives.txt
@@ -1,0 +1,2 @@
+2320703bf5434bbc4b1050a90f0fbf842d4878f9@archive01.omega.omni.network:26656
+1afc3479b2a16bca9da5bec7bff750a7b5ffe53d@archive02.omega.omni.network:26656

--- a/lib/netconf/staging/consensus-archives.txt
+++ b/lib/netconf/staging/consensus-archives.txt
@@ -1,0 +1,1 @@
+b0b2f907c12d79d0d74973faf8bbc4f5435a8e86@fullnode01.staging.omni.network:26656

--- a/lib/netconf/static.go
+++ b/lib/netconf/static.go
@@ -33,6 +33,7 @@ type Static struct {
 	MaxValidators        uint32
 	ConsensusGenesisJSON []byte
 	ConsensusSeedTXT     []byte
+	ConsensusArchiveTXT  []byte
 	ExecutionGenesisJSON []byte
 	ExecutionSeedTXT     []byte
 }
@@ -96,6 +97,17 @@ func (s Static) ConsensusSeeds() []string {
 	return resp
 }
 
+func (s Static) ConsensusArchives() []string {
+	var resp []string
+	for _, archive := range strings.Split(string(s.ConsensusArchiveTXT), "\n") {
+		if archive = strings.TrimSpace(archive); archive != "" {
+			resp = append(resp, archive)
+		}
+	}
+
+	return resp
+}
+
 func (s Static) ExecutionSeeds() []string {
 	var resp []string
 	for _, seed := range strings.Split(string(s.ExecutionSeedTXT), "\n") {
@@ -141,6 +153,9 @@ var (
 	//go:embed omega/consensus-seeds.txt
 	omegaConsensusSeedsTXT []byte
 
+	//go:embed omega/consensus-archives.txt
+	omegaConsensusArchivesTXT []byte
+
 	//go:embed omega/execution-genesis.json
 	omegaExecutionGenesisJSON []byte
 
@@ -149,6 +164,9 @@ var (
 
 	//go:embed staging/consensus-seeds.txt
 	stagingConsensusSeedsTXT []byte
+
+	//go:embed staging/consensus-archives.txt
+	stagingConsensusArchivesTXT []byte
 
 	//go:embed staging/execution-seeds.txt
 	stagingExecutionSeedsTXT []byte
@@ -174,6 +192,7 @@ var statics = map[ID]Static{
 		OmniExecutionChainID: evmchain.IDOmniEphemeral,
 		MaxValidators:        maxValidators,
 		ConsensusSeedTXT:     stagingConsensusSeedsTXT,
+		ConsensusArchiveTXT:  stagingConsensusArchivesTXT,
 		ExecutionSeedTXT:     stagingExecutionSeedsTXT,
 	},
 	Omega: {
@@ -190,6 +209,7 @@ var statics = map[ID]Static{
 		},
 		ConsensusGenesisJSON: omegaConsensusGenesisJSON,
 		ConsensusSeedTXT:     omegaConsensusSeedsTXT,
+		ConsensusArchiveTXT:  omegaConsensusArchivesTXT,
 		ExecutionGenesisJSON: omegaExecutionGenesisJSON,
 		ExecutionSeedTXT:     omegaExecutionSeedsTXT,
 	},


### PR DESCRIPTION
Add static archive node P2P info. Add those as persisted peers when joining a network as an archive node when running `omni operator init-nodes --archive`

issue: none