### PR TITLE
chore(monitor/indexer): add routescan id hash to logs

### DIFF
--- a/monitor/xmonitor/indexer/indexer.go
+++ b/monitor/xmonitor/indexer/indexer.go
@@ -403,6 +403,7 @@ func (i *indexer) instrumentMsg(ctx context.Context, link *MsgLink) error {
 		"latency", s.Latency,
 		"msg_tx", msg.TxHash,
 		"receipt_tx", receipt.TxHash,
+		"id_hash", msg.Hash(),
 	)
 
 	return nil


### PR DESCRIPTION
Adds routescan cross transaction id hash to support linking from grafana to routescan.

issue: none