### PR TITLE
chore(monitor/indexer): update cursor on empty blocks

### DIFF
--- a/monitor/xmonitor/indexer/indexer.go
+++ b/monitor/xmonitor/indexer/indexer.go
@@ -21,6 +21,10 @@ import (
 	db "github.com/cosmos/cosmos-db"
 )
 
+// emptyBlockCursorUpdate defines the Nth block to update cursors for empty blocks
+// This avoids needing to catchup a lot on startup for quite streams.
+const emptyBlockCursorUpdate = 100
+
 var confLevel = xchain.ConfFinalized
 
 // Start streams goroutines that streams xblocks and indexes xmsgs vs xreceipt metrics.
@@ -237,6 +241,13 @@ func (i *indexer) index(ctx context.Context, block xchain.Block) error {
 
 	// Skip empty blocks
 	if len(block.Msgs) == 0 && len(block.Receipts) == 0 {
+		// Update cursor for every Nth empty block
+		if block.BlockHeight%emptyBlockCursorUpdate == 0 {
+			if err := i.updateCursor(ctx, block); err != nil {
+				return err
+			}
+		}
+
 		return nil
 	}
 


### PR DESCRIPTION
Mitigate high-load-slow catchups on startup for empty streams by updating cursors on empty blocks.

issue: none