### PR TITLE
chore(monitor/validator): add uptime and rewards

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -88,6 +88,8 @@ issues:
   fix: true
   exclude-files:
     - ".*\\.pb\\.go$" # Ignore generated protobuf files
+  exclude-dirs:
+    - "scratch" # Ignore scratch folder if present
   exclude-rules:
     - path: '(.*)(_test|tutil|scripts)(.*)'
       linters:         # Relax linters for both tests/scripts (non-production code)

--- a/e2e/test/attestations_test.go
+++ b/e2e/test/attestations_test.go
@@ -92,7 +92,7 @@ func TestApprovedValUpdates(t *testing.T) {
 
 		valSetID := consChain.DeployHeight
 		for {
-			vals, ok, err := cprov.ValidatorSet(ctx, valSetID)
+			vals, ok, err := cprov.PortalValidatorSet(ctx, valSetID)
 			require.NoError(t, err)
 			require.True(t, ok, "Validator update not found in any set: node=%s, valSetID=%v", node.Name, valSetID)
 

--- a/halo/app/start_test.go
+++ b/halo/app/start_test.go
@@ -123,7 +123,7 @@ func testCProvider(t *testing.T, ctx context.Context, cprov cprovider.Provider) 
 	require.Equal(t, xblock, xblock2)
 
 	// Ensure it doesn't error for unknown validator sets.
-	_, ok, err = cprov.ValidatorSet(ctx, 33)
+	_, ok, err = cprov.PortalValidatorSet(ctx, 33)
 	require.NoError(t, err)
 	require.False(t, ok)
 

--- a/lib/cchain/provider/provider.go
+++ b/lib/cchain/provider/provider.go
@@ -45,10 +45,11 @@ type headerFunc func(ctx context.Context, height *int64) (*ctypes.ResultHeader, 
 type chainIDFunc func(ctx context.Context) (uint64, error)
 type genesisFunc func(ctx context.Context) (execution []byte, consensus []byte, err error)
 type upgradeFunc func(ctx context.Context) (upgradetypes.Plan, bool, error)
+type signingFunc func(ctx context.Context) ([]cchain.SDKSigningInfo, error)
 
 type valSetResponse struct {
 	ValSetID      uint64
-	Validators    []cchain.Validator
+	Validators    []cchain.PortalValidator
 	CreatedHeight uint64
 	activedHeight uint64
 }
@@ -61,6 +62,7 @@ type Provider struct {
 	window      windowFunc
 	valset      valsetFunc
 	val         valFunc
+	signing     signingFunc
 	vals        valsFunc
 	rewards     rewardsFunc
 	chainID     chainIDFunc
@@ -109,7 +111,7 @@ func (p Provider) WindowCompare(ctx context.Context, chainVer xchain.ChainVersio
 	return p.window(ctx, chainVer, attestOffset)
 }
 
-func (p Provider) ValidatorSet(ctx context.Context, valSetID uint64) ([]cchain.Validator, bool, error) {
+func (p Provider) PortalValidatorSet(ctx context.Context, valSetID uint64) ([]cchain.PortalValidator, bool, error) {
 	resp, ok, err := p.valset(ctx, valSetID, false)
 	return resp.Validators, ok, err
 }
@@ -122,7 +124,11 @@ func (p Provider) SDKValidators(ctx context.Context) ([]cchain.SDKValidator, err
 	return p.vals(ctx)
 }
 
-func (p Provider) Rewards(ctx context.Context, operator common.Address) (float64, bool, error) {
+func (p Provider) SDKSigningInfos(ctx context.Context) ([]cchain.SDKSigningInfo, error) {
+	return p.signing(ctx)
+}
+
+func (p Provider) SDKRewards(ctx context.Context, operator common.Address) (float64, bool, error) {
 	return p.rewards(ctx, operator)
 }
 

--- a/lib/cchain/provider/provider_test.go
+++ b/lib/cchain/provider/provider_test.go
@@ -17,6 +17,34 @@ import (
 
 var integration = flag.Bool("integration", false, "run integration tests")
 
+func TestSigningInfos(t *testing.T) {
+	t.Parallel()
+	if !*integration {
+		t.Skip("skipping integration test")
+	}
+
+	ctx := context.Background()
+
+	cprov, err := provider.Dial(netconf.Omega)
+	require.NoError(t, err)
+
+	infos, err := cprov.SDKSigningInfos(ctx)
+	require.NoError(t, err)
+
+	for _, info := range infos {
+		consCmtAddr, err := info.ConsensusCmtAddr()
+		require.NoError(t, err)
+
+		log.Info(ctx, "Validator Signing Info",
+			"consensus_addr", consCmtAddr,
+			"jailed", info.Jailed(),
+			"uptime", info.Uptime,
+			"tombstoned", info.Tombstoned,
+			"expected_blocks", info.IndexOffset,
+			"missed_blocks", info.MissedBlocksCounter,
+		)
+	}
+}
 func TestSDKValidator(t *testing.T) {
 	t.Parallel()
 	if !*integration {
@@ -35,6 +63,9 @@ func TestSDKValidator(t *testing.T) {
 		opAddr, err := val.OperatorEthAddr()
 		require.NoError(t, err)
 
+		consEthAddr, err := val.ConsensusEthAddr()
+		require.NoError(t, err)
+
 		consCmtAddr, err := val.ConsensusCmtAddr()
 		require.NoError(t, err)
 
@@ -43,6 +74,7 @@ func TestSDKValidator(t *testing.T) {
 
 		log.Info(ctx, "Validator",
 			"operator", opAddr,
+			"consensus_eth_addr", consEthAddr,
 			"consensus_addr", consCmtAddr,
 			"power", power,
 			"is_jailed", val.IsJailed(),

--- a/lib/cchain/provider/xblock.go
+++ b/lib/cchain/provider/xblock.go
@@ -125,8 +125,8 @@ func mustGetABI(metadata *bind.MetaData) *abi.ABI {
 	return abi
 }
 
-// toPortalVals converts a slice of cchain.Validator to a slice of bindings.Validator.
-func toPortalVals(vals []cchain.Validator) ([]bindings.Validator, error) {
+// toPortalVals converts a slice of cchain.PortalValidator to a slice of bindings.Validator.
+func toPortalVals(vals []cchain.PortalValidator) ([]bindings.Validator, error) {
 	resp := make([]bindings.Validator, 0, len(vals))
 	for _, val := range vals {
 		if err := val.Verify(); err != nil {

--- a/lib/cchain/provider/xblock_internal_test.go
+++ b/lib/cchain/provider/xblock_internal_test.go
@@ -22,7 +22,7 @@ func TestXBlock(t *testing.T) {
 	t.Parallel()
 	f := fuzz.NewWithSeed(99).NilChance(0).Funcs(
 		// Fuzz valid validators.
-		func(e *cchain.Validator, c fuzz.Continue) {
+		func(e *cchain.PortalValidator, c fuzz.Continue) {
 			c.FuzzNoCustom(e)
 			if e.Power < 0 {
 				e.Power = -e.Power
@@ -38,7 +38,7 @@ func TestXBlock(t *testing.T) {
 
 	valFunc := func(ctx context.Context, h uint64, _ bool) (valSetResponse, bool, error) {
 		require.EqualValues(t, height, h)
-		var resp []cchain.Validator
+		var resp []cchain.PortalValidator
 		f.Fuzz(&resp)
 
 		return valSetResponse{

--- a/lib/cchain/types.go
+++ b/lib/cchain/types.go
@@ -1,0 +1,119 @@
+package cchain
+
+import (
+	"crypto/ecdsa"
+
+	"github.com/omni-network/omni/lib/errors"
+	"github.com/omni-network/omni/lib/umath"
+
+	cmtcrypto "github.com/cometbft/cometbft/crypto"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/crypto"
+
+	cosmosk1 "github.com/cosmos/cosmos-sdk/crypto/keys/secp256k1"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	sltypes "github.com/cosmos/cosmos-sdk/x/slashing/types"
+	stypes "github.com/cosmos/cosmos-sdk/x/staking/types"
+	"github.com/cosmos/gogoproto/proto"
+)
+
+// PortalValidator is a consensus chain validator in a validator set emitted/submitted by/tp portals .
+type PortalValidator struct {
+	Address common.Address
+	Power   int64
+}
+
+// Verify returns an error if the validator is invalid.
+func (v PortalValidator) Verify() error {
+	if v.Address == (common.Address{}) {
+		return errors.New("empty validator address")
+	}
+	if v.Power <= 0 {
+		return errors.New("invalid validator power")
+	}
+
+	return nil
+}
+
+// SDKSigningInfo wraps the cosmos slashing signing info type and extends it with convenience functions.
+type SDKSigningInfo struct {
+	sltypes.ValidatorSigningInfo
+	// Uptime is the percentage [0,1] of blocks signed in the previous <SignedBlockWindow> (1000).
+	Uptime float64
+}
+
+func (i SDKSigningInfo) Jailed() bool {
+	return i.JailedUntil.Unix() != 0
+}
+
+func (i SDKSigningInfo) ConsensusCmtAddr() (cmtcrypto.Address, error) {
+	valAddr, err := sdk.ConsAddressFromBech32(i.Address)
+	if err != nil {
+		return cmtcrypto.Address{}, errors.Wrap(err, "parse validator address")
+	} else if len(valAddr) != cmtcrypto.AddressSize {
+		return nil, errors.New("invalid consensus address length")
+	}
+
+	return cmtcrypto.Address(valAddr), nil
+}
+
+// SDKValidator wraps the cosmos staking validator type and extends it with
+// convenience functions.
+type SDKValidator struct {
+	stypes.Validator
+}
+
+// Power returns the validators cometBFT power.
+func (v SDKValidator) Power() (uint64, error) {
+	return umath.ToUint64(v.ConsensusPower(sdk.DefaultPowerReduction))
+}
+
+// OperatorEthAddr returns the validator operator ethereum address.
+func (v SDKValidator) OperatorEthAddr() (common.Address, error) {
+	opAddr, err := sdk.ValAddressFromBech32(v.OperatorAddress)
+	if err != nil {
+		return common.Address{}, errors.Wrap(err, "parse operator address")
+	} else if len(opAddr) != common.AddressLength {
+		return common.Address{}, errors.New("invalid operator address length")
+	}
+
+	return common.BytesToAddress(opAddr), nil
+}
+
+// ConsensusEthAddr returns the validator consensus eth address.
+func (v SDKValidator) ConsensusEthAddr() (common.Address, error) {
+	pk, err := v.ConsensusPublicKey()
+	if err != nil {
+		return common.Address{}, err
+	}
+
+	return crypto.PubkeyToAddress(*pk), nil
+}
+
+// ConsensusCmtAddr returns the validator consensus cometBFT address.
+func (v SDKValidator) ConsensusCmtAddr() (cmtcrypto.Address, error) {
+	pk := new(cosmosk1.PubKey)
+	err := proto.Unmarshal(v.ConsensusPubkey.Value, pk)
+	if err != nil {
+		return nil, errors.Wrap(err, "unmarshal consensus pubkey")
+	}
+
+	return pk.Address(), nil
+}
+
+// ConsensusPublicKey returns the validator consensus public key (eth ecdsa style).
+func (v SDKValidator) ConsensusPublicKey() (*ecdsa.PublicKey, error) {
+	pk := new(cosmosk1.PubKey)
+	err := proto.Unmarshal(v.ConsensusPubkey.Value, pk)
+	if err != nil {
+		return nil, errors.Wrap(err, "unmarshal consensus pubkey")
+	}
+
+	pubkey, err := crypto.DecompressPubkey(pk.Bytes())
+	if err != nil {
+		return nil, errors.Wrap(err, "decompress pubkey")
+	}
+
+	return pubkey, nil
+}

--- a/monitor/validator/metrics.go
+++ b/monitor/validator/metrics.go
@@ -3,6 +3,10 @@ package validator
 import (
 	"github.com/omni-network/omni/lib/promutil"
 
+	"github.com/cometbft/cometbft/crypto"
+
+	"github.com/ethereum/go-ethereum/common"
+
 	"github.com/prometheus/client_golang/prometheus"
 )
 
@@ -27,4 +31,46 @@ var (
 		Name:      "bonded",
 		Help:      "Constant gauge set to 1 if the validator is bonded otherwise 0",
 	}, []string{"validator"})
+
+	tombstonedGauge = promutil.NewResetGaugeVec(prometheus.GaugeOpts{
+		Namespace: "monitor",
+		Subsystem: "validator",
+		Name:      "tombstoned",
+		Help:      "Constant gauge set to 1 if the validator is tombstoned otherwise 0",
+	}, []string{"validator"})
+
+	uptimeGauge = promutil.NewResetGaugeVec(prometheus.GaugeOpts{
+		Namespace: "monitor",
+		Subsystem: "validator",
+		Name:      "uptime",
+		Help:      "Percentage of blocks signed in past <slashing_signing_window>",
+	}, []string{"validator"})
+
+	rewardsGauge = promutil.NewResetGaugeVec(prometheus.GaugeOpts{
+		Namespace: "monitor",
+		Subsystem: "validator",
+		Name:      "rewards",
+		Help:      "Validator rewards",
+	}, []string{"validator"})
 )
+
+type sample struct {
+	ConsensusEthAddr common.Address
+	ConsensusCmtAddr crypto.Address
+	OperatorEthAddr  common.Address
+	Power            int64
+	Jailed           bool
+	Bonded           bool
+	Tombstoned       bool
+	Uptime           float64
+	Rewards          float64
+}
+
+func sampleValidator(s sample) {
+	powerGauge.WithLabelValues(s.ConsensusEthAddr.String(), s.ConsensusCmtAddr.String(), s.OperatorEthAddr.String()).Set(float64(s.Power))
+	jailedGauge.WithLabelValues(s.ConsensusEthAddr.String()).Set(boolToFloat(s.Jailed))
+	bondedGauge.WithLabelValues(s.ConsensusEthAddr.String()).Set(boolToFloat(s.Bonded))
+	tombstonedGauge.WithLabelValues(s.ConsensusEthAddr.String()).Set(boolToFloat(s.Tombstoned))
+	uptimeGauge.WithLabelValues(s.ConsensusEthAddr.String()).Set(s.Uptime)
+	rewardsGauge.WithLabelValues(s.ConsensusEthAddr.String()).Set(s.Rewards)
+}

--- a/monitor/validator/validator_internal_test.go
+++ b/monitor/validator/validator_internal_test.go
@@ -1,0 +1,33 @@
+package validator
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"testing"
+
+	"github.com/omni-network/omni/lib/cchain/provider"
+	"github.com/omni-network/omni/lib/log"
+	"github.com/omni-network/omni/lib/netconf"
+
+	"github.com/stretchr/testify/require"
+)
+
+var integration = flag.Bool("integration", false, "enable integration tests")
+
+func TestMonitorOnce(t *testing.T) {
+	t.Parallel()
+	if !*integration {
+		t.Skip("skipping integration tests")
+	}
+
+	ctx := context.Background()
+
+	cprov, err := provider.Dial(netconf.Omega)
+	require.NoError(t, err)
+
+	err = monitorOnce(ctx, cprov, func(s sample) {
+		log.Info(ctx, "Sample validator", "sample", fmt.Sprintf("%#v", s))
+	})
+	require.NoError(t, err)
+}


### PR DESCRIPTION
Adds `monitor_validator_uptime` and `monitor_validator_rewrads` and `monitor_validator_tombstoned` metrics.

Also improve cprovider naming.

issue: #1811 