### PR TITLE
chore(omni/cli): add create-consensus-key command

### DIFF
--- a/cli/cmd/cmd.go
+++ b/cli/cmd/cmd.go
@@ -31,7 +31,8 @@ func newOperatorCmds() *cobra.Command {
 		newRegisterCmd(),
 		newInitCmd(),
 		newCreateValCmd(),
-		newCreateKeyCmd(),
+		newCreateOperatorKeyCmd(),
+		newCreateConsensusKeyCmd(),
 		newUnjailCmd(),
 	)
 

--- a/halo/cmd/init.go
+++ b/halo/cmd/init.go
@@ -277,11 +277,7 @@ func InitFiles(ctx context.Context, initCfg InitConfig) error {
 	privValKeyFile := comet.PrivValidatorKeyFile()
 	privValStateFile := comet.PrivValidatorStateFile()
 	if cmtos.FileExists(privValKeyFile) {
-		pv = privval.LoadFilePV(privValKeyFile, privValStateFile) // This hard exits on any error.
-		log.Info(ctx, "Found cometBFT private validator",
-			"key_file", privValKeyFile,
-			"state_file", privValStateFile,
-		)
+		log.Info(ctx, "Found cometBFT private validator", "key_file", privValKeyFile)
 	} else {
 		pv = privval.NewFilePV(k1.GenPrivKey(), privValKeyFile, privValStateFile)
 		pv.Save()


### PR DESCRIPTION
Adds `omni create-consensus-key` command that generates the following two files:
 - `<home>/config/priv_validator_key.json`
 - `<home>/data/priv_validator_state.json`
.

issue: none