### PR TITLE
chore(goreleaser): only include external binaries in release

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -75,7 +75,9 @@ dockers:
 
 archives:
   - format: tar.gz
-    allow_different_binary_count: true # Required since anvilproxy only has linux-amd64
+    builds: # Only include external facing binaries. We use docker internally.
+      - halo
+      - omni
     # this name template makes the OS and Arch compatible with the results of `uname`.
     name_template: >-
       {{ .ProjectName }}_


### PR DESCRIPTION
Remove internal binaries from release tarball. Only include external facing `halo` and `omni` binary.

issue: #1844 