### PR TITLE
ci(e2e): add p2p keys to all omega nodes

### DIFF
--- a/e2e/manifests/omega.toml
+++ b/e2e/manifests/omega.toml
@@ -40,38 +40,86 @@ mode = "archive"
 [node.archive02]
 mode = "archive"
 
+# Validator Keys
 [keys.validator01]
 validator = "0xCE624ce5C5717b63CED36AfB76857183E0a8a6eb"
-
+p2p_consensus = "949145F115F83488A91179D51D7D3BAB5AE6B244"
+[keys.validator01_evm]
+p2p_execution = "0x243499570DabEFA3e51f66eb670293498525504A"
 [keys.validator02]
 validator = "0x98Eb13371c095905985cddE937018881d4D7f229"
-
+p2p_consensus = "F3CC7B678464BD2271E909BD7151B6538B9BD1DE"
+[keys.validator02_evm]
+p2p_execution = "0x73b857e0Cf1bD85C9c45c9CAaa727c0b8bcf8Dcf"
 [keys.validator03]
 validator = "0xe96cF9Ad91cD6dc911817603Dfb3c65d5f532B95"
-
+p2p_consensus = "2FA6ACCE36ECE9E6520424CE80D77746FA8994FC"
+[keys.validator03_evm]
+p2p_execution = "0x238C8B4C109f92B145f821f653E5c3F823B7eB02"
 [keys.validator04]
 validator = "0xdBd26a685DB4475b6c58ADEC0DE06c6eE387EAa8"
+p2p_consensus = "811E42EE1131DDF07BA139269BF541917261DD7C"
+[keys.validator04_evm]
+p2p_execution = "0x04DC956cDe2F3311f5492B582d86e53DCc59BF9e"
 
+# Seed keys
 [keys.seed01]
 p2p_consensus = "623AB30714ECFC8A0C0DA0227A1B5BD9CF5B3D8B"
-
 [keys.seed01_evm]
 p2p_execution = "0x4480E59696A840a4A1CFf5Ca20cB925de152a024"
-
 [keys.seed02]
 p2p_consensus = "7582E893545ECDC8D43402198CCB9100584973B6"
-
 [keys.seed02_evm]
 p2p_execution = "0x492dA9a43ADD943A5359bF83CCD2d3Fd4235b870"
 
+# Archive keys
 [keys.archive01]
 p2p_consensus = "2320703BF5434BBC4B1050A90F0FBF842D4878F9"
-
 [keys.archive01_evm]
 p2p_execution = "0x33194570113B14FFD00b9E53cf2e405Bc62C2a5E"
-
 [keys.archive02]
 p2p_consensus = "1AFC3479B2A16BCA9DA5BEC7BFF750A7B5FFE53D"
-
 [keys.archive02_evm]
 p2p_execution = "0xd9B2Ca2215f5a04C1BbaAb8379A37cE21C025AE8"
+
+# Fullnode keys
+[keys.fullnode01]
+p2p_consensus = "AD9C13930160CE5A452794D6C73E1F9C38FDBC16"
+[keys.fullnode01_evm]
+p2p_execution = "0xa22ae699EE8b08FF30F6dE68dAAF73Ed97A77F59"
+[keys.fullnode02]
+p2p_consensus = "15EB1CD69EFA8260F613C8D0F59CBEE7A109DBB9"
+[keys.fullnode02_evm]
+p2p_execution = "0x82C7b4316cB494548CDe0bdaAEC530E0bdEb85Ab"
+[keys.fullnode03]
+p2p_consensus = "A57CE25D5CBFA7F6BF94C58D5132C98E4EA5245B"
+[keys.fullnode03_evm]
+p2p_execution = "0x71FfDaa6F0a74bAAc3e6Ca57AE655C99B7203a6c"
+[keys.fullnode04]
+p2p_consensus = "F832F960730B88303F027840586E26EA2474DB13"
+[keys.fullnode04_evm]
+p2p_execution = "0xc1DD19F1CD5fFEf6c7631B2B25448d09160A8Cbe"
+[keys.fullnode05]
+p2p_consensus = "10C19EBA0D8D200C740070F3FA4817CA315C3693"
+[keys.fullnode05_evm]
+p2p_execution = "0xBB5980C75B4C1982886b07b80dC05cf2a91fB4d4"
+[keys.fullnode06]
+p2p_consensus = "BCA38CD010A9D33D8DF0FA434867BADA7DF451FF"
+[keys.fullnode06_evm]
+p2p_execution = "0xB10354108150a3b74B394f5F9d3f4EA9222cdE14"
+[keys.fullnode07]
+p2p_consensus = "9711E6A26E56E0F5E1E55AF23460F686D104F4B6"
+[keys.fullnode07_evm]
+p2p_execution = "0x2feEac31C7212fa7f128B0579BccD30553cCa759"
+[keys.fullnode08]
+p2p_consensus = "1A765F6D460F7C5DF3E3D308D56206991002013D"
+[keys.fullnode08_evm]
+p2p_execution = "0x2706B03F3eB9a11Cf242aB7a73Ab568b2DBcf5A5"
+[keys.fullnode09]
+p2p_consensus = "876E7F362D7D3D43EB8AC669631A44A60B612E47"
+[keys.fullnode09_evm]
+p2p_execution = "0xcE19ebB4196Ab6F7a1aDf54860DB57F6bd687e5b"
+[keys.fullnode10]
+p2p_consensus = "AC937CE7B60DA2800BA791BB35721E9AFA925EDB"
+[keys.fullnode10_evm]
+p2p_execution = "0xA8B13740D33cfF1330f224125fCa289Fbe2cA5Cb"

--- a/monitor/xmonitor/emitcache/emitcursorcache.go
+++ b/monitor/xmonitor/emitcache/emitcursorcache.go
@@ -61,7 +61,7 @@ func Start(
 					emit, _, err := xprov.GetEmittedCursor(ctx, ref, stream)
 					if err != nil {
 						latest, _ := xprov.ChainVersionHeight(ctx, xchain.ChainVersion{ID: chain.ID, ConfLevel: xchain.ConfLatest})
-						return errors.Wrap(err, "get emit cursor", err,
+						return errors.Wrap(err, "get emit cursor",
 							"stream", network.StreamName(stream),
 							"lagging", umath.SubtractOrZero(latest, block.BlockHeight),
 						)

--- a/relayer/app/worker.go
+++ b/relayer/app/worker.go
@@ -281,7 +281,8 @@ func fetchXBlock(rootCtx context.Context, xProvider xchain.Provider, att xchain.
 				return block, false, nil
 			}
 
-			return xchain.Block{}, false, errors.Wrap(err, "mismatching block vs finalized attestation [BUG]")
+			return xchain.Block{}, false, errors.Wrap(err, "mismatching block vs finalized attestation [BUG]",
+				"block_height", block.BlockHeight)
 		}
 
 		// We got the xblock, it is finalized and its hash matches the attestation block hash.


### PR DESCRIPTION
Add P2P keys to all omega nodes to ensure that upgrades don't negatively affect P2P peers by rotating keys and needing to timeout and reconnect and refresh.

issue: none