### PR TITLE
chore(halo/attest): improve xchain vote metrics

### DIFF
--- a/halo/attest/keeper/helper.go
+++ b/halo/attest/keeper/helper.go
@@ -125,3 +125,11 @@ func fuzzyDependents(chainVer xchain.ChainVersion, confLevels map[uint64][]xchai
 
 	return resp
 }
+
+func boolToFloat(b bool) float64 {
+	if !b {
+		return 0
+	}
+
+	return 1
+}

--- a/halo/attest/keeper/metrics.go
+++ b/halo/attest/keeper/metrics.go
@@ -57,27 +57,34 @@ var (
 		Namespace: "halo",
 		Subsystem: "attest",
 		Name:      "votes_approved_total",
-		Help: "Total number of votes included in approved attestations per validator per stream. " +
+		Help: "Total number of votes included in approved attestations per validator per chain version. " +
 			"Approved votes were present in approved attestations at time of deletion. They count towards rewards",
-	}, []string{"validator", "stream"})
+	}, []string{"validator", "chain_version"})
 
 	discardedVotesCounter = promauto.NewCounterVec(prometheus.CounterOpts{
 		Namespace: "halo",
 		Subsystem: "attest",
 		Name:      "votes_discarded_total",
-		Help: "Total number of votes included in discarded attestations per validator per stream. " +
+		Help: "Total number of votes included in discarded attestations per validator per chain version. " +
 			"Discarded votes were included on-chain but were either for previously approved attestations (late) or " +
 			"for non-quorum attestations (wrong). They don't count towards rewards",
-	}, []string{"validator", "stream"})
+	}, []string{"validator", "chain_version"})
 
 	missingVotesCounter = promauto.NewCounterVec(prometheus.CounterOpts{
 		Namespace: "halo",
 		Subsystem: "attest",
 		Name:      "votes_missing_total",
-		Help: "Total number of votes missing from approved attestations per validator per stream. " +
+		Help: "Total number of votes missing from approved attestations per validator per chain version. " +
 			"Missing votes were missing from approved attestations at time of deletion. " +
 			"They may be late or never included on-chain. missing-discarded==not-voting",
-	}, []string{"validator", "stream"})
+	}, []string{"validator", "chain_version"})
+
+	expectedVotesCounter = promauto.NewCounterVec(prometheus.CounterOpts{
+		Namespace: "halo",
+		Subsystem: "attest",
+		Name:      "votes_expected_total",
+		Help:      "Total number of expected votes for attestations per validator per chain version.",
+	}, []string{"validator", "chain_version"})
 )
 
 func latency(method string) func() {


### PR DESCRIPTION
Improves xchain vote monitoring to allow for easier uptime metrics.
- Adds `halo_attest_votes_expected_total` and init all metrics with correct metrics so calculating uptime is simply `halo_attest_votes_approved_total/halo_attest_votes_expected_total`.
- Rename `stream` label to `chain_version` since it isn't streams but chain vers.

issue: #1811 