### PR TITLE
chore(ci): use full docs dir for vercel trigger

### DIFF
--- a/.github/workflows/ci-pr-docs.yml
+++ b/.github/workflows/ci-pr-docs.yml
@@ -5,7 +5,7 @@ env:
 on:
   pull_request:
     paths:
-      - 'docs/website/**'
+      - 'docs/**'
 jobs:
   deploy:
     runs-on: ubuntu-latest


### PR DESCRIPTION
the `docs/content` dir should also trigger preview deployments

issue: none
