### PR TITLE
chore(*): some spearbit audit fixes

### DIFF
--- a/halo/attest/keeper/valaddr.go
+++ b/halo/attest/keeper/valaddr.go
@@ -30,9 +30,6 @@ func (c *valAddrCache) GetEthAddress(cmtAddr [crypto.AddressSize]byte) (common.A
 }
 
 func (c *valAddrCache) SetAll(vals []*vtypes.Validator) error {
-	c.Lock()
-	defer c.Unlock()
-
 	var ethAddrs = make(map[[crypto.AddressSize]byte]common.Address, len(vals))
 	for _, val := range vals {
 		cmtAddr, err := val.CometAddress()
@@ -49,6 +46,9 @@ func (c *valAddrCache) SetAll(vals []*vtypes.Validator) error {
 
 		ethAddrs[[crypto.AddressSize]byte(cmtAddr)] = ethAddr
 	}
+
+	c.Lock()
+	defer c.Unlock()
 
 	c.ethAddrs = ethAddrs
 

--- a/halo/attest/types/tx.go
+++ b/halo/attest/types/tx.go
@@ -80,6 +80,10 @@ func (h *AttestHeader) Verify() error {
 		return errors.New("zero attestation offset")
 	}
 
+	if (h.ConfLevel >> 8) > 0 { // Ensure conf level is max 1 byte
+		return errors.New("invalid conf level")
+	}
+
 	return nil
 }
 
@@ -195,6 +199,10 @@ func (a *Attestation) Verify() error {
 
 	if err := a.AttestHeader.Verify(); err != nil {
 		return errors.Wrap(err, "verify attest header")
+	}
+
+	if a.BlockHeader.ChainId != a.AttestHeader.SourceChainId {
+		return errors.New("chain ID mismatch")
 	}
 
 	if len(a.MsgRoot) != len(common.Hash{}) {


### PR DESCRIPTION
Fixes some spearbit audit issues:
- omni-halo#2: `AttestHeader::Verify()` accepts invalid confirmation level
- omni-halo#3: `Verify()` functions do not check that headers are for the same chain ID
- omni-halo#4: `*valAddrCache.SetAll()` mutex use can be optimized

issue: none