### PR TITLE
chore(*): refactor cached pointers

### DIFF
--- a/halo/registry/keeper/cache.go
+++ b/halo/registry/keeper/cache.go
@@ -11,6 +11,7 @@ import (
 	"github.com/omni-network/omni/lib/xchain"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	"google.golang.org/protobuf/proto"
 )
 
 var _ types.PortalRegistry = Keeper{}
@@ -22,16 +23,25 @@ type cache struct {
 }
 
 func (c *cache) Set(network *Network) {
+	if network == nil {
+		return
+	}
+
 	c.Lock()
-	c.network = network
-	c.Unlock()
+	defer c.Unlock()
+
+	c.network = proto.Clone(network).(*Network) //nolint:revive,forcetypeassert // Panic not possible
 }
 
 func (c *cache) Get() (*Network, bool) {
 	c.RLock()
 	defer c.RUnlock()
 
-	return c.network, c.network != nil
+	if c.network == nil {
+		return nil, false
+	}
+
+	return proto.Clone(c.network).(*Network), true //nolint:revive,forcetypeassert // Panic not possible
 }
 
 func (k Keeper) updateNetwork(ctx context.Context, network *Network) error {

--- a/octane/evmengine/keeper/abci_internal_test.go
+++ b/octane/evmengine/keeper/abci_internal_test.go
@@ -188,7 +188,7 @@ func TestKeeper_PrepareProposal(t *testing.T) {
 		// initialize mutable payload so we trigger the optimistic flow
 		keeper.mutablePayload.Height = 2
 		keeper.mutablePayload.UpdatedAt = time.Now()
-		keeper.mutablePayload.ID = payloadID
+		keeper.mutablePayload.ID = *payloadID
 
 		resp, err := keeper.PrepareProposal(withRandomErrs(t, ctx), req)
 		require.NoError(t, err)
@@ -309,7 +309,7 @@ func TestOptimistic(t *testing.T) {
 	b, err := mockEngine.HeaderByType(ctx, ethclient.HeadLatest)
 	require.NoError(t, err)
 
-	env, err := mockEngine.GetPayloadV3(ctx, *payloadID)
+	env, err := mockEngine.GetPayloadV3(ctx, payloadID)
 	require.NoError(t, err)
 
 	payload := env.ExecutionPayload

--- a/octane/evmengine/keeper/keeper.go
+++ b/octane/evmengine/keeper/keeper.go
@@ -42,7 +42,7 @@ type Keeper struct {
 	// so we might not actually be the next proposer.
 	mutablePayload struct {
 		sync.Mutex
-		ID        *engine.PayloadID
+		ID        engine.PayloadID
 		Height    uint64
 		UpdatedAt time.Time
 	}
@@ -194,7 +194,7 @@ func (k *Keeper) isNextProposer(ctx context.Context, currentProposer []byte, cur
 	return isNextProposer, nil
 }
 
-func (k *Keeper) setOptimisticPayload(id *engine.PayloadID, height uint64) {
+func (k *Keeper) setOptimisticPayload(id engine.PayloadID, height uint64) {
 	k.mutablePayload.Lock()
 	defer k.mutablePayload.Unlock()
 
@@ -203,7 +203,7 @@ func (k *Keeper) setOptimisticPayload(id *engine.PayloadID, height uint64) {
 	k.mutablePayload.UpdatedAt = time.Now()
 }
 
-func (k *Keeper) getOptimisticPayload() (*engine.PayloadID, uint64, time.Time) {
+func (k *Keeper) getOptimisticPayload() (engine.PayloadID, uint64, time.Time) {
 	k.mutablePayload.Lock()
 	defer k.mutablePayload.Unlock()
 


### PR DESCRIPTION
Refactor a few caches that store/return pointers to avoid mutation of the cached value before/after getting/setting.

This was pointed out by spearbit audit.

issue: none