### PR TITLE
chore(monitor/indexer): strip 0x for omniscan links

### DIFF
--- a/monitor/xmonitor/indexer/indexer.go
+++ b/monitor/xmonitor/indexer/indexer.go
@@ -3,6 +3,7 @@ package indexer
 import (
 	"context"
 	"encoding/json"
+	"strings"
 	"sync"
 	"time"
 
@@ -414,7 +415,7 @@ func (i *indexer) instrumentMsg(ctx context.Context, link *MsgLink) error {
 		"latency", s.Latency,
 		"msg_tx", msg.TxHash,
 		"receipt_tx", receipt.TxHash,
-		"id_hash", msg.Hash(),
+		"id_hash", strings.TrimPrefix(msg.Hash().Hex(), "0x"), // Trim 0x prefix since omniscan doesn't use it in urls.
 	)
 
 	return nil


### PR DESCRIPTION
Strip 0x from `id_hash` logs since routescan strips it from urls which is what we use this for.

issue: #1811 
