### PR TITLE
fix(halo/attest): fix ListAllAttestations

### DIFF
--- a/halo/attest/keeper/keeper_test.go
+++ b/halo/attest/keeper/keeper_test.go
@@ -65,7 +65,7 @@ func TestKeeper_Add(t *testing.T) {
 					ChainId:    expectAtt.GetChainId(),
 					ConfLevel:  expectAtt.GetConfLevel(),
 					Status:     uint32(keeper.Status_Pending),
-					FromOffset: defaultOffset,
+					FromOffset: 0,
 				})
 
 				require.NoError(t, err)

--- a/halo/attest/types/tx.go
+++ b/halo/attest/types/tx.go
@@ -8,6 +8,12 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 )
 
+const (
+	StatusUnknown  uint32 = 0
+	StatusPending  uint32 = 1
+	StatusApproved uint32 = 2
+)
+
 func (v *Vote) AttestationRoot() (common.Hash, error) {
 	return xchain.AttestationRoot(v.AttestHeader.ToXChain(), v.BlockHeader.ToXChain(), common.Hash(v.MsgRoot))
 }

--- a/lib/cchain/provider.go
+++ b/lib/cchain/provider.go
@@ -42,6 +42,10 @@ type Provider interface {
 	// and attestOffset (inclusive). It will return max 100 attestations per call.
 	AttestationsFrom(ctx context.Context, chainVer xchain.ChainVersion, attestOffset uint64) ([]xchain.Attestation, error)
 
+	// AllAttestationsFrom returns the all pending and approve attestations for the provided source chain
+	// and attestOffset (inclusive).
+	AllAttestationsFrom(ctx context.Context, chainVer xchain.ChainVersion, attestOffset uint64) ([]xchain.Attestation, error)
+
 	// LatestAttestation returns the latest approved attestation for the provided source chain or false
 	// if none exist.
 	LatestAttestation(ctx context.Context, chainVer xchain.ChainVersion) (xchain.Attestation, bool, error)

--- a/lib/cchain/provider/provider.go
+++ b/lib/cchain/provider/provider.go
@@ -33,6 +33,7 @@ import (
 var _ cchain.Provider = Provider{}
 
 type fetchFunc func(ctx context.Context, chainVer xchain.ChainVersion, fromOffset uint64) ([]xchain.Attestation, error)
+type allAttsFunc func(ctx context.Context, chainVer xchain.ChainVersion, fromOffset uint64) ([]xchain.Attestation, error)
 type latestFunc func(ctx context.Context, chainVer xchain.ChainVersion) (xchain.Attestation, bool, error)
 type windowFunc func(ctx context.Context, chainVer xchain.ChainVersion, attestOffset uint64) (int, error)
 type portalBlockFunc func(ctx context.Context, attestOffset uint64, latest bool) (*ptypes.BlockResponse, bool, error)
@@ -58,6 +59,7 @@ type valSetResponse struct {
 type Provider struct {
 	cometCl     rpcclient.Client
 	fetch       fetchFunc
+	allAtts     allAttsFunc
 	latest      latestFunc
 	window      windowFunc
 	valset      valsetFunc
@@ -100,6 +102,11 @@ func (p Provider) CurrentUpgradePlan(ctx context.Context) (upgradetypes.Plan, bo
 func (p Provider) AttestationsFrom(ctx context.Context, chainVer xchain.ChainVersion, attestOffset uint64,
 ) ([]xchain.Attestation, error) {
 	return p.fetch(ctx, chainVer, attestOffset)
+}
+
+func (p Provider) AllAttestationsFrom(ctx context.Context, chainVer xchain.ChainVersion, attestOffset uint64,
+) ([]xchain.Attestation, error) {
+	return p.allAtts(ctx, chainVer, attestOffset)
 }
 
 func (p Provider) LatestAttestation(ctx context.Context, chainVer xchain.ChainVersion,


### PR DESCRIPTION
Fixes `attest.ListAllAttestations` to use `ListRange` instead of `List` which is a perfix query. Also enforce a `maxLimit=100`.

issue: #1895