### PR TITLE
ci(goreleaser): fix monitor version

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -27,6 +27,8 @@ builds:
     env: [CGO_ENABLED=0]
     goos: [linux, darwin]
     goarch: [amd64, arm64]
+    ldflags:
+      - -s -w -X github.com/omni-network/omni/lib/buildinfo.version={{ if .IsSnapshot }}main{{ else }}{{.Tag}}{{ end }}
 
   - id: omni
     main: ./cli/cmd/omni


### PR DESCRIPTION
Fixes incorrect `main` version of `monitor` service for official releases.

issue: none