### PR TITLE
ci(contracts/core): add release worflows for contracts npm

### DIFF
--- a/.github/workflows/check-contracts-version.yml
+++ b/.github/workflows/check-contracts-version.yml
@@ -1,0 +1,29 @@
+name: Check @omni-network/contracts version
+
+on:
+  push:
+    tags:
+      - 'contracts/v*'   # Trigger on contracts/v* tags
+
+jobs:
+  check-version:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout the repository
+      uses: actions/checkout@v3
+
+    - name: Check version
+      run: |
+        cd contracts/core
+        npm_version=$(cat package.json | jq -r '.version')
+        tag_version=${GITHUB_REF#refs/tags/contracts/v}
+
+        echo "npm version: $npm_version"
+        echo "tag version: $tag_version"
+
+        if [ "$npm_version" != "$tag_version" ]; then
+          echo "Error: package.json version '$npm_version' does not match github tag '$tag_version')"
+          exit 1
+        fi
+      shell: bash

--- a/.github/workflows/release-contracts-npm.yml
+++ b/.github/workflows/release-contracts-npm.yml
@@ -1,0 +1,28 @@
+name: Publish @omni-network/contracts to npm
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  publish-release:
+    # only run for contracts/v* tags
+    if: startsWith(github.ref, 'refs/tags/contracts/v')
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '20.x'
+          registry-url: 'https://registry.npmjs.org'
+      - uses: pnpm/action-setup@v4
+      - run: |
+          cd contracts/core
+          pnpm publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/contracts/core/package.json
+++ b/contracts/core/package.json
@@ -1,9 +1,9 @@
 {
   "name": "@omni-network/contracts",
-  "version": "0.2.0-alpha.6",
+  "version": "0.2.0-alpha.7",
   "license": "GPL-3.0-only",
   "packageManager": "pnpm@8.14.0",
-  "repository": "https://github.com/omni-network/omni/contracts",
+  "repository": "https://github.com/omni-network/omni/tree/main/contracts/core",
   "files": [
     "src/**/*.sol",
     "test/**/*.sol",


### PR DESCRIPTION
Release `@omni-network/contracts` on npm when github release published.

- only on github tags `contracts/v*`
- add check on tag to make sure npm version matches 

issue: #1450
