### PR TITLE
chore(monitor/validator): use potential power instead

### DIFF
--- a/monitor/validator/metrics.go
+++ b/monitor/validator/metrics.go
@@ -15,7 +15,7 @@ var (
 		Namespace: "monitor",
 		Subsystem: "validator",
 		Name:      "power",
-		Help:      "Current power by validator",
+		Help:      "Current potential power by validator (may not be bonded)",
 	}, []string{"validator", "validator_address", "operator"}) // Main metric with additional label identifiers
 
 	jailedGauge = promutil.NewResetGaugeVec(prometheus.GaugeOpts{

--- a/monitor/validator/validator.go
+++ b/monitor/validator/validator.go
@@ -81,7 +81,7 @@ func monitorOnce(ctx context.Context, cprov cchain.Provider, sampleFunc func(sam
 			ConsensusEthAddr: consAddrEth,
 			ConsensusCmtAddr: consAddrCmt,
 			OperatorEthAddr:  opAddr,
-			Power:            val.ConsensusPower(sdk.DefaultPowerReduction),
+			Power:            val.PotentialConsensusPower(sdk.DefaultPowerReduction),
 			Jailed:           val.IsJailed(),
 			Bonded:           val.IsBonded(),
 			Tombstoned:       info.Tombstoned,


### PR DESCRIPTION
Use potential power since this allows tracking power of unbonded validators

issue: none