### PR TITLE
ci(e2e): fix port clash

### DIFF
--- a/e2e/docker/compose.yaml.tmpl
+++ b/e2e/docker/compose.yaml.tmpl
@@ -23,7 +23,7 @@ services:
     ports:
     - {{ if $.BindAll }}26656:{{end}}26656 # CometBFT Consensus P2P
     - {{ if .ProxyPort }}{{ .ProxyPort }}:{{ end }}26657 # CometBFT Consensus RPC
-    - {{ if $.BindAll }}9090:{{end}}9090 # Cosmos gRPC API
+    - {{ if $.BindAll }}9999:{{end}}9090 # Cosmos gRPC API (VM port 9090 used by grafana-agent)
     - {{ if $.BindAll }}1317:{{end}}1317 # Cosmos REST API
 {{- if .PrometheusProxyPort }}
     - {{ .PrometheusProxyPort }}:26660 # Prometheus

--- a/e2e/docker/testdata/TestComposeTemplate_commit.golden
+++ b/e2e/docker/testdata/TestComposeTemplate_commit.golden
@@ -20,7 +20,7 @@ services:
     ports:
     - 26656 # CometBFT Consensus P2P
     - 8584:26657 # CometBFT Consensus RPC
-    - 9090 # Cosmos gRPC API
+    - 9090 # Cosmos gRPC API (VM port 9090 used by grafana-agent)
     - 1317 # Cosmos REST API
     - 6060 # Pprof
     volumes:

--- a/e2e/docker/testdata/TestComposeTemplate_empheral_network.golden
+++ b/e2e/docker/testdata/TestComposeTemplate_empheral_network.golden
@@ -20,7 +20,7 @@ services:
     ports:
     - 26656 # CometBFT Consensus P2P
     - 8584:26657 # CometBFT Consensus RPC
-    - 9090 # Cosmos gRPC API
+    - 9090 # Cosmos gRPC API (VM port 9090 used by grafana-agent)
     - 1317 # Cosmos REST API
     - 6060 # Pprof
     volumes:

--- a/e2e/docker/testdata/TestComposeTemplate_empheral_network_upgrade.golden
+++ b/e2e/docker/testdata/TestComposeTemplate_empheral_network_upgrade.golden
@@ -20,7 +20,7 @@ services:
     ports:
     - 26656 # CometBFT Consensus P2P
     - 8584:26657 # CometBFT Consensus RPC
-    - 9090 # Cosmos gRPC API
+    - 9090 # Cosmos gRPC API (VM port 9090 used by grafana-agent)
     - 1317 # Cosmos REST API
     - 6060 # Pprof
     volumes:

--- a/e2e/vmcompose/testdata/TestSetup_127-0-0-1-compose.yaml.golden
+++ b/e2e/vmcompose/testdata/TestSetup_127-0-0-1-compose.yaml.golden
@@ -16,7 +16,7 @@ services:
     ports:
     - 26656:26656 # CometBFT Consensus P2P
     - 26657:26657 # CometBFT Consensus RPC
-    - 9090:9090 # Cosmos gRPC API
+    - 9999:9090 # Cosmos gRPC API (VM port 9090 used by grafana-agent)
     - 1317:1317 # Cosmos REST API
     - 6060 # Pprof
     volumes:

--- a/e2e/vmcompose/testdata/TestSetup_127-0-0-2-compose.yaml.golden
+++ b/e2e/vmcompose/testdata/TestSetup_127-0-0-2-compose.yaml.golden
@@ -16,7 +16,7 @@ services:
     ports:
     - 26656:26656 # CometBFT Consensus P2P
     - 26657:26657 # CometBFT Consensus RPC
-    - 9090:9090 # Cosmos gRPC API
+    - 9999:9090 # Cosmos gRPC API (VM port 9090 used by grafana-agent)
     - 1317:1317 # Cosmos REST API
     - 6060 # Pprof
     volumes:

--- a/e2e/vmcompose/testdata/TestSetup_127-0-0-4-compose.yaml.golden
+++ b/e2e/vmcompose/testdata/TestSetup_127-0-0-4-compose.yaml.golden
@@ -16,7 +16,7 @@ services:
     ports:
     - 26656:26656 # CometBFT Consensus P2P
     - 26657:26657 # CometBFT Consensus RPC
-    - 9090:9090 # Cosmos gRPC API
+    - 9999:9090 # Cosmos gRPC API (VM port 9090 used by grafana-agent)
     - 1317:1317 # Cosmos REST API
     - 6060 # Pprof
     volumes:

--- a/e2e/vmcompose/testdata/TestSetup_127-0-0-5-compose.yaml.golden
+++ b/e2e/vmcompose/testdata/TestSetup_127-0-0-5-compose.yaml.golden
@@ -16,7 +16,7 @@ services:
     ports:
     - 26656:26656 # CometBFT Consensus P2P
     - 26657:26657 # CometBFT Consensus RPC
-    - 9090:9090 # Cosmos gRPC API
+    - 9999:9090 # Cosmos gRPC API (VM port 9090 used by grafana-agent)
     - 1317:1317 # Cosmos REST API
     - 6060 # Pprof
     volumes:


### PR DESCRIPTION
We can't bind Cosmos gRPC to port 9090 on our VMs since it clashes with grafana agent.

issue: #1861 