### PR TITLE
ci(e2e): align snapshot period

### DIFF
--- a/e2e/app/geth/config.go
+++ b/e2e/app/geth/config.go
@@ -17,8 +17,8 @@ import (
 
 // snapshotCacheMB increases the default snapshot cache size of 102MB.
 // This is required to support SnapSync since it must overlap with cosmos which
-// takes snapshots every 1000 blocks.
-const snapshotCacheMB = 2 * 1024
+// takes snapshots every 100 blocks.
+const snapshotCacheMB = 1024
 
 // WriteAllConfig writes all the geth config files for all omniEVMs.
 func WriteAllConfig(testnet types.Testnet, genesis core.Genesis) error {

--- a/halo/cmd/init.go
+++ b/halo/cmd/init.go
@@ -390,7 +390,7 @@ func getTrustHeightAndHash(ctx context.Context, cl *rpchttp.HTTP) (int64, string
 	}
 
 	// Truncate height to last defaultSnapshotPeriod
-	const defaultSnapshotPeriod int64 = 1000
+	const defaultSnapshotPeriod int64 = 100
 	snapshotHeight := defaultSnapshotPeriod * (latest.Block.Height / defaultSnapshotPeriod)
 
 	if snapshotHeight == 0 {

--- a/halo/config/config.go
+++ b/halo/config/config.go
@@ -33,7 +33,7 @@ const (
 	executionGenesisFile = "execution_genesis.json"
 
 	DefaultHomeDir            = "./halo" // Defaults to "halo" in current directory
-	defaultSnapshotInterval   = 100      // Roughly once an hour (given 3s blocks)
+	defaultSnapshotInterval   = 100      // Can't be too large, must overlap with geth snapshotcache.
 	defaultSnapshotKeepRecent = 2
 	defaultMinRetainBlocks    = 1 // Prune all blocks by default, Cosmsos will still respect other needs like snapshots
 


### PR DESCRIPTION
Align `omni` cli snapshot period. Also decrease geth snapshot cache back to 1GB.

issue: #1675 