### PR TITLE
ci(github): improve CI docker images

### DIFF
--- a/.github/workflows/release-official.yml
+++ b/.github/workflows/release-official.yml
@@ -14,6 +14,12 @@ jobs:
         with:
           go-version: 'stable'
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Login to Dockerhub container registry
         uses: docker/login-action@v3
         with:
@@ -29,8 +35,17 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push halovisor
-        run: |
-          scripts/halovisor/build.sh ${{ github.ref_name }}
-          docker tag  omniops/halovisor:${{ github.ref_name }}  omniops/halovisor:latest
-          docker push omniops/halovisor:${{ github.ref_name }}
-          docker push omniops/halovisor:latest
+        uses: docker/build-push-action@v6
+        with:
+          file: scripts/halovisor/Dockerfile
+          build-args: |
+            HALO_VERSION_GENESIS=${{ github.ref_name }}
+          platforms: |
+            linux/amd64
+            linux/arm64
+            darwin/amd64
+            darwin/arm64
+          push: true
+          tags: |
+            omniops/halovisor:latest
+            omniops/halovisor:${{ github.ref_name }}

--- a/.github/workflows/release-snapshot.yml
+++ b/.github/workflows/release-snapshot.yml
@@ -12,17 +12,33 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version: 'stable'
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Login to Dockerhub container registry
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      # Speed up CI by skipping multi-arch builds
+      - name: Skip multi-arch builds
+        run: |
+          cp .goreleaser.yaml .snapshot-goreleaser.yaml
+          sed -i -e 's/linux, darwin/linux/g' .snapshot-goreleaser.yaml
+          sed -i -e 's/amd64, arm64/amd64/g' .snapshot-goreleaser.yaml
+          cat .snapshot-goreleaser.yaml
+
       - name: Build docker images
         uses: goreleaser/goreleaser-action@v5
         with:
           version: 2
           # Use --snapshot to build current HEAD commit (this doesn't publish images)
-          args: release --snapshot --clean
+          args: release --snapshot --clean --config=.snapshot-goreleaser.yaml
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -31,10 +47,17 @@ jobs:
         run: echo "short_sha=`echo ${GITHUB_SHA::7}`" >> "$GITHUB_OUTPUT"
 
       - name: Build and push halovisor
-        run: |
-          scripts/halovisor/build.sh ${GITHUB_SHA::7}
-          docker push omniops/halovisor:${GITHUB_SHA::7}
-          docker push omniops/halovisor:main
+        uses: docker/build-push-action@v6
+        with:
+          file: scripts/halovisor/Dockerfile
+          build-args: |
+            HALO_VERSION_GENESIS=${GITHUB_SHA::7}
+          platforms: |
+            linux/amd64
+          push: true
+          tags: |
+            omniops/halovisor:main
+            omniops/halovisor:${GITHUB_SHA::7}
 
       - name: Push Halo to Dockerhub
         run: |


### PR DESCRIPTION
Improves CI docker images:
 - Skip multi-arch builds during snapshots (normal CI) #speed
 - Add multi-arch builds for halovisor during official release

issue: #1735 