### PR TITLE
chore(cli): add operator address to privkey file

### DIFF
--- a/cli/cmd/flags.go
+++ b/cli/cmd/flags.go
@@ -86,5 +86,5 @@ func bindPrivateKeyFile(cmd *cobra.Command, privateKeyFile *string) {
 
 func bindCreateKeyConfig(cmd *cobra.Command, cfg *createKeyConfig) {
 	cmd.Flags().StringVar((*string)(&cfg.Type), flagType, string(cfg.Type), "Type of key to create")
-	cmd.Flags().StringVar(&cfg.PrivateKeyFile, "output-file", cfg.PrivateKeyFile, "Path to output private key file")
+	cmd.Flags().StringVar(&cfg.PrivateKeyFile, "output-file", cfg.PrivateKeyFile, "Path to output private key file. Note that '{ADDRESS}' will be replaced with the address")
 }

--- a/cli/cmd/key.go
+++ b/cli/cmd/key.go
@@ -4,6 +4,7 @@ import (
 	"encoding/hex"
 	"os"
 	"path"
+	"strings"
 
 	"github.com/omni-network/omni/halo/attest/voter"
 	halocmd "github.com/omni-network/omni/halo/cmd"
@@ -114,14 +115,18 @@ func newCreateOperatorKeyCmd() *cobra.Command {
 			if err != nil {
 				return errors.Wrap(err, "generate key")
 			}
-			if err := crypto.SaveECDSA(cfg.PrivateKeyFile, privKey); err != nil {
+
+			addr := crypto.PubkeyToAddress(privKey.PublicKey).Hex()
+			privKeyfile := strings.Replace(cfg.PrivateKeyFile, "{ADDRESS}", addr, 1)
+
+			if err := crypto.SaveECDSA(privKeyfile, privKey); err != nil {
 				return errors.Wrap(err, "save key")
 			}
 
 			log.Info(cmd.Context(), "🎉 Created operator private key",
 				"type", cfg.Type,
-				"file", cfg.PrivateKeyFile,
-				"address", crypto.PubkeyToAddress(privKey.PublicKey).Hex(),
+				"file", privKeyfile,
+				"address", addr,
 			)
 			log.Info(cmd.Context(), "🚧 Remember to backup this key 🚧")
 
@@ -168,7 +173,7 @@ func (c createKeyConfig) Verify() error {
 func defaultCreateKeyConfig() createKeyConfig {
 	return createKeyConfig{
 		Type:           KeyTypeInsecure,
-		PrivateKeyFile: "./operator-private-key",
+		PrivateKeyFile: "./operator-private-key-{ADDRESS}",
 	}
 }
 


### PR DESCRIPTION
Suffix the operator address to the private key filename. This mitigates the risk of loosing track of the operator address or of mixing up multiple private keys.

Example
```
omni operator create-operator-key

🎉 Created operator private key                                                            type=insecure file=./operator-private-key-0xe06C945CD25198086C9369CEd1A414Ba028BB177 address=0xe06C945CD25198086C9369CEd1A414Ba028BB177
🚧 Remember to backup this key 🚧
```

issue: none