### PR TITLE
feat(halo): add status command

### DIFF
--- a/halo/cmd/cmd.go
+++ b/halo/cmd/cmd.go
@@ -27,6 +27,7 @@ func New() *cobra.Command {
 		newRollbackCmd(),
 		buildinfo.NewVersionCmd(),
 		newConsKeyCmd(),
+		newStatusCmd(),
 	)
 }
 

--- a/halo/cmd/flags.go
+++ b/halo/cmd/flags.go
@@ -53,3 +53,10 @@ func bindRPCFlags(flags *pflag.FlagSet, prefix string, cfg *halocfg.RPCConfig) {
 	flags.BoolVar(&cfg.Enable, prefix+"-enable", cfg.Enable, fmt.Sprintf("Enable defines if the %s server should be enabled.", strings.ToUpper(prefix)))
 	flags.StringVar(&cfg.Address, prefix+"-address", cfg.Address, fmt.Sprintf("Address defines the %s server to listen on", strings.ToUpper(prefix)))
 }
+
+func bindStatusFlags(cmd *cobra.Command, cfg *statusConfig) {
+	flags := cmd.Flags()
+
+	flags.StringVarP(&cfg.Node, "node", "n", cfg.Node, "Node to connect to")
+	flags.StringVarP(&cfg.Output, "output", "o", cfg.Output, "Output format (text|json)")
+}

--- a/halo/cmd/status.go
+++ b/halo/cmd/status.go
@@ -1,0 +1,73 @@
+package cmd
+
+import (
+	"context"
+
+	"github.com/omni-network/omni/lib/errors"
+
+	cmtconfig "github.com/cometbft/cometbft/config"
+	cmtjson "github.com/cometbft/cometbft/libs/json"
+	cmthttp "github.com/cometbft/cometbft/rpc/client/http"
+
+	"github.com/cosmos/cosmos-sdk/client"
+	sdkflags "github.com/cosmos/cosmos-sdk/client/flags"
+	"github.com/spf13/cobra"
+)
+
+type statusConfig struct {
+	Node   string
+	Output string
+}
+
+func defaultStatusConfig() statusConfig {
+	return statusConfig{
+		Output: sdkflags.OutputFormatJSON,
+		Node:   cmtconfig.DefaultRPCConfig().ListenAddress,
+	}
+}
+
+func newStatusCmd() *cobra.Command {
+	cfg := defaultStatusConfig()
+
+	cmd := &cobra.Command{
+		Use:   "status",
+		Short: "Query remote node for status",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			err := printStatus(cmd.Context(), cfg)
+			if err != nil {
+				return errors.Wrap(err, "status failed")
+			}
+
+			return nil
+		},
+	}
+
+	bindStatusFlags(cmd, &cfg)
+
+	return cmd
+}
+
+func printStatus(ctx context.Context, cfg statusConfig) error {
+	rpcCl, err := cmthttp.New(cfg.Node, "/websocket")
+	if err != nil {
+		return errors.Wrap(err, "create rpc client", "address", cfg.Node)
+	}
+
+	status, err := rpcCl.Status(ctx)
+	if err != nil {
+		return errors.Wrap(err, "query status", "address", cfg.Node)
+	}
+
+	output, err := cmtjson.Marshal(status)
+	if err != nil {
+		return errors.Wrap(err, "marshal status")
+	}
+
+	err = new(client.Context).WithOutputFormat(cfg.Output).PrintRaw(output)
+	if err != nil {
+		return errors.Wrap(err, "print status")
+	}
+
+	return nil
+}

--- a/halo/cmd/testdata/TestCLIReference_halo.golden
+++ b/halo/cmd/testdata/TestCLIReference_halo.golden
@@ -10,6 +10,7 @@ Available Commands:
   init             Initializes required halo files and directories
   rollback         Rollback Cosmos SDK and CometBFT state by one height
   run              Runs the halo consensus client
+  status           Query remote node for status
   version          Print the version information of this binary
 
 Flags:


### PR DESCRIPTION
Adds the CosmosSDK standard `halo status` command. This is going to be used by cosmovisor during upgrades. 

issue: #1834 