### PR TITLE
fix(ci): do not require etherscan api keys in ci

### DIFF
--- a/contracts/core/foundry.toml
+++ b/contracts/core/foundry.toml
@@ -34,7 +34,8 @@ seed = "0x6eed"
 bracket_spacing = true
 number_underscore = "thousands"
 
-[etherscan]
-holesky = { key = "${ETHERSCAN_KEY}" }
-optimism_sepolia = { key = "${OPSCAN_KEY}" }
-arbitrum_sepolia = { key = "${ARBSCAN_KEY}" }
+# uncomment to verify contracts
+# [etherscan]
+# holesky = { key = "${ETHERSCAN_KEY}" }
+# optimism_sepolia = { key = "${OPSCAN_KEY}" }
+# arbitrum_sepolia = { key = "${ARBSCAN_KEY}" }


### PR DESCRIPTION
Avoid 'env var not found' errors in ci.

issue: none
