### PR TITLE
ci(e2e): enable geth udp ports

### DIFF
--- a/cli/cmd/compose.yml.tpl
+++ b/cli/cmd/compose.yml.tpl
@@ -30,10 +30,11 @@ services:
       #- --pprof.addr=0.0.0.0         # Enable prometheus metrics
 
     ports:
-      - 8551         # Auth-RPC (used by halo)
-      - 8545:8545    # JSON-RCP
-      - 8546:8546    # Websocket-RPC
-      - 30303:30303  # Execution P2P
-      #- 6060:6060   # Prometheus metrics
+      - 8551             # Auth-RPC (used by halo)
+      - 8545:8545        # JSON-RCP
+      - 8546:8546        # Websocket-RPC
+      - 30303:30303      # Execution P2P
+      - 30303:30303/udp  # Execution P2P Discovery
+      #- 6060:6060       # Prometheus metrics
     volumes:
       - ./geth:/geth

--- a/e2e/docker/compose.yaml.tmpl
+++ b/e2e/docker/compose.yaml.tmpl
@@ -82,6 +82,7 @@ services:
       - {{ if $.BindAll }}8551:{{end}}8551 # Auth RPC
       - {{ if .ProxyPort }}{{ .ProxyPort }}:{{ end }}8545 # HTTP RPC
       - {{ if $.BindAll }}30303:{{end}}30303 # Execution P2P
+      - {{ if $.BindAll }}30303:{{end}}30303/udp # Execution P2P Discovery
       - {{ if $.BindAll }}8546:{{end}}8546 # Websockets RPC
       - 6060 # Prometheus metrics and pprof
     healthcheck:

--- a/e2e/docker/testdata/TestComposeTemplate_commit.golden
+++ b/e2e/docker/testdata/TestComposeTemplate_commit.golden
@@ -89,6 +89,7 @@ services:
       - 8551 # Auth RPC
       - 8000:8545 # HTTP RPC
       - 30303 # Execution P2P
+      - 30303/udp # Execution P2P Discovery
       - 8546 # Websockets RPC
       - 6060 # Prometheus metrics and pprof
     healthcheck:

--- a/e2e/docker/testdata/TestComposeTemplate_empheral_network.golden
+++ b/e2e/docker/testdata/TestComposeTemplate_empheral_network.golden
@@ -89,6 +89,7 @@ services:
       - 8551 # Auth RPC
       - 8000:8545 # HTTP RPC
       - 30303 # Execution P2P
+      - 30303/udp # Execution P2P Discovery
       - 8546 # Websockets RPC
       - 6060 # Prometheus metrics and pprof
     healthcheck:

--- a/e2e/docker/testdata/TestComposeTemplate_empheral_network_upgrade.golden
+++ b/e2e/docker/testdata/TestComposeTemplate_empheral_network_upgrade.golden
@@ -89,6 +89,7 @@ services:
       - 8551 # Auth RPC
       - 8000:8545 # HTTP RPC
       - 30303 # Execution P2P
+      - 30303/udp # Execution P2P Discovery
       - 8546 # Websockets RPC
       - 6060 # Prometheus metrics and pprof
     healthcheck:

--- a/e2e/vmcompose/testdata/TestSetup_127-0-0-1-compose.yaml.golden
+++ b/e2e/vmcompose/testdata/TestSetup_127-0-0-1-compose.yaml.golden
@@ -48,6 +48,7 @@ services:
       - 8551:8551 # Auth RPC
       - 8545:8545 # HTTP RPC
       - 30303:30303 # Execution P2P
+      - 30303:30303/udp # Execution P2P Discovery
       - 8546:8546 # Websockets RPC
       - 6060 # Prometheus metrics and pprof
     healthcheck:

--- a/e2e/vmcompose/testdata/TestSetup_127-0-0-2-compose.yaml.golden
+++ b/e2e/vmcompose/testdata/TestSetup_127-0-0-2-compose.yaml.golden
@@ -48,6 +48,7 @@ services:
       - 8551:8551 # Auth RPC
       - 8545:8545 # HTTP RPC
       - 30303:30303 # Execution P2P
+      - 30303:30303/udp # Execution P2P Discovery
       - 8546:8546 # Websockets RPC
       - 6060 # Prometheus metrics and pprof
     healthcheck:

--- a/e2e/vmcompose/testdata/TestSetup_127-0-0-4-compose.yaml.golden
+++ b/e2e/vmcompose/testdata/TestSetup_127-0-0-4-compose.yaml.golden
@@ -48,6 +48,7 @@ services:
       - 8551:8551 # Auth RPC
       - 8545:8545 # HTTP RPC
       - 30303:30303 # Execution P2P
+      - 30303:30303/udp # Execution P2P Discovery
       - 8546:8546 # Websockets RPC
       - 6060 # Prometheus metrics and pprof
     healthcheck:

--- a/e2e/vmcompose/testdata/TestSetup_127-0-0-5-compose.yaml.golden
+++ b/e2e/vmcompose/testdata/TestSetup_127-0-0-5-compose.yaml.golden
@@ -48,6 +48,7 @@ services:
       - 8551:8551 # Auth RPC
       - 8545:8545 # HTTP RPC
       - 30303:30303 # Execution P2P
+      - 30303:30303/udp # Execution P2P Discovery
       - 8546:8546 # Websockets RPC
       - 6060 # Prometheus metrics and pprof
     healthcheck:


### PR DESCRIPTION
Enables geth docker compose udp ports. This should fix discv5 which isn't working on omega.

issue: #1674 