### PR TITLE
chore(halo/valsync): validate inserted validators

### DIFF
--- a/halo/valsync/keeper/helper.go
+++ b/halo/valsync/keeper/helper.go
@@ -1,0 +1,22 @@
+package keeper
+
+import (
+	"github.com/omni-network/omni/lib/errors"
+
+	k1 "github.com/cometbft/cometbft/crypto/secp256k1"
+)
+
+// Validate returns an error if the validator is invalid.
+func (v *Validator) Validate() error {
+	if v == nil {
+		return errors.New("nil validator")
+	} else if v.GetPower() < 0 {
+		return errors.New("negative power")
+	} else if len(v.GetPubKey()) != k1.PubKeySize {
+		return errors.New("invalid pubkey size")
+	} else if v.GetValsetId() != 0 {
+		return errors.New("valset id already set")
+	}
+
+	return nil
+}

--- a/halo/valsync/keeper/keeper.go
+++ b/halo/valsync/keeper/keeper.go
@@ -231,6 +231,10 @@ func (k *Keeper) insertValidatorSet(ctx context.Context, vals []*Validator, isGe
 	var totalPower, totalUpdated, totalLen, totalRemoved int64
 	powers := make(map[common.Address]int64)
 	for _, val := range vals {
+		if err := val.Validate(); err != nil {
+			return 0, err
+		}
+
 		val.ValsetId = valset.GetId()
 		err = k.valTable.Insert(ctx, val)
 		if err != nil {

--- a/halo/valsync/keeper/keeper_internal_test.go
+++ b/halo/valsync/keeper/keeper_internal_test.go
@@ -1,0 +1,67 @@
+package keeper
+
+import (
+	"testing"
+
+	k1 "github.com/cometbft/cometbft/crypto/secp256k1"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestInsertInvalidValidators(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		Name string
+		Val  *Validator
+		Err  string
+	}{
+		{
+			Name: "nil pubkey",
+			Err:  "invalid pubkey",
+			Val: &Validator{
+				PubKey: nil,
+			},
+		},
+		{
+			Name: "invalid pubkey",
+			Err:  "invalid pubkey",
+			Val: &Validator{
+				PubKey: []byte{1, 2, 3, 4, 5, 6, 7},
+			},
+		},
+		{
+			Name: "negative power",
+			Err:  "negative power",
+			Val: &Validator{
+				PubKey: k1.GenPrivKey().PubKey().Bytes(),
+				Power:  -1,
+			},
+		},
+		{
+			Name: "valset id",
+			Err:  "valset id already set",
+			Val: &Validator{
+				PubKey:   k1.GenPrivKey().PubKey().Bytes(),
+				ValsetId: 1,
+			},
+		},
+		{
+			Name: "nil validator",
+			Err:  "nil validator",
+			Val:  nil,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.Name, func(t *testing.T) {
+			t.Parallel()
+			keeper, sdkCtx := setupKeeper(t, defaultExpectation())
+
+			sdkCtx = sdkCtx.WithBlockHeight(1)
+
+			_, err := keeper.insertValidatorSet(sdkCtx, []*Validator{test.Val}, false)
+			require.ErrorContains(t, err, test.Err)
+		})
+	}
+}


### PR DESCRIPTION
Additional validation before inserting validators into valsync module.

This was raised during the speardit audit.

issue: none