### PR TITLE
ci(e2e): pull latest images on compose up

### DIFF
--- a/e2e/vmcompose/provider.go
+++ b/e2e/vmcompose/provider.go
@@ -17,7 +17,6 @@ import (
 	"github.com/omni-network/omni/e2e/types"
 	"github.com/omni-network/omni/lib/errors"
 	"github.com/omni-network/omni/lib/log"
-	"github.com/omni-network/omni/lib/netconf"
 
 	e2e "github.com/cometbft/cometbft/test/e2e/pkg"
 
@@ -85,9 +84,6 @@ func (p *Provider) Setup() error {
 		}
 
 		gethVerbosity := 3 // Info level
-		if p.Testnet.Network == netconf.Staging {
-			gethVerbosity = 5 // TODO(corver): Revert to info logs after debugging snapsync issues.
-		}
 
 		def := docker.ComposeDef{
 			UpgradeVersion: p.Testnet.UpgradeVersion,

--- a/e2e/vmcompose/provider.go
+++ b/e2e/vmcompose/provider.go
@@ -158,7 +158,7 @@ func (p *Provider) Restart(ctx context.Context, cfg types.ServiceConfig) error {
 
 		startCmd := fmt.Sprintf("cd /omni/%s && "+
 			"sudo docker compose down && "+
-			"sudo docker compose up -d",
+			"sudo docker compose up -d", // Don't pull on restart
 			p.Testnet.Name)
 
 		err := execOnVM(ctx, vmName, startCmd)
@@ -279,7 +279,7 @@ func (p *Provider) Upgrade(ctx context.Context, cfg types.ServiceConfig) error {
 			startCmd := fmt.Sprintf("cd /omni/%s && "+
 				"sudo mv %s docker-compose.yaml && "+
 				"sudo docker compose down && "+
-				"sudo docker compose up -d",
+				"sudo docker compose up -d --pull=always",
 				p.Testnet.Name, composeFile)
 
 			log.Debug(ctx, "Executing docker-compose up", "vm", vmName)
@@ -346,7 +346,7 @@ func (p *Provider) StartNodes(ctx context.Context, _ ...*e2e.Node) error {
 				"sudo mv %s evm-init.sh && "+
 				"sudo mv %s prometheus/prometheus.yml && "+
 				"sudo ./evm-init.sh && "+
-				"sudo docker compose up -d",
+				"sudo docker compose up -d --pull=always",
 				p.Testnet.Name, composeFile, initFile, agentFile)
 
 			err := execOnVM(ctx, vmName, startCmd)


### PR DESCRIPTION
Pull images when deploying or upgrading. This resolve issue of using `main` or `latest` images that are not being updated on deploy.

issue: none