### PR TITLE
ci(e2e): fix docker compose pull

### DIFF
--- a/e2e/vmcompose/provider.go
+++ b/e2e/vmcompose/provider.go
@@ -274,8 +274,9 @@ func (p *Provider) Upgrade(ctx context.Context, cfg types.ServiceConfig) error {
 
 			startCmd := fmt.Sprintf("cd /omni/%s && "+
 				"sudo mv %s docker-compose.yaml && "+
+				"sudo docker compose pull && "+
 				"sudo docker compose down && "+
-				"sudo docker compose up -d --pull=always",
+				"sudo docker compose up -d",
 				p.Testnet.Name, composeFile)
 
 			log.Debug(ctx, "Executing docker-compose up", "vm", vmName)
@@ -341,8 +342,9 @@ func (p *Provider) StartNodes(ctx context.Context, _ ...*e2e.Node) error {
 				"sudo mv %s docker-compose.yaml && "+
 				"sudo mv %s evm-init.sh && "+
 				"sudo mv %s prometheus/prometheus.yml && "+
+				"sudo docker compose pull &&"+
 				"sudo ./evm-init.sh && "+
-				"sudo docker compose up -d --pull=always",
+				"sudo docker compose up -d",
 				p.Testnet.Name, composeFile, initFile, agentFile)
 
 			err := execOnVM(ctx, vmName, startCmd)


### PR DESCRIPTION
Ununtu VMs doesn't support `docker compose --pull` flag so switch to explicit `docker compose pull`.

issue: none