### PR TITLE
ci(github): run PR ci against upgrade branches

### DIFF
--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -6,6 +6,7 @@ on:
     branches:
       - main
       - release/**
+      - upgrade/** # Run CI against upgrade PRs
 
 permissions:
   contents: read

--- a/.github/workflows/pr-label.yml
+++ b/.github/workflows/pr-label.yml
@@ -22,8 +22,8 @@ jobs:
           if [[ $GIT_BRANCH = main ]]; then
             # Do not label main branch PRs
             LABEL="skip"
-          elif [[ $GIT_BRANCH = release* ]]; then
-            # Label release branches
+          elif [[ $GIT_BRANCH =~ (release*|upgrade*) ]]; then
+            # Label release/upgrade branches
             LABEL="$GIT_BRANCH"
           else
             # Label all other branches as invalid


### PR DESCRIPTION
PRs against `upgrade/**` branches should also run CI.

issue: none