### PR TITLE
chore(monitor/validator): fix uptime metric

### DIFF
--- a/lib/cchain/provider/abci.go
+++ b/lib/cchain/provider/abci.go
@@ -108,15 +108,14 @@ func newABCISigningFunc(cl sltypes.QueryClient) signingFunc {
 		if err != nil {
 			incQueryErr(endpoint)
 			return nil, errors.Wrap(err, "abci query params")
+		} else if params.Params.SignedBlocksWindow == 0 {
+			return nil, errors.New("signed blocks window is zero")
 		}
 
 		var infos []cchain.SDKSigningInfo
 		for _, info := range resp.Info {
 			// uptime over the past <SignedBlocksWindow> blocks.
 			uptime := 1.0 - (float64(info.MissedBlocksCounter) / float64(params.Params.SignedBlocksWindow))
-			if info.JailedUntil.Unix() != 0 {
-				uptime = 0
-			}
 
 			infos = append(infos, cchain.SDKSigningInfo{
 				ValidatorSigningInfo: info,

--- a/lib/cchain/types.go
+++ b/lib/cchain/types.go
@@ -40,6 +40,7 @@ func (v PortalValidator) Verify() error {
 type SDKSigningInfo struct {
 	sltypes.ValidatorSigningInfo
 	// Uptime is the percentage [0,1] of blocks signed in the previous <SignedBlockWindow> (1000).
+	// Note this is 100% if the validator isn't bonded, since it can't technically miss blocks.
 	Uptime float64
 }
 


### PR DESCRIPTION
Fixes 0% uptime metric for validator previously jailed.

issue: none