### PR TITLE
feat(lib/netconf): deterministic staging network version

### DIFF
--- a/e2e/cmd/cmd.go
+++ b/e2e/cmd/cmd.go
@@ -14,6 +14,7 @@ import (
 	"github.com/omni-network/omni/lib/errors"
 	"github.com/omni-network/omni/lib/log"
 	"github.com/omni-network/omni/lib/netconf"
+	"github.com/omni-network/omni/lib/netconf/genesis"
 
 	"github.com/ethereum/go-ethereum/common"
 
@@ -45,6 +46,10 @@ func New() *cobra.Command {
 		def, err = app.MakeDefinition(ctx, defCfg, cmd.Use)
 		if err != nil {
 			return errors.Wrap(err, "make definition")
+		}
+
+		if err := genesis.Init(ctx, def.Testnet.Network); err != nil {
+			return errors.Wrap(err, "init genesis")
 		}
 
 		// Some commands require networking, this ensures proper errors instead of panics.

--- a/lib/netconf/genesis/genesis.go
+++ b/lib/netconf/genesis/genesis.go
@@ -1,0 +1,57 @@
+package genesis
+
+import (
+	"context"
+
+	cprovider "github.com/omni-network/omni/lib/cchain/provider"
+	"github.com/omni-network/omni/lib/errors"
+	"github.com/omni-network/omni/lib/log"
+	"github.com/omni-network/omni/lib/netconf"
+	"github.com/omni-network/omni/lib/xchain"
+
+	rpchttp "github.com/cometbft/cometbft/rpc/client/http"
+)
+
+// MaybeDownload downloads the genesis files via cprovider the network if they are not already set.
+func MaybeDownload(ctx context.Context, network netconf.ID) error {
+	if network.IsProtected() {
+		return nil // No need to download genesis for protected networks
+	}
+
+	if network.Static().ConsensusGenesisJSON != nil && network.Static().ExecutionGenesisJSON != nil {
+		return nil // Already set
+	}
+
+	rpcServer := network.Static().ConsensusRPC()
+	rpcCl, err := rpchttp.New(rpcServer, "/websocket")
+	if err != nil {
+		return errors.Wrap(err, "create rpc client")
+	}
+	stubNamer := func(xchain.ChainVersion) string { return "" }
+	cprov := cprovider.NewABCIProvider(rpcCl, network, stubNamer)
+
+	execution, consensus, err := cprov.GenesisFiles(ctx)
+	if err != nil {
+		return errors.Wrap(err, "fetching genesis files")
+	} else if len(execution) == 0 {
+		return errors.New("empty execution genesis file downloaded", "server", rpcServer)
+	}
+
+	log.Info(ctx, "Downloaded genesis files", "execution", len(execution), "consensus", len(consensus), "rpc", rpcServer)
+
+	return netconf.SetEphemeralGenesisBz(network, execution, consensus)
+}
+
+// Init downloads the network's genesis files to static, if necessary.
+func Init(ctx context.Context, network netconf.ID) error {
+	if network != netconf.Staging {
+		return nil // Only staging needs initialization
+	}
+
+	err := MaybeDownload(ctx, network)
+	if err != nil {
+		return errors.Wrap(err, "download genesis", "network", network)
+	}
+
+	return nil
+}

--- a/lib/netconf/network.go
+++ b/lib/netconf/network.go
@@ -35,7 +35,7 @@ func (i ID) String() string {
 }
 
 func (i ID) Version() string {
-	return i.Static().Version
+	return i.Static().Version()
 }
 
 const (

--- a/lib/tracer/rooted.go
+++ b/lib/tracer/rooted.go
@@ -23,7 +23,7 @@ func StartChainHeight(ctx context.Context, network netconf.ID, chain string, hei
 
 	h := fnv.New128a()
 	_, _ = h.Write([]byte(network.String()))
-	_, _ = h.Write([]byte(network.Static().Version))
+	_, _ = h.Write([]byte(network.Static().Version()))
 	_, _ = h.Write([]byte(chain))
 	_ = binary.Write(h, binary.BigEndian, height)
 


### PR DESCRIPTION
Derive staging network version from genesis. This let's use lib/contract addresses across run times.

Additional:

- refactor e2e to setup before deployments
- download genesis in e2e for non-deployments


issue: #1958

