### PR TITLE
chore(halo): add uluwatu network upgrade

### DIFF
--- a/.github/workflows/release-official.yml
+++ b/.github/workflows/release-official.yml
@@ -39,7 +39,7 @@ jobs:
         with:
           file: scripts/halovisor/Dockerfile
           build-args: |
-            HALO_VERSION_0_GENESIS=${{ github.ref_name }}
+            HALO_VERSION_1_ULUWATU=${{ github.ref_name }}
           platforms: |
             linux/amd64
           push: true

--- a/.github/workflows/release-snapshot.yml
+++ b/.github/workflows/release-snapshot.yml
@@ -76,7 +76,7 @@ jobs:
         with:
           file: scripts/halovisor/Dockerfile
           build-args: |
-            HALO_VERSION_0_GENESIS=${{ steps.git_ref.outputs.short_sha }}
+            HALO_VERSION_1_ULUWATU=${{ steps.git_ref.outputs.short_sha }}
           platforms: |
             linux/amd64
           push: true

--- a/e2e/app/setup.go
+++ b/e2e/app/setup.go
@@ -18,6 +18,7 @@ import (
 	"github.com/omni-network/omni/e2e/app/static"
 	"github.com/omni-network/omni/e2e/types"
 	"github.com/omni-network/omni/e2e/vmcompose"
+	uluwatu1 "github.com/omni-network/omni/halo/app/upgrades/uluwatu"
 	halocmd "github.com/omni-network/omni/halo/cmd"
 	halocfg "github.com/omni-network/omni/halo/config"
 	"github.com/omni-network/omni/halo/genutil"
@@ -48,6 +49,8 @@ const (
 
 	PrivvalKeyFile   = "config/priv_validator_key.json"
 	PrivvalStateFile = "data/priv_validator_state.json"
+
+	latestUpgrade = uluwatu1.UpgradeName
 )
 
 // Setup sets up the testnet configuration.
@@ -87,10 +90,16 @@ func Setup(ctx context.Context, def Definition, depCfg DeployConfig) error {
 		valPrivKeys = append(valPrivKeys, val.PrivvalKey)
 	}
 
+	var upgrade string
+	if def.Manifest.NetworkUpgradeHeight == 0 {
+		upgrade = latestUpgrade // Genesis upgrade.
+	}
+
 	cosmosGenesis, err := genutil.MakeGenesis(
 		def.Manifest.Network,
 		time.Now(),
 		gethGenesis.ToBlock().Hash(),
+		upgrade,
 		vals...)
 	if err != nil {
 		return errors.Wrap(err, "make genesis")

--- a/e2e/manifests/backwards.toml
+++ b/e2e/manifests/backwards.toml
@@ -3,6 +3,7 @@ network = "devnet"
 anvil_chains = ["mock_l1", "mock_l2"]
 
 multi_omni_evms = true
+network_upgrade_height = -1 # Disable network upgrade
 
 [node.validator01]
 [node.validator02]

--- a/e2e/manifests/ci.toml
+++ b/e2e/manifests/ci.toml
@@ -2,7 +2,7 @@ network = "devnet"
 anvil_chains = ["mock_l2", "mock_l1"]
 
 multi_omni_evms = true
-
+network_upgrade_height = 15
 pingpong_n = 5 # Increased ping pong to span validator updates
 
 [node.validator01]

--- a/e2e/types/manifest.go
+++ b/e2e/types/manifest.go
@@ -114,6 +114,10 @@ type Manifest struct {
 	// This allows source code defined versions for protected networks.
 	// This overrides the --omni-image-tag if non-empty.
 	PinnedRelayerTag string `toml:"pinned_relayer_tag"`
+
+	// NetworkUpgradeHeight defines the network upgrade height, default is genesis, negative is disabled.
+	// Note that it might be scheduled at a later height.
+	NetworkUpgradeHeight int64 `toml:"network_upgrade_height"`
 }
 
 // Seeds returns a map of seed nodes by name.

--- a/halo/app/app.go
+++ b/halo/app/app.go
@@ -183,6 +183,12 @@ func newApp(
 		})
 	}
 
+	// setUpgradeHandlers should be called before `Load()`
+	// because StoreLoad is sealed after that
+	if err := app.setUpgradeHandlers(); err != nil {
+		return nil, errors.Wrap(err, "set upgrade handlers")
+	}
+
 	if err := app.Load(true); err != nil {
 		return nil, errors.Wrap(err, "load app")
 	}

--- a/halo/app/start_test.go
+++ b/halo/app/start_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	haloapp "github.com/omni-network/omni/halo/app"
+	uluwatu1 "github.com/omni-network/omni/halo/app/upgrades/uluwatu"
 	atypes "github.com/omni-network/omni/halo/attest/types"
 	halocmd "github.com/omni-network/omni/halo/cmd"
 	halocfg "github.com/omni-network/omni/halo/config"
@@ -223,9 +224,10 @@ func setupSimnet(t *testing.T) haloapp.Config {
 	tutil.RequireNoError(t, err)
 
 	err = halocmd.InitFiles(log.WithNoopLogger(context.Background()), halocmd.InitConfig{
-		HomeDir:       homeDir,
-		Network:       netconf.Simnet,
-		ExecutionHash: executionGenesis.Hash(),
+		HomeDir:        homeDir,
+		Network:        netconf.Simnet,
+		ExecutionHash:  executionGenesis.Hash(),
+		GenesisUpgrade: uluwatu1.UpgradeName,
 	})
 	tutil.RequireNoError(t, err)
 

--- a/halo/app/upgrades.go
+++ b/halo/app/upgrades.go
@@ -1,0 +1,46 @@
+package app
+
+import (
+	uluwatu1 "github.com/omni-network/omni/halo/app/upgrades/uluwatu"
+	"github.com/omni-network/omni/lib/errors"
+
+	storetypes "cosmossdk.io/store/types"
+	upgradetypes "cosmossdk.io/x/upgrade/types"
+)
+
+func (a App) setUpgradeHandlers() error {
+	upgrades := []struct {
+		Name    string
+		Handler upgradetypes.UpgradeHandler
+		Store   storetypes.StoreUpgrades
+	}{
+		{
+			Name:    uluwatu1.UpgradeName,
+			Handler: uluwatu1.CreateUpgradeHandler(a.ModuleManager, a.Configurator()),
+			Store:   uluwatu1.StoreUpgrades,
+		},
+	}
+
+	for _, u := range upgrades {
+		a.UpgradeKeeper.SetUpgradeHandler(u.Name, u.Handler)
+	}
+
+	upgradeInfo, err := a.UpgradeKeeper.ReadUpgradeInfoFromDisk()
+	if err != nil {
+		return errors.Wrap(err, "read upgrade info from disk")
+	} else if upgradeInfo.Name == "" {
+		return nil // No upgrade info found
+	}
+
+	for _, u := range upgrades {
+		if u.Name != upgradeInfo.Name {
+			continue
+		}
+
+		a.SetStoreLoader(upgradetypes.UpgradeStoreLoader(upgradeInfo.Height, &u.Store))
+
+		return nil
+	}
+
+	return errors.New("unknown upgrade info [BUG]", "name", upgradeInfo.Name)
+}

--- a/halo/app/upgrades/uluwatu/upgrade.go
+++ b/halo/app/upgrades/uluwatu/upgrade.go
@@ -1,0 +1,25 @@
+// Package uluwatu defines the first omni consensus chain upgrade named after the iconic surf spot in Bali.
+// It only includes attest module migration including constructor and logic changes.
+// It doesn't include any store migrations.
+package uluwatu
+
+import (
+	"context"
+
+	storetypes "cosmossdk.io/store/types"
+	upgradetypes "cosmossdk.io/x/upgrade/types"
+	"github.com/cosmos/cosmos-sdk/types/module"
+)
+
+const UpgradeName = "1_uluwatu"
+
+var StoreUpgrades storetypes.StoreUpgrades // Zero store upgrades
+
+func CreateUpgradeHandler(
+	mm *module.Manager,
+	configurator module.Configurator,
+) upgradetypes.UpgradeHandler {
+	return func(ctx context.Context, _ upgradetypes.Plan, fromVM module.VersionMap) (module.VersionMap, error) {
+		return mm.RunMigrations(ctx, configurator, fromVM)
+	}
+}

--- a/halo/attest/module/migrations.go
+++ b/halo/attest/module/migrations.go
@@ -1,0 +1,32 @@
+package module
+
+import (
+	"github.com/omni-network/omni/halo/attest/types"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/types/module"
+)
+
+// noopMigration doesn't perform any store migrations.
+var noopMigration = func(_ sdk.Context) error { return nil }
+
+func registerMigrations(cfg module.Configurator) {
+	migrations := []struct {
+		FromVersion uint64
+		Handler     module.MigrationHandler
+	}{
+		{
+			// 1_uluwatu doesn't include any store migrations.
+			// It only includes constructor and logic changes.
+			FromVersion: 1,
+			Handler:     noopMigration,
+		},
+	}
+
+	for _, m := range migrations {
+		err := cfg.RegisterMigration(types.ModuleName, m.FromVersion, m.Handler)
+		if err != nil {
+			panic(err)
+		}
+	}
+}

--- a/halo/attest/module/module.go
+++ b/halo/attest/module/module.go
@@ -18,7 +18,7 @@ import (
 	"github.com/grpc-ecosystem/grpc-gateway/runtime"
 )
 
-const ConsensusVersion = 1
+const ConsensusVersion = 2
 
 var (
 	_ module.AppModuleBasic     = (*AppModule)(nil)
@@ -95,6 +95,7 @@ func (m AppModule) EndBlock(ctx context.Context) error {
 func (m AppModule) RegisterServices(cfg module.Configurator) {
 	types.RegisterMsgServiceServer(cfg.MsgServer(), keeper.NewMsgServerImpl(m.keeper))
 	types.RegisterQueryServer(cfg.QueryServer(), m.keeper)
+	registerMigrations(cfg)
 }
 
 // IsOnePerModuleType implements the depinject.OnePerModuleType interface.

--- a/halo/cmd/init.go
+++ b/halo/cmd/init.go
@@ -33,17 +33,18 @@ const maxPeers = 5 // Limit the amount of peers to add to the address book.
 
 // InitConfig is the config for the init command.
 type InitConfig struct {
-	HomeDir       string
-	Moniker       string
-	Network       netconf.ID
-	TrustedSync   bool
-	AddrBook      bool
-	LogCfgFunc    func(*log.Config)
-	HaloCfgFunc   func(*halocfg.Config)
-	CometCfgFunc  func(*cmtconfig.Config)
-	Force         bool
-	Clean         bool
-	ExecutionHash common.Hash
+	HomeDir        string
+	Moniker        string
+	Network        netconf.ID
+	TrustedSync    bool
+	AddrBook       bool
+	LogCfgFunc     func(*log.Config)
+	HaloCfgFunc    func(*halocfg.Config)
+	CometCfgFunc   func(*cmtconfig.Config)
+	Force          bool
+	Clean          bool
+	ExecutionHash  common.Hash
+	GenesisUpgrade string // Zero value omits network upgrade genesis tx
 }
 
 func (c InitConfig) Verify() error {
@@ -294,7 +295,7 @@ func InitFiles(ctx context.Context, initCfg InitConfig) error {
 			return errors.Wrap(err, "get public key")
 		}
 
-		cosmosGen, err := genutil.MakeGenesis(network, time.Now(), initCfg.ExecutionHash, pubKey)
+		cosmosGen, err := genutil.MakeGenesis(network, time.Now(), initCfg.ExecutionHash, initCfg.GenesisUpgrade, pubKey)
 		if err != nil {
 			return err
 		}

--- a/halo/genutil/genutil_test.go
+++ b/halo/genutil/genutil_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 	"time"
 
+	uluwatu1 "github.com/omni-network/omni/halo/app/upgrades/uluwatu"
 	"github.com/omni-network/omni/halo/genutil"
 	"github.com/omni-network/omni/lib/netconf"
 	"github.com/omni-network/omni/lib/tutil"
@@ -26,7 +27,7 @@ func TestMakeGenesis(t *testing.T) {
 
 	executionBlockHash := common.BytesToHash([]byte("blockhash"))
 
-	resp, err := genutil.MakeGenesis(netconf.Simnet, timestamp, executionBlockHash, val1, val2)
+	resp, err := genutil.MakeGenesis(netconf.Simnet, timestamp, executionBlockHash, uluwatu1.UpgradeName, val1, val2)
 	tutil.RequireNoError(t, err)
 
 	tutil.RequireGoldenJSON(t, resp)

--- a/halo/genutil/testdata/TestMakeGenesis.golden
+++ b/halo/genutil/testdata/TestMakeGenesis.golden
@@ -185,6 +185,38 @@
       "tip": null
      },
      "signatures": []
+    },
+    {
+     "body": {
+      "messages": [
+       {
+        "@type": "/cosmos.upgrade.v1beta1.MsgSoftwareUpgrade",
+        "authority": "omni1h0hvs2xgpfxg304npntxzpuddttp5n8lcmpz6u",
+        "plan": {
+         "name": "1_uluwatu",
+         "time": "0001-01-01T00:00:00Z",
+         "height": "1",
+         "info": "genesis upgrade",
+         "upgraded_client_state": null
+        }
+       }
+      ],
+      "memo": "",
+      "timeout_height": "0",
+      "extension_options": [],
+      "non_critical_extension_options": []
+     },
+     "auth_info": {
+      "signer_infos": [],
+      "fee": {
+       "amount": [],
+       "gas_limit": "0",
+       "payer": "",
+       "granter": ""
+      },
+      "tip": null
+     },
+     "signatures": []
     }
    ]
   },

--- a/scripts/halovisor/Dockerfile
+++ b/scripts/halovisor/Dockerfile
@@ -1,10 +1,12 @@
 # Docker build args
 ARG OMNI_COSMOVISOR_VERSION=v0.1.0
 ARG HALO_VERSION_0_GENESIS=v0.8.0
+ARG HALO_VERSION_1_ULUWATU=main
 
 # Build stages
 FROM omniops/cosmovisor:${OMNI_COSMOVISOR_VERSION} AS build-cosmovisor
 FROM omniops/halo:${HALO_VERSION_0_GENESIS} AS build-0-genesis
+FROM omniops/halo:${HALO_VERSION_1_ULUWATU} AS build-1-uluwatu
 
 # Runtime stage
 FROM scratch AS runtime
@@ -30,6 +32,7 @@ VOLUME /halo
 # Copy binaries from build stages.
 COPY --from=build-cosmovisor /ko-app/cosmovisor /usr/local/bin/cosmovisor
 COPY --from=build-0-genesis /app /halovisor/genesis/bin/halo
+COPY --from=build-1-uluwatu /app /halovisor/upgrades/1_uluwatu/bin/halo
 
 # Cosmovisor is the entrypoint
 ENTRYPOINT [ "cosmovisor" ]

--- a/scripts/halovisor/build.sh
+++ b/scripts/halovisor/build.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# ./build.sh <HALO_VERSION_0_GENESIS>
+# ./build.sh <HALO_VERSION_0_GENESIS> <HALO_VERSION_1_ULUWATU>
 # This scripts builds the halovisor docker image
 # Halovisor wraps cosmovisor and multiple halo versions into a single docker image.
 # It allows for docker based deployments that support halo network upgrades.
@@ -9,24 +9,26 @@ set -e
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
 HALO_VERSION_0_GENESIS="${1}"
-if [ -z "${HALO_VERSION_0_GENESIS}" ]; then
-  HALO_VERSION_0_GENESIS=$(git rev-parse --short=7 HEAD)
-  echo "Using head as HALO_VERSION_GENESIS: ${HALO_VERSION_0_GENESIS}"
+if [ -z "$HALO_VERSION_0_GENESIS" ]; then
+  HALO_VERSION_0_GENESIS=v0.8.0
+  echo "Using HALO_VERSION_GENESIS: ${HALO_VERSION_0_GENESIS}"
 fi
 
-IMAGEREF="omniops/halovisor:${HALO_VERSION_0_GENESIS}"
+HALO_VERSION_1_ULUWATU="${2}"
+if [ -z "$HALO_VERSION_1_ULUWATU" ]; then
+  HALO_VERSION_1_ULUWATU=$(git rev-parse --short=7 HEAD)
+  echo "Using head as HALO_VERSION_ULUWATU: ${HALO_VERSION_1_ULUWATU}"
+fi
+
+IMAGEREF="omniops/halovisor:${HALO_VERSION_1_ULUWATU}"
 IMAGEMAIN="omniops/halovisor:main"
 
 docker build \
   --build-arg HALO_VERSION_0_GENESIS="${HALO_VERSION_0_GENESIS}" \
+  --build-arg HALO_VERSION_1_ULUWATU="${HALO_VERSION_1_ULUWATU}" \
   -t "${IMAGEREF}" \
   -t "${IMAGEMAIN}" \
   "${SCRIPT_DIR}"
 
 echo "Built docker image: ${IMAGEREF}"
 echo "Built docker image: ${IMAGEMAIN}"
-
-# TODOs:
-# - Add support for multiple halo versions/upgrades
-# - Add support for official releases
-# - Support multiple architectures


### PR DESCRIPTION
Adds the uluwatu network upgrade to halo.

Also:
 - Adds the additional binary to halovisor
 - Support genesis network upgrades (to run a post-upgrade network).
 - Add a wrapper to halovisor to support explicit binary links via env vars.
 - Support network upgrades in e2e.

issue: #1787 