### PR TITLE
fix(e2e/netman): do not initialize private portal addrs

### DIFF
--- a/e2e/app/definition.go
+++ b/e2e/app/definition.go
@@ -135,7 +135,7 @@ func MakeDefinition(ctx context.Context, cfg DefinitionConfig, commandName strin
 			return ethbackend.Backends{}, nil, errors.Wrap(err, "new backends")
 		}
 
-		netman, err := netman.NewManager(ctx, testnet, backends)
+		netman, err := netman.NewManager(testnet, backends)
 		if err != nil {
 			return ethbackend.Backends{}, nil, errors.Wrap(err, "get network")
 		}


### PR DESCRIPTION
Do not initialize private portal addresses.

We set them later post deployment anyways.

issue: none