### PR TITLE
fix(halo/app): dump old height

### DIFF
--- a/halo/app/app_internal_test.go
+++ b/halo/app/app_internal_test.go
@@ -11,13 +11,12 @@ import (
 )
 
 //nolint:forbidigo // We use cosmos errors explicitly.
-func TestIsErrWrongVersion(t *testing.T) {
+func TestIsErrOldBinary(t *testing.T) {
 	t.Parallel()
 	tests := []struct {
-		name               string
-		err                error
-		want               bool
-		lastAppliedUpgrade string
+		name string
+		err  error
+		want bool
 	}{
 		{
 			name: "nil error",
@@ -30,27 +29,24 @@ func TestIsErrWrongVersion(t *testing.T) {
 			want: false,
 		},
 		{
-			name:               "wrong version error",
-			err:                fmt.Errorf("wrong app version %d, upgrade handler is missing for %s upgrade plan", 99, "test"),
-			want:               true,
-			lastAppliedUpgrade: "test",
+			name: "wrong version error",
+			err:  fmt.Errorf("wrong app version %d, upgrade handler is missing for %s upgrade plan", 99, "test"),
+			want: true,
 		},
 		{
 			name: "wrapped wrong version error",
 			err: errors.Wrap(
 				fmt.Errorf("wrong app version %d, upgrade handler is missing for %s upgrade plan", 98, "wrapped"),
 				"wrapper"),
-			want:               true,
-			lastAppliedUpgrade: "wrapped",
+			want: true,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			lastAppliedUpgrade, ok := isErrWrongVersion(tt.err)
+			ok := isErrOldBinary(tt.err)
 			require.Equal(t, tt.want, ok)
-			require.Equal(t, tt.lastAppliedUpgrade, lastAppliedUpgrade)
 		})
 	}
 }


### PR DESCRIPTION
When dupmping upgrade info the disk in the "old binary" use-case, ensure that we set the original upgrade height, not current. This would have caused the new binary to re-run store upgrade loaders.

issue: #1834 