### PR TITLE
ci(halovisor): swap to omni cosmovisor fork

### DIFF
--- a/cli/cmd/compose.yml.tpl
+++ b/cli/cmd/compose.yml.tpl
@@ -11,8 +11,7 @@ services:
       # - 1317:1317   # Cosmos REST API
       # - 9090:9090   # Cosmos gRPC API
     volumes:
-      - ./halo/config:/halo/config
-      - ./halo/data:/halo/data
+      - ./halo:/halo
       - ./geth/geth/jwtsecret:/geth/jwtsecret
 
   omni_evm:

--- a/e2e/docker/compose.yaml.tmpl
+++ b/e2e/docker/compose.yaml.tmpl
@@ -30,8 +30,7 @@ services:
 {{- end }}
     - 6060 # Pprof
     volumes:
-    - ./{{ .Name }}/config:/halo/config
-    - ./{{ .Name }}/data:/halo/data
+    - ./{{ .Name }}:/halo
     networks:
       {{ $.NetworkName }}:
         {{ if $.Network }}ipv4_address: {{ .InternalIP }}{{ end }}

--- a/e2e/docker/testdata/TestComposeTemplate_commit.golden
+++ b/e2e/docker/testdata/TestComposeTemplate_commit.golden
@@ -24,8 +24,7 @@ services:
     - 1317 # Cosmos REST API
     - 6060 # Pprof
     volumes:
-    - ./node0/config:/halo/config
-    - ./node0/data:/halo/data
+    - ./node0:/halo
     networks:
       test:
         ipv4_address: 10.186.73.0

--- a/e2e/docker/testdata/TestComposeTemplate_empheral_network.golden
+++ b/e2e/docker/testdata/TestComposeTemplate_empheral_network.golden
@@ -24,8 +24,7 @@ services:
     - 1317 # Cosmos REST API
     - 6060 # Pprof
     volumes:
-    - ./node0/config:/halo/config
-    - ./node0/data:/halo/data
+    - ./node0:/halo
     networks:
       test:
         ipv4_address: 10.186.73.0

--- a/e2e/docker/testdata/TestComposeTemplate_empheral_network_upgrade.golden
+++ b/e2e/docker/testdata/TestComposeTemplate_empheral_network_upgrade.golden
@@ -24,8 +24,7 @@ services:
     - 1317 # Cosmos REST API
     - 6060 # Pprof
     volumes:
-    - ./node0/config:/halo/config
-    - ./node0/data:/halo/data
+    - ./node0:/halo
     networks:
       test:
         ipv4_address: 10.186.73.0

--- a/e2e/manifests/backwards.toml
+++ b/e2e/manifests/backwards.toml
@@ -1,4 +1,4 @@
-# Backwards ensures backwards-compatibility with v0.4.0.
+# Backwards ensures backwards-compatibility with v0.8.0.
 network = "devnet"
 anvil_chains = ["mock_l1", "mock_l2"]
 
@@ -9,9 +9,9 @@ multi_omni_evms = true
 mode = "archive"
 
 [node.validator03]
-version="omniops/halovisor:v0.4.0"
+version="omniops/halovisor:v0.8.0"
 perturb = ["upgrade"]
 
 [node.validator04]
-version="omniops/halovisor:v0.4.0"
+version="omniops/halovisor:v0.8.0"
 perturb = ["upgrade"]

--- a/e2e/vmcompose/testdata/TestSetup_127-0-0-1-compose.yaml.golden
+++ b/e2e/vmcompose/testdata/TestSetup_127-0-0-1-compose.yaml.golden
@@ -20,8 +20,7 @@ services:
     - 1317:1317 # Cosmos REST API
     - 6060 # Pprof
     volumes:
-    - ./validator01/config:/halo/config
-    - ./validator01/data:/halo/data
+    - ./validator01:/halo
     networks:
       test:
         

--- a/e2e/vmcompose/testdata/TestSetup_127-0-0-2-compose.yaml.golden
+++ b/e2e/vmcompose/testdata/TestSetup_127-0-0-2-compose.yaml.golden
@@ -20,8 +20,7 @@ services:
     - 1317:1317 # Cosmos REST API
     - 6060 # Pprof
     volumes:
-    - ./validator02/config:/halo/config
-    - ./validator02/data:/halo/data
+    - ./validator02:/halo
     networks:
       test:
         

--- a/e2e/vmcompose/testdata/TestSetup_127-0-0-4-compose.yaml.golden
+++ b/e2e/vmcompose/testdata/TestSetup_127-0-0-4-compose.yaml.golden
@@ -20,8 +20,7 @@ services:
     - 1317:1317 # Cosmos REST API
     - 6060 # Pprof
     volumes:
-    - ./seed01/config:/halo/config
-    - ./seed01/data:/halo/data
+    - ./seed01:/halo
     networks:
       test:
         

--- a/e2e/vmcompose/testdata/TestSetup_127-0-0-5-compose.yaml.golden
+++ b/e2e/vmcompose/testdata/TestSetup_127-0-0-5-compose.yaml.golden
@@ -20,8 +20,7 @@ services:
     - 1317:1317 # Cosmos REST API
     - 6060 # Pprof
     volumes:
-    - ./fullnode01/config:/halo/config
-    - ./fullnode01/data:/halo/data
+    - ./fullnode01:/halo
     networks:
       test:
         

--- a/scripts/halovisor/Dockerfile
+++ b/scripts/halovisor/Dockerfile
@@ -1,15 +1,10 @@
 # Docker build args
-# TODO: Pin halo genesis to public omega release
-ARG HALO_VERSION_GENESIS=main
+ARG OMNI_COSMOVISOR_VERSION=v0.1.0
+ARG HALO_VERSION_0_GENESIS=v0.8.0
 
 # Build stages
-FROM golang:alpine AS build-cosmovisor
-ENV COSMOVISOR_VERSION=v1.5.0
-RUN go install cosmossdk.io/tools/cosmovisor/cmd/cosmovisor@${COSMOVISOR_VERSION}
-
-FROM omniops/halo:${HALO_VERSION_GENESIS} AS build-genesis
-
-# TODO: Add post-genesis network-upgrade versions here.
+FROM omniops/cosmovisor:${OMNI_COSMOVISOR_VERSION} AS build-cosmovisor
+FROM omniops/halo:${HALO_VERSION_0_GENESIS} AS build-0-genesis
 
 # Runtime stage
 FROM scratch AS runtime
@@ -26,14 +21,15 @@ ENV DAEMON_NAME=halo
 ENV DAEMON_ALLOW_DOWNLOAD_BINARIES=false
 ENV DAEMON_RESTART_AFTER_UPGRADE=true
 ENV COSMOVISOR_TIMEFORMAT_LOGS=rfc3339nano
+ENV COSMOVISOR_CUSTOM_ROOT=/halovisor
+ENV COSMOVISOR_CUSTOM_CURRENT_LINK=/halo/halovisor-current
 
-# Define mounted volumes
-VOLUME /halo/config
-VOLUME /halo/data
+# Define mounted volume
+VOLUME /halo
 
 # Copy binaries from build stages.
-COPY --from=build-cosmovisor /go/bin/cosmovisor /usr/local/bin/cosmovisor
-COPY --from=build-genesis /app $DAEMON_HOME/cosmovisor/genesis/bin/halo
+COPY --from=build-cosmovisor /ko-app/cosmovisor /usr/local/bin/cosmovisor
+COPY --from=build-0-genesis /app /halovisor/genesis/bin/halo
 
 # Cosmovisor is the entrypoint
 ENTRYPOINT [ "cosmovisor" ]

--- a/scripts/halovisor/build.sh
+++ b/scripts/halovisor/build.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# ./build.sh <HALO_VERSION_GENESIS>
+# ./build.sh <HALO_VERSION_0_GENESIS>
 # This scripts builds the halovisor docker image
 # Halovisor wraps cosmovisor and multiple halo versions into a single docker image.
 # It allows for docker based deployments that support halo network upgrades.
@@ -8,17 +8,17 @@
 set -e
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
-HALO_VERSION_GENESIS="${1}"
-if [ -z "$HALO_VERSION_GENESIS" ]; then
-  HALO_VERSION_GENESIS=$(git rev-parse --short=7 HEAD)
-  echo "Using head as HALO_VERSION_GENESIS: ${HALO_VERSION_GENESIS}"
+HALO_VERSION_0_GENESIS="${1}"
+if [ -z "${HALO_VERSION_0_GENESIS}" ]; then
+  HALO_VERSION_0_GENESIS=$(git rev-parse --short=7 HEAD)
+  echo "Using head as HALO_VERSION_GENESIS: ${HALO_VERSION_0_GENESIS}"
 fi
 
-IMAGEREF="omniops/halovisor:${HALO_VERSION_GENESIS}"
+IMAGEREF="omniops/halovisor:${HALO_VERSION_0_GENESIS}"
 IMAGEMAIN="omniops/halovisor:main"
 
 docker build \
-  --build-arg HALO_VERSION_GENESIS="${HALO_VERSION_GENESIS}" \
+  --build-arg HALO_VERSION_0_GENESIS="${HALO_VERSION_0_GENESIS}" \
   -t "${IMAGEREF}" \
   -t "${IMAGEMAIN}" \
   "${SCRIPT_DIR}"


### PR DESCRIPTION
Swap the cosmovisor binary inside halovisor to the omni [fork](https://github.com/omni-network/cosmovisor).

This ensures that the next version, `v0.8.0`. Will be compatible with subsequent e2e app that mounts only a single `/halo` folder to halovisor. This ensures we can use `v0.8.0`as LTS "genesis version" and backwards compatibility target.

issue: none