### PR TITLE
ci(github): fix failing release action

### DIFF
--- a/.github/workflows/release-official.yml
+++ b/.github/workflows/release-official.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   release-official:
-    runs-on: namespace-profile-default
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
Fix failing release action be removing special namespace runner.

issue: none