### PR TITLE
ci(github): fix failing release action again

### DIFF
--- a/.github/workflows/release-official.yml
+++ b/.github/workflows/release-official.yml
@@ -42,9 +42,6 @@ jobs:
             HALO_VERSION_0_GENESIS=${{ github.ref_name }}
           platforms: |
             linux/amd64
-            linux/arm64
-            darwin/amd64
-            darwin/arm64
           push: true
           tags: |
             omniops/halovisor:latest


### PR DESCRIPTION
We only support linux/amd64 images at this point.

issue: none