### PR TITLE
chore(monitor): workaround fee manager failure

### DIFF
--- a/monitor/app/app.go
+++ b/monitor/app/app.go
@@ -100,7 +100,7 @@ func Run(ctx context.Context, cfg Config) error {
 	}
 
 	if err := xfeemngr.Start(ctx, network, cfg.XFeeMngr, cfg.PrivateKey); err != nil {
-		return errors.Wrap(err, "start xfee manager")
+		log.Error(ctx, "Failed to start xfee manager [BUG]", err)
 	}
 
 	startMonitoringSyncDiff(ctx, network, ethClients)


### PR DESCRIPTION
Feemgr contract address failures on omega, this is workaround to get monitor up in anycase.
```
start xfee manager: make oracle: new bound fee oracle: fee oracle addr: no contract code at given address

```

issue: none