### PR TITLE
fix(halo/voter): abort app if persistence fails

### DIFF
--- a/halo/app/app.go
+++ b/halo/app/app.go
@@ -97,7 +97,7 @@ func newApp(
 	chainNamer rtypes.ChainNameFunc,
 	feeRecProvider etypes.FeeRecipientProvider,
 	appOpts servertypes.AppOptions,
-	quitChan chan<- error,
+	asyncAbort chan<- error,
 	baseAppOpts ...func(*baseapp.BaseApp),
 ) (*App, error) {
 	depCfg := depinject.Configs(
@@ -177,10 +177,10 @@ func newApp(
 				if err := dumpLastAppliedUpgradeInfo(ctx, app.UpgradeKeeper); err != nil {
 					log.Error(ctx, "Failed writing last applied upgrade info", err)
 				}
-				quitChan <- errors.Wrap(err, "⛔️ network already upgraded, switch halo binary", "upgrade", upgrade)
+				asyncAbort <- errors.Wrap(err, "⛔️ network already upgraded, switch halo binary", "upgrade", upgrade)
 				<-ctx.Done() // Wait for shutdown.
 			} else if upgrade, ok := isErrUpgradeNeeded(err); ok {
-				quitChan <- errors.Wrap(err, "⛔️ network upgrade needed now, switch halo binary", "upgrade", upgrade)
+				asyncAbort <- errors.Wrap(err, "⛔️ network upgrade needed now, switch halo binary", "upgrade", upgrade)
 				<-ctx.Done() // Wait for shutdown.
 			}
 

--- a/halo/app/lazyvoter.go
+++ b/halo/app/lazyvoter.go
@@ -70,6 +70,7 @@ func (l *voterLoader) LazyLoad(
 	privKey crypto.PrivKey,
 	voterStateFile string,
 	cmtAPI comet.API,
+	asyncAbort chan<- error,
 ) error {
 	if len(endpoints) == 0 {
 		log.Warn(ctx, "Flag --xchain-evm-rpc-endpoints empty. The app will crash if it becomes a validator since it cannot perform xchain voting duties", nil)
@@ -157,7 +158,7 @@ func (l *voterLoader) LazyLoad(
 		Provider: cprov,
 	}
 
-	v, err := voter.LoadVoter(privKey, voterStateFile, xprov, deps, network)
+	v, err := voter.LoadVoter(privKey, voterStateFile, xprov, deps, network, asyncAbort)
 	if err != nil {
 		return errors.Wrap(err, "create voter")
 	}

--- a/halo/attest/voter/voter_internal_test.go
+++ b/halo/attest/voter/voter_internal_test.go
@@ -19,7 +19,7 @@ func LoadVoterForT(t *testing.T, privKey crypto.PrivKey, path string, provider x
 	deps types.VoterDeps, network netconf.Network, backoff func(),
 ) *Voter {
 	t.Helper()
-	v, err := LoadVoter(privKey, path, provider, deps, network)
+	v, err := LoadVoter(privKey, path, provider, deps, network, make(chan error, 1))
 	require.NoError(t, err)
 
 	v.backoffFunc = func(ctx context.Context) func() { return backoff }


### PR DESCRIPTION
If voter fails to persist state to disk, then the in-memory state is inconsistent. This could result in double-signing and possible slashing.

Instead of trying to fix in-memory state via rollbacks or compare-and-swap type logic, just abort the voter (and shutdown halo). This indicates a full disk (or loss of validator state file), so best crash(loop). 

This issue was raised by the spearbit audit.

issue: none