### PR TITLE
fix(e2e/fbproxy): forward req and resp headers

### DIFF
--- a/e2e/app/admin/common.go
+++ b/e2e/app/admin/common.go
@@ -88,8 +88,7 @@ func setupChain(ctx context.Context, s shared, name string) (chain, error) {
 		c.PortalAddress = addrs.Portal
 	}
 
-	// only use fb proxy for non-devnet - devnet uses anvil accounts
-	if s.network.ID != netconf.Devnet {
+	if s.fireAPIKey != "" || s.fireKeyPath != "" {
 		rpc, err = startFBProxy(ctx, s.network.ID, rpc, s.fireAPIKey, s.fireKeyPath)
 		if err != nil {
 			return chain{}, errors.Wrap(err, "start fb proxy")

--- a/e2e/fbproxy/app/proxy.go
+++ b/e2e/fbproxy/app/proxy.go
@@ -101,13 +101,26 @@ func (p *proxy) proxy(ctx context.Context, w http.ResponseWriter, r *http.Reques
 	if err != nil {
 		return errors.Wrap(err, "create next request")
 	}
-	nextReq.Header = r.Header
+
+	// copy request headers
+	for k, vs := range r.Header {
+		for _, v := range vs {
+			nextReq.Header.Add(k, v)
+		}
+	}
 
 	resp, err := new(http.Client).Do(nextReq)
 	if err != nil {
 		return errors.Wrap(err, "do request")
 	}
 	defer resp.Body.Close()
+
+	// copy response headers
+	for k, vs := range resp.Header {
+		for _, v := range vs {
+			w.Header().Add(k, v)
+		}
+	}
 
 	w.WriteHeader(resp.StatusCode)
 	_, _ = io.Copy(w, resp.Body)


### PR DESCRIPTION
Forward req headers to remote addr, and response headers back to sender. 

issue: none