### PR TITLE
chore(halo/app): smooth cosmovisor upgrades 

### DIFF
--- a/halo/app/app_internal_test.go
+++ b/halo/app/app_internal_test.go
@@ -1,3 +1,4 @@
+//nolint:forbidigo,govet,staticcheck // We use cosmos errors explicitly.
 package app
 
 import (
@@ -7,16 +8,18 @@ import (
 
 	"github.com/omni-network/omni/lib/errors"
 
+	"cosmossdk.io/x/upgrade"
+	utypes "cosmossdk.io/x/upgrade/types"
 	"github.com/stretchr/testify/require"
 )
 
-//nolint:forbidigo // We use cosmos errors explicitly.
 func TestIsErrOldBinary(t *testing.T) {
 	t.Parallel()
 	tests := []struct {
-		name string
-		err  error
-		want bool
+		name    string
+		err     error
+		want    bool
+		upgrade string
 	}{
 		{
 			name: "nil error",
@@ -29,24 +32,69 @@ func TestIsErrOldBinary(t *testing.T) {
 			want: false,
 		},
 		{
-			name: "wrong version error",
-			err:  fmt.Errorf("wrong app version %d, upgrade handler is missing for %s upgrade plan", 99, "test"),
-			want: true,
+			name:    "wrong version error",
+			err:     fmt.Errorf("wrong app version %d, upgrade handler is missing for %s upgrade plan", 99, "test"),
+			want:    true,
+			upgrade: "test",
 		},
 		{
 			name: "wrapped wrong version error",
 			err: errors.Wrap(
-				fmt.Errorf("wrong app version %d, upgrade handler is missing for %s upgrade plan", 98, "wrapped"),
+				fmt.Errorf("wrong app version %d, upgrade handler is missing for %s upgrade plan", 98, "genesis upgrade"),
 				"wrapper"),
-			want: true,
+			want:    true,
+			upgrade: "genesis upgrade",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			ok := isErrOldBinary(tt.err)
+			upgrade, ok := isErrOldBinary(tt.err)
 			require.Equal(t, tt.want, ok)
+			require.Equal(t, tt.upgrade, upgrade)
+		})
+	}
+}
+
+func TestIsErrUpgradeNeeded(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name    string
+		err     error
+		want    bool
+		upgrade string
+	}{
+		{
+			name: "nil error",
+			err:  nil,
+		},
+		{
+			name: "eof error",
+			err:  io.EOF,
+		},
+		{
+			name:    "wrong version error",
+			err:     fmt.Errorf(upgrade.BuildUpgradeNeededMsg(utypes.Plan{Name: "1_uluwatu", Height: 1, Info: "genesis upgrade"})),
+			want:    true,
+			upgrade: "1_uluwatu",
+		},
+		{
+			name: "wrapped wrong version error",
+			err: errors.Wrap(
+				fmt.Errorf(upgrade.BuildUpgradeNeededMsg(utypes.Plan{Name: "1_uluwatu", Height: 1, Info: "genesis upgrade"})),
+				"wrapper"),
+			want:    true,
+			upgrade: "1_uluwatu",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			upgrade, ok := isErrUpgradeNeeded(tt.err)
+			require.Equal(t, tt.want, ok)
+			require.Equal(t, tt.upgrade, upgrade)
 		})
 	}
 }

--- a/halo/app/rollback.go
+++ b/halo/app/rollback.go
@@ -61,6 +61,7 @@ func Rollback(ctx context.Context, cfg Config, rCfg RollbackConfig) error {
 		netconf.ChainNamer(cfg.Network),
 		burnEVMFees{},
 		serverAppOptsFromCfg(cfg),
+		make(chan<- error, 1),
 		baseAppOpts...,
 	)
 	if err != nil {

--- a/halo/app/start.go
+++ b/halo/app/start.go
@@ -139,6 +139,7 @@ func Start(ctx context.Context, cfg Config) (<-chan error, func(context.Context)
 	}
 
 	sdkLogger := newSDKLogger(ctx)
+	async := make(chan error, 1)
 
 	//nolint:contextcheck // False positive
 	app, err := newApp(
@@ -150,6 +151,7 @@ func Start(ctx context.Context, cfg Config) (<-chan error, func(context.Context)
 		netconf.ChainNamer(cfg.Network),
 		burnEVMFees{},
 		serverAppOptsFromCfg(cfg),
+		async,
 		baseAppOpts...,
 	)
 	if err != nil {
@@ -174,7 +176,6 @@ func Start(ctx context.Context, cfg Config) (<-chan error, func(context.Context)
 
 	cProvider := cprovider.NewABCIProvider(rpcClient, cfg.Network, netconf.ChainVersionNamer(cfg.Network))
 
-	async := make(chan error, 1)
 	go func() {
 		err := voter.LazyLoad(
 			ctx,

--- a/lib/errors/errors.go
+++ b/lib/errors/errors.go
@@ -40,3 +40,15 @@ func Wrap(err error, msg string, attrs ...any) error {
 		attrs: attrs,
 	}
 }
+
+// Cause calls Unwrap until it finds the root cause of the error.
+func Cause(err error) error {
+	cause := err
+	for {
+		next := pkgerrors.Unwrap(cause)
+		if next == nil {
+			return cause
+		}
+		cause = next
+	}
+}

--- a/monitor/xmonitor/monitor.go
+++ b/monitor/xmonitor/monitor.go
@@ -95,7 +95,7 @@ func monitorConsOffsetOnce(ctx context.Context, network netconf.Network, xprovid
 		ref := xchain.EmitRef{ConfLevel: ptr(stream.ConfLevel())}
 		emitted, ok, err := xprovider.GetEmittedCursor(ctx, ref, stream)
 		if err != nil {
-			return err
+			return errors.Wrap(err, "get emit cursor", "stream", network.StreamName(stream))
 		} else if !ok {
 			continue
 		}
@@ -105,7 +105,7 @@ func monitorConsOffsetOnce(ctx context.Context, network netconf.Network, xprovid
 
 		submitted, ok, err := xprovider.GetSubmittedCursor(ctx, stream)
 		if err != nil {
-			return err
+			return errors.Wrap(err, "get submit cursor", "stream", network.StreamName(stream))
 		} else if !ok {
 			continue
 		}


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `release/v0.8`:
 - [chore(halo/app): smooth cosmovisor upgrades (#1996)](https://github.com/omni-network/omni/pull/1996)
 
 issue: none