### PR TITLE
fix(e2e/fbproxy): set req content length

### DIFF
--- a/e2e/fbproxy/app/proxy.go
+++ b/e2e/fbproxy/app/proxy.go
@@ -102,12 +102,8 @@ func (p *proxy) proxy(ctx context.Context, w http.ResponseWriter, r *http.Reques
 		return errors.Wrap(err, "create next request")
 	}
 
-	// copy request headers
-	for k, vs := range r.Header {
-		for _, v := range vs {
-			nextReq.Header.Add(k, v)
-		}
-	}
+	nextReq.ContentLength = int64(len(reqBody))
+	nextReq.Header = r.Header.Clone()
 
 	resp, err := new(http.Client).Do(nextReq)
 	if err != nil {


### PR DESCRIPTION
Set proxied request content length.

Additionally, use header.Clone() to clone request header.

issue: none