### PR TITLE
test(e2e): reset to default bridge spec

### DIFF
--- a/.github/workflows/check-sol-artifacts.yml
+++ b/.github/workflows/check-sol-artifacts.yml
@@ -18,6 +18,9 @@ jobs:
           go-version: 'stable'
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
+        with:
+          version:
+            nightly-9dbfb2f1115466b28f2697e158131f90df6b2590
       - name: Install pnpm
         uses: pnpm/action-setup@v4
         with:


### PR DESCRIPTION
Reset to defaults after testing rand bridge spec.
Allows bridge upgrade tests to pass. 

issue: none
