### PR TITLE
ci(halovisor): use multiarch v080-rc1 for halovisor genesis

### DIFF
--- a/scripts/halovisor/Dockerfile
+++ b/scripts/halovisor/Dockerfile
@@ -1,7 +1,7 @@
 # Docker build args
 ARG OMNI_COSMOVISOR_VERSION=v0.1.0
-# TODO(corver): Replace with v0.8.1 when released. Below is v0.8.1-rc1
-ARG HALO_VERSION_0_GENESIS=b9964ac
+# TODO(corver): Replace with v0.8.1 when released
+ARG HALO_VERSION_0_GENESIS=v0.8.0-rc1
 ARG HALO_VERSION_1_ULUWATU=main
 
 # Build stages

--- a/scripts/halovisor/build.sh
+++ b/scripts/halovisor/build.sh
@@ -11,7 +11,7 @@ SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 HALO_VERSION_0_GENESIS="${1}"
 if [ -z "$HALO_VERSION_0_GENESIS" ]; then
   # TODO(corver): Replace with v0.8.1 when released. Below is v0.8.1-rc1
-  HALO_VERSION_0_GENESIS=b9964ac
+  HALO_VERSION_0_GENESIS=v0.8.0-rc1
   echo "Using HALO_VERSION_GENESIS: ${HALO_VERSION_0_GENESIS}"
 fi
 


### PR DESCRIPTION
Use multi-arch v0.8.0-rc1 halo image as halovisor genesis. This ensures snappy e2e tests on local macs.

issue: #1984 