### PR TITLE
fix(monitor): do not exit on failed staging connection

### DIFF
--- a/monitor/app/app.go
+++ b/monitor/app/app.go
@@ -79,7 +79,7 @@ func Run(ctx context.Context, cfg Config) error {
 
 	account.StartMonitoring(ctx, network, ethClients)
 
-	if err := contract.StartMonitoring(ctx, network, ethClients); err != nil {
+	if err := contract.StartMonitoring(ctx, network, cfg.RPCEndpoints, ethClients); err != nil {
 		return errors.Wrap(err, "monitor contracts")
 	}
 


### PR DESCRIPTION
Do not exit on failed connection to staging rpc, made
when getting conrtract addrs.

Additionally, use omni evm staging rpc passed in endpoins to gen staging addresses,
to reduce chance of failed conntection.

issue: none