### PR TITLE
chore(halo): start RPCs before comet

### DIFF
--- a/halo/app/start.go
+++ b/halo/app/start.go
@@ -193,15 +193,15 @@ func Start(ctx context.Context, cfg Config) (<-chan error, func(context.Context)
 		}
 	}()
 
-	log.Info(ctx, "Starting CometBFT", "listeners", cmtNode.Listeners())
-
-	if err := cmtNode.Start(); err != nil {
-		return nil, nil, errors.Wrap(err, "start comet node")
-	}
-
 	clientCtx := app.ClientContext(ctx).WithClient(rpcClient).WithHomeDir(cfg.HomeDir)
 	if err := startRPCServers(ctx, cfg, app, sdkLogger, metrics, asyncAbort, clientCtx); err != nil {
 		return nil, nil, err
+	}
+
+	log.Info(ctx, "Starting CometBFT")
+
+	if err := cmtNode.Start(); err != nil {
+		return nil, nil, errors.Wrap(err, "start comet node")
 	}
 
 	go monitorCometForever(ctx, cfg.Network, rpcClient, cmtNode.ConsensusReactor().WaitSync, cfg.DataDir())

--- a/halo/cmd/cometconfig.go
+++ b/halo/cmd/cometconfig.go
@@ -45,6 +45,7 @@ func DefaultCometConfig(homeDir string) cfg.Config {
 	conf.ProxyApp = ""                                 // Only support built-in ABCI app supported.
 	conf.ABCI = ""                                     // Only support built-in ABCI app supported.
 	conf.Consensus.TimeoutPropose = time.Second        // Mitigate slow blocks when proposer inactive (default=3s).
+	conf.RPC.ListenAddress = "tcp://0.0.0.0:26657"     // Halo always run inside docker
 
 	return *conf
 }

--- a/halo/cmd/testdata/TestCLIReference_rollback.golden
+++ b/halo/cmd/testdata/TestCLIReference_rollback.golden
@@ -11,14 +11,14 @@ Usage:
   halo rollback [flags]
 
 Flags:
-      --api-address string                        Address defines the API server to listen on (default "tcp://localhost:1317")
-      --api-enable                                Enable defines if the API server should be enabled.
+      --api-address string                        Address defines the API server to listen on (default "tcp://0.0.0.0:1317")
+      --api-enable                                Enable defines if the API server should be enabled. (default true)
       --app-db-backend string                     The type of database for application and snapshots databases (default "goleveldb")
       --engine-endpoint string                    An EVM execution client Engine API http endpoint
       --engine-jwt-file string                    The path to the Engine API JWT file
       --evm-build-delay duration                  Minimum delay between triggering and fetching a EVM payload build (default 600ms)
       --evm-build-optimistic                      Enables optimistic building of EVM payloads on previous block finalize (default true)
-      --grpc-address string                       Address defines the GRPC server to listen on (default "localhost:9090")
+      --grpc-address string                       Address defines the GRPC server to listen on (default "0.0.0.0:9090")
       --grpc-enable                               Enable defines if the GRPC server should be enabled. (default true)
       --hard                                      Remove last block as well as state
   -h, --help                                      help for rollback

--- a/halo/cmd/testdata/TestCLIReference_run.golden
+++ b/halo/cmd/testdata/TestCLIReference_run.golden
@@ -4,14 +4,14 @@ Usage:
   halo run [flags]
 
 Flags:
-      --api-address string                        Address defines the API server to listen on (default "tcp://localhost:1317")
-      --api-enable                                Enable defines if the API server should be enabled.
+      --api-address string                        Address defines the API server to listen on (default "tcp://0.0.0.0:1317")
+      --api-enable                                Enable defines if the API server should be enabled. (default true)
       --app-db-backend string                     The type of database for application and snapshots databases (default "goleveldb")
       --engine-endpoint string                    An EVM execution client Engine API http endpoint
       --engine-jwt-file string                    The path to the Engine API JWT file
       --evm-build-delay duration                  Minimum delay between triggering and fetching a EVM payload build (default 600ms)
       --evm-build-optimistic                      Enables optimistic building of EVM payloads on previous block finalize (default true)
-      --grpc-address string                       Address defines the GRPC server to listen on (default "localhost:9090")
+      --grpc-address string                       Address defines the GRPC server to listen on (default "0.0.0.0:9090")
       --grpc-enable                               Enable defines if the GRPC server should be enabled. (default true)
   -h, --help                                      help for run
       --home string                               The application home directory containing config and data (default "./halo")

--- a/halo/cmd/testdata/TestRunCmd_defaults.golden
+++ b/halo/cmd/testdata/TestRunCmd_defaults.golden
@@ -17,12 +17,12 @@
  },
  "UnsafeSkipUpgrades": null,
  "SDKAPI": {
-  "Enable": false,
-  "Address": "tcp://localhost:1317"
+  "Enable": true,
+  "Address": "tcp://0.0.0.0:1317"
  },
  "SDKGRPC": {
   "Enable": true,
-  "Address": "localhost:9090"
+  "Address": "0.0.0.0:9090"
  },
  "Comet": {
   "Version": "0.38.12",
@@ -42,7 +42,7 @@
   "FilterPeers": false,
   "RPC": {
    "RootDir": "./halo",
-   "ListenAddress": "tcp://127.0.0.1:26657",
+   "ListenAddress": "tcp://0.0.0.0:26657",
    "CORSAllowedOrigins": [],
    "CORSAllowedMethods": [
     "HEAD",

--- a/halo/cmd/testdata/TestRunCmd_flags.golden
+++ b/halo/cmd/testdata/TestRunCmd_flags.golden
@@ -17,12 +17,12 @@
  },
  "UnsafeSkipUpgrades": null,
  "SDKAPI": {
-  "Enable": false,
-  "Address": "tcp://localhost:1317"
+  "Enable": true,
+  "Address": "tcp://0.0.0.0:1317"
  },
  "SDKGRPC": {
   "Enable": true,
-  "Address": "localhost:9090"
+  "Address": "0.0.0.0:9090"
  },
  "Comet": {
   "Version": "0.38.12",
@@ -42,7 +42,7 @@
   "FilterPeers": false,
   "RPC": {
    "RootDir": "foo",
-   "ListenAddress": "tcp://127.0.0.1:26657",
+   "ListenAddress": "tcp://0.0.0.0:26657",
    "CORSAllowedOrigins": [],
    "CORSAllowedMethods": [
     "HEAD",

--- a/halo/cmd/testdata/TestRunCmd_json_files.golden
+++ b/halo/cmd/testdata/TestRunCmd_json_files.golden
@@ -17,12 +17,12 @@
  },
  "UnsafeSkipUpgrades": null,
  "SDKAPI": {
-  "Enable": false,
+  "Enable": true,
   "Address": "api/json"
  },
  "SDKGRPC": {
   "Enable": true,
-  "Address": "localhost:9090"
+  "Address": "0.0.0.0:9090"
  },
  "Comet": {
   "Version": "0.38.12",
@@ -42,7 +42,7 @@
   "FilterPeers": false,
   "RPC": {
    "RootDir": "testinput/input2",
-   "ListenAddress": "tcp://127.0.0.1:26657",
+   "ListenAddress": "tcp://0.0.0.0:26657",
    "CORSAllowedOrigins": [],
    "CORSAllowedMethods": [
     "HEAD",

--- a/halo/cmd/testdata/TestRunCmd_toml_files.golden
+++ b/halo/cmd/testdata/TestRunCmd_toml_files.golden
@@ -20,7 +20,7 @@
  },
  "UnsafeSkipUpgrades": null,
  "SDKAPI": {
-  "Enable": false,
+  "Enable": true,
   "Address": "api/toml"
  },
  "SDKGRPC": {

--- a/halo/config/config.go
+++ b/halo/config/config.go
@@ -41,12 +41,15 @@ const (
 	defaultDBBackend          = db.GoLevelDBBackend
 	defaultEVMBuildDelay      = time.Millisecond * 600 // 100ms longer than geth's --miner.recommit=500ms.
 	defaultEVMBuildOptimistic = true
+
+	defaultAPIEnable   = true                 // Halo runs in docker, so enabled via port mapping
+	defaultAPIAddress  = "tcp://0.0.0.0:1317" // Halo runs inside docker
+	defaultGRPCEnable  = true                 // Halo runs in docker, so enabled via port mapping
+	defaultGRPCAddress = "0.0.0.0:9090"       // Halo runs inside docker
 )
 
 // DefaultConfig returns the default halo config.
 func DefaultConfig() Config {
-	sdkConfig := srvconfig.DefaultConfig()
-
 	return Config{
 		HomeDir:            DefaultHomeDir,
 		Network:            "", // No default
@@ -60,8 +63,8 @@ func DefaultConfig() Config {
 		EVMBuildDelay:      defaultEVMBuildDelay,
 		EVMBuildOptimistic: defaultEVMBuildOptimistic,
 		Tracer:             tracer.DefaultConfig(),
-		SDKAPI:             RPCConfig{Enable: sdkConfig.API.Enable, Address: sdkConfig.API.Address},
-		SDKGRPC:            RPCConfig{Enable: sdkConfig.GRPC.Enable, Address: sdkConfig.GRPC.Address},
+		SDKAPI:             RPCConfig{Enable: defaultAPIEnable, Address: defaultAPIAddress},
+		SDKGRPC:            RPCConfig{Enable: defaultGRPCEnable, Address: defaultGRPCAddress},
 	}
 }
 

--- a/halo/config/testdata/default_halo.toml
+++ b/halo/config/testdata/default_halo.toml
@@ -77,10 +77,10 @@ unsafe-skip-upgrades = [1,2,3]
 [api]
 
 # Enable defines if the API server should be enabled.
-enable = false
+enable = true
 
 # Address defines the API server to listen on.
-address = "tcp://localhost:1317"
+address = "tcp://0.0.0.0:1317"
 
 ###############################################################################
 ###                     Cosmos SDK gRPC Configuration                       ###
@@ -92,7 +92,7 @@ address = "tcp://localhost:1317"
 enable = true
 
 # Address defines the gRPC server address to bind to.
-address = "localhost:9090"
+address = "0.0.0.0:9090"
 
 #######################################################################
 ###                             X-Chain                             ###


### PR DESCRIPTION
This backports the following commits from `main` to `release/v0.8`:
- [ci(halo): enable RPCs for docker (#2036)](https://github.com/omni-network/omni/pull/2036). It is mainly backported in order to start CosmosSDK RPC servers before comet service.

issue: none