### PR TITLE
chore(monitor): instrument planned upgrades

### DIFF
--- a/halo/app/start_test.go
+++ b/halo/app/start_test.go
@@ -192,7 +192,7 @@ func testCProvider(t *testing.T, ctx context.Context, cprov cprovider.Provider) 
 	require.NotNil(t, cons)
 
 	require.Eventually(t, func() bool {
-		_, ok, err := cprov.CurrentUpgradePlan(ctx)
+		_, ok, err := cprov.CurrentPlannedPlan(ctx)
 		require.NoError(t, err)
 
 		return ok

--- a/lib/cchain/provider.go
+++ b/lib/cchain/provider.go
@@ -83,6 +83,6 @@ type Provider interface {
 	// Portals returns the portals registered in the registry module.
 	Portals(ctx context.Context) ([]*rtypes.Portal, bool, error)
 
-	// CurrentUpgradePlan returns the current (non-activated) upgrade plan.
-	CurrentUpgradePlan(ctx context.Context) (utypes.Plan, bool, error)
+	// CurrentPlannedPlan returns the current (non-activated) upgrade plan.
+	CurrentPlannedPlan(ctx context.Context) (utypes.Plan, bool, error)
 }

--- a/lib/cchain/provider/provider.go
+++ b/lib/cchain/provider/provider.go
@@ -95,7 +95,7 @@ func (p Provider) CometClient() rpcclient.Client {
 	return p.cometCl
 }
 
-func (p Provider) CurrentUpgradePlan(ctx context.Context) (upgradetypes.Plan, bool, error) {
+func (p Provider) CurrentPlannedPlan(ctx context.Context) (upgradetypes.Plan, bool, error) {
 	return p.upgradeFunc(ctx)
 }
 

--- a/monitor/app/app.go
+++ b/monitor/app/app.go
@@ -105,6 +105,7 @@ func Run(ctx context.Context, cfg Config) error {
 
 	startMonitoringSyncDiff(ctx, network, ethClients)
 	go runHistoricalBaselineForever(ctx, network, cprov)
+	go monitorUpgradesForever(ctx, cprov)
 	go routerecon.ReconForever(ctx, network, xprov, ethClients)
 	go validator.MonitorForever(ctx, cprov)
 

--- a/monitor/app/metrics.go
+++ b/monitor/app/metrics.go
@@ -28,6 +28,6 @@ var (
 	plannedUpgradeGauge = promutil.NewResetGaugeVec(prometheus.GaugeOpts{
 		Namespace: "monitor",
 		Name:      "planned_upgrade",
-		Help:      "Constant gauge set to 1 with labels matching the upgrade name and height",
-	}, []string{"upgrade", "height"})
+		Help:      "Height of current planned (non-progressed) upgrade by name",
+	}, []string{"upgrade"})
 )

--- a/monitor/app/metrics.go
+++ b/monitor/app/metrics.go
@@ -3,6 +3,8 @@ package monitor
 import (
 	"time"
 
+	"github.com/omni-network/omni/lib/promutil"
+
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 )
@@ -22,4 +24,10 @@ var (
 		Help:      "Baseline time (in seconds) to stream historical approved attestation",
 		Buckets:   prometheus.ExponentialBucketsRange(time.Second.Seconds(), time.Hour.Seconds(), 8),
 	}, []string{"chain", "size"})
+
+	plannedUpgradeGauge = promutil.NewResetGaugeVec(prometheus.GaugeOpts{
+		Namespace: "monitor",
+		Name:      "planned_upgrade",
+		Help:      "Constant gauge set to 1 with labels matching the upgrade name and height",
+	}, []string{"upgrade", "height"})
 )

--- a/monitor/app/upgrade.go
+++ b/monitor/app/upgrade.go
@@ -2,7 +2,6 @@ package monitor
 
 import (
 	"context"
-	"strconv"
 	"time"
 
 	"github.com/omni-network/omni/lib/cchain"
@@ -11,6 +10,8 @@ import (
 	utypes "cosmossdk.io/x/upgrade/types"
 )
 
+// monitorUpgradesForever blocks until the context is closed and
+// periodically updates the planned upgrade gauge.
 func monitorUpgradesForever(ctx context.Context, cprov cchain.Provider) {
 	ticker := time.NewTicker(time.Second * 15)
 	defer ticker.Stop()
@@ -32,7 +33,7 @@ func monitorUpgradesForever(ctx context.Context, cprov cchain.Provider) {
 			}
 
 			plannedUpgradeGauge.Reset()
-			plannedUpgradeGauge.WithLabelValues(plan.Name, strconv.FormatInt(plan.Height, 10)).Set(1)
+			plannedUpgradeGauge.WithLabelValues(plan.Name).Set(float64(plan.Height))
 		}
 	}
 }

--- a/monitor/app/upgrade.go
+++ b/monitor/app/upgrade.go
@@ -1,0 +1,38 @@
+package monitor
+
+import (
+	"context"
+	"strconv"
+	"time"
+
+	"github.com/omni-network/omni/lib/cchain"
+	"github.com/omni-network/omni/lib/log"
+
+	utypes "cosmossdk.io/x/upgrade/types"
+)
+
+func monitorUpgradesForever(ctx context.Context, cprov cchain.Provider) {
+	ticker := time.NewTicker(time.Second * 15)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			plan, ok, err := cprov.CurrentPlannedPlan(ctx)
+			if err != nil {
+				log.Warn(ctx, "Failed fetching planned upgrade (will retry)", err)
+				continue
+			} else if !ok {
+				plan = utypes.Plan{
+					Name:   "none",
+					Height: 0,
+				}
+			}
+
+			plannedUpgradeGauge.Reset()
+			plannedUpgradeGauge.WithLabelValues(plan.Name, strconv.FormatInt(plan.Height, 10)).Set(1)
+		}
+	}
+}


### PR DESCRIPTION
Add `monitor_planned_upgrade` metric to track planned upgrades.

issue: none