### PR TITLE
fix(ci): docker build on x86_64 linux

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ help:  ## Display this help message
 ###                                Docker                                 	###
 ###############################################################################
 
-ARCH := $(shell arch)
+ARCH := $(shell arch | sed 's/x86_64/amd64/')
 
 .PHONY: build-docker
 build-docker: ensure-go-releaser ## Builds the docker images using local arch.


### PR DESCRIPTION
Currently, if `make build-docker` is executed on a Linux machine, `arch` returns `x86_64` which is _not_ a valid `$GOARCH` value. Instead, `amd64` should be used.

issue: none