### PR TITLE
fix(monitor): guageBuffered unsafe read access to price map

### DIFF
--- a/monitor/xfeemngr/tokenprice/buffer.go
+++ b/monitor/xfeemngr/tokenprice/buffer.go
@@ -88,7 +88,7 @@ func (b *Buffer) stream(ctx context.Context) {
 			b.setPrice(token, price)
 		}
 
-		guageBuffered(b.buffer)
+		b.guageBuffered()
 	}
 
 	tick.Go(ctx, callback)
@@ -117,15 +117,17 @@ func guageLive(prices map[tokens.Token]float64) {
 }
 
 // guageBuffered updates "buffered" guages for token prices and conversion rates.
-func guageBuffered(prices map[tokens.Token]float64) {
-	for token, price := range prices {
+func (b *Buffer) guageBuffered() {
+	b.mu.RLock()
+	defer b.mu.RUnlock()
+	for token, price := range b.buffer {
 		if price == 0 {
 			continue
 		}
 
 		bufferedTokenPrice.WithLabelValues(token.String()).Set(price)
 
-		for otherToken, otherPrice := range prices {
+		for otherToken, otherPrice := range b.buffer {
 			if otherToken == token {
 				continue
 			}

--- a/monitor/xfeemngr/tokenprice/buffer.go
+++ b/monitor/xfeemngr/tokenprice/buffer.go
@@ -88,7 +88,7 @@ func (b *Buffer) stream(ctx context.Context) {
 			b.setPrice(token, price)
 		}
 
-		b.guageBuffered()
+		b.gaugeBuffered()
 	}
 
 	tick.Go(ctx, callback)
@@ -116,8 +116,8 @@ func guageLive(prices map[tokens.Token]float64) {
 	}
 }
 
-// guageBuffered updates "buffered" guages for token prices and conversion rates.
-func (b *Buffer) guageBuffered() {
+// gaugeBuffered updates "buffered" gauges for token prices and conversion rates.
+func (b *Buffer) gaugeBuffered() {
 	b.mu.RLock()
 	defer b.mu.RUnlock()
 	for token, price := range b.buffer {


### PR DESCRIPTION
This PR updates the `guageBuffered` func and protects the `b.buffer` price map with the available RW mutex. 

issue: none
