### PR TITLE
chore(lib/cmd): improve invalid command errors

### DIFF
--- a/e2e/app/rpc.go
+++ b/e2e/app/rpc.go
@@ -66,8 +66,8 @@ func waitForHeight(ctx context.Context, testnet *e2e.Testnet, height int64) (*ty
 				}
 
 				result, err := currentBlock(ctx, client)
-				if errors.Is(err, context.DeadlineExceeded) {
-					return nil, nil, errors.Wrap(err, "timeout")
+				if ctx.Err() != nil {
+					return nil, nil, errors.Wrap(err, "parent context canceled")
 				} else if err != nil {
 					continue
 				}

--- a/halo/cmd/cmd_internal_test.go
+++ b/halo/cmd/cmd_internal_test.go
@@ -167,6 +167,37 @@ func TestTomlConfig(t *testing.T) {
 	tutil.RequireNoError(t, rootCmd.Execute())
 }
 
+func TestInvalidCmds(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		Name        string
+		Args        []string
+		ErrContains string
+	}{
+		{
+			Name:        "no args",
+			Args:        []string{},
+			ErrContains: "no sub-command specified, see --help",
+		},
+		{
+			Name:        "invalid args",
+			Args:        []string{"invalid"},
+			ErrContains: "unknown command \"invalid\" for \"halo\"",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.Name, func(t *testing.T) {
+			t.Parallel()
+			rootCmd := libcmd.NewRootCmd("halo", "", New())
+			rootCmd.SetArgs(test.Args)
+			err := rootCmd.Execute()
+			require.Error(t, err)
+			require.Contains(t, err.Error(), test.ErrContains)
+		})
+	}
+}
+
 // slice is a convenience function for creating string slice literals.
 func slice(strs ...string) []string {
 	return strs

--- a/halo/cmd/testdata/TestCLIReference_halo.golden
+++ b/halo/cmd/testdata/TestCLIReference_halo.golden
@@ -1,6 +1,7 @@
 Halo is a consensus client implementation for the Omni Protocol
 
 Usage:
+  halo [flags]
   halo [command]
 
 Available Commands:

--- a/lib/cmd/cmd.go
+++ b/lib/cmd/cmd.go
@@ -174,6 +174,10 @@ func wrapRunCmd(cmd *cobra.Command) {
 	SilenceErrUsage(runCmd)
 	runFunc := runCmd.RunE
 	runCmd.RunE = func(cmd *cobra.Command, args []string) error {
+		if runFunc == nil {
+			return errors.New("run command RunE nil [BUG]")
+		}
+
 		err := runFunc(cmd, args)
 		if err != nil {
 			log.Error(cmd.Context(), "!! Fatal error occurred, app died !!", err)


### PR DESCRIPTION
Improve binary errors when subcommands are invalid or not specified, reverting to default cobra behaviour.

issue: none