### PR TITLE
fix(halo): unsafe pointer dereference

### DIFF
--- a/e2e/anvilproxy/app/app.go
+++ b/e2e/anvilproxy/app/app.go
@@ -63,7 +63,7 @@ func Run(ctx context.Context, cfg Config) error {
 			return errors.Wrap(err, "server shutdown")
 		}
 
-		proxy.getInstance().stop()
+		proxy.stopInstance()
 
 		return nil
 	})

--- a/e2e/anvilproxy/app/proxy.go
+++ b/e2e/anvilproxy/app/proxy.go
@@ -168,11 +168,11 @@ func (p *proxy) GetTarget() *url.URL {
 	return p.target
 }
 
-func (p *proxy) getInstance() *anvilInstance {
+func (p *proxy) stopInstance() {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 
-	return p.instance
+	p.instance.stop()
 }
 
 func (p *proxy) setTarget(target anvilInstance) error {


### PR DESCRIPTION
Replaces getInstance func with stopInstance.

issue: none