### PR TITLE
fix(lib): check length of xBlock.Msgs before indexing

### DIFF
--- a/lib/xchain/provider/fetch.go
+++ b/lib/xchain/provider/fetch.go
@@ -444,6 +444,8 @@ func getConsXBlock(ctx context.Context, ref xchain.EmitRef, cprov cchain.Provide
 		return xchain.Block{}, errors.Wrap(err, "fetch consensus xblock")
 	} else if !ok {
 		return xchain.Block{}, errors.New("no consensus xblocks [BUG]")
+	} else if len(xblock.Msgs) == 0 {
+		return xchain.Block{}, errors.New("no messages [BUG]")
 	} else if xblock.Msgs[0].DestChainID != 0 {
 		return xchain.Block{}, errors.New("non-broadcast consensus chain xmsg [BUG]")
 	}


### PR DESCRIPTION
Add an else if block to check length of Msgs slice before indexing in next else if block, this prevents potential index out of bounds errors. 
 
issue: none