### PR TITLE
chore(github): fix backport action

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -7,7 +7,9 @@ on:
 jobs:
   backport:
     name: Backport PR
-    if: github.event.pull_request.merged == true && !(contains(github.event.pull_request.labels.*.name, 'backport'))
+    # Only run on merged PRs with the 'backport-to` label
+    if: github.event.pull_request.merged == true &&
+      contains(github.event.pull_request.labels.*.name, 'backport-to')
     runs-on: ubuntu-latest
     steps:
       - name: Backport Action


### PR DESCRIPTION
Backport action is running on all merged PR and failing. Only run on merged PRs with `backport-to` label.

issue: none