### PR TITLE
ci(halovisor): use halo v0_8_1 as genesis bin

### DIFF
--- a/docs/content/operate/3-uluwatu.md
+++ b/docs/content/operate/3-uluwatu.md
@@ -5,15 +5,15 @@ This guide describes the process to participate in the *critical coordinated* Om
 ## TL;DR
 
 - Simply ensure the `omniops/halovisor:v0.9.0` docker image is running **BEFORE** the upgrade height.
-  - `halovisor:v0.9.0`: wraps cosmovisor with `halo:v0.8.0` and `halo:v0.9.0`
+  - `halovisor:v0.9.0`: wraps cosmovisor with `halo:v0.8.1` and `halo:v0.9.0`
   - It will perform the binary switch automatically at the required block.
   - Note that `omniops/halovisor:v0.9.0` will be released in week of 1 Oct 2024
 - Omega upgrade height: TBD
 - Approximate upgrade date: 7~11 Oct 2024
-- Version(s) supported before upgrade: `halo:v0.4.0 .. v0.8.0`
+- Version(s) supported before upgrade: `halo:v0.4.0 .. v0.8.1`
 - Version required after upgrade: `halo:v0.9.0`  (not yet released)
 
-> 🚧 Like any blockchain network upgrade (hard fork), nodes that do not upgrade will crash or stall.
+> 🚧 Like any blockchain network upgrade (hard fork), nodes that do not upgrade will crash or stall.
 
 ## Details
 
@@ -31,13 +31,13 @@ There are basically three ways to run a `halo`:
 
 1. **🥇`omniops/halovisor:<latest>` docker container**
     - Simply run the latest version of `halovisor` docker container **BEFORE** the upgrade height. It will automatically detect and run the correct halo binary version using cosmovisor internally.
-    - E.g. `omniops/halovisor:v0.9.0` contains the `halo:v0.8.0` and `halo:v0.9.0` binaries and will automatically switch at the correct height.
+    - E.g. `omniops/halovisor:v0.9.0` contains the `halo:v0.8.1` and `halo:v0.9.0` binaries and will automatically switch at the correct height.
     - It only requires a single docker volume mount: `-v ~/.omni/omega/halo:/halo`
     - It will persist the cosmovisor “current” binary symlink to: `/halo/halovisor-current`
 2. **🥈Standard Cosmovisor with `halo` binaries**
     - Install and configure stock-standard CosmosSDK Cosmovisor with `halo` binaries, see docs [here](https://docs.cosmos.network/main/build/tooling/cosmovisor#setup) and [here](https://docs.archway.io/validators/running-a-node/cosmovisor) and [here](https://docs.junonetwork.io/validators/setting-up-cosmovisor). This will also automatically swap the “current” binary at the correct height.
     - The binaries versions to use are:
-        - `genesis: halo:v0.8.0`
+        - `genesis: halo:v0.8.1`
         - `upgrade/1_uluwatu: halo:v0.9.0`
     - Suggested env vars:
         - `ENV DAEMON_ALLOW_DOWNLOAD_BINARIES=false`
@@ -50,12 +50,12 @@ There are basically three ways to run a `halo`:
       ├─ data/...
       ├─ config/...
       ├─ cosmovisor/
-      │ ├── genesis/bin/$DEAMONNAME # halo:v0.8.0
+      │ ├── genesis/bin/$DEAMONNAME # halo:v0.8.1
       │ ├── upgrades/1_uluwatu/bin/$DEAMONNAME # halo:v0.9.0
     ```
 3. **🥉Manual binary/docker swapping**
     - Swapping halo binary version manually is also an option.
-    - When `halo:v0.8.0` reaches the network upgrade height, it will stall.
+    - When `halo:v0.8.1` reaches the network upgrade height, it will stall.
     - Stop it, and replace it with `halo:v0.9.0`
     - Start the node and it should catch up and continue processing the chain.
     - Note this will include downtime and is therefore not advised for validators as will negatively impact validator performance.

--- a/scripts/halovisor/Dockerfile
+++ b/scripts/halovisor/Dockerfile
@@ -1,7 +1,6 @@
 # Docker build args
-ARG OMNI_COSMOVISOR_VERSION=v0.2.0
-# TODO(corver): Replace with v0.8.1 when released
-ARG HALO_VERSION_0_GENESIS=v0.8.0-rc1
+ARG OMNI_COSMOVISOR_VERSION=v0.3.0
+ARG HALO_VERSION_0_GENESIS=v0.8.1
 ARG HALO_VERSION_1_ULUWATU=main
 
 # Build stages

--- a/scripts/halovisor/build.sh
+++ b/scripts/halovisor/build.sh
@@ -10,8 +10,7 @@ SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
 HALO_VERSION_0_GENESIS="${1}"
 if [ -z "$HALO_VERSION_0_GENESIS" ]; then
-  # TODO(corver): Replace with v0.8.1 when released. Below is v0.8.1-rc1
-  HALO_VERSION_0_GENESIS=v0.8.0-rc1
+  HALO_VERSION_0_GENESIS=v0.8.1
   echo "Using HALO_VERSION_GENESIS: ${HALO_VERSION_0_GENESIS}"
 fi
 


### PR DESCRIPTION
Use latest release LTS v0.8.1 as halovisor genesis binary.

Also bump cosmovisor for improved logging and error handling.

issue: none
