### PR TITLE
chore(lib/cast): refactor unsafe casts

### DIFF
--- a/contracts/core/script/helpverify/proxycreate3.go
+++ b/contracts/core/script/helpverify/proxycreate3.go
@@ -74,9 +74,8 @@ func parseProxyCreate3Tx(ctx context.Context, chain ChainName, txHash common.Has
 
 	constructorArgs := creationCode[len(mustDecodeHex(bindings.TransparentUpgradeableProxyBin)):]
 
-	// implementation is first 20 byte word of constructor args
-	// TODO(kevin): EthAddress length != 32
-	impl, err := cast.EthAddress(constructorArgs[:20])
+	// Address is encoded in first word (32 bytes), but left padded.
+	impl, err := cast.EthAddress(constructorArgs[12:32])
 	if err != nil {
 		return ProxyCreate3Tx{}, err
 	}

--- a/contracts/core/script/helpverify/proxycreate3.go
+++ b/contracts/core/script/helpverify/proxycreate3.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/omni-network/omni/contracts/bindings"
+	"github.com/omni-network/omni/lib/cast"
 	"github.com/omni-network/omni/lib/errors"
 	"github.com/omni-network/omni/lib/ethclient"
 	"github.com/omni-network/omni/lib/log"
@@ -73,9 +74,15 @@ func parseProxyCreate3Tx(ctx context.Context, chain ChainName, txHash common.Has
 
 	constructorArgs := creationCode[len(mustDecodeHex(bindings.TransparentUpgradeableProxyBin)):]
 
+	// implementation is first 20 byte word of constructor args
+	// TODO(kevin): EthAddress length != 32
+	impl, err := cast.EthAddress(constructorArgs[:20])
+	if err != nil {
+		return ProxyCreate3Tx{}, err
+	}
+
 	return ProxyCreate3Tx{
-		// implementation is first 32 byte word of constructor args
-		Implementation:  common.BytesToAddress(constructorArgs[:32]),
+		Implementation:  impl,
 		ConstructorArgs: hexutil.Encode(constructorArgs),
 	}, nil
 }

--- a/halo/attest/keeper/builder_test.go
+++ b/halo/attest/keeper/builder_test.go
@@ -234,9 +234,10 @@ func sigsTuples(vals ...*vtypes.Validator) []*types.SigTuple {
 	var sigs []*types.SigTuple
 	for _, v := range vals {
 		ethAddr, _ := v.EthereumAddress()
+		paddedSig := pad65(ethAddr.Bytes()) // Just make it valid and deterministic
 		sigs = append(sigs, &types.SigTuple{
 			ValidatorAddress: ethAddr.Bytes(),
-			Signature:        ethAddr.Bytes(), // Just make it non-nil for now
+			Signature:        paddedSig[:],
 		})
 	}
 
@@ -249,4 +250,11 @@ func defaultMsg() *MsgBuilder {
 
 func defaultAggVote() *AggVoteBuilder {
 	return new(AggVoteBuilder).Default()
+}
+
+func pad65(b []byte) [65]byte {
+	var arr [65]byte
+	copy(arr[:], b)
+
+	return arr
 }

--- a/halo/attest/keeper/cpayload_internal_test.go
+++ b/halo/attest/keeper/cpayload_internal_test.go
@@ -173,10 +173,8 @@ func TestVotesFromCommit(t *testing.T) {
 		attRoot, err := agg.AttestationRoot()
 		require.NoError(t, err)
 		for _, s := range agg.Signatures {
-			sig := xchain.SigTuple{
-				ValidatorAddress: common.BytesToAddress(s.ValidatorAddress),
-				Signature:        xchain.Signature65(s.Signature),
-			}
+			sig, err := s.ToXChain()
+			require.NoError(t, err)
 			require.True(t, expected[attRoot][sig], agg, sig)
 			delete(expected[attRoot], sig)
 			if len(expected[attRoot]) == 0 {

--- a/halo/attest/keeper/keeper_test.go
+++ b/halo/attest/keeper/keeper_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/omni-network/omni/halo/attest/keeper"
 	"github.com/omni-network/omni/halo/attest/types"
 	vtypes "github.com/omni-network/omni/halo/valsync/types"
+	"github.com/omni-network/omni/lib/tutil"
 	"github.com/omni-network/omni/lib/umath"
 	"github.com/omni-network/omni/lib/xchain"
 
@@ -341,7 +342,7 @@ func TestKeeper_Approve(t *testing.T) {
 					t.Helper()
 					msg := defaultMsg().Msg() // Signed by 1 and 2, but also approved by 1 and 2
 					err := k.Add(ctx, msg)
-					require.NoError(t, err)
+					tutil.RequireNoError(t, err)
 				},
 			},
 			args: args{
@@ -1042,9 +1043,11 @@ func toValSet(valset *vtypes.ValidatorSetResponse) keeper.ValSet {
 
 func expectValSig(id uint64, attID uint64, val *vtypes.Validator, offset uint64) *keeper.Signature {
 	ethAddr, _ := val.EthereumAddress()
+	paddedSig := pad65(ethAddr.Bytes())
+
 	return &keeper.Signature{
 		Id:               id,
-		Signature:        ethAddr.Bytes(),
+		Signature:        paddedSig[:],
 		ValidatorAddress: ethAddr.Bytes(),
 		AttId:            attID,
 		ChainId:          defaultChainID,

--- a/halo/attest/keeper/valaddr.go
+++ b/halo/attest/keeper/valaddr.go
@@ -67,7 +67,7 @@ func (c *valAddrCache) SetAll(vals []*vtypes.Validator) error {
 func (k *Keeper) getValEthAddr(ctx context.Context, cmtAddr []byte) (common.Address, error) {
 	addr, err := cast.Array20(cmtAddr)
 	if err != nil {
-		return common.Address{}, errors.Wrap(err, "invalid comet address length [BUG]", "len", len(cmtAddr))
+		return common.Address{}, errors.Wrap(err, "invalid comet address length [BUG]")
 	}
 
 	// Check cache

--- a/halo/attest/types/translate.go
+++ b/halo/attest/types/translate.go
@@ -2,6 +2,7 @@ package types
 
 import (
 	"github.com/omni-network/omni/lib/cast"
+	"github.com/omni-network/omni/lib/errors"
 	"github.com/omni-network/omni/lib/xchain"
 )
 
@@ -78,6 +79,10 @@ func SigFromProto(sig *SigTuple) (xchain.SigTuple, error) {
 
 // BlockHeaderFromProto converts a protobuf BlockHeader to a xchain.BlockHeader.
 func BlockHeaderFromProto(header *BlockHeader) (xchain.BlockHeader, error) {
+	if header == nil {
+		return xchain.BlockHeader{}, errors.New("nil block header")
+	}
+
 	hash, err := cast.Array32(header.GetBlockHash())
 	if err != nil {
 		return xchain.BlockHeader{}, err

--- a/halo/attest/types/translate.go
+++ b/halo/attest/types/translate.go
@@ -78,7 +78,7 @@ func SigFromProto(sig *SigTuple) (xchain.SigTuple, error) {
 
 // BlockHeaderFromProto converts a protobuf BlockHeader to a xchain.BlockHeader.
 func BlockHeaderFromProto(header *BlockHeader) (xchain.BlockHeader, error) {
-	addr, err := cast.Array32(header.GetBlockHash())
+	hash, err := cast.Array32(header.GetBlockHash())
 	if err != nil {
 		return xchain.BlockHeader{}, err
 	}
@@ -86,7 +86,7 @@ func BlockHeaderFromProto(header *BlockHeader) (xchain.BlockHeader, error) {
 	return xchain.BlockHeader{
 		ChainID:     header.GetChainId(),
 		BlockHeight: header.GetBlockHeight(),
-		BlockHash:   addr,
+		BlockHash:   hash,
 	}, nil
 }
 

--- a/halo/attest/types/tx.go
+++ b/halo/attest/types/tx.go
@@ -16,6 +16,10 @@ const (
 )
 
 func (v *Vote) AttestationRoot() (common.Hash, error) {
+	if v == nil {
+		return common.Hash{}, errors.New("nil vote")
+	}
+
 	msgRoot, err := cast.Array32(v.MsgRoot)
 	if err != nil {
 		return common.Hash{}, err
@@ -146,6 +150,10 @@ func (s *SigTuple) Verify() error {
 }
 
 func (s *SigTuple) ToXChain() (xchain.SigTuple, error) {
+	if s == nil {
+		return xchain.SigTuple{}, errors.New("nil sig tuple")
+	}
+
 	addr, err := cast.EthAddress(s.ValidatorAddress)
 	if err != nil {
 		return xchain.SigTuple{}, err
@@ -220,6 +228,10 @@ func (a *AggVote) Verify() error {
 }
 
 func (a *AggVote) AttestationRoot() (common.Hash, error) {
+	if a == nil {
+		return common.Hash{}, errors.New("nil agg vote")
+	}
+
 	msgRoot, err := cast.Array32(a.MsgRoot)
 	if err != nil {
 		return common.Hash{}, err
@@ -272,6 +284,10 @@ func (a *Attestation) Verify() error {
 }
 
 func (a *Attestation) ToXChain() (xchain.Attestation, error) {
+	if a == nil {
+		return xchain.Attestation{}, errors.New("nil attestation")
+	}
+
 	sigs := make([]xchain.SigTuple, 0, len(a.Signatures))
 	for _, sig := range a.Signatures {
 		sigTuple, err := sig.ToXChain()
@@ -302,6 +318,10 @@ func (a *Attestation) ToXChain() (xchain.Attestation, error) {
 }
 
 func (a *Attestation) AttestationRoot() (common.Hash, error) {
+	if a == nil {
+		return common.Hash{}, errors.New("nil attestation")
+	}
+
 	msgRoot, err := cast.Array32(a.MsgRoot)
 	if err != nil {
 		return common.Hash{}, err
@@ -316,6 +336,10 @@ func (a *Attestation) AttestationRoot() (common.Hash, error) {
 }
 
 func (v *Vote) ToXChain() (xchain.Vote, error) {
+	if v == nil {
+		return xchain.Vote{}, errors.New("nil vote")
+	}
+
 	msgRoot, err := cast.Array32(v.MsgRoot)
 	if err != nil {
 		return xchain.Vote{}, err

--- a/halo/attest/types/tx.go
+++ b/halo/attest/types/tx.go
@@ -1,6 +1,7 @@
 package types
 
 import (
+	"github.com/omni-network/omni/lib/cast"
 	"github.com/omni-network/omni/lib/errors"
 	"github.com/omni-network/omni/lib/k1util"
 	"github.com/omni-network/omni/lib/xchain"
@@ -15,7 +16,17 @@ const (
 )
 
 func (v *Vote) AttestationRoot() (common.Hash, error) {
-	return xchain.AttestationRoot(v.AttestHeader.ToXChain(), v.BlockHeader.ToXChain(), common.Hash(v.MsgRoot))
+	msgRoot, err := cast.Array32(v.MsgRoot)
+	if err != nil {
+		return common.Hash{}, err
+	}
+
+	header, err := v.BlockHeader.ToXChain()
+	if err != nil {
+		return common.Hash{}, err
+	}
+
+	return xchain.AttestationRoot(v.AttestHeader.ToXChain(), header, msgRoot)
 }
 
 func (v *Vote) Verify() error {
@@ -51,10 +62,15 @@ func (v *Vote) Verify() error {
 		return err
 	}
 
+	sigTuple, err := v.Signature.ToXChain()
+	if err != nil {
+		return err
+	}
+
 	ok, err := k1util.Verify(
-		common.Address(v.Signature.ValidatorAddress),
+		sigTuple.ValidatorAddress,
 		attRoot,
-		xchain.Signature65(v.Signature.Signature),
+		sigTuple.Signature,
 	)
 	if err != nil {
 		return err
@@ -109,7 +125,7 @@ func (h *BlockHeader) Verify() error {
 	return nil
 }
 
-func (h *BlockHeader) ToXChain() xchain.BlockHeader {
+func (h *BlockHeader) ToXChain() (xchain.BlockHeader, error) {
 	return BlockHeaderFromProto(h)
 }
 
@@ -129,11 +145,21 @@ func (s *SigTuple) Verify() error {
 	return nil
 }
 
-func (s *SigTuple) ToXChain() xchain.SigTuple {
-	return xchain.SigTuple{
-		ValidatorAddress: common.Address(s.ValidatorAddress),
-		Signature:        xchain.Signature65(s.Signature),
+func (s *SigTuple) ToXChain() (xchain.SigTuple, error) {
+	addr, err := cast.EthAddress(s.ValidatorAddress)
+	if err != nil {
+		return xchain.SigTuple{}, err
 	}
+
+	sig, err := cast.Array65(s.Signature)
+	if err != nil {
+		return xchain.SigTuple{}, err
+	}
+
+	return xchain.SigTuple{
+		ValidatorAddress: addr,
+		Signature:        sig,
+	}, nil
 }
 
 func (a *AggVote) Verify() error {
@@ -168,12 +194,15 @@ func (a *AggVote) Verify() error {
 			return errors.Wrap(err, "signature")
 		}
 
-		addr := common.BytesToAddress(sig.ValidatorAddress)
+		sigTup, err := sig.ToXChain()
+		if err != nil {
+			return err
+		}
 
 		ok, err := k1util.Verify(
-			addr,
+			sigTup.ValidatorAddress,
 			attRoot,
-			xchain.Signature65(sig.Signature),
+			sigTup.Signature,
 		)
 		if err != nil {
 			return err
@@ -181,17 +210,27 @@ func (a *AggVote) Verify() error {
 			return errors.New("invalid attestation signature")
 		}
 
-		if duplicateVals[addr] {
-			return errors.New("duplicate validator signature", "validator", addr)
+		if duplicateVals[sigTup.ValidatorAddress] {
+			return errors.New("duplicate validator signature", "validator", sigTup.ValidatorAddress)
 		}
-		duplicateVals[addr] = true
+		duplicateVals[sigTup.ValidatorAddress] = true
 	}
 
 	return nil
 }
 
 func (a *AggVote) AttestationRoot() (common.Hash, error) {
-	return xchain.AttestationRoot(a.AttestHeader.ToXChain(), a.BlockHeader.ToXChain(), common.Hash(a.MsgRoot))
+	msgRoot, err := cast.Array32(a.MsgRoot)
+	if err != nil {
+		return common.Hash{}, err
+	}
+
+	blockHeader, err := a.BlockHeader.ToXChain()
+	if err != nil {
+		return common.Hash{}, err
+	}
+
+	return xchain.AttestationRoot(a.AttestHeader.ToXChain(), blockHeader, msgRoot)
 }
 
 func (a *Attestation) Verify() error {
@@ -232,30 +271,70 @@ func (a *Attestation) Verify() error {
 	return nil
 }
 
-func (a *Attestation) ToXChain() xchain.Attestation {
+func (a *Attestation) ToXChain() (xchain.Attestation, error) {
 	sigs := make([]xchain.SigTuple, 0, len(a.Signatures))
 	for _, sig := range a.Signatures {
-		sigs = append(sigs, sig.ToXChain())
+		sigTuple, err := sig.ToXChain()
+		if err != nil {
+			return xchain.Attestation{}, err
+		}
+
+		sigs = append(sigs, sigTuple)
+	}
+
+	msgRoot, err := cast.Array32(a.MsgRoot)
+	if err != nil {
+		return xchain.Attestation{}, err
+	}
+
+	blockHeader, err := a.BlockHeader.ToXChain()
+	if err != nil {
+		return xchain.Attestation{}, err
 	}
 
 	return xchain.Attestation{
 		AttestHeader:   a.AttestHeader.ToXChain(),
-		BlockHeader:    a.BlockHeader.ToXChain(),
+		BlockHeader:    blockHeader,
 		ValidatorSetID: a.ValidatorSetId,
-		MsgRoot:        common.Hash(a.MsgRoot),
+		MsgRoot:        msgRoot,
 		Signatures:     sigs,
-	}
+	}, nil
 }
 
 func (a *Attestation) AttestationRoot() (common.Hash, error) {
-	return xchain.AttestationRoot(a.AttestHeader.ToXChain(), a.BlockHeader.ToXChain(), common.Hash(a.MsgRoot))
+	msgRoot, err := cast.Array32(a.MsgRoot)
+	if err != nil {
+		return common.Hash{}, err
+	}
+
+	blockHeader, err := a.BlockHeader.ToXChain()
+	if err != nil {
+		return common.Hash{}, err
+	}
+
+	return xchain.AttestationRoot(a.AttestHeader.ToXChain(), blockHeader, msgRoot)
 }
 
-func (v *Vote) ToXChain() xchain.Vote {
+func (v *Vote) ToXChain() (xchain.Vote, error) {
+	msgRoot, err := cast.Array32(v.MsgRoot)
+	if err != nil {
+		return xchain.Vote{}, err
+	}
+
+	blockHeader, err := v.BlockHeader.ToXChain()
+	if err != nil {
+		return xchain.Vote{}, err
+	}
+
+	sigTuple, err := v.Signature.ToXChain()
+	if err != nil {
+		return xchain.Vote{}, err
+	}
+
 	return xchain.Vote{
 		AttestHeader: v.AttestHeader.ToXChain(),
-		BlockHeader:  v.BlockHeader.ToXChain(),
-		MsgRoot:      common.Hash(v.MsgRoot),
-		Signature:    v.Signature.ToXChain(),
-	}
+		BlockHeader:  blockHeader,
+		MsgRoot:      msgRoot,
+		Signature:    sigTuple,
+	}, nil
 }

--- a/halo/attest/voter/vote_test.go
+++ b/halo/attest/voter/vote_test.go
@@ -33,7 +33,9 @@ func TestCreateVerifyVotes(t *testing.T) {
 
 	att, err := voter.CreateVote(privKey, attHeader, block)
 	require.NoError(t, err)
-	require.Equal(t, block.BlockHeader, att.BlockHeader.ToXChain())
+	header, err := att.BlockHeader.ToXChain()
+	require.NoError(t, err)
+	require.Equal(t, block.BlockHeader, header)
 	require.Equal(t, addr, common.Address(att.Signature.ValidatorAddress))
 
 	// Verify the attestation

--- a/halo/evmslashing/evmslashing.go
+++ b/halo/evmslashing/evmslashing.go
@@ -93,7 +93,10 @@ func (p EventProcessor) Addresses() []common.Address {
 // Deliver processes a omni deposit log event, which must be one of:
 // - Unjail.
 func (p EventProcessor) Deliver(ctx context.Context, _ common.Hash, elog *evmenginetypes.EVMEvent) error {
-	ethlog := elog.ToEthLog()
+	ethlog, err := elog.ToEthLog()
+	if err != nil {
+		return err
+	}
 
 	switch ethlog.Topics[0] {
 	case unjailEvent.ID:

--- a/halo/evmstaking/evmstaking.go
+++ b/halo/evmstaking/evmstaking.go
@@ -109,7 +109,10 @@ func (p EventProcessor) Addresses() []common.Address {
 // - CreateValidator
 // - Delegate.
 func (p EventProcessor) Deliver(ctx context.Context, _ common.Hash, elog *evmenginetypes.EVMEvent) error {
-	ethlog := elog.ToEthLog()
+	ethlog, err := elog.ToEthLog()
+	if err != nil {
+		return err
+	}
 
 	switch ethlog.Topics[0] {
 	case createValidatorEvent.ID:

--- a/halo/evmupgrade/evmupgrade.go
+++ b/halo/evmupgrade/evmupgrade.go
@@ -96,7 +96,10 @@ func (p EventProcessor) Addresses() []common.Address {
 // - PlanUpgrade.
 // - CancelUpgrade.
 func (p EventProcessor) Deliver(ctx context.Context, _ common.Hash, elog *evmenginetypes.EVMEvent) error {
-	ethlog := elog.ToEthLog()
+	ethlog, err := elog.ToEthLog()
+	if err != nil {
+		return err
+	}
 
 	switch ethlog.Topics[0] {
 	case planUpgradeEvent.ID:

--- a/halo/registry/keeper/logeventproc.go
+++ b/halo/registry/keeper/logeventproc.go
@@ -62,7 +62,10 @@ func (k Keeper) Prepare(ctx context.Context, blockHash common.Hash) ([]*evmengin
 
 // Deliver processes a omni portal registry events.
 func (k Keeper) Deliver(ctx context.Context, _ common.Hash, elog *evmenginetypes.EVMEvent) error {
-	ethlog := elog.ToEthLog()
+	ethlog, err := elog.ToEthLog()
+	if err != nil {
+		return err
+	}
 
 	switch ethlog.Topics[0] {
 	case portalRegEvent.ID:

--- a/lib/cast/cast.go
+++ b/lib/cast/cast.go
@@ -1,0 +1,74 @@
+// Package cast provides save casting functions for converting between types without panicking.
+package cast
+
+import (
+	"github.com/omni-network/omni/lib/errors"
+
+	"github.com/ethereum/go-ethereum/common"
+)
+
+// Array65 casts a slice to an array of length 65.
+func Array65[A any](slice []A) ([65]A, error) {
+	if len(slice) == 65 {
+		return [65]A(slice), nil
+	}
+
+	return [65]A{}, errors.New("slice length not 65", "len", len(slice))
+}
+
+// Must32 casts a slice to an array of length 32.
+func Must32[A any](slice []A) [32]A {
+	arr, err := Array32(slice)
+	if err != nil {
+		panic(err)
+	}
+
+	return arr
+}
+
+// Must20 casts a slice to an array of length 20.
+func Must20[A any](slice []A) [20]A {
+	arr, err := Array20(slice)
+	if err != nil {
+		panic(err)
+	}
+
+	return arr
+}
+
+// Array32 casts a slice to an array of length 32.
+func Array32[A any](slice []A) ([32]A, error) {
+	if len(slice) == 32 {
+		return [32]A(slice), nil
+	}
+
+	return [32]A{}, errors.New("slice length not 32", "len", len(slice))
+}
+
+// EthAddress casts a byte slice to an Ethereum address.
+func EthAddress(b []byte) (common.Address, error) {
+	resp, err := Array20(b)
+	if err != nil {
+		return common.Address{}, errors.New("invalid address length", "len", len(b))
+	}
+
+	return resp, nil
+}
+
+// Array20 casts a slice to an array of length 32.
+func Array20[A any](slice []A) ([20]A, error) {
+	if len(slice) == 20 {
+		return [20]A(slice), nil
+	}
+
+	return [20]A{}, errors.New("slice length not 20", "len", len(slice))
+}
+
+// Array8 casts a slice to an array of length 2.
+func Array8[A any](slice []A) ([8]A, error) {
+	if len(slice) == 8 {
+		return [8]A(slice), nil
+	}
+
+	return [8]A{}, errors.New("slice length not 8", "len", len(slice))
+}

--- a/lib/cast/cast_test.go
+++ b/lib/cast/cast_test.go
@@ -1,0 +1,59 @@
+package cast_test
+
+import (
+	"crypto/rand"
+	"testing"
+
+	"github.com/omni-network/omni/lib/cast"
+
+	"github.com/ethereum/go-ethereum/common"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCast(t *testing.T) {
+	t.Parallel()
+
+	slice := make([]byte, 100)
+	var resp common.Address
+	_, _ = rand.Read(resp[:])
+
+	// 8
+	_, err := cast.Array8(slice)
+	require.Error(t, err)
+	_, err = cast.Array8(slice[:1])
+	require.Error(t, err)
+	resp8, err := cast.Array8(slice[:8])
+	require.NoError(t, err)
+	require.Equal(t, slice[:8], resp8[:])
+
+	// 20
+	_, err = cast.Array20(slice)
+	require.Error(t, err)
+	_, err = cast.Array20(slice[:1])
+	require.Error(t, err)
+	resp20, err := cast.Array20(slice[:20])
+	require.NoError(t, err)
+	require.Equal(t, slice[:20], resp20[:])
+	addr, err := cast.EthAddress(slice[:20])
+	require.NoError(t, err)
+	require.EqualValues(t, resp20, addr)
+
+	// 32
+	_, err = cast.Array32(slice)
+	require.Error(t, err)
+	_, err = cast.Array32(slice[:1])
+	require.Error(t, err)
+	resp32, err := cast.Array32(slice[:32])
+	require.NoError(t, err)
+	require.Equal(t, slice[:32], resp32[:])
+
+	// 65
+	_, err = cast.Array65(slice)
+	require.Error(t, err)
+	_, err = cast.Array65(slice[:1])
+	require.Error(t, err)
+	resp65, err := cast.Array65(slice[:65])
+	require.NoError(t, err)
+	require.Equal(t, slice[:65], resp65[:])
+}

--- a/lib/cchain/provider/abci.go
+++ b/lib/cchain/provider/abci.go
@@ -309,7 +309,12 @@ func newABCIAllAttsFunc(cl atypes.QueryClient) allAttsFunc {
 			}
 
 			for _, att := range resp.Attestations {
-				atts = append(atts, att.ToXChain())
+				attX, err := att.ToXChain()
+				if err != nil {
+					return nil, err
+				}
+
+				atts = append(atts, attX)
 			}
 		}
 

--- a/lib/cchain/types.go
+++ b/lib/cchain/types.go
@@ -3,6 +3,7 @@ package cchain
 import (
 	"crypto/ecdsa"
 
+	"github.com/omni-network/omni/lib/cast"
 	"github.com/omni-network/omni/lib/errors"
 	"github.com/omni-network/omni/lib/umath"
 
@@ -79,7 +80,7 @@ func (v SDKValidator) OperatorEthAddr() (common.Address, error) {
 		return common.Address{}, errors.New("invalid operator address length")
 	}
 
-	return common.BytesToAddress(opAddr), nil
+	return cast.EthAddress(opAddr)
 }
 
 // ConsensusEthAddr returns the validator consensus eth address.

--- a/lib/ethclient/enginemock.go
+++ b/lib/ethclient/enginemock.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/omni-network/omni/contracts/bindings"
 	"github.com/omni-network/omni/halo/genutil/evm/predeploys"
+	"github.com/omni-network/omni/lib/cast"
 	"github.com/omni-network/omni/lib/errors"
 	"github.com/omni-network/omni/lib/k1util"
 	"github.com/omni-network/omni/lib/log"
@@ -117,7 +118,7 @@ func WithPortalRegister(network netconf.Network) func(*engineMock) {
 				Topics: []common.Hash{
 					portalRegEvent.ID,
 					common.BytesToHash(math.U256Bytes(umath.NewBigInt(chain.ID))), // ChainID
-					common.BytesToHash(chain.PortalAddress.Bytes()),               // Address
+					common.BytesToHash(chain.PortalAddress.Bytes()),               // EthAddress
 				},
 				Data: data,
 			}
@@ -519,7 +520,7 @@ func MockPayloadID(params engine.ExecutableData, beaconRoot *common.Hash) (engin
 	_, _ = h.Write(beaconRoot.Bytes())
 	hash := h.Sum(nil)
 
-	return engine.PayloadID(hash[:8]), nil
+	return cast.Array8(hash[:8])
 }
 
 // verifyChild returns an error if child is not a valid child of parent.

--- a/lib/ethclient/ethbackend/backend.go
+++ b/lib/ethclient/ethbackend/backend.go
@@ -298,9 +298,7 @@ func (backendStubSigner) Sender(tx *ethtypes.Transaction) (common.Address, error
 
 	v, r, s := tx.RawSignatureValues()
 
-	addrLen := len(common.Address{})
-
-	if len(r.Bytes()) > addrLen {
+	if len(r.Bytes()) > common.AddressLength {
 		return common.Address{}, errors.New("invalid r length", "length", len(r.Bytes()))
 	}
 	if s.Uint64() != 0 {
@@ -310,12 +308,12 @@ func (backendStubSigner) Sender(tx *ethtypes.Transaction) (common.Address, error
 		return common.Address{}, errors.New("non-empty v [BUG]", "length", len(v.Bytes()))
 	}
 
-	addr := make([]byte, addrLen)
+	var addr [common.AddressLength]byte
 	// big.Int.Bytes() truncates leading zeros, so we need to left pad the address to 20 bytes.
-	pad := addrLen - len(r.Bytes())
+	pad := common.AddressLength - len(r.Bytes())
 	copy(addr[pad:], r.Bytes())
 
-	return common.Address(addr), nil
+	return addr, nil
 }
 
 //nolint:nonamedreturns // Ambiguous return values

--- a/lib/fireblocks/client_test.go
+++ b/lib/fireblocks/client_test.go
@@ -18,7 +18,6 @@ import (
 	"github.com/omni-network/omni/lib/tutil"
 
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/crypto"
 
 	"github.com/google/uuid"
@@ -117,7 +116,7 @@ func TestSmoke(t *testing.T) {
 	client, err := fireblocks.New(netconf.Staging, apiKey, parseKey(t, privKey))
 	require.NoError(t, err)
 
-	addr := common.BytesToAddress(hexutil.MustDecode("0x7a6cF389082dc698285474976d7C75CAdE08ab7e"))
+	addr := common.HexToAddress("0x7a6cF389082dc698285474976d7C75CAdE08ab7e")
 
 	t.Run("assets", func(t *testing.T) {
 		t.Parallel()

--- a/lib/fireblocks/types.go
+++ b/lib/fireblocks/types.go
@@ -4,6 +4,7 @@ import (
 	"crypto/ecdsa"
 	"encoding/hex"
 
+	"github.com/omni-network/omni/lib/cast"
 	"github.com/omni-network/omni/lib/errors"
 
 	"github.com/ethereum/go-ethereum/crypto"
@@ -183,7 +184,7 @@ func (t transaction) Sig0() ([65]byte, error) {
 	// V is either 0 or 1
 	sig = append(sig, byte(msg.Signature.V))
 
-	return [65]byte(sig), nil
+	return cast.Array65(sig)
 }
 
 type amountInfo struct {

--- a/lib/k1util/k1util.go
+++ b/lib/k1util/k1util.go
@@ -4,6 +4,7 @@ package k1util
 import (
 	stdecdsa "crypto/ecdsa"
 
+	"github.com/omni-network/omni/lib/cast"
 	"github.com/omni-network/omni/lib/errors"
 
 	"github.com/cometbft/cometbft/crypto"
@@ -40,7 +41,7 @@ func Sign(key crypto.PrivKey, input [32]byte) ([65]byte, error) {
 	sig := ecdsa.SignCompact(secp256k1.PrivKeyFromBytes(bz), input[:], false)
 
 	// Convert signature from "compact" into "Ethereum R S V" format.
-	return [65]byte(append(sig[1:], sig[0])), nil
+	return cast.Array65(append(sig[1:], sig[0]))
 }
 
 // Verify returns whether the 65 byte signature is valid for the provided hash

--- a/lib/merkle/core.go
+++ b/lib/merkle/core.go
@@ -7,12 +7,13 @@ import (
 	"bytes"
 	"sort"
 
+	"github.com/omni-network/omni/lib/cast"
 	"github.com/omni-network/omni/lib/errors"
 
 	"github.com/ethereum/go-ethereum/crypto"
 )
 
-// Specifies the domain of a single leaf in the tree.
+// DomainSeparationTag defines the domain of a single leaf in the tree.
 type DomainSeparationTag byte
 
 // StdLeafHash returns the standard leaf hash of the given data.
@@ -206,7 +207,5 @@ func hashPair(a [32]byte, b [32]byte) [32]byte {
 
 // hash returns the 32 byte keccak256 hash of the given byte slice.
 func hash(buf []byte) [32]byte {
-	resp := crypto.Keccak256(buf)
-
-	return [32]byte(resp)
+	return cast.Must32(crypto.Keccak256(buf)) // Fine to use Must, as Keccak256 always returns 32 bytes.
 }

--- a/lib/xchain/abi_internal_test.go
+++ b/lib/xchain/abi_internal_test.go
@@ -67,7 +67,8 @@ func TestSubmissionToFromBinding(t *testing.T) {
 	sub.AttHeader.ChainVersion.ID = sub.BlockHeader.ChainID // Align headers
 
 	xsub := SubmissionToBinding(sub)
-	reversedSub := SubmissionFromBinding(xsub, sub.DestChainID)
+	reversedSub, err := SubmissionFromBinding(xsub, sub.DestChainID)
+	require.NoError(t, err)
 
 	// Zero TxHash, ChainID, and Fees for comparison since they aren't translated.
 	for i := range sub.Msgs {

--- a/lib/xchain/provider/fetch.go
+++ b/lib/xchain/provider/fetch.go
@@ -390,7 +390,7 @@ func (p *Provider) GetSubmission(ctx context.Context, chainID uint64, txHash com
 		return xchain.Submission{}, errors.Wrap(err, "decode xsubmit")
 	}
 
-	return xchain.SubmissionFromBinding(sub, chain.ID), nil
+	return xchain.SubmissionFromBinding(sub, chain.ID)
 }
 
 // confirmedCache returns true if the height is confirmedCache based on the chain version

--- a/lib/xchain/provider/mock.go
+++ b/lib/xchain/provider/mock.go
@@ -51,7 +51,7 @@ func NewMock(period time.Duration, cChainID uint64, cProvider cchain.Provider) (
 		blocks:     make(map[blockKey]xchain.Block),
 		cChainID:   cChainID,
 		cProvider:  cProvider,
-		destChains: [2]uint64(destChains),
+		destChains: [2]uint64{destChains[0], destChains[1]},
 	}, nil
 }
 

--- a/octane/evmengine/keeper/abci_internal_test.go
+++ b/octane/evmengine/keeper/abci_internal_test.go
@@ -125,7 +125,7 @@ func TestKeeper_PrepareProposal(t *testing.T) {
 				require.NoError(t, err)
 
 				ap := mockAddressProvider{
-					address: common.BytesToAddress([]byte("test")),
+					address: tutil.RandomAddress(),
 				}
 				frp := newRandomFeeRecipientProvider()
 				k, err := NewKeeper(cdc, storeService, &tt.mockEngine, txConfig, ap, frp)

--- a/relayer/app/creator_test.go
+++ b/relayer/app/creator_test.go
@@ -59,18 +59,26 @@ func TestCreatorService_CreateSubmissions(t *testing.T) {
 
 	vote, err := voter.CreateVote(privKey, attestHeader, block)
 	require.NoError(t, err)
-	require.Equal(t, block.BlockHeader, vote.BlockHeader.ToXChain())
+	header, err := vote.BlockHeader.ToXChain()
+	require.NoError(t, err)
+	require.Equal(t, block.BlockHeader, header)
 	require.Equal(t, addr, common.Address(vote.Signature.ValidatorAddress))
 
 	tree, err := xchain.NewMsgTree(block.Msgs)
 	require.NoError(t, err)
 
+	blockHeader, err := vote.BlockHeader.ToXChain()
+	require.NoError(t, err)
+
+	sig, err := vote.Signature.ToXChain()
+	require.NoError(t, err)
+
 	att := xchain.Attestation{
 		AttestHeader:   vote.AttestHeader.ToXChain(),
-		BlockHeader:    vote.BlockHeader.ToXChain(),
+		BlockHeader:    blockHeader,
 		ValidatorSetID: valSetID,
 		MsgRoot:        [32]byte(vote.MsgRoot),
-		Signatures:     []xchain.SigTuple{vote.Signature.ToXChain()},
+		Signatures:     []xchain.SigTuple{sig},
 	}
 
 	ensureNoDuplicates := func(t *testing.T, msgs []xchain.Msg) {

--- a/scripts/golint/arraycast.go
+++ b/scripts/golint/arraycast.go
@@ -1,0 +1,98 @@
+package main
+
+import (
+	"go/ast"
+	"go/types"
+
+	"github.com/omni-network/omni/lib/errors"
+
+	"golang.org/x/tools/go/analysis"
+	"golang.org/x/tools/go/analysis/passes/inspect"
+	"golang.org/x/tools/go/ast/inspector"
+)
+
+var arrayCastAnalyzer = &analysis.Analyzer{
+	Name: "arraycast",
+	Doc:  "Ensures panic-prone array casting isn't used",
+	Run: func(p *analysis.Pass) (interface{}, error) {
+		if isTestPass(p) { // Skip tests for this analyser
+			return nil, nil //nolint:nilnil // API requires nil-nil return
+		}
+		if p.Pkg.Name() == "cast" { // Skip cast package
+			return nil, nil //nolint:nilnil // API requires nil-nil return
+		}
+
+		i, ok := p.ResultOf[inspect.Analyzer].(*inspector.Inspector)
+		if !ok {
+			return nil, errors.New("analyzer is not of type *inspector.Inspector")
+		}
+		diags, err := arrayCast(p.TypesInfo, i)
+		if err != nil {
+			return nil, errors.Wrap(err, "detect uint subtract")
+		}
+
+		for _, diag := range diags {
+			p.Report(diag)
+		}
+
+		return nil, nil //nolint:nilnil // API requires nil-nil return
+	},
+	Requires: []*analysis.Analyzer{inspect.Analyzer},
+}
+
+func arrayCast(info *types.Info, i *inspector.Inspector) ([]analysis.Diagnostic, error) {
+	var diags []analysis.Diagnostic
+	var err error
+	filter := []ast.Node{new(ast.CallExpr)}
+	i.Preorder(filter, func(n ast.Node) {
+		call, ok := n.(*ast.CallExpr)
+		if !ok {
+			err = errors.New("expected *ast.CallExpr")
+			return
+		} else if len(call.Args) != 1 {
+			return // Casts should only have one argument
+		}
+
+		_, ok = isArrayCast(info, call)
+		if !ok {
+			return
+		}
+
+		if !isSliceArg(info, call.Args[0]) {
+			return
+		}
+
+		diags = append(diags, analysis.Diagnostic{
+			Pos:     call.Pos(),
+			Message: "panicable array casting, use cast.Array* instead",
+		})
+	})
+
+	return diags, err
+}
+
+func isSliceArg(info *types.Info, arg ast.Expr) bool {
+	argType := info.TypeOf(arg)
+	if _, ok := argType.(*types.Slice); ok {
+		return true
+	}
+
+	if _, ok := argType.Underlying().(*types.Slice); ok {
+		return true
+	}
+
+	return false
+}
+
+func isArrayCast(info *types.Info, call *ast.CallExpr) (int64, bool) {
+	funType := info.TypeOf(call.Fun)
+	if a, ok := funType.(*types.Array); ok {
+		return a.Len(), true
+	}
+
+	if a, ok := funType.Underlying().(*types.Array); ok {
+		return a.Len(), true
+	}
+
+	return 0, false
+}

--- a/scripts/golint/arraycast_internal_test.go
+++ b/scripts/golint/arraycast_internal_test.go
@@ -1,0 +1,34 @@
+package main
+
+import (
+	"testing"
+
+	"golang.org/x/tools/go/analysis/analysistest"
+)
+
+func TestArrayCast(t *testing.T) {
+	t.Parallel()
+
+	content := `package main
+
+type Array [2]int
+
+func main() {
+	var slice []int
+	a := Array(slice) // want "panicable array cast"
+	_ = Array(a[:]) // want "panicable array cast"
+	_ = Array(append(slice, 0)) // want "panicable array cast"
+	_ = [3]int(slice) // want "panicable array cast"
+
+	_ = Array([2]int{1, 2}) // OK
+	_ = Array(Array{}) // OK
+}
+`
+
+	dir, cleanup, err := analysistest.WriteFiles(map[string]string{"main/main.go": content})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cleanup()
+	_ = analysistest.Run(t, dir, arrayCastAnalyzer, "main")
+}

--- a/scripts/golint/helper.go
+++ b/scripts/golint/helper.go
@@ -1,0 +1,23 @@
+package main
+
+import (
+	"strings"
+
+	"golang.org/x/tools/go/analysis"
+)
+
+// isTestPass returns true if the package being analyzed is a test package.
+func isTestPass(p *analysis.Pass) bool {
+	if strings.HasSuffix(p.Pkg.Name(), "_test") {
+		return true
+	}
+
+	for _, file := range p.Files {
+		pos := p.Fset.Position(file.Package)
+		if strings.HasSuffix(pos.Filename, "_test.go") {
+			return true
+		}
+	}
+
+	return false
+}

--- a/scripts/golint/main.go
+++ b/scripts/golint/main.go
@@ -11,5 +11,6 @@ func main() {
 	multichecker.Main(
 		uintSubtractAnalyzer,
 		logAttrsAnalyzer,
+		arrayCastAnalyzer,
 	)
 }


### PR DESCRIPTION
Adds the `cast` package that casts slices into arrays safely. Also adds a linter that detects unsafe casts.

Refactor all instances of unsafe casts to use new cast package.

This was raised in the spearbit audit.

issue: none