### PR TITLE
docs(operate): improve v0-9-0 docs

### DIFF
--- a/docs/content/operate/1-run-full-node.md
+++ b/docs/content/operate/1-run-full-node.md
@@ -29,17 +29,58 @@ Congrats, you're running a full node!
 What's actually happening here?
 
 - First, you're installing the `omni` cli. We've packaged up several flows into this CLI to make running a node easier for operators.
-- The `init-nodes` command is used to generate genesis files and node initialization configs in your `~/.omni/` directory.
-- `docker compose up` spins up a docker container for `halo` and `geth`, and starts your node.
+- The `init-nodes` command is used to generate genesis files and config files and docker compose in the `~/.omni/<network>` directory.
+- `docker compose up -d` spins up docker containers `halovisor` and `geth`.
+
+Note that this is the preferred way to run an omni node and results in a production quality deployment (as long as docker is started on startup of the machine).
 
 ### Node Requirements
 
-| Category | Recommendation |
-| --- | --- |
-| Cores | 4 |
-| Bandwidth | 100 Mbps |
-| RAM | 16GB |
-| SSD Hard Disk | 500 GB |
-| Docker | 24.0.7 |
-| Operating System | `linux/amd64` (soon adding support for multi-platform docker images) |
-| Inbound ports | Enabled for cometBFT (`tcp://26656`) and Geth (`tcp://30303`, `udp://30303`) |
+| Category         | Recommendation                                                               |
+|------------------|------------------------------------------------------------------------------|
+| Cores            | 4                                                                            |
+| Bandwidth        | 100 Mbps                                                                     |
+| RAM              | 16GB                                                                         |
+| SSD Hard Disk    | 500 GB                                                                       |
+| Docker           | 24.0.7                                                                       |
+| Operating System | `linux/amd64`                                                                |
+| Inbound ports    | Enabled for cometBFT (`tcp://26656`) and Geth (`tcp://30303`, `udp://30303`) |
+
+### `halo` Deployment Instructions
+
+Note that `halo` is a CosmosSDK application which requires a specific binary version to run at each network upgrade height.
+CosmosSDK uses [Cosmovisor](https://docs.cosmos.network/main/build/tooling/cosmovisor) to manage the binary versioning and swapping at the correct height.
+
+There are basically three ways to run `halo`:
+
+1. **🥇`omniops/halovisor:<latest>` docker container**
+    - Simply run the latest version of `halovisor` docker container. It will automatically detect and run the correct halo binary version using cosmovisor internally.
+    - E.g. `omniops/halovisor:v0.9.0` contains the `halo:v0.8.1` and `halo:v0.9.0` binaries and will automatically switch at the correct height.
+    - It only requires a single docker volume mount: `-v ~/.omni/<network>/halo:/halo`
+    - It will persist the cosmovisor “current” binary symlink to: `halo/halovisor-current`
+2. **🥈Standard Cosmovisor with `halo` binaries**
+    - Install and configure stock-standard CosmosSDK Cosmovisor with `halo` binaries, see docs [here](https://docs.cosmos.network/main/build/tooling/cosmovisor#setup) and [here](https://docs.archway.io/validators/running-a-node/cosmovisor) and [here](https://docs.junonetwork.io/validators/setting-up-cosmovisor). This will also automatically swap the “current” binary at the correct height.
+    - The binaries versions to use are:
+        - `genesis: halo:v0.8.1`
+        - `upgrade/1_uluwatu: halo:v0.9.0`
+    - Suggested env vars:
+        - `ENV DAEMON_ALLOW_DOWNLOAD_BINARIES=false`
+        - `ENV DAEMON_RESTART_AFTER_UPGRADE=true`
+        - `ENV UNSAFE_SKIP_BACKUP=true`
+    - The folder structure should be:
+    ```bash
+    ~/.omni/<network>/halo # $DEAMONHOME
+      ├─ data/...
+      ├─ config/...
+      ├─ cosmovisor/
+      │ ├── genesis/bin/$DEAMONNAME # halo:v0.8.1
+      │ ├── upgrades/1_uluwatu/bin/$DEAMONNAME # halo:v0.9.0
+    ```
+3. **🥉Manual binary/docker swapping**
+    - Swapping halo binary version manually is also an option.
+    - When `halo:v0.8.1` reaches the network upgrade height, it will stall.
+    - Stop it, and replace it with `halo:v0.9.0`
+    - Start the node and it should catch up and continue processing the chain.
+    - Note this will include downtime and is therefore not advised for validators as will negatively impact validator performance.
+
+See the [Operator FAQ](./5-faq.md)  for details on `halovisor vs halo` and `docker vs binaries`

--- a/docs/content/operate/3-uluwatu.md
+++ b/docs/content/operate/3-uluwatu.md
@@ -7,11 +7,10 @@ This guide describes the process to participate in the *critical coordinated* Om
 - Simply ensure the `omniops/halovisor:v0.9.0` docker image is running **BEFORE** the upgrade height.
   - `halovisor:v0.9.0`: wraps cosmovisor with `halo:v0.8.1` and `halo:v0.9.0`
   - It will perform the binary switch automatically at the required block.
-  - Note that `omniops/halovisor:v0.9.0` will be released in week of 1 Oct 2024
 - Omega upgrade height: TBD
 - Approximate upgrade date: 7~11 Oct 2024
 - Version(s) supported before upgrade: `halo:v0.4.0 .. v0.8.1`
-- Version required after upgrade: `halo:v0.9.0`  (not yet released)
+- Version required after upgrade: `halo:v0.9.0`
 
 > 🚧 Like any blockchain network upgrade (hard fork), nodes that do not upgrade will crash or stall.
 

--- a/docs/content/operate/3-uluwatu.md
+++ b/docs/content/operate/3-uluwatu.md
@@ -21,41 +21,8 @@ The “uluwatu” upgrade is the first network upgrade (hard fork) planned for t
 
 The upgrade contains changes to `halo`’s `attest` module logic ensuring that attestations are only deleted when they exit the modified vote window. See [issue](https://github.com/omni-network/omni/issues/1787) and [PR](https://github.com/omni-network/omni/pull/1983) for details.
 
-No changes to `geth` is required, this version is still compatible with `v1.14.8`. (Note that geth `v1.14.9` has been released but hasn’t published docker images, see [issue](https://github.com/ethereum/go-ethereum/issues/30469) for details.)
+No changes to `geth` is required, this version is compatible with `v1.14.11`.
 
-See the [Validator FAQ](https://www.notion.so/External-Running-a-Validator-on-Omni-Omega-f7e53b98e38b467cba0aad7d640c0556?pvs=21)  for details on `halovisor vs halo` and `docker vs binaries`
+See [Run a Full Node](./1-run-full-node.md#halo-deployment-instructions) for more details on running `halo` with `cosmovisor`.
 
-## `halo` Deployment Instructions
-
-There are basically three ways to run a `halo`:
-
-1. **🥇`omniops/halovisor:<latest>` docker container**
-    - Simply run the latest version of `halovisor` docker container **BEFORE** the upgrade height. It will automatically detect and run the correct halo binary version using cosmovisor internally.
-    - E.g. `omniops/halovisor:v0.9.0` contains the `halo:v0.8.1` and `halo:v0.9.0` binaries and will automatically switch at the correct height.
-    - It only requires a single docker volume mount: `-v ~/.omni/omega/halo:/halo`
-    - It will persist the cosmovisor “current” binary symlink to: `/halo/halovisor-current`
-2. **🥈Standard Cosmovisor with `halo` binaries**
-    - Install and configure stock-standard CosmosSDK Cosmovisor with `halo` binaries, see docs [here](https://docs.cosmos.network/main/build/tooling/cosmovisor#setup) and [here](https://docs.archway.io/validators/running-a-node/cosmovisor) and [here](https://docs.junonetwork.io/validators/setting-up-cosmovisor). This will also automatically swap the “current” binary at the correct height.
-    - The binaries versions to use are:
-        - `genesis: halo:v0.8.1`
-        - `upgrade/1_uluwatu: halo:v0.9.0`
-    - Suggested env vars:
-        - `ENV DAEMON_ALLOW_DOWNLOAD_BINARIES=false`
-        - `ENV DAEMON_RESTART_AFTER_UPGRADE=true`
-        - `ENV UNSAFE_SKIP_BACKUP=true`
-    - The folder structure should be:
-
-    ```bash
-    ~/.omni/omega/halo # $DEAMONHOME
-      ├─ data/...
-      ├─ config/...
-      ├─ cosmovisor/
-      │ ├── genesis/bin/$DEAMONNAME # halo:v0.8.1
-      │ ├── upgrades/1_uluwatu/bin/$DEAMONNAME # halo:v0.9.0
-    ```
-3. **🥉Manual binary/docker swapping**
-    - Swapping halo binary version manually is also an option.
-    - When `halo:v0.8.1` reaches the network upgrade height, it will stall.
-    - Stop it, and replace it with `halo:v0.9.0`
-    - Start the node and it should catch up and continue processing the chain.
-    - Note this will include downtime and is therefore not advised for validators as will negatively impact validator performance.
+See the [Operator FAQ](./5-faq.md)  for details on `halovisor vs halo` and `docker vs binaries`


### PR DESCRIPTION
Improve docs for v0.9.0 release.

Move `halo Deployment Instruction` to `Run a Full Node` since all nodes, not only validators, need to support network upgrades.

issue: none