### PR TITLE
fix(lib/cmd): fix missing cli errors

### DIFF
--- a/e2e/cmd/cmd.go
+++ b/e2e/cmd/cmd.go
@@ -31,7 +31,12 @@ func New() *cobra.Command {
 	var def app.Definition
 
 	cmd := libcmd.NewRootCmd("e2e", "e2e network generator and test runner")
+	cachedPreRun := cmd.PersistentPreRunE
 	cmd.PersistentPreRunE = func(cmd *cobra.Command, _ []string) error {
+		if err := cachedPreRun(cmd, nil); err != nil {
+			return err
+		}
+
 		ctx := cmd.Context()
 		if _, err := log.Init(ctx, logCfg); err != nil {
 			return err

--- a/halo/cmd/testdata/TestRunCmd_json_files.golden
+++ b/halo/cmd/testdata/TestRunCmd_json_files.golden
@@ -1,6 +1,6 @@
 {
  "HomeDir": "testinput/input2",
- "Network": "",
+ "Network": "GOTEST",
  "EngineJWTFile": "jwt.json",
  "EngineEndpoint": "",
  "RPCEndpoints": null,


### PR DESCRIPTION
Fixes an issue introduced in #2054:
 - Only `run` or root commands logged omni-style app fatal error logs
 - All other commands didn't log anything when crashing.
 - Now only cobra cli flags or usage issues do cli style logging, everything else is omni style.
 
 This affects v0.9.0, but only halo subcommands like `halo rollback` or `halo init` which will not log fatal errors.
 This doesn't affect omni cli thought which has custom logic
 
Also fixes legacy issue with `e2e` app not supporting viper (e2e vars).

issue: none