### PR TITLE
ci(backwards): use v0-9-0 as reference

### DIFF
--- a/e2e/manifests/backwards.toml
+++ b/e2e/manifests/backwards.toml
@@ -1,18 +1,17 @@
-# Backwards ensures backwards-compatibility with v0.8.0.
+# Backwards ensures backwards-compatibility with v0.9.0 (the first version supporting uluwatu)
 network = "devnet"
 anvil_chains = ["mock_l1", "mock_l2"]
 
 multi_omni_evms = true
-network_upgrade_height = -1 # Disable network upgrade
 
 [node.validator01]
 [node.validator02]
 mode = "archive"
 
 [node.validator03]
-version="omniops/halovisor:v0.8.0"
+version="omniops/halovisor:v0.9.0"
 perturb = ["upgrade"]
 
 [node.validator04]
-version="omniops/halovisor:v0.8.0"
+version="omniops/halovisor:v0.9.0"
 perturb = ["upgrade"]


### PR DESCRIPTION
Update `backwards.toml` by doing genesis upgrade and testing backwards compatibility with v0.9.0 which is first uluwatu release. 

The `release/v0.8` branch does backwards compatibility with `v0.8.0 -> v0.8.x`

issue: none