### PR TITLE
chore(*): prevent uses of common BytesTo

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -9,6 +9,8 @@ linters-settings:
       - 'fmt\.Print.*(# Avoid debug logging)?'
       - 'fmt\.Errorf.*(# Prefer lib/errors.Wrap)?'
       - 'prometheus\.New.*(# Prefer promauto)?'
+      - 'common\.BytesToAddress.*(# Prefer cast pkg)?'
+      - 'common\.BytesToHash.*(# Prefer cast pkg)?'
   gci: # Auto-format imports
     sections:
       - standard                           # Go stdlib
@@ -101,12 +103,17 @@ issues:
         - maintidx     # Relax linter for table driven tests
         - dupl         # Many tests share similar testing logic but call different methods with different args
         - forcetypeassert # Asserting casts in tests not required.
+    - path: '(.*)(_test|tutil|scripts)(.*)'
+      linters: # Relax forbidigo common.BytesTo* in non-production code
+        - forbidigo
+      text: "Prefer cast"
     - path: '(.*)(e2e)(.*)'
       linters:         # Relax linters for both e2e (performance not required)
         - perfsprint   # Performance not an issue here
     - path: '(.*)(scripts|cli)(.*)'
       linters:        # Relax linters for scripts and clis
         - forbidigo   # Allow debug printing
+      text: "debug"
   exclude:
     - add-constant         # Ignore "add-constant: avoid magic numbers like" since it is too strict
     - fieldalignment # Ignore "fieldalignment: struct with XXX pointer bytes could be YYY"

--- a/halo/attest/keeper/helper.go
+++ b/halo/attest/keeper/helper.go
@@ -4,10 +4,17 @@ import (
 	"context"
 
 	"github.com/omni-network/omni/halo/attest/types"
+	"github.com/omni-network/omni/lib/cast"
 	"github.com/omni-network/omni/lib/errors"
 	"github.com/omni-network/omni/lib/umath"
 	"github.com/omni-network/omni/lib/xchain"
+
+	"github.com/ethereum/go-ethereum/common"
 )
+
+func (s *Signature) ValidatorEthAddress() (common.Address, error) {
+	return cast.EthAddress(s.GetValidatorAddress())
+}
 
 func (a *Attestation) XChainVersion() xchain.ChainVersion {
 	return xchain.ChainVersion{

--- a/halo/attest/types/tx.go
+++ b/halo/attest/types/tx.go
@@ -149,6 +149,14 @@ func (s *SigTuple) Verify() error {
 	return nil
 }
 
+func (s *SigTuple) ValidatorEthAddress() (common.Address, error) {
+	if s == nil {
+		return common.Address{}, errors.New("nil sig tuple")
+	}
+
+	return cast.EthAddress(s.ValidatorAddress)
+}
+
 func (s *SigTuple) ToXChain() (xchain.SigTuple, error) {
 	if s == nil {
 		return xchain.SigTuple{}, errors.New("nil sig tuple")

--- a/halo/genutil/evm/evm.go
+++ b/halo/genutil/evm/evm.go
@@ -73,6 +73,8 @@ func defaultChainConfig(network netconf.ID) *params.ChainConfig {
 
 // precompilesAlloc returns allocs for precompiled contracts
 // precompile balances are set to 1 as a performance optimization, as done in geth.
+//
+//nolint:forbidigo // Explicitly use BytesToAddress with left padding.
 func precompilesAlloc() types.GenesisAlloc {
 	return types.GenesisAlloc{
 		common.BytesToAddress([]byte{1}): {Balance: big.NewInt(1)}, // ECRecover

--- a/lib/cast/cast.go
+++ b/lib/cast/cast.go
@@ -36,6 +36,16 @@ func Must20[A any](slice []A) [20]A {
 	return arr
 }
 
+// EthHash casts a byte slice to an Ethereum hash.
+func EthHash(b []byte) (common.Hash, error) {
+	resp, err := Array32(b)
+	if err != nil {
+		return common.Hash{}, errors.New("invalid hash length", "len", len(b))
+	}
+
+	return resp, nil
+}
+
 // Array32 casts a slice to an array of length 32.
 func Array32[A any](slice []A) ([32]A, error) {
 	if len(slice) == 32 {

--- a/lib/cast/cast_test.go
+++ b/lib/cast/cast_test.go
@@ -47,6 +47,9 @@ func TestCast(t *testing.T) {
 	resp32, err := cast.Array32(slice[:32])
 	require.NoError(t, err)
 	require.Equal(t, slice[:32], resp32[:])
+	hash, err := cast.EthHash(slice[:32])
+	require.NoError(t, err)
+	require.EqualValues(t, resp32, hash)
 
 	// 65
 	_, err = cast.Array65(slice)

--- a/lib/ethclient/enginemock.go
+++ b/lib/ethclient/enginemock.go
@@ -113,12 +113,17 @@ func WithPortalRegister(network netconf.Network) func(*engineMock) {
 				panic(errors.Wrap(err, "pack delegate"))
 			}
 
+			topicChainID, err := cast.EthHash(math.U256Bytes(umath.NewBigInt(chain.ID)))
+			if err != nil {
+				panic(errors.Wrap(err, "cast chain ID"))
+			}
+
 			eventLog := types.Log{
 				Address: contractAddr,
 				Topics: []common.Hash{
 					portalRegEvent.ID,
-					common.BytesToHash(math.U256Bytes(umath.NewBigInt(chain.ID))), // ChainID
-					common.BytesToHash(chain.PortalAddress.Bytes()),               // EthAddress
+					topicChainID,
+					common.BytesToHash(chain.PortalAddress.Bytes()), //nolint:forbidigo // Explicit left padded
 				},
 				Data: data,
 			}

--- a/monitor/xmonitor/indexer/helper.go
+++ b/monitor/xmonitor/indexer/helper.go
@@ -1,8 +1,10 @@
 package indexer
 
 import (
+	"bytes"
 	"encoding/json"
 
+	"github.com/omni-network/omni/lib/cast"
 	"github.com/omni-network/omni/lib/errors"
 	"github.com/omni-network/omni/lib/xchain"
 
@@ -18,6 +20,16 @@ func (b *Block) XChainBlock() (xchain.Block, error) {
 	return resp, nil
 }
 
-func (l *MsgLink) Hash() common.Hash {
-	return common.BytesToHash(l.GetIdHash())
+func (l *MsgLink) Hash() (common.Hash, error) {
+	return cast.EthHash(l.GetIdHash())
+}
+
+// IsMsg returns true if the message belongs to this link.
+func (l *MsgLink) IsMsg(msg xchain.Msg) bool {
+	return bytes.Equal(l.GetIdHash(), msg.Hash().Bytes())
+}
+
+// IsReceipt returns true if the receipt belongs to this link.
+func (l *MsgLink) IsReceipt(receipt xchain.Receipt) bool {
+	return bytes.Equal(l.GetIdHash(), receipt.Hash().Bytes())
 }

--- a/monitor/xmonitor/indexer/indexer.go
+++ b/monitor/xmonitor/indexer/indexer.go
@@ -378,7 +378,7 @@ func (i *indexer) instrumentMsg(ctx context.Context, link *MsgLink) error {
 
 	var msg xchain.Msg
 	for _, m := range msgBlock.Msgs {
-		if m.Hash() == link.Hash() {
+		if link.IsMsg(m) {
 			msg = m
 		}
 	}
@@ -388,7 +388,7 @@ func (i *indexer) instrumentMsg(ctx context.Context, link *MsgLink) error {
 
 	var receipt xchain.Receipt
 	for _, r := range receiptBlock.Receipts {
-		if r.Hash() == link.Hash() {
+		if link.IsReceipt(r) {
 			receipt = r
 		}
 	}

--- a/octane/evmengine/keeper/db.go
+++ b/octane/evmengine/keeper/db.go
@@ -1,8 +1,10 @@
 package keeper
 
 import (
+	"bytes"
 	"context"
 
+	"github.com/omni-network/omni/lib/cast"
 	"github.com/omni-network/omni/lib/errors"
 
 	"github.com/ethereum/go-ethereum/beacon/engine"
@@ -11,8 +13,8 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
-func (h *ExecutionHead) Hash() common.Hash {
-	return common.BytesToHash(h.GetBlockHash())
+func (h *ExecutionHead) Hash() (common.Hash, error) {
+	return cast.EthHash(h.GetBlockHash())
 }
 
 // executionHeadID is the ID of the singleton execution head row in the database.
@@ -22,7 +24,7 @@ const executionHeadID = 1
 func (k *Keeper) InsertGenesisHead(ctx context.Context, executionBlockHash []byte) error {
 	if len(executionBlockHash) != common.HashLength {
 		return errors.New("invalid execution block hash length", "length", len(executionBlockHash))
-	} else if common.BytesToHash(executionBlockHash) == (common.Hash{}) {
+	} else if bytes.Equal(executionBlockHash, common.Hash{}.Bytes()) {
 		return errors.New("invalid zero execution block hash")
 	}
 

--- a/octane/evmengine/keeper/keeper.go
+++ b/octane/evmengine/keeper/keeper.go
@@ -132,12 +132,16 @@ func (k *Keeper) parseAndVerifyProposedPayload(ctx context.Context, msg *types.M
 	if err != nil {
 		return engine.ExecutableData{}, errors.Wrap(err, "latest execution block")
 	}
+	headHash, err := head.Hash()
+	if err != nil {
+		return engine.ExecutableData{}, err
+	}
 
 	// Ensure the parent hash and block height matches
 	if payload.Number != head.GetBlockHeight()+1 {
 		return engine.ExecutableData{}, errors.New("invalid proposed payload number", "proposed", payload.Number, "head", head.GetBlockHeight())
-	} else if payload.ParentHash != head.Hash() {
-		return engine.ExecutableData{}, errors.New("invalid proposed payload parent hash", "proposed", payload.ParentHash, "head", head.Hash())
+	} else if payload.ParentHash != headHash {
+		return engine.ExecutableData{}, errors.New("invalid proposed payload parent hash", "proposed", payload.ParentHash, "head", headHash)
 	}
 
 	// Ensure the payload timestamp is after latest execution block and before or equaled to the current consensus block.
@@ -153,8 +157,8 @@ func (k *Keeper) parseAndVerifyProposedPayload(ctx context.Context, msg *types.M
 	}
 
 	// Ensure the Randao Digest is equaled to parent hash as this is our workaround at this point.
-	if payload.Random != head.Hash() {
-		return engine.ExecutableData{}, errors.New("invalid payload random", "proposed", payload.Random, "latest", head.Hash())
+	if payload.Random != headHash {
+		return engine.ExecutableData{}, errors.New("invalid payload random", "proposed", payload.Random, "latest", headHash)
 	}
 
 	return payload, nil

--- a/octane/evmengine/keeper/proposal_server_internal_test.go
+++ b/octane/evmengine/keeper/proposal_server_internal_test.go
@@ -7,10 +7,7 @@ import (
 
 	"github.com/omni-network/omni/lib/ethclient"
 	"github.com/omni-network/omni/lib/expbackoff"
-	"github.com/omni-network/omni/lib/tutil"
 	"github.com/omni-network/omni/octane/evmengine/types"
-
-	cmtproto "github.com/cometbft/cometbft/proto/tendermint/types"
 
 	"github.com/ethereum/go-ethereum/beacon/engine"
 	"github.com/ethereum/go-ethereum/common"
@@ -30,7 +27,7 @@ func Test_proposalServer_ExecutionPayload(t *testing.T) {
 	mockEngine, err := newMockEngineAPI(0)
 	require.NoError(t, err)
 
-	sdkCtx, storeService := setupCtxStore(t, &cmtproto.Header{AppHash: tutil.RandomHash().Bytes()})
+	sdkCtx, storeService := setupCtxStore(t, nil)
 	sdkCtx = sdkCtx.WithExecMode(sdk.ExecModeFinalize)
 
 	frp := newRandomFeeRecipientProvider()

--- a/octane/evmengine/types/tx.go
+++ b/octane/evmengine/types/tx.go
@@ -19,7 +19,12 @@ func (l *EVMEvent) ToEthLog() (ethtypes.Log, error) {
 
 	topics := make([]common.Hash, 0, len(l.Topics))
 	for _, t := range l.Topics {
-		topics = append(topics, common.BytesToHash(t))
+		hash, err := cast.EthHash(t)
+		if err != nil {
+			return ethtypes.Log{}, err
+		}
+
+		topics = append(topics, hash)
 	}
 
 	addr, err := cast.EthAddress(l.Address)

--- a/scripts/verifypr/verify.go
+++ b/scripts/verifypr/verify.go
@@ -3,12 +3,13 @@ package main
 
 import (
 	"encoding/json"
-	"errors"
 	"fmt"
 	"log"
 	"os"
 	"regexp"
 	"strings"
+
+	"github.com/omni-network/omni/lib/errors"
 
 	cc "github.com/leodido/go-conventionalcommits"
 	"github.com/leodido/go-conventionalcommits/parser"
@@ -80,7 +81,7 @@ func verify(commitMsg string) error {
 	m.WithTypes(cc.TypesConventional)
 	msg, err := m.Parse([]byte(commitMsg))
 	if err != nil {
-		return fmt.Errorf("parse conventional commit message: %w", err)
+		return errors.Wrap(err, "parse conventional commit message")
 	}
 
 	commit, ok := msg.(*cc.ConventionalCommit)


### PR DESCRIPTION
Prevent usage of `common.BytesTo(Address/Hash)` which silently pads or trim to the correct length. Rather use `cast` package for explicit length checks.

issue: none