### PR TITLE
chore(xfeemngr): Add info logs to gas price and native token rate syncing

### DIFF
--- a/monitor/xfeemngr/contract/bound.go
+++ b/monitor/xfeemngr/contract/bound.go
@@ -10,6 +10,7 @@ import (
 	"github.com/omni-network/omni/lib/ethclient"
 	"github.com/omni-network/omni/lib/ethclient/ethbackend"
 	"github.com/omni-network/omni/lib/evmchain"
+	"github.com/omni-network/omni/lib/log"
 	"github.com/omni-network/omni/lib/netconf"
 	"github.com/omni-network/omni/lib/umath"
 
@@ -87,6 +88,7 @@ func (c BoundFeeOracleV1) SetGasPriceOn(ctx context.Context, destChainID uint64,
 		return errors.Wrap(err, "tx opts")
 	}
 
+	log.Info(ctx, "Setting gas price on chain", "destination_chain_id", destChainID, "rate", gasPrice.Int64())
 	tx, err := c.bound.SetGasPrice(txOpts, destChainID, gasPrice)
 	if err != nil {
 		return errors.Wrap(err, "set gas price")
@@ -109,6 +111,7 @@ func (c BoundFeeOracleV1) SetToNativeRate(ctx context.Context, destChainID uint6
 		return errors.Wrap(err, "tx opts")
 	}
 
+	log.Info(ctx, "Setting native rate on chain", "destination_chain_id", destChainID, "rate", rate.Int64())
 	tx, err := c.bound.SetToNativeRate(txOpts, destChainID, rate)
 	if err != nil {
 		return errors.Wrap(err, "set conversion rate")

--- a/monitor/xfeemngr/oracle.go
+++ b/monitor/xfeemngr/oracle.go
@@ -120,6 +120,7 @@ func (o feeOracle) syncGasPrice(ctx context.Context, dest evmchain.Metadata) err
 
 	shielded := withGasPriceShield(buffered)
 
+	log.Info(ctx, "Syncing gas price", "buffered", buffered, "buffered_w_shield", shielded, "on_chain", onChain.Uint64())
 	// if on chain gas price is within epsilon of buffered + GasPriceShield, do nothing
 	// The shield helps keep on-chain gas prices higher than live gas prices
 	if inEpsilon(float64(onChain.Uint64()), float64(shielded), 0.001) {
@@ -206,6 +207,7 @@ func (o feeOracle) syncToNativeRate(ctx context.Context, dest evmchain.Metadata)
 	// bufferedRate "source token per destination token" is "USD per dest" / "USD per src"
 	bufferedRate := destPrice / srcPrice
 
+	log.Info(ctx, "Syncing native token rate", "source_price", srcPrice, "destination_price", destPrice, "buffered_rate", bufferedRate)
 	if o.chain.NativeToken == tokens.OMNI && dest.NativeToken == tokens.ETH && bufferedRate > maxSaneOmniPerEth {
 		log.Warn(ctx, "Buffered omni-per-eth exceeds sane max", errors.New("unexpected conversion rate"), "buffered", bufferedRate, "max_sane", maxSaneOmniPerEth)
 		bufferedRate = maxSaneOmniPerEth


### PR DESCRIPTION
Add info logs to gas price and native token rate syncing. This will allow us to debug Grafana alert firing further. 
issue: none
