### PR TITLE
chore(contracts/allocs): lock omega allocs to omega genesis

### DIFF
--- a/contracts/allocs/allocs.go
+++ b/contracts/allocs/allocs.go
@@ -26,6 +26,17 @@ var (
 	omegaAlloc   = mustUnmarshalAlloc(omegaJSON)
 )
 
+// locked maps network ID to whether the network's allocations are locked.
+// Once a persistent network has been deployed, its allocs should be locked,
+// so that allocs here are consistent with the live network's genesis.
+var locked = map[netconf.ID]bool{
+	netconf.Omega: true,
+}
+
+func IsLocked(network netconf.ID) bool {
+	return locked[network]
+}
+
 func Alloc(network netconf.ID) (types.GenesisAlloc, error) {
 	switch network {
 	case netconf.Devnet:

--- a/contracts/allocs/allocs_test.go
+++ b/contracts/allocs/allocs_test.go
@@ -1,0 +1,69 @@
+package allocs_test
+
+import (
+	"encoding/json"
+	"math/big"
+	"testing"
+
+	"github.com/omni-network/omni/contracts/allocs"
+	"github.com/omni-network/omni/halo/genutil/evm"
+	"github.com/omni-network/omni/lib/netconf"
+
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/core"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestIsLocked ensures that if a persistent network has it's genesis
+// set in lib/netconf/static.go, then the allocs are locked in contracts/allocs.
+func TestIsLocked(t *testing.T) {
+	t.Parallel()
+
+	for _, network := range netconf.All() {
+		if network.IsEphemeral() {
+			continue
+		}
+
+		if network.Static().ExecutionGenesisJSON == nil {
+			continue
+		}
+
+		require.True(t, allocs.IsLocked(network), "allocs should be locked for %s", network)
+
+		locked := allocs.MustAlloc(network)
+
+		var genesis core.Genesis
+		err := json.Unmarshal(network.Static().ExecutionGenesisJSON, &genesis)
+		require.NoError(t, err)
+
+		precompile := evm.PrecompilesAlloc()
+		prefund, err := evm.PrefundAlloc(network)
+		require.NoError(t, err)
+
+		for addr, acc := range genesis.Alloc {
+			if _, ok := precompile[addr]; ok {
+				continue
+			}
+
+			if _, ok := prefund[addr]; ok {
+				continue
+			}
+
+			lockedAcc, ok := locked[addr]
+			require.True(t, ok, "missing locked alloc for %s", addr)
+			require.Equal(t, hexBytes(acc.Code), hexBytes(lockedAcc.Code), "code mismatch for %s", addr)
+			require.Equal(t, hexBig(acc.Balance), hexBig(lockedAcc.Balance), "balance mismatch for %s", addr)
+			require.Equal(t, acc.Nonce, lockedAcc.Nonce, "nonce mismatch for %s", addr)
+
+			for key, val := range acc.Storage {
+				lockedVal, ok := lockedAcc.Storage[key]
+				require.True(t, ok, "missing storage key %s for %s", key, addr)
+				require.Equal(t, hexBytes(val[:]), hexBytes(lockedVal[:]), "storage mismatch for %s[%s]", addr, key)
+			}
+		}
+	}
+}
+
+func hexBytes(b []byte) string { return hexutil.Encode(b) }
+func hexBig(b *big.Int) string { return hexutil.EncodeBig(b) }

--- a/contracts/allocs/scripts/genallocs.go
+++ b/contracts/allocs/scripts/genallocs.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"os/exec"
 
+	"github.com/omni-network/omni/contracts/allocs"
 	"github.com/omni-network/omni/contracts/bindings"
 	"github.com/omni-network/omni/e2e/app/eoa"
 	"github.com/omni-network/omni/halo/genutil/evm"
@@ -40,6 +41,10 @@ func genallocs() error {
 	for _, network := range netconf.All() {
 		// always skip simnet. skip mainnet until it is required
 		if network == netconf.Simnet || network == netconf.Mainnet {
+			continue
+		}
+
+		if allocs.IsLocked(network) {
 			continue
 		}
 

--- a/halo/genutil/evm/evm.go
+++ b/halo/genutil/evm/evm.go
@@ -42,7 +42,7 @@ func MakeGenesis(network netconf.ID) (core.Genesis, error) {
 		GasLimit:   miner.DefaultConfig.GasCeil,
 		BaseFee:    big.NewInt(params.InitialBaseFee),
 		Difficulty: big.NewInt(0),
-		Alloc:      mergeAllocs(precompilesAlloc(), predeps, prefunds),
+		Alloc:      mergeAllocs(PrecompilesAlloc(), predeps, prefunds),
 	}, nil
 }
 
@@ -75,7 +75,7 @@ func defaultChainConfig(network netconf.ID) *params.ChainConfig {
 // precompile balances are set to 1 as a performance optimization, as done in geth.
 //
 //nolint:forbidigo // Explicitly use BytesToAddress with left padding.
-func precompilesAlloc() types.GenesisAlloc {
+func PrecompilesAlloc() types.GenesisAlloc {
 	return types.GenesisAlloc{
 		common.BytesToAddress([]byte{1}): {Balance: big.NewInt(1)}, // ECRecover
 		common.BytesToAddress([]byte{2}): {Balance: big.NewInt(1)}, // SHA256


### PR DESCRIPTION
Lock omega allocs to those used at deployment.

issue: none