### PR TITLE
chore(ci): add npm dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,3 +5,11 @@ updates:
   schedule:
     interval: "daily"
   labels: []
+- package-ecosystem: "npm"
+  directories:
+    - "/docs/website"
+    - "/contracts/avs"
+    - "/contracts/core"
+  schedule:
+    interval: "daily"
+  labels: []


### PR DESCRIPTION
Add ci for dependabot to open PRs for npm packages. 

issue: #2060
