### PR TITLE
fix(octane/keeper): retry fecthing evm event logs

### DIFF
--- a/octane/evmengine/keeper/abci.go
+++ b/octane/evmengine/keeper/abci.go
@@ -191,6 +191,7 @@ func (k *Keeper) PostFinalize(ctx sdk.Context) error {
 	logAttr := slog.Int64("next_height", nextHeight)
 	log.Debug(ctx, "Starting optimistic EVM payload build", logAttr)
 
+	// No need to wrap this in retryForever since this is a best-effort optimisation, if it fails, just skip it.
 	fcr, err := k.startBuild(ctx, appHash, timestamp)
 	if err != nil || isUnknown(fcr.PayloadStatus) {
 		log.Warn(ctx, "Starting optimistic build failed", err, logAttr)

--- a/octane/evmengine/keeper/evmmsgs.go
+++ b/octane/evmengine/keeper/evmmsgs.go
@@ -22,12 +22,12 @@ func (k *Keeper) evmEvents(ctx context.Context, blockHash common.Hash) ([]*types
 			ll, err := proc.Prepare(ctx, blockHash)
 			if err != nil {
 				log.Warn(ctx, "Failed fetching evm events (will retry)", err, "proc", proc.Name())
-				return false, nil
+				return false, nil // Retry
 			}
 
 			events = append(events, ll...)
 
-			return true, nil
+			return true, nil // Done
 		})
 		if err != nil {
 			return nil, err

--- a/octane/evmengine/keeper/evmmsgs.go
+++ b/octane/evmengine/keeper/evmmsgs.go
@@ -44,6 +44,8 @@ func (k *Keeper) evmEvents(ctx context.Context, blockHash common.Hash) ([]*types
 		if cmp := bytes.Compare(events[i].Address, events[j].Address); cmp != 0 {
 			return cmp < 0
 		}
+
+		// TODO: replace this with sort.CompareFunc in next network upgrade which is more performant but has slightly different results
 		topicI := slices.Concat(events[i].Topics...)
 		topicJ := slices.Concat(events[j].Topics...)
 		if cmp := bytes.Compare(topicI, topicJ); cmp != 0 {

--- a/octane/evmengine/keeper/evmmsgs.go
+++ b/octane/evmengine/keeper/evmmsgs.go
@@ -7,6 +7,7 @@ import (
 	"sort"
 
 	"github.com/omni-network/omni/lib/errors"
+	"github.com/omni-network/omni/lib/log"
 	"github.com/omni-network/omni/octane/evmengine/types"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -16,17 +17,25 @@ import (
 func (k *Keeper) evmEvents(ctx context.Context, blockHash common.Hash) ([]*types.EVMEvent, error) {
 	var events []*types.EVMEvent
 	for _, proc := range k.eventProcs {
-		ll, err := proc.Prepare(ctx, blockHash)
-		if err != nil {
-			return nil, errors.Wrap(err, "prepare msgs")
-		}
-		for _, log := range ll {
-			if err := log.Verify(); err != nil {
-				return nil, errors.Wrap(err, "verify log")
+		err := retryForever(ctx, func(ctx context.Context) (bool, error) {
+			ll, err := proc.Prepare(ctx, blockHash)
+			if err != nil {
+				log.Warn(ctx, "Failed fetching evm logs (will retry)", err, "proc", proc)
+				return false, nil
 			}
-		}
+			// Verify all logs
+			for _, l := range ll {
+				if err := l.Verify(); err != nil {
+					return false, errors.Wrap(err, "verify log")
+				}
+			}
+			events = append(events, ll...)
 
-		events = append(events, ll...)
+			return true, nil
+		})
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	// Sort by Address > Topics > Data
@@ -35,8 +44,6 @@ func (k *Keeper) evmEvents(ctx context.Context, blockHash common.Hash) ([]*types
 		if cmp := bytes.Compare(events[i].Address, events[j].Address); cmp != 0 {
 			return cmp < 0
 		}
-
-		// TODO: replace this with sort.CompareFunc in next network upgrade which is more performant but has slightly different results
 		topicI := slices.Concat(events[i].Topics...)
 		topicJ := slices.Concat(events[j].Topics...)
 		if cmp := bytes.Compare(topicI, topicJ); cmp != 0 {

--- a/octane/evmengine/keeper/helpers.go
+++ b/octane/evmengine/keeper/helpers.go
@@ -16,6 +16,11 @@ var (
 	backoffFunc   = expbackoff.New
 )
 
+// retryForever retries the given function forever until it returns true or an error.
+// In order for the function to be retried, it must return false and no error.
+//
+// Networking (any IO) is non-deterministic and can fail with temporary errors.
+// Keeper logic must however be deterministic, retrying forever mitigates this.
 func retryForever(ctx context.Context, fn func(ctx context.Context) (bool, error)) error {
 	backoffFuncMu.RLock()
 	backoff := backoffFunc(ctx)

--- a/octane/evmengine/keeper/msg_server.go
+++ b/octane/evmengine/keeper/msg_server.go
@@ -46,12 +46,13 @@ func (s msgServer) ExecutionPayload(ctx context.Context, msg *types.MsgExecution
 			// This should never happen. This node will stall now.
 			log.Error(ctx, "Processing finalized payload failed; payload invalid [BUG]", err)
 
-			return false, err // Don't retry, error out.
+			return false, err // // Abort, don't retry
 		} else if isSyncing(status) {
+			// Payload pushed, but EVM syncing continue to ForkChoiceUpdate below
 			log.Warn(ctx, "Processing finalized payload; evm syncing", nil)
 		}
 
-		return true, nil // We are done, don't retry
+		return true, nil // Done
 	})
 	if err != nil {
 		return nil, err
@@ -81,10 +82,10 @@ func (s msgServer) ExecutionPayload(ctx context.Context, msg *types.MsgExecution
 			log.Error(ctx, "Processing finalized payload failed; forkchoice update invalid [BUG]", err,
 				"payload_height", payload.Number)
 
-			return false, err // Don't retry
+			return false, err // Abort, don't retry
 		}
 
-		return true, nil
+		return true, nil // Done
 	})
 	if err != nil {
 		return nil, err

--- a/octane/evmengine/keeper/proposal_server.go
+++ b/octane/evmengine/keeper/proposal_server.go
@@ -33,14 +33,14 @@ func (s proposalServer) ExecutionPayload(ctx context.Context, msg *types.MsgExec
 
 			return false, nil // Retry
 		} else if invalid, err := isInvalid(status); invalid {
-			return false, errors.Wrap(err, "invalid payload, rejecting proposal") // Don't retry
+			return false, errors.Wrap(err, "invalid payload, rejecting proposal") // Abort, don't retry
 		} else if isSyncing(status) {
 			// If this is initial sync, we need to continue and set a target head to sync to, so don't retry.
 			log.Warn(ctx, "Can't properly verifying proposal: evm syncing", err,
 				"payload_height", payload.Number)
 		}
 
-		return true, nil // We are done, don't retry.
+		return true, nil // Done
 	})
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Fixes a possible chain halting issue when a networking error causes fetching evm event logs to fail.

Wrap this like all other network calls inside keeper logic inside a `retryForever`.

issue: none