### PR TITLE
fix(cchain): check length of publickey after unmarshal

### DIFF
--- a/lib/cchain/types.go
+++ b/lib/cchain/types.go
@@ -8,6 +8,7 @@ import (
 	"github.com/omni-network/omni/lib/umath"
 
 	cmtcrypto "github.com/cometbft/cometbft/crypto"
+	k1 "github.com/cometbft/cometbft/crypto/secp256k1"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
@@ -99,6 +100,10 @@ func (v SDKValidator) ConsensusCmtAddr() (cmtcrypto.Address, error) {
 	err := proto.Unmarshal(v.ConsensusPubkey.Value, pk)
 	if err != nil {
 		return nil, errors.Wrap(err, "unmarshal consensus pubkey")
+	}
+
+	if len(pk.Bytes()) != k1.PubKeySize {
+		return nil, errors.Wrap(err, "invalid public key size after unmarshal consensus pubkey")
 	}
 
 	return pk.Address(), nil


### PR DESCRIPTION
This PR adds a check for the size of the public key ensuring it is the expected secp256k1.PubKeySize (33) after unmarshaling the public key. This prevents unexpected panics. 

issue: none
