### PR TITLE
refactor(e2e/eoa): Setup mainnet roles and eoa accounts with Fireblocks 

### DIFF
--- a/cli/cmd/register_test.go
+++ b/cli/cmd/register_test.go
@@ -141,7 +141,7 @@ func testDeployCfg(t *testing.T) deployConfig {
 
 	return deployConfig{
 		deployer:         eoa.MustAddress(netconf.Devnet, eoa.RoleDeployer),
-		owner:            eoa.MustAddress(netconf.Devnet, eoa.RoleOwner),
+		owner:            eoa.MustAddress(netconf.Devnet, eoa.RoleManager),
 		eigen:            devnetEigenDeployments(t),
 		metadataURI:      "https://test-operator.com",
 		omniChainID:      netconf.Devnet.Static().OmniExecutionChainID,
@@ -245,7 +245,7 @@ func makeEOAS(t *testing.T, backend *ethbackend.Backend) EOAS {
 	require.NoError(t, err)
 
 	return EOAS{
-		AVSOwner:     eoa.MustAddress(netconf.Devnet, eoa.RoleOwner),
+		AVSOwner:     eoa.MustAddress(netconf.Devnet, eoa.RoleManager),
 		EigenOwner:   anvil.DevAccount9(), // account used to deploy eigen contracts
 		Operator1:    operator1,
 		Operator1Key: operator1Key,

--- a/cli/cmd/register_test.go
+++ b/cli/cmd/register_test.go
@@ -141,7 +141,7 @@ func testDeployCfg(t *testing.T) deployConfig {
 
 	return deployConfig{
 		deployer:         eoa.MustAddress(netconf.Devnet, eoa.RoleDeployer),
-		owner:            eoa.MustAddress(netconf.Devnet, eoa.RoleAdmin),
+		owner:            eoa.MustAddress(netconf.Devnet, eoa.RoleOwner),
 		eigen:            devnetEigenDeployments(t),
 		metadataURI:      "https://test-operator.com",
 		omniChainID:      netconf.Devnet.Static().OmniExecutionChainID,
@@ -245,7 +245,7 @@ func makeEOAS(t *testing.T, backend *ethbackend.Backend) EOAS {
 	require.NoError(t, err)
 
 	return EOAS{
-		AVSOwner:     eoa.MustAddress(netconf.Devnet, eoa.RoleAdmin),
+		AVSOwner:     eoa.MustAddress(netconf.Devnet, eoa.RoleOwner),
 		EigenOwner:   anvil.DevAccount9(), // account used to deploy eigen contracts
 		Operator1:    operator1,
 		Operator1Key: operator1Key,

--- a/cli/cmd/register_test.go
+++ b/cli/cmd/register_test.go
@@ -110,7 +110,7 @@ type eigenDeployments struct {
 type deployConfig struct {
 	eigen            eigenDeployments
 	deployer         common.Address
-	owner            common.Address
+	manager          common.Address
 	portal           common.Address
 	omniChainID      uint64
 	metadataURI      string
@@ -141,7 +141,7 @@ func testDeployCfg(t *testing.T) deployConfig {
 
 	return deployConfig{
 		deployer:         eoa.MustAddress(netconf.Devnet, eoa.RoleDeployer),
-		owner:            eoa.MustAddress(netconf.Devnet, eoa.RoleManager),
+		manager:          eoa.MustAddress(netconf.Devnet, eoa.RoleManager),
 		eigen:            devnetEigenDeployments(t),
 		metadataURI:      "https://test-operator.com",
 		omniChainID:      netconf.Devnet.Static().OmniExecutionChainID,
@@ -168,7 +168,7 @@ func deployAVS(t *testing.T, ctx context.Context, backend *ethbackend.Backend) c
 	_, err = backend.WaitMined(ctx, tx)
 	require.NoError(t, err)
 
-	addr, tx, _, err := bindings.DeployTransparentUpgradeableProxy(txOpts, backend, impl, cfg.owner, packInitialzer(t, cfg))
+	addr, tx, _, err := bindings.DeployTransparentUpgradeableProxy(txOpts, backend, impl, cfg.manager, packInitialzer(t, cfg))
 	require.NoError(t, err)
 	_, err = backend.WaitMined(ctx, tx)
 	require.NoError(t, err)
@@ -185,7 +185,7 @@ func packInitialzer(t *testing.T, cfg deployConfig) []byte {
 	t.Helper()
 
 	enc, err := avsABI.Pack("initialize",
-		cfg.owner, cfg.portal, cfg.omniChainID, cfg.ethStakeInbox,
+		cfg.manager, cfg.portal, cfg.omniChainID, cfg.ethStakeInbox,
 		cfg.minOperatorStake, cfg.maxOperatorCount, cfg.stratParams,
 		cfg.metadataURI, cfg.allowlistEnabled)
 	require.NoError(t, err)
@@ -204,7 +204,7 @@ func devnetEigenDeployments(t *testing.T) eigenDeployments {
 }
 
 type EOAS struct {
-	AVSOwner     common.Address
+	AVSManager   common.Address
 	EigenOwner   common.Address
 	Operator1    common.Address
 	Operator1Key *ecdsa.PrivateKey
@@ -245,7 +245,7 @@ func makeEOAS(t *testing.T, backend *ethbackend.Backend) EOAS {
 	require.NoError(t, err)
 
 	return EOAS{
-		AVSOwner:     eoa.MustAddress(netconf.Devnet, eoa.RoleManager),
+		AVSManager:   eoa.MustAddress(netconf.Devnet, eoa.RoleManager),
 		EigenOwner:   anvil.DevAccount9(), // account used to deploy eigen contracts
 		Operator1:    operator1,
 		Operator1Key: operator1Key,

--- a/contracts/allocs/scripts/genallocs.go
+++ b/contracts/allocs/scripts/genallocs.go
@@ -39,7 +39,7 @@ func genallocs() error {
 		}
 
 		cfg := bindings.AllocPredeploysConfig{
-			Admin:                  eoa.MustAddress(network, eoa.RoleAdmin),
+			Admin:                  eoa.MustAddress(network, eoa.RoleOwner),
 			ChainId:                new(big.Int).SetUint64(network.Static().OmniExecutionChainID),
 			EnableStakingAllowlist: network.IsProtected(),
 			Output:                 "allocs/" + network.String() + ".json",

--- a/contracts/allocs/scripts/genallocs.go
+++ b/contracts/allocs/scripts/genallocs.go
@@ -39,7 +39,7 @@ func genallocs() error {
 		}
 
 		cfg := bindings.AllocPredeploysConfig{
-			Admin:                  eoa.MustAddress(network, eoa.RoleOwner),
+			Admin:                  eoa.MustAddress(network, eoa.RoleManager),
 			ChainId:                new(big.Int).SetUint64(network.Static().OmniExecutionChainID),
 			EnableStakingAllowlist: network.IsProtected(),
 			Output:                 "allocs/" + network.String() + ".json",

--- a/contracts/bindings/omnigaspump.go
+++ b/contracts/bindings/omnigaspump.go
@@ -34,7 +34,7 @@ type OmniGasPumpInitParams struct {
 	GasStation common.Address
 	Oracle     common.Address
 	Portal     common.Address
-	Owner      common.Address
+	Manager    common.Address
 	MaxSwap    *big.Int
 	Toll       *big.Int
 }

--- a/e2e/app/admin/allowoperator.go
+++ b/e2e/app/admin/allowoperator.go
@@ -61,7 +61,7 @@ func AllowOperators(ctx context.Context, def app.Definition, cfg Config) error {
 		return nil
 	}
 
-	txOpts, err := backend.BindOpts(ctx, eoa.MustAddress(network, eoa.RoleOwner))
+	txOpts, err := backend.BindOpts(ctx, eoa.MustAddress(network, eoa.RoleManager))
 	if err != nil {
 		return errors.Wrap(err, "bind tx opts")
 	}

--- a/e2e/app/admin/allowoperator.go
+++ b/e2e/app/admin/allowoperator.go
@@ -61,7 +61,7 @@ func AllowOperators(ctx context.Context, def app.Definition, cfg Config) error {
 		return nil
 	}
 
-	txOpts, err := backend.BindOpts(ctx, eoa.MustAddress(network, eoa.RoleAdmin))
+	txOpts, err := backend.BindOpts(ctx, eoa.MustAddress(network, eoa.RoleOwner))
 	if err != nil {
 		return errors.Wrap(err, "bind tx opts")
 	}

--- a/e2e/app/admin/common.go
+++ b/e2e/app/admin/common.go
@@ -47,7 +47,7 @@ type chain struct {
 // setup returns common resources for all admin operations.
 func setup(def app.Definition, cfg Config) shared {
 	netID := def.Testnet.Network
-	admin := eoa.MustAddress(netID, eoa.RoleAdmin)
+	admin := eoa.MustAddress(netID, eoa.RoleOwner)
 	deployer := eoa.MustAddress(netID, eoa.RoleDeployer)
 	endpoints := app.ExternalEndpoints(def)
 	network := app.NetworkFromDef(def)

--- a/e2e/app/admin/common.go
+++ b/e2e/app/admin/common.go
@@ -29,7 +29,7 @@ const omniEVMName = "omni_evm"
 
 // shared contains common resources for all admin operations.
 type shared struct {
-	owner       common.Address
+	manager     common.Address
 	upgrader    common.Address
 	deployer    common.Address
 	endpoints   xchain.RPCEndpoints
@@ -57,7 +57,7 @@ func setup(def app.Definition, cfg Config) shared {
 	// addrs set lazily in setupChain
 
 	return shared{
-		owner:       owner,
+		manager:     owner,
 		upgrader:    upgrader,
 		deployer:    deployer,
 		endpoints:   endpoints,

--- a/e2e/app/admin/common.go
+++ b/e2e/app/admin/common.go
@@ -29,7 +29,8 @@ const omniEVMName = "omni_evm"
 
 // shared contains common resources for all admin operations.
 type shared struct {
-	admin       common.Address
+	owner       common.Address
+	upgrader    common.Address
 	deployer    common.Address
 	endpoints   xchain.RPCEndpoints
 	network     netconf.Network
@@ -47,7 +48,8 @@ type chain struct {
 // setup returns common resources for all admin operations.
 func setup(def app.Definition, cfg Config) shared {
 	netID := def.Testnet.Network
-	admin := eoa.MustAddress(netID, eoa.RoleOwner)
+	owner := eoa.MustAddress(netID, eoa.RoleManager)
+	upgrader := eoa.MustAddress(netID, eoa.RoleUpgrader)
 	deployer := eoa.MustAddress(netID, eoa.RoleDeployer)
 	endpoints := app.ExternalEndpoints(def)
 	network := app.NetworkFromDef(def)
@@ -55,7 +57,8 @@ func setup(def app.Definition, cfg Config) shared {
 	// addrs set lazily in setupChain
 
 	return shared{
-		admin:       admin,
+		owner:       owner,
+		upgrader:    upgrader,
 		deployer:    deployer,
 		endpoints:   endpoints,
 		network:     network,

--- a/e2e/app/admin/common.go
+++ b/e2e/app/admin/common.go
@@ -48,7 +48,7 @@ type chain struct {
 // setup returns common resources for all admin operations.
 func setup(def app.Definition, cfg Config) shared {
 	netID := def.Testnet.Network
-	owner := eoa.MustAddress(netID, eoa.RoleManager)
+	manager := eoa.MustAddress(netID, eoa.RoleManager)
 	upgrader := eoa.MustAddress(netID, eoa.RoleUpgrader)
 	deployer := eoa.MustAddress(netID, eoa.RoleDeployer)
 	endpoints := app.ExternalEndpoints(def)
@@ -57,7 +57,7 @@ func setup(def app.Definition, cfg Config) shared {
 	// addrs set lazily in setupChain
 
 	return shared{
-		manager:     owner,
+		manager:     manager,
 		upgrader:    upgrader,
 		deployer:    deployer,
 		endpoints:   endpoints,

--- a/e2e/app/admin/pausebridge.go
+++ b/e2e/app/admin/pausebridge.go
@@ -13,12 +13,12 @@ import (
 func pauseBridge(ctx context.Context, s shared, c chain, addr common.Address, actionID [32]byte, actionLabel string) error {
 	log.Info(ctx, "Pausing bridge...", "chain", c.Name, "addr", addr, "action", actionLabel)
 
-	calldata, err := adminABI.Pack("pauseBridge", s.owner, addr, actionID)
+	calldata, err := adminABI.Pack("pauseBridge", s.manager, addr, actionID)
 	if err != nil {
 		return errors.Wrap(err, "pack calldata", "chain", c.Name)
 	}
 
-	out, err := s.runForge(ctx, c.rpc, calldata, s.owner)
+	out, err := s.runForge(ctx, c.rpc, calldata, s.manager)
 	if err != nil {
 		return errors.Wrap(err, "run forge", "out", out, "chain", c.Name)
 	}
@@ -32,12 +32,12 @@ func pauseBridge(ctx context.Context, s shared, c chain, addr common.Address, ac
 func unpauseBridge(ctx context.Context, s shared, c chain, addr common.Address, actionID [32]byte, actionLabel string) error {
 	log.Info(ctx, "Unpausing bridge...", "chain", c.Name, "addr", addr, "action", actionLabel)
 
-	calldata, err := adminABI.Pack("unpauseBridge", s.owner, addr, actionID)
+	calldata, err := adminABI.Pack("unpauseBridge", s.manager, addr, actionID)
 	if err != nil {
 		return errors.Wrap(err, "pack calldata", "chain", c.Name)
 	}
 
-	out, err := s.runForge(ctx, c.rpc, calldata, s.owner)
+	out, err := s.runForge(ctx, c.rpc, calldata, s.manager)
 	if err != nil {
 		return errors.Wrap(err, "run forge", "out", out, "chain", c.Name)
 	}

--- a/e2e/app/admin/pausebridge.go
+++ b/e2e/app/admin/pausebridge.go
@@ -13,12 +13,12 @@ import (
 func pauseBridge(ctx context.Context, s shared, c chain, addr common.Address, actionID [32]byte, actionLabel string) error {
 	log.Info(ctx, "Pausing bridge...", "chain", c.Name, "addr", addr, "action", actionLabel)
 
-	calldata, err := adminABI.Pack("pauseBridge", s.admin, addr, actionID)
+	calldata, err := adminABI.Pack("pauseBridge", s.owner, addr, actionID)
 	if err != nil {
 		return errors.Wrap(err, "pack calldata", "chain", c.Name)
 	}
 
-	out, err := s.runForge(ctx, c.rpc, calldata, s.admin)
+	out, err := s.runForge(ctx, c.rpc, calldata, s.owner)
 	if err != nil {
 		return errors.Wrap(err, "run forge", "out", out, "chain", c.Name)
 	}
@@ -32,12 +32,12 @@ func pauseBridge(ctx context.Context, s shared, c chain, addr common.Address, ac
 func unpauseBridge(ctx context.Context, s shared, c chain, addr common.Address, actionID [32]byte, actionLabel string) error {
 	log.Info(ctx, "Unpausing bridge...", "chain", c.Name, "addr", addr, "action", actionLabel)
 
-	calldata, err := adminABI.Pack("unpauseBridge", s.admin, addr, actionID)
+	calldata, err := adminABI.Pack("unpauseBridge", s.owner, addr, actionID)
 	if err != nil {
 		return errors.Wrap(err, "pack calldata", "chain", c.Name)
 	}
 
-	out, err := s.runForge(ctx, c.rpc, calldata, s.admin)
+	out, err := s.runForge(ctx, c.rpc, calldata, s.owner)
 	if err != nil {
 		return errors.Wrap(err, "run forge", "out", out, "chain", c.Name)
 	}

--- a/e2e/app/admin/pauseportal.go
+++ b/e2e/app/admin/pauseportal.go
@@ -11,12 +11,12 @@ import (
 func pausePortal(ctx context.Context, s shared, c chain) error {
 	log.Info(ctx, "Pausing portal...", "chain", c.Name, "addr", c.PortalAddress)
 
-	calldata, err := adminABI.Pack("pausePortal", s.owner, c.PortalAddress)
+	calldata, err := adminABI.Pack("pausePortal", s.manager, c.PortalAddress)
 	if err != nil {
 		return errors.Wrap(err, "pack calldata", "chain", c.Name)
 	}
 
-	out, err := s.runForge(ctx, c.rpc, calldata, s.owner)
+	out, err := s.runForge(ctx, c.rpc, calldata, s.manager)
 	if err != nil {
 		return errors.Wrap(err, "run forge", "out", out, "chain", c.Name)
 	}
@@ -30,12 +30,12 @@ func pausePortal(ctx context.Context, s shared, c chain) error {
 func unpausePortal(ctx context.Context, s shared, c chain) error {
 	log.Info(ctx, "Unpausing portal...", "chain", c.Name, "addr", c.PortalAddress)
 
-	calldata, err := adminABI.Pack("unpausePortal", s.owner, c.PortalAddress)
+	calldata, err := adminABI.Pack("unpausePortal", s.manager, c.PortalAddress)
 	if err != nil {
 		return errors.Wrap(err, "pack calldata", "chain", c.Name)
 	}
 
-	out, err := s.runForge(ctx, c.rpc, calldata, s.owner)
+	out, err := s.runForge(ctx, c.rpc, calldata, s.manager)
 	if err != nil {
 		return errors.Wrap(err, "run forge", "out", out, "chain", c.Name)
 	}

--- a/e2e/app/admin/pauseportal.go
+++ b/e2e/app/admin/pauseportal.go
@@ -11,12 +11,12 @@ import (
 func pausePortal(ctx context.Context, s shared, c chain) error {
 	log.Info(ctx, "Pausing portal...", "chain", c.Name, "addr", c.PortalAddress)
 
-	calldata, err := adminABI.Pack("pausePortal", s.admin, c.PortalAddress)
+	calldata, err := adminABI.Pack("pausePortal", s.owner, c.PortalAddress)
 	if err != nil {
 		return errors.Wrap(err, "pack calldata", "chain", c.Name)
 	}
 
-	out, err := s.runForge(ctx, c.rpc, calldata, s.admin)
+	out, err := s.runForge(ctx, c.rpc, calldata, s.owner)
 	if err != nil {
 		return errors.Wrap(err, "run forge", "out", out, "chain", c.Name)
 	}
@@ -30,12 +30,12 @@ func pausePortal(ctx context.Context, s shared, c chain) error {
 func unpausePortal(ctx context.Context, s shared, c chain) error {
 	log.Info(ctx, "Unpausing portal...", "chain", c.Name, "addr", c.PortalAddress)
 
-	calldata, err := adminABI.Pack("unpausePortal", s.admin, c.PortalAddress)
+	calldata, err := adminABI.Pack("unpausePortal", s.owner, c.PortalAddress)
 	if err != nil {
 		return errors.Wrap(err, "pack calldata", "chain", c.Name)
 	}
 
-	out, err := s.runForge(ctx, c.rpc, calldata, s.admin)
+	out, err := s.runForge(ctx, c.rpc, calldata, s.owner)
 	if err != nil {
 		return errors.Wrap(err, "run forge", "out", out, "chain", c.Name)
 	}

--- a/e2e/app/admin/pausexcall.go
+++ b/e2e/app/admin/pausexcall.go
@@ -12,12 +12,12 @@ import (
 func pauseXCall(ctx context.Context, s shared, c chain) error {
 	log.Info(ctx, "Pausing xcall...", "chain", c.Name, "addr", c.PortalAddress)
 
-	calldata, err := adminABI.Pack("pauseXCall", s.admin, c.PortalAddress)
+	calldata, err := adminABI.Pack("pauseXCall", s.owner, c.PortalAddress)
 	if err != nil {
 		return errors.Wrap(err, "pack calldata", "chain", c.Name)
 	}
 
-	out, err := s.runForge(ctx, c.rpc, calldata, s.admin)
+	out, err := s.runForge(ctx, c.rpc, calldata, s.owner)
 	if err != nil {
 		return errors.Wrap(err, "run forge", "out", out, "chain", c.Name)
 	}
@@ -36,12 +36,12 @@ func pauseXCallTo(ctx context.Context, s shared, c chain, toID uint64) error {
 
 	log.Info(ctx, "Pausing xcall...", "chain", c.Name, "to", to.Name, "addr", c.PortalAddress)
 
-	calldata, err := adminABI.Pack("pauseXCallTo", s.admin, c.PortalAddress, to.ID)
+	calldata, err := adminABI.Pack("pauseXCallTo", s.owner, c.PortalAddress, to.ID)
 	if err != nil {
 		return errors.Wrap(err, "pack calldata", "chain", c.Name)
 	}
 
-	out, err := s.runForge(ctx, c.rpc, calldata, s.admin)
+	out, err := s.runForge(ctx, c.rpc, calldata, s.owner)
 	if err != nil {
 		return errors.Wrap(err, "run forge", "out", out, "chain", c.Name)
 	}
@@ -55,12 +55,12 @@ func pauseXCallTo(ctx context.Context, s shared, c chain, toID uint64) error {
 func unpauseXCall(ctx context.Context, s shared, c chain) error {
 	log.Info(ctx, "Unpausing xcall...", "chain", c.Name, "addr", c.PortalAddress)
 
-	calldata, err := adminABI.Pack("unpauseXCall", s.admin, c.PortalAddress)
+	calldata, err := adminABI.Pack("unpauseXCall", s.owner, c.PortalAddress)
 	if err != nil {
 		return errors.Wrap(err, "pack calldata", "chain", c.Name)
 	}
 
-	out, err := s.runForge(ctx, c.rpc, calldata, s.admin)
+	out, err := s.runForge(ctx, c.rpc, calldata, s.owner)
 	if err != nil {
 		return errors.Wrap(err, "run forge", "out", out, "chain", c.Name)
 	}
@@ -79,12 +79,12 @@ func unpauseXCallTo(ctx context.Context, s shared, c chain, toID uint64) error {
 
 	log.Info(ctx, "Unpausing xcall...", "chain", c.Name, "to", to.Name, "addr", c.PortalAddress)
 
-	calldata, err := adminABI.Pack("unpauseXCallTo", s.admin, c.PortalAddress, to.ID)
+	calldata, err := adminABI.Pack("unpauseXCallTo", s.owner, c.PortalAddress, to.ID)
 	if err != nil {
 		return errors.Wrap(err, "pack calldata", "chain", c.Name)
 	}
 
-	out, err := s.runForge(ctx, c.rpc, calldata, s.admin)
+	out, err := s.runForge(ctx, c.rpc, calldata, s.owner)
 	if err != nil {
 		return errors.Wrap(err, "run forge", "out", out, "chain", c.Name)
 	}

--- a/e2e/app/admin/pausexcall.go
+++ b/e2e/app/admin/pausexcall.go
@@ -12,12 +12,12 @@ import (
 func pauseXCall(ctx context.Context, s shared, c chain) error {
 	log.Info(ctx, "Pausing xcall...", "chain", c.Name, "addr", c.PortalAddress)
 
-	calldata, err := adminABI.Pack("pauseXCall", s.owner, c.PortalAddress)
+	calldata, err := adminABI.Pack("pauseXCall", s.manager, c.PortalAddress)
 	if err != nil {
 		return errors.Wrap(err, "pack calldata", "chain", c.Name)
 	}
 
-	out, err := s.runForge(ctx, c.rpc, calldata, s.owner)
+	out, err := s.runForge(ctx, c.rpc, calldata, s.manager)
 	if err != nil {
 		return errors.Wrap(err, "run forge", "out", out, "chain", c.Name)
 	}
@@ -36,12 +36,12 @@ func pauseXCallTo(ctx context.Context, s shared, c chain, toID uint64) error {
 
 	log.Info(ctx, "Pausing xcall...", "chain", c.Name, "to", to.Name, "addr", c.PortalAddress)
 
-	calldata, err := adminABI.Pack("pauseXCallTo", s.owner, c.PortalAddress, to.ID)
+	calldata, err := adminABI.Pack("pauseXCallTo", s.manager, c.PortalAddress, to.ID)
 	if err != nil {
 		return errors.Wrap(err, "pack calldata", "chain", c.Name)
 	}
 
-	out, err := s.runForge(ctx, c.rpc, calldata, s.owner)
+	out, err := s.runForge(ctx, c.rpc, calldata, s.manager)
 	if err != nil {
 		return errors.Wrap(err, "run forge", "out", out, "chain", c.Name)
 	}
@@ -55,12 +55,12 @@ func pauseXCallTo(ctx context.Context, s shared, c chain, toID uint64) error {
 func unpauseXCall(ctx context.Context, s shared, c chain) error {
 	log.Info(ctx, "Unpausing xcall...", "chain", c.Name, "addr", c.PortalAddress)
 
-	calldata, err := adminABI.Pack("unpauseXCall", s.owner, c.PortalAddress)
+	calldata, err := adminABI.Pack("unpauseXCall", s.manager, c.PortalAddress)
 	if err != nil {
 		return errors.Wrap(err, "pack calldata", "chain", c.Name)
 	}
 
-	out, err := s.runForge(ctx, c.rpc, calldata, s.owner)
+	out, err := s.runForge(ctx, c.rpc, calldata, s.manager)
 	if err != nil {
 		return errors.Wrap(err, "run forge", "out", out, "chain", c.Name)
 	}
@@ -79,12 +79,12 @@ func unpauseXCallTo(ctx context.Context, s shared, c chain, toID uint64) error {
 
 	log.Info(ctx, "Unpausing xcall...", "chain", c.Name, "to", to.Name, "addr", c.PortalAddress)
 
-	calldata, err := adminABI.Pack("unpauseXCallTo", s.owner, c.PortalAddress, to.ID)
+	calldata, err := adminABI.Pack("unpauseXCallTo", s.manager, c.PortalAddress, to.ID)
 	if err != nil {
 		return errors.Wrap(err, "pack calldata", "chain", c.Name)
 	}
 
-	out, err := s.runForge(ctx, c.rpc, calldata, s.owner)
+	out, err := s.runForge(ctx, c.rpc, calldata, s.manager)
 	if err != nil {
 		return errors.Wrap(err, "run forge", "out", out, "chain", c.Name)
 	}

--- a/e2e/app/admin/pausexsubmit.go
+++ b/e2e/app/admin/pausexsubmit.go
@@ -12,12 +12,12 @@ import (
 func pauseXSubmit(ctx context.Context, s shared, c chain) error {
 	log.Info(ctx, "Pausing xsubmit...", "chain", c.Name, "addr", c.PortalAddress)
 
-	calldata, err := adminABI.Pack("pauseXSubmit", s.admin, c.PortalAddress)
+	calldata, err := adminABI.Pack("pauseXSubmit", s.owner, c.PortalAddress)
 	if err != nil {
 		return errors.Wrap(err, "pack calldata", "chain", c.Name)
 	}
 
-	out, err := s.runForge(ctx, c.rpc, calldata, s.admin)
+	out, err := s.runForge(ctx, c.rpc, calldata, s.owner)
 	if err != nil {
 		return errors.Wrap(err, "run forge", "out", out, "chain", c.Name)
 	}
@@ -36,12 +36,12 @@ func pauseXSubmitFrom(ctx context.Context, s shared, c chain, fromID uint64) err
 
 	log.Info(ctx, "Pausing xsubmit...", "chain", c.Name, "from", from.Name, "addr", c.PortalAddress)
 
-	calldata, err := adminABI.Pack("pauseXSubmitFrom", s.admin, c.PortalAddress, from.ID)
+	calldata, err := adminABI.Pack("pauseXSubmitFrom", s.owner, c.PortalAddress, from.ID)
 	if err != nil {
 		return errors.Wrap(err, "pack calldata", "chain", c.Name)
 	}
 
-	out, err := s.runForge(ctx, c.rpc, calldata, s.admin)
+	out, err := s.runForge(ctx, c.rpc, calldata, s.owner)
 	if err != nil {
 		return errors.Wrap(err, "run forge", "out", out, "chain", c.Name)
 	}
@@ -55,12 +55,12 @@ func pauseXSubmitFrom(ctx context.Context, s shared, c chain, fromID uint64) err
 func unpauseXSubmit(ctx context.Context, s shared, c chain) error {
 	log.Info(ctx, "Unpausing xsubmit...", "chain", c.Name, "addr", c.PortalAddress)
 
-	calldata, err := adminABI.Pack("unpauseXSubmit", s.admin, c.PortalAddress)
+	calldata, err := adminABI.Pack("unpauseXSubmit", s.owner, c.PortalAddress)
 	if err != nil {
 		return errors.Wrap(err, "pack calldata", "chain", c.Name)
 	}
 
-	out, err := s.runForge(ctx, c.rpc, calldata, s.admin)
+	out, err := s.runForge(ctx, c.rpc, calldata, s.owner)
 	if err != nil {
 		return errors.Wrap(err, "run forge", "out", out, "chain", c.Name)
 	}
@@ -79,12 +79,12 @@ func unpauseXSubmitFrom(ctx context.Context, s shared, c chain, fromID uint64) e
 
 	log.Info(ctx, "Unpausing xsubmit...", "chain", c.Name, "from", from.Name, "addr", c.PortalAddress)
 
-	calldata, err := adminABI.Pack("unpauseXSubmitFrom", s.admin, c.PortalAddress, from.ID)
+	calldata, err := adminABI.Pack("unpauseXSubmitFrom", s.owner, c.PortalAddress, from.ID)
 	if err != nil {
 		return errors.Wrap(err, "pack calldata", "chain", c.Name)
 	}
 
-	out, err := s.runForge(ctx, c.rpc, calldata, s.admin)
+	out, err := s.runForge(ctx, c.rpc, calldata, s.owner)
 	if err != nil {
 		return errors.Wrap(err, "run forge", "out", out, "chain", c.Name)
 	}

--- a/e2e/app/admin/pausexsubmit.go
+++ b/e2e/app/admin/pausexsubmit.go
@@ -12,12 +12,12 @@ import (
 func pauseXSubmit(ctx context.Context, s shared, c chain) error {
 	log.Info(ctx, "Pausing xsubmit...", "chain", c.Name, "addr", c.PortalAddress)
 
-	calldata, err := adminABI.Pack("pauseXSubmit", s.owner, c.PortalAddress)
+	calldata, err := adminABI.Pack("pauseXSubmit", s.manager, c.PortalAddress)
 	if err != nil {
 		return errors.Wrap(err, "pack calldata", "chain", c.Name)
 	}
 
-	out, err := s.runForge(ctx, c.rpc, calldata, s.owner)
+	out, err := s.runForge(ctx, c.rpc, calldata, s.manager)
 	if err != nil {
 		return errors.Wrap(err, "run forge", "out", out, "chain", c.Name)
 	}
@@ -36,12 +36,12 @@ func pauseXSubmitFrom(ctx context.Context, s shared, c chain, fromID uint64) err
 
 	log.Info(ctx, "Pausing xsubmit...", "chain", c.Name, "from", from.Name, "addr", c.PortalAddress)
 
-	calldata, err := adminABI.Pack("pauseXSubmitFrom", s.owner, c.PortalAddress, from.ID)
+	calldata, err := adminABI.Pack("pauseXSubmitFrom", s.manager, c.PortalAddress, from.ID)
 	if err != nil {
 		return errors.Wrap(err, "pack calldata", "chain", c.Name)
 	}
 
-	out, err := s.runForge(ctx, c.rpc, calldata, s.owner)
+	out, err := s.runForge(ctx, c.rpc, calldata, s.manager)
 	if err != nil {
 		return errors.Wrap(err, "run forge", "out", out, "chain", c.Name)
 	}
@@ -55,12 +55,12 @@ func pauseXSubmitFrom(ctx context.Context, s shared, c chain, fromID uint64) err
 func unpauseXSubmit(ctx context.Context, s shared, c chain) error {
 	log.Info(ctx, "Unpausing xsubmit...", "chain", c.Name, "addr", c.PortalAddress)
 
-	calldata, err := adminABI.Pack("unpauseXSubmit", s.owner, c.PortalAddress)
+	calldata, err := adminABI.Pack("unpauseXSubmit", s.manager, c.PortalAddress)
 	if err != nil {
 		return errors.Wrap(err, "pack calldata", "chain", c.Name)
 	}
 
-	out, err := s.runForge(ctx, c.rpc, calldata, s.owner)
+	out, err := s.runForge(ctx, c.rpc, calldata, s.manager)
 	if err != nil {
 		return errors.Wrap(err, "run forge", "out", out, "chain", c.Name)
 	}
@@ -79,12 +79,12 @@ func unpauseXSubmitFrom(ctx context.Context, s shared, c chain, fromID uint64) e
 
 	log.Info(ctx, "Unpausing xsubmit...", "chain", c.Name, "from", from.Name, "addr", c.PortalAddress)
 
-	calldata, err := adminABI.Pack("unpauseXSubmitFrom", s.owner, c.PortalAddress, from.ID)
+	calldata, err := adminABI.Pack("unpauseXSubmitFrom", s.manager, c.PortalAddress, from.ID)
 	if err != nil {
 		return errors.Wrap(err, "pack calldata", "chain", c.Name)
 	}
 
-	out, err := s.runForge(ctx, c.rpc, calldata, s.owner)
+	out, err := s.runForge(ctx, c.rpc, calldata, s.manager)
 	if err != nil {
 		return errors.Wrap(err, "run forge", "out", out, "chain", c.Name)
 	}

--- a/e2e/app/admin/planupgrade.go
+++ b/e2e/app/admin/planupgrade.go
@@ -52,7 +52,7 @@ func PlanUpgrade(ctx context.Context, def app.Definition, cfg Config) error {
 		return errors.Wrap(err, "new staking contract")
 	}
 
-	txOpts, err := backend.BindOpts(ctx, eoa.MustAddress(network, eoa.RoleOwner))
+	txOpts, err := backend.BindOpts(ctx, eoa.MustAddress(network, eoa.RoleUpgrader))
 	if err != nil {
 		return errors.Wrap(err, "bind tx opts")
 	}

--- a/e2e/app/admin/planupgrade.go
+++ b/e2e/app/admin/planupgrade.go
@@ -52,7 +52,7 @@ func PlanUpgrade(ctx context.Context, def app.Definition, cfg Config) error {
 		return errors.Wrap(err, "new staking contract")
 	}
 
-	txOpts, err := backend.BindOpts(ctx, eoa.MustAddress(network, eoa.RoleAdmin))
+	txOpts, err := backend.BindOpts(ctx, eoa.MustAddress(network, eoa.RoleOwner))
 	if err != nil {
 		return errors.Wrap(err, "bind tx opts")
 	}

--- a/e2e/app/admin/upgrade.go
+++ b/e2e/app/admin/upgrade.go
@@ -109,12 +109,12 @@ func upgradePortal(ctx context.Context, s shared, c chain) error {
 	// TODO: replace if re-initialization is required
 	initializer := []byte{}
 
-	calldata, err := adminABI.Pack("upgradePortal", s.admin, s.deployer, c.PortalAddress, initializer)
+	calldata, err := adminABI.Pack("upgradePortal", s.upgrader, s.deployer, c.PortalAddress, initializer)
 	if err != nil {
 		return errors.Wrap(err, "pack calldata")
 	}
 
-	out, err := s.runForge(ctx, c.rpc, calldata, s.admin, s.deployer)
+	out, err := s.runForge(ctx, c.rpc, calldata, s.upgrader, s.deployer)
 	if err != nil {
 		return errors.Wrap(err, "run forge", "out", out)
 	}
@@ -146,12 +146,12 @@ func upgradeFeeOracleV1(ctx context.Context, s shared, c chain) error {
 	// TODO: replace if re-initialization is required
 	initializer := []byte{}
 
-	calldata, err := adminABI.Pack("upgradeFeeOracleV1", s.admin, s.deployer, proxy, initializer)
+	calldata, err := adminABI.Pack("upgradeFeeOracleV1", s.upgrader, s.deployer, proxy, initializer)
 	if err != nil {
 		return errors.Wrap(err, "pack calldata")
 	}
 
-	out, err := s.runForge(ctx, c.rpc, calldata, s.admin, s.deployer)
+	out, err := s.runForge(ctx, c.rpc, calldata, s.upgrader, s.deployer)
 	if err != nil {
 		return errors.Wrap(err, "run forge", "out", out)
 	}
@@ -170,12 +170,12 @@ func upgradeGasStation(ctx context.Context, s shared, c chain) error {
 	// TODO: replace if re-initialization is required
 	initializer := []byte{}
 
-	calldata, err := adminABI.Pack("upgradeGasStation", s.admin, s.deployer, addrs.GasStation, initializer)
+	calldata, err := adminABI.Pack("upgradeGasStation", s.upgrader, s.deployer, addrs.GasStation, initializer)
 	if err != nil {
 		return errors.Wrap(err, "pack calldata")
 	}
 
-	out, err := s.runForge(ctx, c.rpc, calldata, s.admin, s.deployer)
+	out, err := s.runForge(ctx, c.rpc, calldata, s.upgrader, s.deployer)
 	if err != nil {
 		return errors.Wrap(err, "run forge", "out", out)
 	}
@@ -194,12 +194,12 @@ func upgradeGasPump(ctx context.Context, s shared, c chain) error {
 	// TODO: replace if re-initialization is required
 	initializer := []byte{}
 
-	calldata, err := adminABI.Pack("upgradeGasPump", s.admin, s.deployer, addrs.GasPump, initializer)
+	calldata, err := adminABI.Pack("upgradeGasPump", s.upgrader, s.deployer, addrs.GasPump, initializer)
 	if err != nil {
 		return errors.Wrap(err, "pack calldata")
 	}
 
-	out, err := s.runForge(ctx, c.rpc, calldata, s.admin, s.deployer)
+	out, err := s.runForge(ctx, c.rpc, calldata, s.upgrader, s.deployer)
 	if err != nil {
 		return errors.Wrap(err, "run forge", "out", out)
 	}
@@ -213,12 +213,12 @@ func ugpradeSlashing(ctx context.Context, s shared, c chain) error {
 	// TODO: replace if re-initialization is required
 	initializer := []byte{}
 
-	calldata, err := adminABI.Pack("upgradeSlashing", s.admin, s.deployer, initializer)
+	calldata, err := adminABI.Pack("upgradeSlashing", s.upgrader, s.deployer, initializer)
 	if err != nil {
 		return errors.Wrap(err, "pack calldata")
 	}
 
-	out, err := s.runForge(ctx, c.rpc, calldata, s.admin, s.deployer)
+	out, err := s.runForge(ctx, c.rpc, calldata, s.upgrader, s.deployer)
 	if err != nil {
 		return errors.Wrap(err, "run forge", "out", out)
 	}
@@ -232,12 +232,12 @@ func upgradeStaking(ctx context.Context, s shared, c chain) error {
 	// TODO: replace if re-initialization is required
 	initializer := []byte{}
 
-	calldata, err := adminABI.Pack("upgradeStaking", s.admin, s.deployer, initializer)
+	calldata, err := adminABI.Pack("upgradeStaking", s.upgrader, s.deployer, initializer)
 	if err != nil {
 		return errors.Wrap(err, "pack calldata")
 	}
 
-	out, err := s.runForge(ctx, c.rpc, calldata, s.admin, s.deployer)
+	out, err := s.runForge(ctx, c.rpc, calldata, s.upgrader, s.deployer)
 	if err != nil {
 		return errors.Wrap(err, "run forge", "out", out)
 	}
@@ -251,12 +251,12 @@ func upgradeBridgeNative(ctx context.Context, s shared, c chain) error {
 	// TODO: replace if re-initialization is required
 	initializer := []byte{}
 
-	calldata, err := adminABI.Pack("upgradeBridgeNative", s.admin, s.deployer, initializer)
+	calldata, err := adminABI.Pack("upgradeBridgeNative", s.upgrader, s.deployer, initializer)
 	if err != nil {
 		return errors.Wrap(err, "pack calldata")
 	}
 
-	out, err := s.runForge(ctx, c.rpc, calldata, s.admin, s.deployer)
+	out, err := s.runForge(ctx, c.rpc, calldata, s.upgrader, s.deployer)
 	if err != nil {
 		return errors.Wrap(err, "run forge", "out", out)
 	}
@@ -275,12 +275,12 @@ func upgradeBridgeL1(ctx context.Context, s shared, c chain) error {
 	// TODO: replace if re-initialization is required
 	initializer := []byte{}
 
-	calldata, err := adminABI.Pack("upgradeBridgeL1", s.admin, s.deployer, addrs.L1Bridge, initializer)
+	calldata, err := adminABI.Pack("upgradeBridgeL1", s.upgrader, s.deployer, addrs.L1Bridge, initializer)
 	if err != nil {
 		return errors.Wrap(err, "pack calldata")
 	}
 
-	out, err := s.runForge(ctx, c.rpc, calldata, s.admin, s.deployer)
+	out, err := s.runForge(ctx, c.rpc, calldata, s.upgrader, s.deployer)
 	if err != nil {
 		return errors.Wrap(err, "run forge", "out", out)
 	}
@@ -294,12 +294,12 @@ func upgradePortalRegistry(ctx context.Context, s shared, c chain) error {
 	// TODO: replace if re-initialization is required
 	initializer := []byte{}
 
-	calldata, err := adminABI.Pack("upgradePortalRegistry", s.admin, s.deployer, initializer)
+	calldata, err := adminABI.Pack("upgradePortalRegistry", s.upgrader, s.deployer, initializer)
 	if err != nil {
 		return errors.Wrap(err, "pack calldata")
 	}
 
-	out, err := s.runForge(ctx, c.rpc, calldata, s.admin, s.deployer)
+	out, err := s.runForge(ctx, c.rpc, calldata, s.upgrader, s.deployer)
 	if err != nil {
 		return errors.Wrap(err, "run forge", "out", out)
 	}

--- a/e2e/app/eoa/eoa.go
+++ b/e2e/app/eoa/eoa.go
@@ -23,8 +23,8 @@ const (
 	RoleCreate3Deployer Role = "create3-deployer"
 	// RoleDeployer is used to deploy official omni contracts on all chains.
 	RoleDeployer Role = "deployer"
-	// RoleAdmin is used to manage the omni contracts on all chains. It has admin privileges on official omni contracts.
-	RoleAdmin Role = "admin"
+	// RoleOwner is used to manage the omni contracts on all chains. It has admin privileges on official omni contracts.
+	RoleOwner Role = "owner"
 	// RoleTester is used for general tasks and testing in non-mainnet networks.
 	RoleTester Role = "tester"
 )
@@ -35,7 +35,7 @@ func AllRoles() []Role {
 		RoleMonitor,
 		RoleCreate3Deployer,
 		RoleDeployer,
-		RoleAdmin,
+		RoleOwner,
 		RoleTester,
 	}
 }

--- a/e2e/app/eoa/eoa.go
+++ b/e2e/app/eoa/eoa.go
@@ -15,6 +15,8 @@ import (
 type Role string
 
 const (
+	// RoleFunder is used to fund omni accounts on all networks.
+	RoleFunder Role = "funder"
 	// RoleRelayer is the relayer eoa on all networks. It creates submissions to portals.
 	RoleRelayer Role = "relayer"
 	// RoleMonitor is the monitor service eoa on all networks. It is used by the feemanager.
@@ -23,8 +25,11 @@ const (
 	RoleCreate3Deployer Role = "create3-deployer"
 	// RoleDeployer is used to deploy official omni contracts on all chains.
 	RoleDeployer Role = "deployer"
-	// RoleOwner is used to manage the omni contracts on all chains. It has admin privileges on official omni contracts.
-	RoleOwner Role = "owner"
+	// RoleManager is used to manage the omni contracts on all chains. It has admin privileges on official omni contracts.
+	// The role can pause, unpause and configure contracts.
+	RoleManager Role = "manager"
+	// RoleUpgrader is the owner of each proxy contract and can trigger upgrade actions.
+	RoleUpgrader Role = "upgrader"
 	// RoleTester is used for general tasks and testing in non-mainnet networks.
 	RoleTester Role = "tester"
 )
@@ -35,7 +40,8 @@ func AllRoles() []Role {
 		RoleMonitor,
 		RoleCreate3Deployer,
 		RoleDeployer,
-		RoleOwner,
+		RoleManager,
+		RoleUpgrader,
 		RoleTester,
 	}
 }

--- a/e2e/app/eoa/fund.go
+++ b/e2e/app/eoa/fund.go
@@ -42,7 +42,8 @@ var (
 		RoleRelayer:         thresholdLarge,  // Relayer needs a ton of balance.
 		RoleMonitor:         thresholdMedium, // Dynamic Fee updates every few hours.
 		RoleCreate3Deployer: thresholdTiny,   // Only 1 contract per chain
-		RoleOwner:           thresholdTiny,   // Rarely used
+		RoleManager:         thresholdTiny,   // Rarely used
+		RoleUpgrader:        thresholdTiny,   // Rarely used
 		RoleDeployer:        thresholdTiny,   // Protected chains are only deployed once
 		RoleTester:          thresholdLarge,  // Tester funds pingpongs, validator updates, etc.
 	}

--- a/e2e/app/eoa/fund.go
+++ b/e2e/app/eoa/fund.go
@@ -42,7 +42,7 @@ var (
 		RoleRelayer:         thresholdLarge,  // Relayer needs a ton of balance.
 		RoleMonitor:         thresholdMedium, // Dynamic Fee updates every few hours.
 		RoleCreate3Deployer: thresholdTiny,   // Only 1 contract per chain
-		RoleAdmin:           thresholdTiny,   // Rarely used
+		RoleOwner:           thresholdTiny,   // Rarely used
 		RoleDeployer:        thresholdTiny,   // Protected chains are only deployed once
 		RoleTester:          thresholdLarge,  // Tester funds pingpongs, validator updates, etc.
 	}

--- a/e2e/app/eoa/helpers.go
+++ b/e2e/app/eoa/helpers.go
@@ -7,11 +7,6 @@ import (
 	ethcrypto "github.com/ethereum/go-ethereum/crypto"
 )
 
-// Funder returns the address of the funder account.
-func Funder() common.Address {
-	return common.HexToAddress(fbFunder)
-}
-
 func dummy(roles ...Role) []Account {
 	var resp []Account
 	for _, role := range roles {

--- a/e2e/app/eoa/static.go
+++ b/e2e/app/eoa/static.go
@@ -5,22 +5,21 @@ import (
 	"github.com/omni-network/omni/lib/netconf"
 )
 
-const (
-	// fbFunder is the address of the fireblocks "funder" account.
-	fbFunder  = "0xf63316AA39fEc9D2109AB0D9c7B1eE3a6F60AEA4"
-	ZeroXDead = "0x000000000000000000000000000000000000dead"
-)
+const ZeroXDead = "0x000000000000000000000000000000000000dead"
 
 //nolint:gochecknoglobals // Static mappings.
 var statics = map[netconf.ID][]Account{
 	netconf.Devnet: flatten(
-		wellKnown(anvil.DevPrivateKey0(), RoleCreate3Deployer, RoleDeployer, RoleOwner),
+		wellKnown(anvil.DevPrivateKey0(), RoleCreate3Deployer, RoleDeployer, RoleManager, RoleUpgrader),
 		wellKnown(anvil.DevPrivateKey5(), RoleRelayer),
 		wellKnown(anvil.DevPrivateKey6(), RoleMonitor),
 		wellKnown(anvil.DevPrivateKey7(), RoleTester),
+		wellKnown(anvil.DevPrivateKey8(), RoleFunder),
 	),
 	netconf.Staging: flatten(
-		remote("0x4891925c4f13A34FC26453FD168Db80aF3273014", RoleOwner),
+		remote("0x4891925c4f13A34FC26453FD168Db80aF3273014", RoleManager),
+		remote("0xEAD625eB2011394cdD739E91Bf9D51A7169C22F5", RoleUpgrader),
+		remote("0xf63316AA39fEc9D2109AB0D9c7B1eE3a6F60AEA4", RoleFunder), // todo change after fireblocks update
 		remote("0xC8103859Ac7CB547d70307EdeF1A2319FC305fdC", RoleCreate3Deployer),
 		remote("0x274c4B3e5d27A65196d63964532366872F81D261", RoleDeployer),
 		remote("0x7a6cF389082dc698285474976d7C75CAdE08ab7e", RoleTester), // Legacy fbdev account
@@ -28,7 +27,9 @@ var statics = map[netconf.ID][]Account{
 		secret("0x0De553555Fa19d787Af4273B18bDB77282D618c4", RoleMonitor),
 	),
 	netconf.Omega: flatten(
-		remote("0xEAD625eB2011394cdD739E91Bf9D51A7169C22F5", RoleOwner),
+		remote("0xEAD625eB2011394cdD739E91Bf9D51A7169C22F5", RoleManager),  // for omega, we reuse omega-owner-upgrader
+		remote("0xEAD625eB2011394cdD739E91Bf9D51A7169C22F5", RoleUpgrader), // for omega, we reuse omega-owner-upgrader
+		remote("0xf63316AA39fEc9D2109AB0D9c7B1eE3a6F60AEA4", RoleFunder),
 		remote("0xeC5134556da0797A5C5cD51DD622b689Cac97Fe9", RoleCreate3Deployer),
 		remote("0x0CdCc644158b7D03f40197f55454dc7a11Bd92c1", RoleDeployer),
 		remote("0x7a6cF389082dc698285474976d7C75CAdE08ab7e", RoleTester), // Identical address to staging. Concurrent usage will result in nonce clashes.
@@ -36,8 +37,13 @@ var statics = map[netconf.ID][]Account{
 		secret("0xcef2a2c477Ec8473E4DeB9a8c2DF1D0585ea1040", RoleMonitor),
 	),
 	netconf.Mainnet: flatten(
-		dummy(RoleOwner, RoleCreate3Deployer, RoleDeployer, RoleTester),
+		remote("0x4891925c4f13A34FC26453FD168Db80aF3273014", RoleManager),         // todo change after fireblocks update
+		remote("0x4891925c4f13A34FC26453FD168Db80aF3273014", RoleUpgrader),        // todo change after fireblocks update
+		remote("0x4891925c4f13A34FC26453FD168Db80aF3273014", RoleCreate3Deployer), // todo change after fireblocks update
+		remote("0x4891925c4f13A34FC26453FD168Db80aF3273014", RoleDeployer),        // todo change after fireblocks update
+		remote("0x4891925c4f13A34FC26453FD168Db80aF3273014", RoleFunder),          // todo change after fireblocks update
 		secret("0x07804D7B8be635c0C68Cdf3E946114221B12f4F7", RoleRelayer),
 		secret("0x07082fcbFA5F5AC9FBc03A48B7f6391441DB8332", RoleMonitor),
+		dummy(RoleTester),
 	),
 }

--- a/e2e/app/eoa/static.go
+++ b/e2e/app/eoa/static.go
@@ -14,13 +14,13 @@ const (
 //nolint:gochecknoglobals // Static mappings.
 var statics = map[netconf.ID][]Account{
 	netconf.Devnet: flatten(
-		wellKnown(anvil.DevPrivateKey0(), RoleCreate3Deployer, RoleDeployer, RoleAdmin),
+		wellKnown(anvil.DevPrivateKey0(), RoleCreate3Deployer, RoleDeployer, RoleOwner),
 		wellKnown(anvil.DevPrivateKey5(), RoleRelayer),
 		wellKnown(anvil.DevPrivateKey6(), RoleMonitor),
 		wellKnown(anvil.DevPrivateKey7(), RoleTester),
 	),
 	netconf.Staging: flatten(
-		remote("0x4891925c4f13A34FC26453FD168Db80aF3273014", RoleAdmin),
+		remote("0x4891925c4f13A34FC26453FD168Db80aF3273014", RoleOwner),
 		remote("0xC8103859Ac7CB547d70307EdeF1A2319FC305fdC", RoleCreate3Deployer),
 		remote("0x274c4B3e5d27A65196d63964532366872F81D261", RoleDeployer),
 		remote("0x7a6cF389082dc698285474976d7C75CAdE08ab7e", RoleTester), // Legacy fbdev account
@@ -28,7 +28,7 @@ var statics = map[netconf.ID][]Account{
 		secret("0x0De553555Fa19d787Af4273B18bDB77282D618c4", RoleMonitor),
 	),
 	netconf.Omega: flatten(
-		remote("0xEAD625eB2011394cdD739E91Bf9D51A7169C22F5", RoleAdmin),
+		remote("0xEAD625eB2011394cdD739E91Bf9D51A7169C22F5", RoleOwner),
 		remote("0xeC5134556da0797A5C5cD51DD622b689Cac97Fe9", RoleCreate3Deployer),
 		remote("0x0CdCc644158b7D03f40197f55454dc7a11Bd92c1", RoleDeployer),
 		remote("0x7a6cF389082dc698285474976d7C75CAdE08ab7e", RoleTester), // Identical address to staging. Concurrent usage will result in nonce clashes.
@@ -36,7 +36,7 @@ var statics = map[netconf.ID][]Account{
 		secret("0xcef2a2c477Ec8473E4DeB9a8c2DF1D0585ea1040", RoleMonitor),
 	),
 	netconf.Mainnet: flatten(
-		dummy(RoleAdmin, RoleCreate3Deployer, RoleDeployer, RoleTester),
+		dummy(RoleOwner, RoleCreate3Deployer, RoleDeployer, RoleTester),
 		secret("0x07804D7B8be635c0C68Cdf3E946114221B12f4F7", RoleRelayer),
 		secret("0x07082fcbFA5F5AC9FBc03A48B7f6391441DB8332", RoleMonitor),
 	),

--- a/e2e/app/eoa/static.go
+++ b/e2e/app/eoa/static.go
@@ -19,31 +19,31 @@ var statics = map[netconf.ID][]Account{
 	netconf.Staging: flatten(
 		remote("0x4891925c4f13A34FC26453FD168Db80aF3273014", RoleManager),
 		remote("0xEAD625eB2011394cdD739E91Bf9D51A7169C22F5", RoleUpgrader),
-		remote("0xf63316AA39fEc9D2109AB0D9c7B1eE3a6F60AEA4", RoleFunder), // todo change after fireblocks update
+		remote("0xf63316AA39fEc9D2109AB0D9c7B1eE3a6F60AEA4", RoleFunder), // we use shared-funder
 		remote("0xC8103859Ac7CB547d70307EdeF1A2319FC305fdC", RoleCreate3Deployer),
 		remote("0x274c4B3e5d27A65196d63964532366872F81D261", RoleDeployer),
-		remote("0x7a6cF389082dc698285474976d7C75CAdE08ab7e", RoleTester), // Legacy fbdev account
+		remote("0x7a6cF389082dc698285474976d7C75CAdE08ab7e", RoleTester), // reused shared-test with omega. Concurrent usage will result in nonce clashes.
 		secret("0xfE921e06Ed0a22c035b4aCFF0A5D3a434A330c96", RoleRelayer),
 		secret("0x0De553555Fa19d787Af4273B18bDB77282D618c4", RoleMonitor),
 	),
 	netconf.Omega: flatten(
-		remote("0xEAD625eB2011394cdD739E91Bf9D51A7169C22F5", RoleManager),  // for omega, we reuse omega-owner-upgrader
-		remote("0xEAD625eB2011394cdD739E91Bf9D51A7169C22F5", RoleUpgrader), // for omega, we reuse omega-owner-upgrader
-		remote("0xf63316AA39fEc9D2109AB0D9c7B1eE3a6F60AEA4", RoleFunder),
+		remote("0xEAD625eB2011394cdD739E91Bf9D51A7169C22F5", RoleManager),  // we reuse omega-owner-upgrader
+		remote("0xEAD625eB2011394cdD739E91Bf9D51A7169C22F5", RoleUpgrader), // we reuse omega-owner-upgrader
+		remote("0xf63316AA39fEc9D2109AB0D9c7B1eE3a6F60AEA4", RoleFunder),   // we use shared-funder
 		remote("0xeC5134556da0797A5C5cD51DD622b689Cac97Fe9", RoleCreate3Deployer),
 		remote("0x0CdCc644158b7D03f40197f55454dc7a11Bd92c1", RoleDeployer),
-		remote("0x7a6cF389082dc698285474976d7C75CAdE08ab7e", RoleTester), // Identical address to staging. Concurrent usage will result in nonce clashes.
+		remote("0x7a6cF389082dc698285474976d7C75CAdE08ab7e", RoleTester), // reused shared-test with staging. Concurrent usage will result in nonce clashes.
 		secret("0x37AD6f7267454cac494C177127aC017750c8A7DB", RoleRelayer),
 		secret("0xcef2a2c477Ec8473E4DeB9a8c2DF1D0585ea1040", RoleMonitor),
 	),
 	netconf.Mainnet: flatten(
-		remote("0x4891925c4f13A34FC26453FD168Db80aF3273014", RoleManager),         // todo change after fireblocks update
-		remote("0x4891925c4f13A34FC26453FD168Db80aF3273014", RoleUpgrader),        // todo change after fireblocks update
-		remote("0x4891925c4f13A34FC26453FD168Db80aF3273014", RoleCreate3Deployer), // todo change after fireblocks update
-		remote("0x4891925c4f13A34FC26453FD168Db80aF3273014", RoleDeployer),        // todo change after fireblocks update
-		remote("0x4891925c4f13A34FC26453FD168Db80aF3273014", RoleFunder),          // todo change after fireblocks update
-		secret("0x07804D7B8be635c0C68Cdf3E946114221B12f4F7", RoleRelayer),
-		secret("0x07082fcbFA5F5AC9FBc03A48B7f6391441DB8332", RoleMonitor),
+		remote("0xd09DD1126385877352d24B669Fd68f462200756E", RoleManager),
+		remote("0xF8740c09f25E2cbF5C9b34Ef142ED7B343B42360", RoleUpgrader),
+		remote("0x992b9de7D42981B90A75C523842C01e27875b65B", RoleCreate3Deployer),
+		remote("0x9496Bf1Bd2Fa5BCba72062cC781cC97eA6930A13", RoleDeployer),
+		remote("0x8F609f4d58355539c48C98464E1e54ab2709aCfe", RoleFunder),
+		dummy(RoleMonitor), // todo generate accounts and replace with secret type
+		dummy(RoleRelayer), // todo generate accounts and replace with secret type
 		dummy(RoleTester),
 	),
 }

--- a/e2e/app/eoa/static.go
+++ b/e2e/app/eoa/static.go
@@ -42,8 +42,8 @@ var statics = map[netconf.ID][]Account{
 		remote("0x992b9de7D42981B90A75C523842C01e27875b65B", RoleCreate3Deployer),
 		remote("0x9496Bf1Bd2Fa5BCba72062cC781cC97eA6930A13", RoleDeployer),
 		remote("0x8F609f4d58355539c48C98464E1e54ab2709aCfe", RoleFunder),
-		dummy(RoleMonitor), // todo generate accounts and replace with secret type
-		dummy(RoleRelayer), // todo generate accounts and replace with secret type
+		secret("0xfD62020Cee216Dc543E29752058Ee9f60f7D9Ff9", RoleMonitor),
+		secret("0x6191442101086253A636aecBCC870e4778490AaB", RoleRelayer),
 		dummy(RoleTester),
 	),
 }

--- a/e2e/app/eoa/static_test.go
+++ b/e2e/app/eoa/static_test.go
@@ -36,6 +36,25 @@ func TestStatic(t *testing.T) {
 	}
 }
 
+// TestMainnet makes sure the initial accounts used for deployment won't change in the future.
+func TestMainnet(t *testing.T) {
+	t.Parallel()
+	fixed := map[eoa.Role]string{
+		eoa.RoleManager:         "0xd09DD1126385877352d24B669Fd68f462200756E",
+		eoa.RoleUpgrader:        "0xF8740c09f25E2cbF5C9b34Ef142ED7B343B42360",
+		eoa.RoleCreate3Deployer: "0x992b9de7D42981B90A75C523842C01e27875b65B",
+		eoa.RoleDeployer:        "0x9496Bf1Bd2Fa5BCba72062cC781cC97eA6930A13",
+		eoa.RoleFunder:          "0x8F609f4d58355539c48C98464E1e54ab2709aCfe",
+	}
+
+	n := netconf.Mainnet
+	for role := range fixed {
+		acc, ok := eoa.AccountForRole(n, role)
+		require.True(t, ok, "account not found: %s %s", n, role)
+		require.Equal(t, fixed[acc.Role], acc.Address.Hex())
+	}
+}
+
 func etherStr(amount *big.Int) string {
 	b, _ := amount.Float64()
 	b /= params.Ether

--- a/e2e/app/gaspump.go
+++ b/e2e/app/gaspump.go
@@ -12,7 +12,6 @@ import (
 	"github.com/omni-network/omni/lib/contracts/gasstation"
 	"github.com/omni-network/omni/lib/errors"
 	"github.com/omni-network/omni/lib/log"
-	"github.com/omni-network/omni/lib/netconf"
 	"github.com/omni-network/omni/lib/txmgr"
 
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
@@ -113,10 +112,6 @@ func deployGasStation(ctx context.Context, def Definition) error {
 // TODO: handle funding / monitoring properly.
 // consider joining with e2e/app/eoa, or introduce something similar for contracts.
 func fundGasStation(ctx context.Context, def Definition) error {
-	if def.Testnet.Network != netconf.Devnet && def.Testnet.Network != netconf.Staging {
-		return errors.New("funding of gas station only supported on devnet and staging (fixme)")
-	}
-
 	network := NetworkFromDef(def)
 	omniEVM, ok := network.OmniEVMChain()
 	if !ok {
@@ -128,10 +123,7 @@ func fundGasStation(ctx context.Context, def Definition) error {
 		return errors.Wrap(err, "backend")
 	}
 
-	funder := eoa.Funder()
-	if network.ID == netconf.Devnet { // use dev account for devnet
-		funder = anvil.DevAccount8()
-	}
+	funder := eoa.MustAddress(network.ID, eoa.RoleFunder)
 
 	addrs, err := contracts.GetAddresses(ctx, network.ID)
 	if err != nil {

--- a/e2e/app/portalregistry.go
+++ b/e2e/app/portalregistry.go
@@ -64,7 +64,7 @@ func newRegistryMngr(ctx context.Context, def Definition) (registryMngr, error) 
 		return registryMngr{}, errors.Wrap(err, "new portal registry")
 	}
 
-	admin := eoa.MustAddress(def.Testnet.Network, eoa.RoleAdmin)
+	admin := eoa.MustAddress(def.Testnet.Network, eoa.RoleOwner)
 	txOpts, err := backend.BindOpts(ctx, admin)
 	if err != nil {
 		return registryMngr{}, err
@@ -256,7 +256,7 @@ func allowStagingValidators(ctx context.Context, def Definition) error {
 		return errors.Wrap(err, "new staking")
 	}
 
-	admin := eoa.MustAddress(def.Testnet.Network, eoa.RoleAdmin)
+	admin := eoa.MustAddress(def.Testnet.Network, eoa.RoleOwner)
 	txOpts, err := backend.BindOpts(ctx, admin)
 	if err != nil {
 		return err

--- a/e2e/app/portalregistry.go
+++ b/e2e/app/portalregistry.go
@@ -64,8 +64,8 @@ func newRegistryMngr(ctx context.Context, def Definition) (registryMngr, error) 
 		return registryMngr{}, errors.Wrap(err, "new portal registry")
 	}
 
-	owner := eoa.MustAddress(def.Testnet.Network, eoa.RoleManager)
-	txOpts, err := backend.BindOpts(ctx, owner)
+	manager := eoa.MustAddress(def.Testnet.Network, eoa.RoleManager)
+	txOpts, err := backend.BindOpts(ctx, manager)
 	if err != nil {
 		return registryMngr{}, err
 	}
@@ -256,8 +256,8 @@ func allowStagingValidators(ctx context.Context, def Definition) error {
 		return errors.Wrap(err, "new staking")
 	}
 
-	owner := eoa.MustAddress(def.Testnet.Network, eoa.RoleManager)
-	txOpts, err := backend.BindOpts(ctx, owner)
+	manager := eoa.MustAddress(def.Testnet.Network, eoa.RoleManager)
+	txOpts, err := backend.BindOpts(ctx, manager)
 	if err != nil {
 		return err
 	}

--- a/e2e/app/portalregistry.go
+++ b/e2e/app/portalregistry.go
@@ -64,8 +64,8 @@ func newRegistryMngr(ctx context.Context, def Definition) (registryMngr, error) 
 		return registryMngr{}, errors.Wrap(err, "new portal registry")
 	}
 
-	admin := eoa.MustAddress(def.Testnet.Network, eoa.RoleOwner)
-	txOpts, err := backend.BindOpts(ctx, admin)
+	owner := eoa.MustAddress(def.Testnet.Network, eoa.RoleManager)
+	txOpts, err := backend.BindOpts(ctx, owner)
 	if err != nil {
 		return registryMngr{}, err
 	}
@@ -256,8 +256,8 @@ func allowStagingValidators(ctx context.Context, def Definition) error {
 		return errors.Wrap(err, "new staking")
 	}
 
-	admin := eoa.MustAddress(def.Testnet.Network, eoa.RoleOwner)
-	txOpts, err := backend.BindOpts(ctx, admin)
+	owner := eoa.MustAddress(def.Testnet.Network, eoa.RoleManager)
+	txOpts, err := backend.BindOpts(ctx, owner)
 	if err != nil {
 		return err
 	}

--- a/e2e/app/run.go
+++ b/e2e/app/run.go
@@ -410,7 +410,7 @@ func maybeSubmitNetworkUpgrade(ctx context.Context, def Definition) error {
 		return err
 	}
 
-	txOpts, err := backend.BindOpts(ctx, eoa.MustAddress(network, eoa.RoleOwner))
+	txOpts, err := backend.BindOpts(ctx, eoa.MustAddress(network, eoa.RoleUpgrader))
 	if err != nil {
 		return err
 	}

--- a/e2e/app/run.go
+++ b/e2e/app/run.go
@@ -410,7 +410,7 @@ func maybeSubmitNetworkUpgrade(ctx context.Context, def Definition) error {
 		return err
 	}
 
-	txOpts, err := backend.BindOpts(ctx, eoa.MustAddress(network, eoa.RoleAdmin))
+	txOpts, err := backend.BindOpts(ctx, eoa.MustAddress(network, eoa.RoleOwner))
 	if err != nil {
 		return err
 	}

--- a/e2e/app/tokenbridge.go
+++ b/e2e/app/tokenbridge.go
@@ -36,7 +36,7 @@ func setupTokenBridge(ctx context.Context, def Definition) error {
 		return errors.New("no omni evm chain")
 	}
 
-	admin := eoa.MustAddress(networkID, eoa.RoleAdmin)
+	admin := eoa.MustAddress(networkID, eoa.RoleOwner)
 
 	addrs, err := contracts.GetAddresses(ctx, networkID)
 	if err != nil {

--- a/e2e/app/tokenbridge.go
+++ b/e2e/app/tokenbridge.go
@@ -36,7 +36,7 @@ func setupTokenBridge(ctx context.Context, def Definition) error {
 		return errors.New("no omni evm chain")
 	}
 
-	owner := eoa.MustAddress(networkID, eoa.RoleManager)
+	manager := eoa.MustAddress(networkID, eoa.RoleManager)
 
 	addrs, err := contracts.GetAddresses(ctx, networkID)
 	if err != nil {
@@ -86,7 +86,7 @@ func setupTokenBridge(ctx context.Context, def Definition) error {
 		return errors.Wrap(err, "bridge native")
 	}
 
-	txOpts, err := l1Backend.BindOpts(ctx, owner)
+	txOpts, err := l1Backend.BindOpts(ctx, manager)
 	if err != nil {
 		return errors.Wrap(err, "bind opts")
 	}

--- a/e2e/app/tokenbridge.go
+++ b/e2e/app/tokenbridge.go
@@ -36,7 +36,7 @@ func setupTokenBridge(ctx context.Context, def Definition) error {
 		return errors.New("no omni evm chain")
 	}
 
-	admin := eoa.MustAddress(networkID, eoa.RoleOwner)
+	owner := eoa.MustAddress(networkID, eoa.RoleManager)
 
 	addrs, err := contracts.GetAddresses(ctx, networkID)
 	if err != nil {
@@ -86,7 +86,7 @@ func setupTokenBridge(ctx context.Context, def Definition) error {
 		return errors.Wrap(err, "bridge native")
 	}
 
-	txOpts, err := l1Backend.BindOpts(ctx, admin)
+	txOpts, err := l1Backend.BindOpts(ctx, owner)
 	if err != nil {
 		return errors.Wrap(err, "bind opts")
 	}

--- a/halo/genutil/evm/evm.go
+++ b/halo/genutil/evm/evm.go
@@ -118,15 +118,15 @@ func ephemeralPrefundAlloc() types.GenesisAlloc {
 		eoa.MustAddress(netconf.Staging, eoa.RoleMonitor):  {Balance: eth1m},
 		eoa.MustAddress(netconf.Staging, eoa.RoleRelayer):  {Balance: eth1m},
 		eoa.MustAddress(netconf.Staging, eoa.RoleDeployer): {Balance: eth1m},
-		eoa.Funder(): {Balance: eth1m},
+		eoa.MustAddress(netconf.Staging, eoa.RoleFunder):   {Balance: eth1m},
+		eoa.MustAddress(netconf.Staging, eoa.RoleUpgrader): {Balance: eth1m},
+		eoa.MustAddress(netconf.Staging, eoa.RoleManager):  {Balance: eth1m},
 
 		// team ops accounts
 		common.HexToAddress("0xfE921e06Ed0a22c035b4aCFF0A5D3a434A330c96"): {Balance: eth1m}, // dev relayer (local)
 		common.HexToAddress("0xfC9D554D69DdCfC0A731b2DC64550177b0723bE5"): {Balance: eth1m}, // dev deployer (local)
 		common.HexToAddress("0x7a6cF389082dc698285474976d7C75CAdE08ab7e"): {Balance: eth1m}, // fb: dev
 		common.HexToAddress("0xC8103859Ac7CB547d70307EdeF1A2319FC305fdC"): {Balance: eth1m}, // fb: create3-deployer
-		common.HexToAddress("0x274c4B3e5d27A65196d63964532366872F81D261"): {Balance: eth1m}, // fb: deployer
-		common.HexToAddress("0x4891925c4f13A34FC26453FD168Db80aF3273014"): {Balance: eth1m}, // fb: owner
 	}
 }
 

--- a/lib/contracts/feeoraclev1/deploy.go
+++ b/lib/contracts/feeoraclev1/deploy.go
@@ -47,10 +47,10 @@ func (cfg deploymentConfig) Validate() error {
 
 func Deploy(ctx context.Context, network netconf.ID, chainID uint64, destChainIDs []uint64, backends ethbackend.Backends) (common.Address, *ethtypes.Receipt, error) {
 	cfg := deploymentConfig{
-		Owner:           eoa.MustAddress(network, eoa.RoleOwner),
+		Owner:           eoa.MustAddress(network, eoa.RoleManager),
 		Manager:         eoa.MustAddress(network, eoa.RoleMonitor), // NOTE: monitor is owner of fee oracle contracts, because monitor manages on chain gas prices / conversion rates
 		Deployer:        eoa.MustAddress(network, eoa.RoleDeployer),
-		ProxyAdminOwner: eoa.MustAddress(network, eoa.RoleOwner),
+		ProxyAdminOwner: eoa.MustAddress(network, eoa.RoleUpgrader),
 		BaseGasLimit:    50_000,
 		ProtocolFee:     big.NewInt(0),
 	}

--- a/lib/contracts/feeoraclev1/deploy.go
+++ b/lib/contracts/feeoraclev1/deploy.go
@@ -47,10 +47,10 @@ func (cfg deploymentConfig) Validate() error {
 
 func Deploy(ctx context.Context, network netconf.ID, chainID uint64, destChainIDs []uint64, backends ethbackend.Backends) (common.Address, *ethtypes.Receipt, error) {
 	cfg := deploymentConfig{
-		Owner:           eoa.MustAddress(network, eoa.RoleAdmin),
+		Owner:           eoa.MustAddress(network, eoa.RoleOwner),
 		Manager:         eoa.MustAddress(network, eoa.RoleMonitor), // NOTE: monitor is owner of fee oracle contracts, because monitor manages on chain gas prices / conversion rates
 		Deployer:        eoa.MustAddress(network, eoa.RoleDeployer),
-		ProxyAdminOwner: eoa.MustAddress(network, eoa.RoleAdmin),
+		ProxyAdminOwner: eoa.MustAddress(network, eoa.RoleOwner),
 		BaseGasLimit:    50_000,
 		ProtocolFee:     big.NewInt(0),
 	}

--- a/lib/contracts/gaspump/deploy.go
+++ b/lib/contracts/gaspump/deploy.go
@@ -131,9 +131,9 @@ func Deploy(ctx context.Context, network netconf.ID, backend *ethbackend.Backend
 	cfg := DeploymentConfig{
 		Create3Factory:  addrs.Create3Factory,
 		Create3Salt:     salts.GasPump,
-		Owner:           eoa.MustAddress(network, eoa.RoleAdmin),
+		Owner:           eoa.MustAddress(network, eoa.RoleOwner),
 		Deployer:        eoa.MustAddress(network, eoa.RoleDeployer),
-		ProxyAdminOwner: eoa.MustAddress(network, eoa.RoleAdmin),
+		ProxyAdminOwner: eoa.MustAddress(network, eoa.RoleOwner),
 		Portal:          addrs.Portal,
 		GasStation:      addrs.GasStation,
 		Oracle:          oracle,

--- a/lib/contracts/gaspump/deploy.go
+++ b/lib/contracts/gaspump/deploy.go
@@ -131,9 +131,9 @@ func Deploy(ctx context.Context, network netconf.ID, backend *ethbackend.Backend
 	cfg := DeploymentConfig{
 		Create3Factory:  addrs.Create3Factory,
 		Create3Salt:     salts.GasPump,
-		Owner:           eoa.MustAddress(network, eoa.RoleOwner),
+		Owner:           eoa.MustAddress(network, eoa.RoleManager),
 		Deployer:        eoa.MustAddress(network, eoa.RoleDeployer),
-		ProxyAdminOwner: eoa.MustAddress(network, eoa.RoleOwner),
+		ProxyAdminOwner: eoa.MustAddress(network, eoa.RoleUpgrader),
 		Portal:          addrs.Portal,
 		GasStation:      addrs.GasStation,
 		Oracle:          oracle,

--- a/lib/contracts/gasstation/deploy.go
+++ b/lib/contracts/gasstation/deploy.go
@@ -113,9 +113,9 @@ func Deploy(
 	cfg := DeploymentConfig{
 		Create3Factory:  addrs.Create3Factory,
 		Create3Salt:     salts.GasStation,
-		Owner:           eoa.MustAddress(network, eoa.RoleAdmin),
+		Owner:           eoa.MustAddress(network, eoa.RoleOwner),
 		Deployer:        eoa.MustAddress(network, eoa.RoleDeployer),
-		ProxyAdminOwner: eoa.MustAddress(network, eoa.RoleAdmin),
+		ProxyAdminOwner: eoa.MustAddress(network, eoa.RoleOwner),
 		Portal:          addrs.Portal,
 		ExpectedAddr:    addrs.GasStation,
 	}

--- a/lib/contracts/gasstation/deploy.go
+++ b/lib/contracts/gasstation/deploy.go
@@ -113,9 +113,9 @@ func Deploy(
 	cfg := DeploymentConfig{
 		Create3Factory:  addrs.Create3Factory,
 		Create3Salt:     salts.GasStation,
-		Owner:           eoa.MustAddress(network, eoa.RoleOwner),
+		Owner:           eoa.MustAddress(network, eoa.RoleManager),
 		Deployer:        eoa.MustAddress(network, eoa.RoleDeployer),
-		ProxyAdminOwner: eoa.MustAddress(network, eoa.RoleOwner),
+		ProxyAdminOwner: eoa.MustAddress(network, eoa.RoleUpgrader),
 		Portal:          addrs.Portal,
 		ExpectedAddr:    addrs.GasStation,
 	}

--- a/lib/contracts/gasstation/deploy.go
+++ b/lib/contracts/gasstation/deploy.go
@@ -19,7 +19,7 @@ type DeploymentConfig struct {
 	Create3Factory  common.Address
 	Create3Salt     string
 	ProxyAdminOwner common.Address
-	Owner           common.Address
+	Manager         common.Address
 	Deployer        common.Address
 	Portal          common.Address
 	ExpectedAddr    common.Address
@@ -42,7 +42,7 @@ func (cfg DeploymentConfig) Validate() error {
 	if isDeadOrEmpty(cfg.Deployer) {
 		return errors.New("deployer is not set")
 	}
-	if isDeadOrEmpty(cfg.Owner) {
+	if isDeadOrEmpty(cfg.Manager) {
 		return errors.New("owner is not set")
 	}
 	if (cfg.Portal == common.Address{}) {
@@ -113,7 +113,7 @@ func Deploy(
 	cfg := DeploymentConfig{
 		Create3Factory:  addrs.Create3Factory,
 		Create3Salt:     salts.GasStation,
-		Owner:           eoa.MustAddress(network, eoa.RoleManager),
+		Manager:         eoa.MustAddress(network, eoa.RoleManager),
 		Deployer:        eoa.MustAddress(network, eoa.RoleDeployer),
 		ProxyAdminOwner: eoa.MustAddress(network, eoa.RoleUpgrader),
 		Portal:          addrs.Portal,
@@ -201,7 +201,7 @@ func packInitCode(cfg DeploymentConfig, impl common.Address, gasPumps []bindings
 		return nil, errors.Wrap(err, "get proxy abi")
 	}
 
-	initializer, err := gasStationAbi.Pack("initialize", cfg.Portal, cfg.Owner, gasPumps)
+	initializer, err := gasStationAbi.Pack("initialize", cfg.Portal, cfg.Manager, gasPumps)
 	if err != nil {
 		return nil, errors.Wrap(err, "encode initializer")
 	}

--- a/lib/contracts/l1bridge/deploy.go
+++ b/lib/contracts/l1bridge/deploy.go
@@ -107,9 +107,9 @@ func Deploy(ctx context.Context, network netconf.ID, backend *ethbackend.Backend
 	cfg := DeploymentConfig{
 		Create3Factory:  addrs.Create3Factory,
 		Create3Salt:     salts.L1Bridge,
-		Owner:           eoa.MustAddress(network, eoa.RoleOwner),
+		Owner:           eoa.MustAddress(network, eoa.RoleManager),
 		Deployer:        eoa.MustAddress(network, eoa.RoleDeployer),
-		ProxyAdminOwner: eoa.MustAddress(network, eoa.RoleOwner),
+		ProxyAdminOwner: eoa.MustAddress(network, eoa.RoleUpgrader),
 		Portal:          addrs.Portal,
 		Token:           addrs.Token,
 		ExpectedAddr:    addrs.L1Bridge,

--- a/lib/contracts/l1bridge/deploy.go
+++ b/lib/contracts/l1bridge/deploy.go
@@ -107,9 +107,9 @@ func Deploy(ctx context.Context, network netconf.ID, backend *ethbackend.Backend
 	cfg := DeploymentConfig{
 		Create3Factory:  addrs.Create3Factory,
 		Create3Salt:     salts.L1Bridge,
-		Owner:           eoa.MustAddress(network, eoa.RoleAdmin),
+		Owner:           eoa.MustAddress(network, eoa.RoleOwner),
 		Deployer:        eoa.MustAddress(network, eoa.RoleDeployer),
-		ProxyAdminOwner: eoa.MustAddress(network, eoa.RoleAdmin),
+		ProxyAdminOwner: eoa.MustAddress(network, eoa.RoleOwner),
 		Portal:          addrs.Portal,
 		Token:           addrs.Token,
 		ExpectedAddr:    addrs.L1Bridge,

--- a/lib/contracts/l1bridge/deploy.go
+++ b/lib/contracts/l1bridge/deploy.go
@@ -19,7 +19,7 @@ type DeploymentConfig struct {
 	Create3Factory  common.Address
 	Create3Salt     string
 	ProxyAdminOwner common.Address
-	Owner           common.Address
+	Manager         common.Address
 	Portal          common.Address
 	Token           common.Address
 	Deployer        common.Address
@@ -43,7 +43,7 @@ func (cfg DeploymentConfig) Validate() error {
 	if isDeadOrEmpty(cfg.Deployer) {
 		return errors.New("deployer is not set")
 	}
-	if isDeadOrEmpty(cfg.Owner) {
+	if isDeadOrEmpty(cfg.Manager) {
 		return errors.New("owner is not set")
 	}
 	if (cfg.Token == common.Address{}) {
@@ -107,7 +107,7 @@ func Deploy(ctx context.Context, network netconf.ID, backend *ethbackend.Backend
 	cfg := DeploymentConfig{
 		Create3Factory:  addrs.Create3Factory,
 		Create3Salt:     salts.L1Bridge,
-		Owner:           eoa.MustAddress(network, eoa.RoleManager),
+		Manager:         eoa.MustAddress(network, eoa.RoleManager),
 		Deployer:        eoa.MustAddress(network, eoa.RoleDeployer),
 		ProxyAdminOwner: eoa.MustAddress(network, eoa.RoleUpgrader),
 		Portal:          addrs.Portal,
@@ -181,7 +181,7 @@ func packInitCode(cfg DeploymentConfig, impl common.Address) ([]byte, error) {
 		return nil, errors.Wrap(err, "get proxy abi")
 	}
 
-	initializer, err := bridgeAbi.Pack("initialize", cfg.Owner, cfg.Portal)
+	initializer, err := bridgeAbi.Pack("initialize", cfg.Manager, cfg.Portal)
 	if err != nil {
 		return nil, errors.Wrap(err, "encode initializer")
 	}

--- a/lib/contracts/portal/deploy.go
+++ b/lib/contracts/portal/deploy.go
@@ -20,7 +20,7 @@ type deploymentConfig struct {
 	Create3Salt           string
 	ProxyAdminOwner       common.Address
 	Deployer              common.Address
-	Owner                 common.Address
+	Manager               common.Address
 	OmniChainID           uint64
 	OmniCChainID          uint64
 	XMsgMinGasLimit       uint64
@@ -70,7 +70,7 @@ func (cfg deploymentConfig) Validate() error {
 	if isDeadOrEmpty(cfg.Deployer) {
 		return errors.New("deployer is not set")
 	}
-	if isDeadOrEmpty(cfg.Owner) {
+	if isDeadOrEmpty(cfg.Manager) {
 		return errors.New("owner is not set")
 	}
 	if cfg.XMsgMinGasLimit == 0 {
@@ -141,7 +141,7 @@ func Deploy(ctx context.Context, network netconf.ID, backend *ethbackend.Backend
 	cfg := deploymentConfig{
 		Create3Factory:        addrs.Create3Factory,
 		Create3Salt:           salts.Portal,
-		Owner:                 eoa.MustAddress(network, eoa.RoleManager),
+		Manager:               eoa.MustAddress(network, eoa.RoleManager),
 		Deployer:              eoa.MustAddress(network, eoa.RoleDeployer),
 		ProxyAdminOwner:       eoa.MustAddress(network, eoa.RoleUpgrader),
 		OmniChainID:           network.Static().OmniExecutionChainID,
@@ -226,7 +226,7 @@ func packInitCode(cfg deploymentConfig, feeOracle common.Address, impl common.Ad
 
 	initializer, err := portalAbi.Pack("initialize",
 		&bindings.OmniPortalInitParams{
-			Owner:                cfg.Owner,
+			Owner:                cfg.Manager,
 			FeeOracle:            feeOracle,
 			OmniChainId:          cfg.OmniChainID,
 			OmniCChainId:         cfg.OmniCChainID,

--- a/lib/contracts/portal/deploy.go
+++ b/lib/contracts/portal/deploy.go
@@ -141,9 +141,9 @@ func Deploy(ctx context.Context, network netconf.ID, backend *ethbackend.Backend
 	cfg := deploymentConfig{
 		Create3Factory:        addrs.Create3Factory,
 		Create3Salt:           salts.Portal,
-		Owner:                 eoa.MustAddress(network, eoa.RoleOwner),
+		Owner:                 eoa.MustAddress(network, eoa.RoleManager),
 		Deployer:              eoa.MustAddress(network, eoa.RoleDeployer),
-		ProxyAdminOwner:       eoa.MustAddress(network, eoa.RoleOwner),
+		ProxyAdminOwner:       eoa.MustAddress(network, eoa.RoleUpgrader),
 		OmniChainID:           network.Static().OmniExecutionChainID,
 		OmniCChainID:          network.Static().OmniConsensusChainIDUint64(),
 		XMsgMinGasLimit:       XMsgMinGasLimit,

--- a/lib/contracts/portal/deploy.go
+++ b/lib/contracts/portal/deploy.go
@@ -141,9 +141,9 @@ func Deploy(ctx context.Context, network netconf.ID, backend *ethbackend.Backend
 	cfg := deploymentConfig{
 		Create3Factory:        addrs.Create3Factory,
 		Create3Salt:           salts.Portal,
-		Owner:                 eoa.MustAddress(network, eoa.RoleAdmin),
+		Owner:                 eoa.MustAddress(network, eoa.RoleOwner),
 		Deployer:              eoa.MustAddress(network, eoa.RoleDeployer),
-		ProxyAdminOwner:       eoa.MustAddress(network, eoa.RoleAdmin),
+		ProxyAdminOwner:       eoa.MustAddress(network, eoa.RoleOwner),
 		OmniChainID:           network.Static().OmniExecutionChainID,
 		OmniCChainID:          network.Static().OmniConsensusChainIDUint64(),
 		XMsgMinGasLimit:       XMsgMinGasLimit,

--- a/lib/contracts/portal/deploy_test.go
+++ b/lib/contracts/portal/deploy_test.go
@@ -63,7 +63,7 @@ func TestDeployDevnet(t *testing.T) {
 
 	owner, err := portal.Owner(nil)
 	require.NoError(t, err)
-	require.Equal(t, eoa.MustAddress(network, eoa.RoleOwner), owner)
+	require.Equal(t, eoa.MustAddress(network, eoa.RoleManager), owner)
 
 	// check validators
 	totalPower, err := portal.ValSetTotalPower(nil, 1)

--- a/lib/contracts/portal/deploy_test.go
+++ b/lib/contracts/portal/deploy_test.go
@@ -63,7 +63,7 @@ func TestDeployDevnet(t *testing.T) {
 
 	owner, err := portal.Owner(nil)
 	require.NoError(t, err)
-	require.Equal(t, eoa.MustAddress(network, eoa.RoleAdmin), owner)
+	require.Equal(t, eoa.MustAddress(network, eoa.RoleOwner), owner)
 
 	// check validators
 	totalPower, err := portal.ValSetTotalPower(nil, 1)

--- a/lib/contracts/testdata/TestContractAddressReference.golden
+++ b/lib/contracts/testdata/TestContractAddressReference.golden
@@ -10,11 +10,11 @@
  },
  "mainnet": {
   "avs": "0xed2f4d90b073128ae6769a9a8d51547b1df766c8",
-  "create3": "0x9b137463d4e7986d7f535f9b79e28b4ef1938e9b",
-  "gaspump": "0x47174077a08b1a88f4fa9db8e9d32e6917a4c5a9",
-  "gasstation": "0xc0ae1198bac99175e1e84bd5e53f02c054f870c0",
-  "l1bridge": "0x1ef02175337fd1b808d95a2e15498e767fe5e87c",
-  "portal": "0x84db9693ba18e77f66a3906aa4544a0d238b6221",
+  "create3": "0xa0375c267c6300b11cd9b9ec460b71db2d2655cd",
+  "gaspump": "0x47e926852ec1235adb2d3dc3dc130394e06bd4ed",
+  "gasstation": "0x6d8bf1db48c03eb5e7a65d5d5f2cc7e58fb9f577",
+  "l1bridge": "0xd5e3a7e388aa18e28d8b3a80763877c53fad6a5b",
+  "portal": "0xfa4b72a03b252e881c64828a1ae073a29c79ee72",
   "token": "0x36e66fbbce51e4cd5bd3c62b637eb411b18949d4"
  },
  "omega": {

--- a/lib/contracts/testdata/TestContractAddressReference.golden
+++ b/lib/contracts/testdata/TestContractAddressReference.golden
@@ -10,11 +10,11 @@
  },
  "mainnet": {
   "avs": "0xed2f4d90b073128ae6769a9a8d51547b1df766c8",
-  "create3": "0xa0375c267c6300b11cd9b9ec460b71db2d2655cd",
-  "gaspump": "0x47e926852ec1235adb2d3dc3dc130394e06bd4ed",
-  "gasstation": "0x6d8bf1db48c03eb5e7a65d5d5f2cc7e58fb9f577",
-  "l1bridge": "0xd5e3a7e388aa18e28d8b3a80763877c53fad6a5b",
-  "portal": "0xfa4b72a03b252e881c64828a1ae073a29c79ee72",
+  "create3": "0xe58e1002b51bc5ddf941de3b900d7179e4ea97bc",
+  "gaspump": "0xefe16889ee64a7c8af9de93855e283d1adf193e6",
+  "gasstation": "0x42bb1575df16f02e172bfb99e2e4ba9486351e42",
+  "l1bridge": "0x6bd6cf05285d1352ee9719fb3894734a5c8cedb2",
+  "portal": "0x88ebac668d54510699882f89eeb981cdc89782fe",
   "token": "0x36e66fbbce51e4cd5bd3c62b637eb411b18949d4"
  },
  "omega": {


### PR DESCRIPTION
Setup codebase to work with new Fireblock setup for mainnet as well as updated staging vaults. Omega setup stays the same although we introduce few new roles they map to the same vault on Fireblocks.

New vaults roles introduced:
`RoleManager` (previously `RoleAdmin` but split into two: manager and upgrader), used to pause and unpause contracts
`RoleUpgrader` used to upgrade contracts and registering new portals
`RoleFuner` is a new role extracted from before hard-coded single value for all networks

issue: https://github.com/omni-network/ops/issues/483