### PR TITLE
chose(ci): update pnpm and add make install tools

### DIFF
--- a/.github/workflows/check-sol-artifacts.yml
+++ b/.github/workflows/check-sol-artifacts.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@v4
         with:
-          version: 8
+          version: 9
           run_install: false
       - name: Build artifacts
         run: make all

--- a/contracts/Makefile
+++ b/contracts/Makefile
@@ -9,6 +9,11 @@ version: ## Print tool versions.
 
 
 
+.PHONY: install-tools
+install-tools:
+	@which npm > /dev/null || echo "npm not installed, see https://nodejs.org/en/download/package-manager"
+	@which pnpm > /dev/null || (echo "pnpm not installed, installing..."; npm install -g pnpm@9.0.0)
+
 .PHONY: install-deps
 install-deps: ## Install dependencies.
 	(cd avs && pnpm install --frozen-lockfile)


### PR DESCRIPTION
This PR adds make action to install PNPM version that matches the version in CI so no lockfile conflicts are caused.
It also makes installing tools easier.

issue: none