### PR TITLE
fix(e2e): fix portal owner

### DIFF
--- a/e2e/app/portalregistry.go
+++ b/e2e/app/portalregistry.go
@@ -64,7 +64,7 @@ func newRegistryMngr(ctx context.Context, def Definition) (registryMngr, error) 
 		return registryMngr{}, errors.Wrap(err, "new portal registry")
 	}
 
-	manager := eoa.MustAddress(def.Testnet.Network, eoa.RoleManager)
+	manager := eoa.MustAddress(def.Testnet.Network, eoa.RoleUpgrader)
 	txOpts, err := backend.BindOpts(ctx, manager)
 	if err != nil {
 		return registryMngr{}, err


### PR DESCRIPTION
Fix wrongly assigned manager to upgrader for portal registry.

issue: none