### PR TITLE
chore(admin): set omega uluwatu upgrade height

### DIFF
--- a/e2e/app/admin/planupgrade.go
+++ b/e2e/app/admin/planupgrade.go
@@ -21,6 +21,10 @@ var upgradePlans = map[netconf.ID]bindings.UpgradePlan{
 		Name:   uluwatu1.UpgradeName,
 		Height: 0, // Dynamically calculated for ephemeral networks
 	},
+	netconf.Omega: {
+		Name:   uluwatu1.UpgradeName,
+		Height: 3_073_000, // Mon 14 Oct 9am EST
+	},
 }
 
 // PlanUpgrade plans the above configured network upgrade.


### PR DESCRIPTION
Sets the omega `uluwatu` network-upgrade height to 3_073_000 which is roughly 9am Mon 14 Oct EST.

issue: https://github.com/omni-network/ops/issues/499