### PR TITLE
chore(lib): validate inputs before locking

### DIFF
--- a/lib/contracts/address.go
+++ b/lib/contracts/address.go
@@ -114,17 +114,17 @@ var (
 
 // GetAddresses returns the contract addresses for the given network.
 func GetAddresses(ctx context.Context, network netconf.ID) (Addresses, error) {
+	ver, err := version(ctx, network)
+	if err != nil {
+		return Addresses{}, err
+	}
+
 	addrsCache.mu.Lock()
 	defer addrsCache.mu.Unlock()
 
 	addrs, ok := addrsCache.cache[network]
 	if ok {
 		return addrs, nil
-	}
-
-	ver, err := version(ctx, network)
-	if err != nil {
-		return Addresses{}, err
 	}
 
 	addrs = Addresses{


### PR DESCRIPTION
The PR https://github.com/omni-network/omni/pull/2140 introduced a locking around a cache. Some parts of the critical section seem unrelated to the locking and can be done before without changing the read semantics (because this check happened after the cache read before).

issue: none