### PR TITLE
test(contracts/core): fix predeploy num alloc tests

### DIFF
--- a/contracts/core/test/script/AllocPredeploys.t.sol
+++ b/contracts/core/test/script/AllocPredeploys.t.sol
@@ -54,10 +54,10 @@ contract AllocPredeploys_Test is Test, AllocPredeploys {
         expected += 1024 * 2 - 1;
 
         // predeploy implementations (excl. not proxied WOmni)
-        expected += 4;
+        expected += 5;
 
-        // preinstalls
-        expected += 16;
+        // preinstalls (excl 4788 deployer)
+        expected += 15;
 
         // 4788 deployer account (nonce set to 1)
         expected += 1;


### PR DESCRIPTION
Num alloc test had correct number but wrong breakdown.

- We have 5 predeploy impls (Staking, Slashing, Upgrades, PortalReg, BridgeNative)
- 15 preinstall contracts
- 1 account we bump nonce off

issue: none
