### PR TITLE
chore(monitor/routerecon): reduce rate limit issues

### DIFF
--- a/monitor/routerecon/recon.go
+++ b/monitor/routerecon/recon.go
@@ -23,7 +23,7 @@ func ReconForever(ctx context.Context, network netconf.Network, xprov xchain.Pro
 		return
 	}
 
-	ticker := time.NewTicker(time.Minute * 10) // RouteScan rate limits prevent faster recon.
+	ticker := time.NewTicker(time.Minute * 30) // RouteScan rate limits prevent faster recon.
 	defer ticker.Stop()
 
 	for {
@@ -43,6 +43,14 @@ func ReconForever(ctx context.Context, network netconf.Network, xprov xchain.Pro
 				} else {
 					reconSuccess.Inc()
 					log.Info(ctx, "RouteRecon success", "stream", network.StreamName(stream))
+				}
+
+				// Sleep to avoid rate limiting.
+				select {
+				case <-ctx.Done():
+					return
+				case <-time.After(time.Minute):
+					// Continue
 				}
 			}
 		}


### PR DESCRIPTION
Reduce routescan recon loop frequency to mitigate rate limit errors.

issue: none