### PR TITLE
test(lib/xchain): fix flapping merkle test

### DIFF
--- a/lib/xchain/merkle_test.go
+++ b/lib/xchain/merkle_test.go
@@ -21,7 +21,7 @@ func TestMsgTreeNoVerify(t *testing.T) {
 
 	// Ensure msg.LogIndex is increasing
 	for i := 1; i < len(msgs); i++ {
-		msgs[i].LogIndex = msgs[i-1].LogIndex + uint64(rand.Intn(1000))
+		msgs[i].LogIndex = msgs[i-1].LogIndex + 1 + uint64(rand.Intn(1000))
 	}
 
 	tree, err := xchain.NewMsgTree(msgs)


### PR DESCRIPTION
Test flapped since it sometimes didn't actually increase the index

issue: none