### PR TITLE
refactor(e2e): remove most netconf usage

### DIFF
--- a/e2e/app/admin/bridgespec.go
+++ b/e2e/app/admin/bridgespec.go
@@ -82,7 +82,7 @@ func (s BridgeSpec) Verify() error {
 func EnsureBridgeSpec(ctx context.Context, def app.Definition, cfg Config, specOverride *NetworkBridgeSpec) error {
 	s := setup(def, cfg)
 
-	l1Chain, ok := s.network.EthereumChain()
+	l1Chain, ok := s.testnet.EthereumChain()
 	if !ok {
 		return errors.New("no ethereum chain")
 	}
@@ -120,12 +120,12 @@ func EnsureBridgeSpec(ctx context.Context, def app.Definition, cfg Config, specO
 
 // ensureNativeBridgeSpec ensures that the live native bridge contract is configured as per the local spec.
 func ensureNativeBridgeSpec(ctx context.Context, s shared, c chain, specOverride *BridgeSpec) error {
-	local := bridgeSpec[s.network.ID].Native
+	local := bridgeSpec[s.testnet.Network].Native
 	if specOverride != nil {
 		local = *specOverride
 	}
 
-	ethCl, err := ethclient.Dial(c.Name, c.rpc)
+	ethCl, err := ethclient.Dial(c.Name, c.RPCEndpoint)
 	if err != nil {
 		return errors.Wrap(err, "dial eth client")
 	}
@@ -152,17 +152,17 @@ func ensureNativeBridgeSpec(ctx context.Context, s shared, c chain, specOverride
 
 // ensureL1BridgeSpec ensures that the live L1 bridge contract is configured as per the local spec.
 func ensureL1BridgeSpec(ctx context.Context, s shared, c chain, specOverride *BridgeSpec) error {
-	local := bridgeSpec[s.network.ID].L1
+	local := bridgeSpec[s.testnet.Network].L1
 	if specOverride != nil {
 		local = *specOverride
 	}
 
-	ethCl, err := ethclient.Dial(c.Name, c.rpc)
+	ethCl, err := ethclient.Dial(c.Name, c.RPCEndpoint)
 	if err != nil {
 		return errors.Wrap(err, "dial eth client")
 	}
 
-	addrs, err := contracts.GetAddresses(ctx, s.network.ID)
+	addrs, err := contracts.GetAddresses(ctx, s.testnet.Network)
 	if err != nil {
 		return errors.Wrap(err, "get addrs")
 	}

--- a/e2e/app/admin/pausebridge.go
+++ b/e2e/app/admin/pausebridge.go
@@ -18,7 +18,7 @@ func pauseBridge(ctx context.Context, s shared, c chain, addr common.Address, ac
 		return errors.Wrap(err, "pack calldata", "chain", c.Name)
 	}
 
-	out, err := s.runForge(ctx, c.rpc, calldata, s.manager)
+	out, err := s.runForge(ctx, c.RPCEndpoint, calldata, s.manager)
 	if err != nil {
 		return errors.Wrap(err, "run forge", "out", out, "chain", c.Name)
 	}
@@ -37,7 +37,7 @@ func unpauseBridge(ctx context.Context, s shared, c chain, addr common.Address, 
 		return errors.Wrap(err, "pack calldata", "chain", c.Name)
 	}
 
-	out, err := s.runForge(ctx, c.rpc, calldata, s.manager)
+	out, err := s.runForge(ctx, c.RPCEndpoint, calldata, s.manager)
 	if err != nil {
 		return errors.Wrap(err, "run forge", "out", out, "chain", c.Name)
 	}

--- a/e2e/app/admin/pauseportal.go
+++ b/e2e/app/admin/pauseportal.go
@@ -16,7 +16,7 @@ func pausePortal(ctx context.Context, s shared, c chain) error {
 		return errors.Wrap(err, "pack calldata", "chain", c.Name)
 	}
 
-	out, err := s.runForge(ctx, c.rpc, calldata, s.manager)
+	out, err := s.runForge(ctx, c.RPCEndpoint, calldata, s.manager)
 	if err != nil {
 		return errors.Wrap(err, "run forge", "out", out, "chain", c.Name)
 	}
@@ -35,7 +35,7 @@ func unpausePortal(ctx context.Context, s shared, c chain) error {
 		return errors.Wrap(err, "pack calldata", "chain", c.Name)
 	}
 
-	out, err := s.runForge(ctx, c.rpc, calldata, s.manager)
+	out, err := s.runForge(ctx, c.RPCEndpoint, calldata, s.manager)
 	if err != nil {
 		return errors.Wrap(err, "run forge", "out", out, "chain", c.Name)
 	}

--- a/e2e/app/admin/pausexcall.go
+++ b/e2e/app/admin/pausexcall.go
@@ -17,7 +17,7 @@ func pauseXCall(ctx context.Context, s shared, c chain) error {
 		return errors.Wrap(err, "pack calldata", "chain", c.Name)
 	}
 
-	out, err := s.runForge(ctx, c.rpc, calldata, s.manager)
+	out, err := s.runForge(ctx, c.RPCEndpoint, calldata, s.manager)
 	if err != nil {
 		return errors.Wrap(err, "run forge", "out", out, "chain", c.Name)
 	}
@@ -29,19 +29,19 @@ func pauseXCall(ctx context.Context, s shared, c chain) error {
 
 // pauseXCallTo pauses xcalls to a chain, on a chain.
 func pauseXCallTo(ctx context.Context, s shared, c chain, toID uint64) error {
-	to, ok := s.network.Chain(toID)
+	to, ok := s.testnet.EVMChainByID(toID)
 	if !ok {
 		return errors.New("chain id not in network", "chain", toID)
 	}
 
 	log.Info(ctx, "Pausing xcall...", "chain", c.Name, "to", to.Name, "addr", c.PortalAddress)
 
-	calldata, err := adminABI.Pack("pauseXCallTo", s.manager, c.PortalAddress, to.ID)
+	calldata, err := adminABI.Pack("pauseXCallTo", s.manager, c.PortalAddress, to.ChainID)
 	if err != nil {
 		return errors.Wrap(err, "pack calldata", "chain", c.Name)
 	}
 
-	out, err := s.runForge(ctx, c.rpc, calldata, s.manager)
+	out, err := s.runForge(ctx, c.RPCEndpoint, calldata, s.manager)
 	if err != nil {
 		return errors.Wrap(err, "run forge", "out", out, "chain", c.Name)
 	}
@@ -60,7 +60,7 @@ func unpauseXCall(ctx context.Context, s shared, c chain) error {
 		return errors.Wrap(err, "pack calldata", "chain", c.Name)
 	}
 
-	out, err := s.runForge(ctx, c.rpc, calldata, s.manager)
+	out, err := s.runForge(ctx, c.RPCEndpoint, calldata, s.manager)
 	if err != nil {
 		return errors.Wrap(err, "run forge", "out", out, "chain", c.Name)
 	}
@@ -72,19 +72,19 @@ func unpauseXCall(ctx context.Context, s shared, c chain) error {
 
 // pauseXCallTo pauses xcalls to a chain, on a chain.
 func unpauseXCallTo(ctx context.Context, s shared, c chain, toID uint64) error {
-	to, ok := s.network.Chain(toID)
+	to, ok := s.testnet.EVMChainByID(toID)
 	if !ok {
 		return errors.New("chain id not in network", "chain", toID)
 	}
 
 	log.Info(ctx, "Unpausing xcall...", "chain", c.Name, "to", to.Name, "addr", c.PortalAddress)
 
-	calldata, err := adminABI.Pack("unpauseXCallTo", s.manager, c.PortalAddress, to.ID)
+	calldata, err := adminABI.Pack("unpauseXCallTo", s.manager, c.PortalAddress, to.ChainID)
 	if err != nil {
 		return errors.Wrap(err, "pack calldata", "chain", c.Name)
 	}
 
-	out, err := s.runForge(ctx, c.rpc, calldata, s.manager)
+	out, err := s.runForge(ctx, c.RPCEndpoint, calldata, s.manager)
 	if err != nil {
 		return errors.Wrap(err, "run forge", "out", out, "chain", c.Name)
 	}

--- a/e2e/app/admin/pausexsubmit.go
+++ b/e2e/app/admin/pausexsubmit.go
@@ -17,7 +17,7 @@ func pauseXSubmit(ctx context.Context, s shared, c chain) error {
 		return errors.Wrap(err, "pack calldata", "chain", c.Name)
 	}
 
-	out, err := s.runForge(ctx, c.rpc, calldata, s.manager)
+	out, err := s.runForge(ctx, c.RPCEndpoint, calldata, s.manager)
 	if err != nil {
 		return errors.Wrap(err, "run forge", "out", out, "chain", c.Name)
 	}
@@ -29,19 +29,19 @@ func pauseXSubmit(ctx context.Context, s shared, c chain) error {
 
 // pauseXSubmitFrom pauses xsubmits from a chain, on a chain.
 func pauseXSubmitFrom(ctx context.Context, s shared, c chain, fromID uint64) error {
-	from, ok := s.network.Chain(fromID)
+	from, ok := s.testnet.EVMChainByID(fromID)
 	if !ok {
 		return errors.New("chain id not in network", "chain", fromID)
 	}
 
 	log.Info(ctx, "Pausing xsubmit...", "chain", c.Name, "from", from.Name, "addr", c.PortalAddress)
 
-	calldata, err := adminABI.Pack("pauseXSubmitFrom", s.manager, c.PortalAddress, from.ID)
+	calldata, err := adminABI.Pack("pauseXSubmitFrom", s.manager, c.PortalAddress, from.ChainID)
 	if err != nil {
 		return errors.Wrap(err, "pack calldata", "chain", c.Name)
 	}
 
-	out, err := s.runForge(ctx, c.rpc, calldata, s.manager)
+	out, err := s.runForge(ctx, c.RPCEndpoint, calldata, s.manager)
 	if err != nil {
 		return errors.Wrap(err, "run forge", "out", out, "chain", c.Name)
 	}
@@ -60,7 +60,7 @@ func unpauseXSubmit(ctx context.Context, s shared, c chain) error {
 		return errors.Wrap(err, "pack calldata", "chain", c.Name)
 	}
 
-	out, err := s.runForge(ctx, c.rpc, calldata, s.manager)
+	out, err := s.runForge(ctx, c.RPCEndpoint, calldata, s.manager)
 	if err != nil {
 		return errors.Wrap(err, "run forge", "out", out, "chain", c.Name)
 	}
@@ -72,19 +72,19 @@ func unpauseXSubmit(ctx context.Context, s shared, c chain) error {
 
 // pauseXSubmitFrom pauses xsubmits from a chain, on a chain.
 func unpauseXSubmitFrom(ctx context.Context, s shared, c chain, fromID uint64) error {
-	from, ok := s.network.Chain(fromID)
+	from, ok := s.testnet.EVMChainByID(fromID)
 	if !ok {
 		return errors.New("chain id not in network", "chain", fromID)
 	}
 
 	log.Info(ctx, "Unpausing xsubmit...", "chain", c.Name, "from", from.Name, "addr", c.PortalAddress)
 
-	calldata, err := adminABI.Pack("unpauseXSubmitFrom", s.manager, c.PortalAddress, from.ID)
+	calldata, err := adminABI.Pack("unpauseXSubmitFrom", s.manager, c.PortalAddress, from.ChainID)
 	if err != nil {
 		return errors.Wrap(err, "pack calldata", "chain", c.Name)
 	}
 
-	out, err := s.runForge(ctx, c.rpc, calldata, s.manager)
+	out, err := s.runForge(ctx, c.RPCEndpoint, calldata, s.manager)
 	if err != nil {
 		return errors.Wrap(err, "run forge", "out", out, "chain", c.Name)
 	}

--- a/e2e/app/admin/upgrade.go
+++ b/e2e/app/admin/upgrade.go
@@ -80,7 +80,7 @@ func UpgradeBridgeNative(ctx context.Context, def app.Definition, cfg Config) er
 func UpgradeBridgeL1(ctx context.Context, def app.Definition, cfg Config) error {
 	s := setup(def, cfg)
 
-	l1, ok := s.network.EthereumChain()
+	l1, ok := s.testnet.EthereumChain()
 	if !ok {
 		return errors.New("no l1 eth chain")
 	}
@@ -114,7 +114,7 @@ func upgradePortal(ctx context.Context, s shared, c chain) error {
 		return errors.Wrap(err, "pack calldata")
 	}
 
-	out, err := s.runForge(ctx, c.rpc, calldata, s.upgrader, s.deployer)
+	out, err := s.runForge(ctx, c.RPCEndpoint, calldata, s.upgrader, s.deployer)
 	if err != nil {
 		return errors.Wrap(err, "run forge", "out", out)
 	}
@@ -128,9 +128,9 @@ func upgradeFeeOracleV1(ctx context.Context, s shared, c chain) error {
 	// FeeOracleV1 contracts were not deployed via Create3
 	// The address must be read from the portal
 
-	client, err := ethclient.Dial(c.Name, c.rpc)
+	client, err := ethclient.Dial(c.Name, c.RPCEndpoint)
 	if err != nil {
-		return errors.Wrap(err, "dial rpc")
+		return errors.Wrap(err, "dial RPCEndpoint")
 	}
 
 	portal, err := bindings.NewOmniPortal(c.PortalAddress, client)
@@ -151,7 +151,7 @@ func upgradeFeeOracleV1(ctx context.Context, s shared, c chain) error {
 		return errors.Wrap(err, "pack calldata")
 	}
 
-	out, err := s.runForge(ctx, c.rpc, calldata, s.upgrader, s.deployer)
+	out, err := s.runForge(ctx, c.RPCEndpoint, calldata, s.upgrader, s.deployer)
 	if err != nil {
 		return errors.Wrap(err, "run forge", "out", out)
 	}
@@ -162,7 +162,7 @@ func upgradeFeeOracleV1(ctx context.Context, s shared, c chain) error {
 }
 
 func upgradeGasStation(ctx context.Context, s shared, c chain) error {
-	addrs, err := contracts.GetAddresses(ctx, s.network.ID)
+	addrs, err := contracts.GetAddresses(ctx, s.testnet.Network)
 	if err != nil {
 		return errors.Wrap(err, "get addrs")
 	}
@@ -175,7 +175,7 @@ func upgradeGasStation(ctx context.Context, s shared, c chain) error {
 		return errors.Wrap(err, "pack calldata")
 	}
 
-	out, err := s.runForge(ctx, c.rpc, calldata, s.upgrader, s.deployer)
+	out, err := s.runForge(ctx, c.RPCEndpoint, calldata, s.upgrader, s.deployer)
 	if err != nil {
 		return errors.Wrap(err, "run forge", "out", out)
 	}
@@ -186,7 +186,7 @@ func upgradeGasStation(ctx context.Context, s shared, c chain) error {
 }
 
 func upgradeGasPump(ctx context.Context, s shared, c chain) error {
-	addrs, err := contracts.GetAddresses(ctx, s.network.ID)
+	addrs, err := contracts.GetAddresses(ctx, s.testnet.Network)
 	if err != nil {
 		return errors.Wrap(err, "get addrs")
 	}
@@ -199,7 +199,7 @@ func upgradeGasPump(ctx context.Context, s shared, c chain) error {
 		return errors.Wrap(err, "pack calldata")
 	}
 
-	out, err := s.runForge(ctx, c.rpc, calldata, s.upgrader, s.deployer)
+	out, err := s.runForge(ctx, c.RPCEndpoint, calldata, s.upgrader, s.deployer)
 	if err != nil {
 		return errors.Wrap(err, "run forge", "out", out)
 	}
@@ -218,7 +218,7 @@ func ugpradeSlashing(ctx context.Context, s shared, c chain) error {
 		return errors.Wrap(err, "pack calldata")
 	}
 
-	out, err := s.runForge(ctx, c.rpc, calldata, s.upgrader, s.deployer)
+	out, err := s.runForge(ctx, c.RPCEndpoint, calldata, s.upgrader, s.deployer)
 	if err != nil {
 		return errors.Wrap(err, "run forge", "out", out)
 	}
@@ -237,7 +237,7 @@ func upgradeStaking(ctx context.Context, s shared, c chain) error {
 		return errors.Wrap(err, "pack calldata")
 	}
 
-	out, err := s.runForge(ctx, c.rpc, calldata, s.upgrader, s.deployer)
+	out, err := s.runForge(ctx, c.RPCEndpoint, calldata, s.upgrader, s.deployer)
 	if err != nil {
 		return errors.Wrap(err, "run forge", "out", out)
 	}
@@ -256,7 +256,7 @@ func upgradeBridgeNative(ctx context.Context, s shared, c chain) error {
 		return errors.Wrap(err, "pack calldata")
 	}
 
-	out, err := s.runForge(ctx, c.rpc, calldata, s.upgrader, s.deployer)
+	out, err := s.runForge(ctx, c.RPCEndpoint, calldata, s.upgrader, s.deployer)
 	if err != nil {
 		return errors.Wrap(err, "run forge", "out", out)
 	}
@@ -267,7 +267,7 @@ func upgradeBridgeNative(ctx context.Context, s shared, c chain) error {
 }
 
 func upgradeBridgeL1(ctx context.Context, s shared, c chain) error {
-	addrs, err := contracts.GetAddresses(ctx, s.network.ID)
+	addrs, err := contracts.GetAddresses(ctx, s.testnet.Network)
 	if err != nil {
 		return errors.Wrap(err, "get addrs")
 	}
@@ -280,7 +280,7 @@ func upgradeBridgeL1(ctx context.Context, s shared, c chain) error {
 		return errors.Wrap(err, "pack calldata")
 	}
 
-	out, err := s.runForge(ctx, c.rpc, calldata, s.upgrader, s.deployer)
+	out, err := s.runForge(ctx, c.RPCEndpoint, calldata, s.upgrader, s.deployer)
 	if err != nil {
 		return errors.Wrap(err, "run forge", "out", out)
 	}
@@ -299,7 +299,7 @@ func upgradePortalRegistry(ctx context.Context, s shared, c chain) error {
 		return errors.Wrap(err, "pack calldata")
 	}
 
-	out, err := s.runForge(ctx, c.rpc, calldata, s.upgrader, s.deployer)
+	out, err := s.runForge(ctx, c.RPCEndpoint, calldata, s.upgrader, s.deployer)
 	if err != nil {
 		return errors.Wrap(err, "run forge", "out", out)
 	}

--- a/e2e/app/definition.go
+++ b/e2e/app/definition.go
@@ -90,6 +90,7 @@ func (d Definition) Netman() netman.Manager {
 }
 
 // DeployInfos returns the deploy information of the OmniPortal and OmniAVS contracts.
+// Note this panics if not called after netman.DeployPortals.
 func (d Definition) DeployInfos() types.DeployInfos {
 	resp := make(types.DeployInfos)
 
@@ -513,6 +514,7 @@ func ExternalEndpoints(def Definition) xchain.RPCEndpoints {
 }
 
 // NetworkFromDef returns the network configuration from the definition.
+// Note that this panics if not called after netman.DeployPortals.
 func NetworkFromDef(def Definition) netconf.Network {
 	var chains []netconf.Chain
 

--- a/e2e/app/erc20faucet.go
+++ b/e2e/app/erc20faucet.go
@@ -44,17 +44,16 @@ func RunERC20Faucet(ctx context.Context, def Definition, cfg RunERC20FaucetConfi
 		return errors.Wrap(err, "get addrs")
 	}
 
-	network := NetworkFromDef(def)
 	account := common.HexToAddress(cfg.AddrToFund)
 	amt := new(big.Int).Mul(umath.NewBigInt(cfg.Amount), big.NewInt(params.Ether))
 	funder := omnitoken.InitialSupplyRecipient(networkID)
 
-	chain, ok := network.EthereumChain()
+	chain, ok := def.Testnet.EthereumChain()
 	if !ok {
 		return errors.New("no ethereum chain")
 	}
 
-	backend, err := def.Backends().Backend(chain.ID)
+	backend, err := def.Backends().Backend(chain.ChainID)
 	if err != nil {
 		return errors.Wrap(err, "backend")
 	}

--- a/e2e/app/monitor.go
+++ b/e2e/app/monitor.go
@@ -18,7 +18,7 @@ import (
 )
 
 func LogMetrics(ctx context.Context, def Definition) error {
-	extNetwork := NetworkFromDef(def)
+	extNetwork := NetworkFromDef(def) // Safe to call NetworkFromDef since this after netman.DeployContracts
 	archiveNode, ok := def.Testnet.ArchiveNode()
 	if !ok {
 		return errors.New("monitor must use archive node, no archive node found")
@@ -43,7 +43,7 @@ func StartMonitoringReceipts(ctx context.Context, def Definition) func() error {
 		return func() error { return errors.Wrap(err, "getting client") }
 	}
 
-	network := NetworkFromDef(def)
+	network := NetworkFromDef(def) // Safe to call NetworkFromDef since this after netman.DeployContracts
 	cProvider := cprovider.NewABCIProvider(client, def.Testnet.Network, netconf.ChainVersionNamer(def.Testnet.Network))
 	xProvider := xprovider.New(network, def.Backends().RPCClients(), cProvider)
 	cChainID := def.Testnet.Network.Static().OmniConsensusChainIDUint64()

--- a/e2e/app/run.go
+++ b/e2e/app/run.go
@@ -118,7 +118,7 @@ func Deploy(ctx context.Context, def Definition, cfg DeployConfig) (*pingpong.XD
 		return nil, nil //nolint:nilnil // No ping pong, no XDapp to return.
 	}
 
-	pp, err := pingpong.Deploy(ctx, NetworkFromDef(def), def.Backends())
+	pp, err := pingpong.Deploy(ctx, NetworkFromDef(def), def.Backends()) // Safe to call NetworkFromDef since this after netman.DeployContracts
 	if err != nil {
 		return nil, errors.Wrap(err, "deploy pingpong")
 	}
@@ -230,7 +230,7 @@ func E2ETest(ctx context.Context, def Definition, cfg E2ETestConfig) error {
 		return errors.Wrap(err, "stop adding portals")
 	}
 
-	network := NetworkFromDef(def)
+	network := NetworkFromDef(def) // Safe to call NetworkFromDef since this after netman.DeployContracts
 	if err := WaitAllSubmissions(ctx, network, def.Netman().Portals(), sum(msgBatches)); err != nil {
 		return err
 	}
@@ -307,11 +307,10 @@ func toPortalValidators(validators map[*e2e.Node]int64) ([]bindings.Validator, e
 }
 
 func logRPCs(ctx context.Context, def Definition) {
-	network := NetworkFromDef(def)
 	endpoints := ExternalEndpoints(def)
-	for _, chain := range network.EVMChains() {
-		rpc, _ := endpoints.ByNameOrID(chain.Name, chain.ID)
-		log.Info(ctx, "EVM Chain RPC available", "chain_id", chain.ID,
+	for _, chain := range def.Testnet.EVMChains() {
+		rpc, _ := endpoints.ByNameOrID(chain.Name, chain.ChainID)
+		log.Info(ctx, "EVM Chain RPC available", "chain_id", chain.ChainID,
 			"chain_name", chain.Name, "url", rpc)
 	}
 }

--- a/e2e/app/valupdates.go
+++ b/e2e/app/valupdates.go
@@ -35,10 +35,9 @@ func FundValidatorsForTesting(ctx context.Context, def Definition) error {
 
 	log.Info(ctx, "Funding validators for testing", "count", len(def.Testnet.Nodes))
 
-	network := NetworkFromDef(def)
-	omniEVM, _ := network.OmniEVMChain()
-	funder := eoa.MustAddress(network.ID, eoa.RoleTester) // Fund validators using tester eoa
-	_, fundBackend, err := def.Backends().BindOpts(ctx, omniEVM.ID, funder)
+	omniEVM, _ := def.Testnet.OmniEVMChain()
+	funder := eoa.MustAddress(def.Testnet.Network, eoa.RoleTester) // Fund validators using tester eoa
+	_, fundBackend, err := def.Backends().BindOpts(ctx, omniEVM.ChainID, funder)
 	if err != nil {
 		return errors.Wrap(err, "bind opts")
 	}
@@ -125,10 +124,9 @@ func StartValidatorUpdates(ctx context.Context, def Definition) func() error {
 		})
 
 		// Create a backend to trigger deposits from
-		network := NetworkFromDef(def)
 		endpoints := ExternalEndpoints(def)
-		omniEVM, _ := network.OmniEVMChain()
-		rpc, err := endpoints.ByNameOrID(omniEVM.Name, omniEVM.ID)
+		omniEVM, _ := def.Testnet.OmniEVMChain()
+		rpc, err := endpoints.ByNameOrID(omniEVM.Name, omniEVM.ChainID)
 		if err != nil {
 			returnErr(errors.Wrap(err, "get rpc"))
 			return
@@ -138,7 +136,7 @@ func StartValidatorUpdates(ctx context.Context, def Definition) func() error {
 			returnErr(errors.Wrap(err, "dial"))
 			return
 		}
-		valBackend, err := ethbackend.NewBackend(omniEVM.Name, omniEVM.ID, omniEVM.BlockPeriod, ethCl, privkeys...)
+		valBackend, err := ethbackend.NewBackend(omniEVM.Name, omniEVM.ChainID, omniEVM.BlockPeriod, ethCl, privkeys...)
 		if err != nil {
 			returnErr(errors.Wrap(err, "new backend"))
 			return

--- a/e2e/types/testnet.go
+++ b/e2e/types/testnet.go
@@ -129,8 +129,36 @@ func (t Testnet) HasPerturbations() bool {
 	return t.Testnet.HasPerturbations()
 }
 
+func (t Testnet) EVMChainByID(id uint64) (EVMChain, bool) {
+	for _, c := range t.EVMChains() {
+		if c.ChainID == id {
+			return c, true
+		}
+	}
+
+	return EVMChain{}, false
+}
+
+func (t Testnet) EVMChainByName(name string) (EVMChain, bool) {
+	for _, c := range t.EVMChains() {
+		if c.Name == name {
+			return c, true
+		}
+	}
+
+	return EVMChain{}, false
+}
+
 func (t Testnet) HasOmniEVM() bool {
 	return len(t.OmniEVMs) > 0
+}
+
+func (t Testnet) OmniEVMChain() (EVMChain, bool) {
+	if len(t.OmniEVMs) == 0 {
+		return EVMChain{}, false
+	}
+
+	return t.OmniEVMs[0].Chain, true
 }
 
 // EVMChains returns all EVM chains in the network.
@@ -151,6 +179,16 @@ func (t Testnet) EVMChains() []EVMChain {
 	}
 
 	return chains
+}
+
+func (t Testnet) EthereumChain() (EVMChain, bool) {
+	for _, c := range t.EVMChains() {
+		if netconf.IsEthereumChain(t.Network, c.ChainID) {
+			return c, true
+		}
+	}
+
+	return EVMChain{}, false
 }
 
 // EVMChain represents a EVM chain in a omni network.


### PR DESCRIPTION
Replaces most usage of `netconf.Network` in e2e since we don't actually have `DeployHeight` in most cases. It can only be used after `netman.DeployPortals` in `Deploy` or `TestE2E` command.

Replace it with `types.Testnet` and `types.EVMChain`.

issue: none
