### PR TITLE
chore(ci): relax npm dependabot interval

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,5 +11,5 @@ updates:
     - "/contracts/avs"
     - "/contracts/core"
   schedule:
-    interval: "daily"
+    interval: "weekly"
   labels: []


### PR DESCRIPTION
Relax npm dependabot interval to weekly.

Too much noise.

issue: none