### PR TITLE
fix(relayer): ensure submission order

### DIFF
--- a/relayer/app/app.go
+++ b/relayer/app/app.go
@@ -61,8 +61,8 @@ func Run(ctx context.Context, cfg Config) error {
 	pnl := newPnlLogger(network.ID, pricer)
 
 	for _, destChain := range network.EVMChains() {
-		// Setup sender provider
-		sendProvider := func() (SendFunc, error) {
+		// Setup send provider
+		sendProvider := func() (SendAsync, error) {
 			sender, err := NewSender(
 				network.ID,
 				destChain,
@@ -75,7 +75,7 @@ func Run(ctx context.Context, cfg Config) error {
 				return nil, err
 			}
 
-			return sender.SendTransaction, nil
+			return sender.SendAsync, nil
 		}
 
 		// Setup validator set awaiter

--- a/relayer/app/cursors_internal_test.go
+++ b/relayer/app/cursors_internal_test.go
@@ -130,10 +130,10 @@ func (m *mockXChainClient) GetEmittedCursor(ctx context.Context, ref xchain.Emit
 }
 
 type mockSender struct {
-	SendTransactionFn func(ctx context.Context, submission xchain.Submission) error
+	SendTransactionFn func(ctx context.Context, submission xchain.Submission) <-chan error
 }
 
-func (m *mockSender) SendTransaction(ctx context.Context, submission xchain.Submission) error {
+func (m *mockSender) SendTransaction(ctx context.Context, submission xchain.Submission) <-chan error {
 	return m.SendTransactionFn(ctx, submission)
 }
 

--- a/relayer/app/sender.go
+++ b/relayer/app/sender.go
@@ -29,7 +29,7 @@ import (
 // Sender uses txmgr to send transactions a specific destination chain.
 type onSubmitFunc func(context.Context, *ethtypes.Transaction, *ethtypes.Receipt, xchain.Submission)
 
-// Sender uses txmgr to send transactions a specific destination chain.
+// Sender uses txmgr to send transactions to a specific destination chain.
 type Sender struct {
 	network      netconf.ID
 	txMgr        txmgr.TxManager
@@ -108,7 +108,7 @@ func (s Sender) SendAsync(ctx context.Context, sub xchain.Submission) <-chan err
 	}
 
 	if s.txMgr == nil {
-		return returnErr(errors.New("tx mgr not found", "dest_chain_id", sub.DestChainID))
+		return returnErr(errors.New("tx mgr not found [BUG]", "dest_chain_id", sub.DestChainID))
 	} else if sub.DestChainID != s.chain.ID {
 		return returnErr(errors.New("unexpected destination chain [BUG]",
 			"got", sub.DestChainID, "expect", s.chain.ID))

--- a/relayer/app/sender.go
+++ b/relayer/app/sender.go
@@ -26,23 +26,23 @@ import (
 	"github.com/ethereum/go-ethereum/params"
 )
 
+// Sender uses txmgr to send transactions a specific destination chain.
 type onSubmitFunc func(context.Context, *ethtypes.Transaction, *ethtypes.Receipt, xchain.Submission)
 
-// Sender uses txmgr to send transactions to the destination chain.
+// Sender uses txmgr to send transactions a specific destination chain.
 type Sender struct {
 	network      netconf.ID
 	txMgr        txmgr.TxManager
 	gasEstimator gasEstimator
-	portal       common.Address
 	abi          *abi.ABI
 	chain        netconf.Chain
 	gasToken     tokens.Token
 	chainNames   map[xchain.ChainVersion]string
-	rpcClient    ethclient.Client
+	ethCl        ethclient.Client
 	onSubmit     onSubmitFunc
 }
 
-// NewSender creates a new sender that uses txmgr to send transactions to the destination chain.
+// NewSender returns a new sender.
 func NewSender(
 	network netconf.ID,
 	chain netconf.Chain,
@@ -51,12 +51,13 @@ func NewSender(
 	chainNames map[xchain.ChainVersion]string,
 	onSubmit onSubmitFunc,
 ) (Sender, error) {
-	// we want to query receipts every 1/3 of the block time
-	cfg, err := txmgr.NewConfig(txmgr.NewCLIConfig(
-		chain.ID,
-		chain.BlockPeriod/3,
-		txmgr.DefaultSenderFlagValues,
-	),
+	const receiptPollFreq = 3 // Query receipts every 1/3 of the block time
+	cfg, err := txmgr.NewConfig(
+		txmgr.NewCLIConfig(
+			chain.ID,
+			chain.BlockPeriod/receiptPollFreq,
+			txmgr.DefaultSenderFlagValues,
+		),
 		&privateKey,
 		rpcClient,
 	)
@@ -84,23 +85,33 @@ func NewSender(
 		network:      network,
 		txMgr:        txMgr,
 		gasEstimator: newGasEstimator(network),
-		portal:       chain.PortalAddress,
 		abi:          &parsedAbi,
 		chain:        chain,
 		gasToken:     meta.NativeToken,
 		chainNames:   chainNames,
-		rpcClient:    rpcClient,
+		ethCl:        rpcClient,
 		onSubmit:     onSubmit,
 	}, nil
 }
 
-// SendTransaction sends the submission to the destination chain.
-func (s Sender) SendTransaction(ctx context.Context, sub xchain.Submission) error {
+// SendAsync sends the submission to the destination chain asynchronously.
+// It returns a channel that will receive an error if the submission fails or nil when it succeeds.
+// Nonces are however reserved synchronously, so ordering of submissions
+// is preserved.
+func (s Sender) SendAsync(ctx context.Context, sub xchain.Submission) <-chan error {
+	// Helper function to return error "synchronously".
+	returnErr := func(err error) chan error {
+		resp := make(chan error, 1)
+		resp <- err
+
+		return resp
+	}
+
 	if s.txMgr == nil {
-		return errors.New("tx mgr not found", "dest_chain_id", sub.DestChainID)
+		return returnErr(errors.New("tx mgr not found", "dest_chain_id", sub.DestChainID))
 	} else if sub.DestChainID != s.chain.ID {
-		return errors.New("unexpected destination chain [BUG]",
-			"got", sub.DestChainID, "expect", s.chain.ID)
+		return returnErr(errors.New("unexpected destination chain [BUG]",
+			"got", sub.DestChainID, "expect", s.chain.ID))
 	}
 
 	// Get some info for logging
@@ -127,67 +138,75 @@ func (s Sender) SendTransaction(ctx context.Context, sub xchain.Submission) erro
 
 	txData, err := xchain.EncodeXSubmit(xchain.SubmissionToBinding(sub))
 	if err != nil {
-		return err
+		return returnErr(err)
 	}
 
 	// Reserve a nonce here to ensure correctly ordered submissions.
 	nonce, err := s.txMgr.ReserveNextNonce(ctx)
 	if err != nil {
-		return err
+		return returnErr(err)
 	}
 
 	estimatedGas := s.gasEstimator(s.chain.ID, sub.Msgs)
 
 	candidate := txmgr.TxCandidate{
 		TxData:   txData,
-		To:       &s.portal,
+		To:       &s.chain.PortalAddress,
 		GasLimit: estimatedGas,
 		Value:    big.NewInt(0),
 		Nonce:    &nonce,
 	}
 
-	tx, rec, err := s.txMgr.Send(ctx, candidate)
-	if err != nil {
-		return errors.Wrap(err, "failed to send tx", reqAttrs...)
-	}
+	asyncResp := make(chan error, 1) // Actual async response populated by goroutine below.
+	go func() {
+		tx, rec, err := s.txMgr.Send(ctx, candidate)
+		if err != nil {
+			asyncResp <- errors.Wrap(err, "failed to send tx", reqAttrs...)
+			return
+		}
 
-	submissionTotal.WithLabelValues(srcChain, dstChain).Inc()
-	msgTotal.WithLabelValues(srcChain, dstChain).Add(float64(len(sub.Msgs)))
-	gasEstimated.WithLabelValues(dstChain).Observe(float64(estimatedGas))
+		submissionTotal.WithLabelValues(srcChain, dstChain).Inc()
+		msgTotal.WithLabelValues(srcChain, dstChain).Add(float64(len(sub.Msgs)))
+		gasEstimated.WithLabelValues(dstChain).Observe(float64(estimatedGas))
 
-	receiptAttrs := []any{
-		"valset_id", sub.ValidatorSetID,
-		"status", rec.Status,
-		"nonce", tx.Nonce(),
-		"height", rec.BlockNumber.Uint64(),
-		"gas_used", rec.GasUsed,
-		"tx_hash", rec.TxHash,
-	}
+		receiptAttrs := []any{
+			"valset_id", sub.ValidatorSetID,
+			"status", rec.Status,
+			"nonce", tx.Nonce(),
+			"height", rec.BlockNumber.Uint64(),
+			"gas_used", rec.GasUsed,
+			"tx_hash", rec.TxHash,
+		}
 
-	spendTotal.WithLabelValues(dstChain, string(s.gasToken)).Add(totalSpendGwei(tx, rec))
+		spendTotal.WithLabelValues(dstChain, string(s.gasToken)).Add(totalSpendGwei(tx, rec))
 
-	if s.onSubmit != nil {
-		go s.onSubmit(ctx, tx, rec, sub)
-	}
+		if s.onSubmit != nil {
+			go s.onSubmit(ctx, tx, rec, sub)
+		}
 
-	if rec.Status == 0 {
-		// Try and get debug information of the reverted transaction
-		resp, err := s.rpcClient.CallContract(ctx, callFromTx(s.txMgr.From(), tx), rec.BlockNumber)
+		const statusReverted = 0
+		if rec.Status == statusReverted {
+			// Try and get debug information of the reverted transaction
+			resp, err := s.ethCl.CallContract(ctx, callFromTx(s.txMgr.From(), tx), rec.BlockNumber)
 
-		errAttrs := slices.Concat(receiptAttrs, reqAttrs, []any{
-			"call_resp", hexutil.Encode(resp),
-			"call_err", err,
-			"gas_limit", tx.Gas(),
-		})
+			errAttrs := slices.Concat(receiptAttrs, reqAttrs, []any{
+				"call_resp", hexutil.Encode(resp),
+				"call_err", err,
+				"gas_limit", tx.Gas(),
+			})
 
-		revertedSubmissionTotal.WithLabelValues(srcChain, dstChain).Inc()
+			revertedSubmissionTotal.WithLabelValues(srcChain, dstChain).Inc()
 
-		return errors.New("submission reverted", errAttrs...)
-	}
+			asyncResp <- errors.New("submission reverted", errAttrs...)
 
-	log.Info(ctx, "Sent submission", receiptAttrs...)
+			return
+		}
 
-	return nil
+		log.Info(ctx, "Sent submission", receiptAttrs...)
+		asyncResp <- nil
+	}()
+
+	return asyncResp
 }
 
 func callFromTx(from common.Address, tx *ethtypes.Transaction) ethereum.CallMsg {

--- a/relayer/app/sender_internal_test.go
+++ b/relayer/app/sender_internal_test.go
@@ -1,0 +1,116 @@
+package relayer
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/omni-network/omni/lib/errors"
+	"github.com/omni-network/omni/lib/netconf"
+	"github.com/omni-network/omni/lib/txmgr"
+	"github.com/omni-network/omni/lib/xchain"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+
+	fuzz "github.com/google/gofuzz"
+	"github.com/stretchr/testify/require"
+)
+
+var errSentAsync = errors.New("sent async")
+
+func TestSendAsync(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	fuzzer := fuzz.New().NilChance(0).NumElements(1, 8)
+	mockGasEstimator := func(destChain uint64, msgs []xchain.Msg) uint64 {
+		return 0
+	}
+	txMgr := newMockTxMgr()
+	sender := Sender{
+		network:      netconf.Simnet,
+		txMgr:        txMgr,
+		gasEstimator: mockGasEstimator,
+		abi:          nil,
+		chain:        netconf.Chain{},
+		gasToken:     "",
+		chainNames:   nil,
+		ethCl:        nil,
+	}
+
+	const total = 10
+
+	// Enqueue a bunch of random submissions
+	var resps []<-chan error
+	for range total {
+		var sub xchain.Submission
+		fuzzer.Fuzz(&sub)
+		sub.DestChainID = 0 // Ensure destChain matches zero netconf chain above
+
+		resp := sender.SendAsync(ctx, sub)
+
+		// Ensure it didn't error synchronously.
+		select {
+		case err := <-resp:
+			require.Fail(t, "unexpected synchronous error", "error: %v", err)
+		default:
+			// Nothing in the channel yet, expected.
+		}
+
+		resps = append(resps, resp)
+	}
+
+	// Ensure nonces were reserved sequentially.
+	require.EqualValues(t, total, txMgr.ReservedNonces())
+
+	// Trigger each send and ensure expected result (errSentAsync)
+	for _, resp := range resps {
+		txMgr.MineNext()
+		require.ErrorIs(t, <-resp, errSentAsync)
+	}
+}
+
+var _ txmgr.TxManager = (*mockTxMgr)(nil)
+
+func newMockTxMgr() *mockTxMgr {
+	return &mockTxMgr{
+		sends: make(chan txmgr.TxCandidate, 1),
+	}
+}
+
+type mockTxMgr struct {
+	sync.Mutex
+	nonces uint64
+	sends  chan txmgr.TxCandidate
+}
+
+func (m *mockTxMgr) Send(_ context.Context, candidate txmgr.TxCandidate) (*types.Transaction, *types.Receipt, error) {
+	// Blocks until MineNext is called.
+	m.sends <- candidate
+
+	return nil, nil, errSentAsync
+}
+
+func (m *mockTxMgr) MineNext() txmgr.TxCandidate {
+	return <-m.sends
+}
+
+func (m *mockTxMgr) From() common.Address {
+	panic("implement me")
+}
+
+func (m *mockTxMgr) ReservedNonces() uint64 {
+	m.Lock()
+	defer m.Unlock()
+
+	return m.nonces
+}
+
+func (m *mockTxMgr) ReserveNextNonce(context.Context) (uint64, error) {
+	m.Lock()
+	defer m.Unlock()
+
+	m.nonces++
+
+	return m.nonces, nil
+}

--- a/relayer/app/types.go
+++ b/relayer/app/types.go
@@ -18,8 +18,12 @@ type StreamUpdate struct {
 // CreateFunc is a function that creates one or more submissions from the given stream update.
 type CreateFunc func(streamUpdate StreamUpdate) ([]xchain.Submission, error)
 
-// SendFunc sends a submission to the destination chain by invoking "xsubmit" on portal contract.
-type SendFunc func(ctx context.Context, submission xchain.Submission) error
+// SendAsync sends a submission to the destination chain asynchronously
+// by invoking "xsubmit" on portal contract. It returns a channel that
+// will receive an error if the submission fails or nil when it succeeds.
+// Nonces are however reserved synchronously, so ordering of submissions
+// is preserved.
+type SendAsync func(ctx context.Context, submission xchain.Submission) <-chan error
 
 // randomHex7 returns a random 7-character hex string.
 func randomHex7() string {

--- a/relayer/app/worker_internal_test.go
+++ b/relayer/app/worker_internal_test.go
@@ -88,7 +88,7 @@ func TestWorker_Run(t *testing.T) {
 
 	// mockSender should never be called, since we return empty slices from the creator.
 	mockSender := &mockSender{
-		SendTransactionFn: func(ctx context.Context, submission xchain.Submission) error {
+		SendTransactionFn: func(ctx context.Context, submission xchain.Submission) <-chan error {
 			require.Fail(t, "should not be called")
 			return nil
 		},
@@ -156,7 +156,7 @@ func TestWorker_Run(t *testing.T) {
 			mockProvider,
 			mockXClient,
 			mockCreateFunc,
-			func() (SendFunc, error) { return mockSender.SendTransaction, nil },
+			func() (SendAsync, error) { return mockSender.SendTransaction, nil },
 			noAwait)
 		go w.Run(ctx)
 	}


### PR DESCRIPTION
Fixes race condition in relayer that resulted in unordered submissions sometimes. 

This refactors the `Sender` to reserve nonces synchronously, but do the actual sending asynchronously. Active buffer refactored to reserves nonces synchronously ensuring strictly ordered submissions.

issue: https://github.com/omni-network/ops/issues/533