### PR TITLE
ci(github): add join nightly

### DIFF
--- a/.github/workflows/ci-join.yml
+++ b/.github/workflows/ci-join.yml
@@ -1,0 +1,56 @@
+name: join omega nightly
+# Nightly action that tests joining omega as a full node.
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 4 * * 1-5" # Weekdays at 4am UTC
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  join:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Run a full node
+        run: |
+          # As per public docs
+          curl -sSfL https://raw.githubusercontent.com/omni-network/omni/main/scripts/install_omni_cli.sh | sh -s
+
+          # init halo and geth
+          omni operator init-nodes --network=omega --moniker=ci-nightly --home=$(pwd)
+
+          # start halo and geth
+          docker compose up -d
+      - name: Wait for sync
+        run:
+          t0=$(date +%s)  # Record the start time
+
+          while true; do
+            elapsed=$(($(date +%s) - t0)) # Calculate the elapsed time in seconds
+
+            # If more than 6 hours (21600 seconds) have passed, exit with a failure message
+            if [ $elapsed -gt 21600 ]; then
+              echo "Node not synced after 6 hours, failing"
+              exit 1
+            fi
+
+            # Get and print halo's health status
+            STATUS=$(docker inspect --format "{{json .State.Health.Status }}" halo | sed 's/"//g')
+            echo "$(date +'%H:%M:%S') status=${STATUS}"
+
+            # If the container is "healthy", it has synced, we are done
+            if [ "${STATUS}" == "healthy" ]; then
+              echo "Node synced"
+              break
+            fi
+
+            # Wait for 5 seconds before checking again
+            sleep 5
+          done
+
+      - name: Stop the node
+        if: always()
+        run: docker compose down


### PR DESCRIPTION
Adds a nightly github action that joins omega and fails if it takes longer than 6 hours.

issue: #2175 