### PR TITLE
refactor(halo): revert to using comet cprovider

### DIFF
--- a/halo/app/start.go
+++ b/halo/app/start.go
@@ -245,10 +245,12 @@ func Start(ctx context.Context, cfg Config) (<-chan error, func(context.Context)
 
 // newCProvider returns a new cchain provider. Either GRPC if enabled since it is faster,
 // otherwise the ABCI provider.
+//
+//nolint:unparam // We will enable grpc later.
 func newCProvider(rpcClient *rpclocal.Local, cfg Config) (cchain.Provider, error) {
-	if cfg.SDKGRPC.Enable {
-		return cprovider.NewGRPC(cfg.SDKGRPC.Address, cfg.Network, netconf.ChainVersionNamer(cfg.Network))
-	}
+	// if cfg.SDKGRPC.Enable {
+	//	return cprovider.NewGRPC(cfg.SDKGRPC.Address, cfg.Network, netconf.ChainVersionNamer(cfg.Network))
+	// }
 
 	return cprovider.NewABCI(rpcClient, cfg.Network, netconf.ChainVersionNamer(cfg.Network)), nil
 }

--- a/halo/app/start_test.go
+++ b/halo/app/start_test.go
@@ -50,8 +50,8 @@ func TestSmoke(t *testing.T) {
 	require.NoError(t, err)
 
 	cprov := cprovider.NewABCI(cl, netconf.Simnet, netconf.ChainVersionNamer(netconf.Simnet))
-	cprovGRPC, err := cprovider.NewGRPC(cfg.SDKGRPC.Address, netconf.Simnet, netconf.ChainVersionNamer(netconf.Simnet))
-	require.NoError(t, err)
+	// cprovGRPC, err := cprovider.NewGRPC(cfg.SDKGRPC.Address, netconf.Simnet, netconf.ChainVersionNamer(netconf.Simnet))
+	// require.NoError(t, err)
 
 	// Wait until we get to block 3.
 	const target = uint64(3)
@@ -68,7 +68,7 @@ func TestSmoke(t *testing.T) {
 	testReadyEndpoint(t, cfg)
 	testAPI(t, cfg)
 	testCProvider(t, ctx, cprov)
-	testCProvider(t, ctx, cprovGRPC)
+	// testCProvider(t, ctx, cprovGRPC)
 
 	genSet, err := cl.Validators(ctx, int64Ptr(1), nil, nil)
 	require.NoError(t, err)


### PR DESCRIPTION
Revert to only using cometBFT cprovider since gRPC based cprovider is causing data races in CI.

issue: #2002 