### PR TITLE
ci(e2e): skip funding omni on mainnet

### DIFF
--- a/e2e/app/fund.go
+++ b/e2e/app/fund.go
@@ -10,6 +10,7 @@ import (
 	"github.com/omni-network/omni/lib/contracts"
 	"github.com/omni-network/omni/lib/errors"
 	"github.com/omni-network/omni/lib/ethclient/ethbackend"
+	"github.com/omni-network/omni/lib/evmchain"
 	"github.com/omni-network/omni/lib/log"
 	"github.com/omni-network/omni/lib/netconf"
 	"github.com/omni-network/omni/lib/tokens"
@@ -84,6 +85,10 @@ func FundAccounts(ctx context.Context, def Definition, hotOnly bool, dryRun bool
 	log.Info(ctx, "Checking accounts to fund", "network", network, "count", len(accounts))
 
 	for _, chain := range def.Testnet.EVMChains() {
+		if chain.ChainID == evmchain.IDOmniMainnet {
+			log.Info(ctx, "Skipping mainnet omni evm", "chain", chain.Name)
+			continue
+		}
 		backend, err := def.Backends().Backend(chain.ChainID)
 		if err != nil {
 			return errors.Wrap(err, "backend")


### PR DESCRIPTION
Skip mainnet omni on funding since it doesn't exist yet.

issue: none