### PR TITLE
fix(monitor): increase gas price threshold

### DIFF
--- a/monitor/xfeemngr/xfeemngr.go
+++ b/monitor/xfeemngr/xfeemngr.go
@@ -40,11 +40,11 @@ const (
 	tokenPriceBufferThreshold = 0.1
 
 	// gasPriceBufferThreshold is the pct threshold at which a new gas price is buffered.
-	gasPriceBufferThreshold = 0.1
+	gasPriceBufferThreshold = 0.2
 
 	// GasPriceShield is the pct offset above the buffered gas price the oracle sets on chain
 	// Setting shield == buffer threshold ensures that on chain gas price is always at least as high as the live gas price.
-	GasPriceShield = 0.1
+	GasPriceShield = 0.2
 
 	// maxSaneGasPrice is the maximum sane gas price in gwei to post for any destination chain. Set to 500 gwei.
 	maxSaneGasPrice = uint64(500_000_000_000)


### PR DESCRIPTION
Increases buffer for gas price threshold to 20% that should cause less updates to the chain which are expensive.

Example of 10% vs 20% updates required:
![Screenshot 2024-10-24 at 13 28 51](https://github.com/user-attachments/assets/0fe758f6-d6d0-4cfc-9b92-24dcd6a9d123)
![Screenshot 2024-10-24 at 13 28 12](https://github.com/user-attachments/assets/b70db8d3-9ddd-4b2f-ac95-d36b2142951a)


issue: none