### PR TITLE
fix(monitor/routerecon): fix lag metric

### DIFF
--- a/monitor/routerecon/metrics.go
+++ b/monitor/routerecon/metrics.go
@@ -24,6 +24,13 @@ var (
 		Namespace: "monitor",
 		Subsystem: "routerecon",
 		Name:      "completed_offset",
-		Help:      "Latest completed attest offset per stream",
+		Help:      "Latest completed offset per stream. Only measured periodically",
+	}, []string{"stream"})
+
+	reconCompletedLag = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: "monitor",
+		Subsystem: "routerecon",
+		Name:      "completed_lag",
+		Help:      "Routescan completed lag per stream. Difference between latest completed offset and submit cursor. Only measured periodically",
 	}, []string{"stream"})
 )

--- a/monitor/routerecon/routescan_internal_test.go
+++ b/monitor/routerecon/routescan_internal_test.go
@@ -30,7 +30,7 @@ func TestReconLag(t *testing.T) {
 
 	for _, stream := range conn.Network.EVMStreams() {
 		if stream.DestChainID == evmchain.IDArbSepolia || stream.SourceChainID == evmchain.IDArbSepolia {
-			// Skip arb since fetching cross txs frmo routescan fails
+			// Skip arb since fetching cross txs from routescan fails
 			continue // TODO(corver): Remove when routescan adds support for arb_sepolia.
 		}
 

--- a/monitor/routerecon/routescan_internal_test.go
+++ b/monitor/routerecon/routescan_internal_test.go
@@ -6,12 +6,50 @@ import (
 	"flag"
 	"testing"
 
+	"github.com/omni-network/omni/lib/evmchain"
+	"github.com/omni-network/omni/lib/log"
+	"github.com/omni-network/omni/lib/netconf"
+	"github.com/omni-network/omni/lib/xchain/connect"
+
 	"github.com/stretchr/testify/require"
 )
 
 //go:generate go test . -integration -v -run=TestQueryLatestXChain
 
 var integration = flag.Bool("integration", false, "run routescan integration tests")
+
+func TestReconLag(t *testing.T) {
+	t.Parallel()
+	if !*integration {
+		t.Skip("skipping integration test")
+	}
+
+	ctx := context.Background()
+	conn, err := connect.New(ctx, netconf.Omega)
+	require.NoError(t, err)
+
+	for _, stream := range conn.Network.EVMStreams() {
+		if stream.DestChainID == evmchain.IDArbSepolia || stream.SourceChainID == evmchain.IDArbSepolia {
+			// Skip arb since fetching cross txs frmo routescan fails
+			continue // TODO(corver): Remove when routescan adds support for arb_sepolia.
+		}
+
+		streamName := conn.Network.StreamName(stream)
+
+		cursor, ok, err := conn.XProvider.GetSubmittedCursor(ctx, stream)
+		require.NoError(t, err, streamName)
+		if !ok {
+			// Skip streams without submissions
+			continue
+		}
+
+		crossTx, err := paginateLatestCrossTx(ctx, queryFilter{Stream: stream})
+		require.NoError(t, err, streamName)
+
+		lag := float64(cursor.MsgOffset) - float64(crossTx.Data.Offset)
+		log.Info(ctx, "Routescan lag", "stream", streamName, "submitted_offset", cursor.MsgOffset, "lag", lag)
+	}
+}
 
 func TestQueryLatestXChain(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
Fix routescan recon lag metric. Previously, we compared the live submit_offset to a stale (up 30min old) routescan_offset which resulted in incorrect insight.

issue: none