### PR TITLE
chore(e2e): cleanup monitorOnly in e2e

### DIFF
--- a/e2e/app/run.go
+++ b/e2e/app/run.go
@@ -56,10 +56,6 @@ func Deploy(ctx context.Context, def Definition, cfg DeployConfig) (*pingpong.XD
 		return nil, errors.New("cannot deploy protected network", "network", def.Testnet.Network)
 	}
 
-	if def.Testnet.OnlyMonitor {
-		return nil, deployMonitorOnly(ctx, def, cfg)
-	}
-
 	const genesisValSetID = 1 // validator set IDs start at 1
 
 	genesisVals, err := toPortalValidators(def.Testnet.Validators)
@@ -316,24 +312,6 @@ func logRPCs(ctx context.Context, def Definition) {
 		log.Info(ctx, "EVM Chain RPC available", "chain_id", chain.ChainID,
 			"chain_name", chain.Name, "url", rpc)
 	}
-}
-
-// deployMonitorOnly deploys the monitor service only.
-// It merely sets up config files and then starts the monitor service.
-func deployMonitorOnly(ctx context.Context, def Definition, cfg DeployConfig) error {
-	if err := Setup(ctx, def, cfg); err != nil {
-		return err
-	}
-
-	if err := CleanInfra(ctx, def); err != nil {
-		return err
-	}
-
-	if err := def.Infra.StartNodes(ctx); err != nil {
-		return errors.Wrap(err, "starting initial nodes")
-	}
-
-	return nil
 }
 
 // waitForSupportedChains waits for all dest chains to be supported by all src chains.

--- a/e2e/app/setup.go
+++ b/e2e/app/setup.go
@@ -54,8 +54,6 @@ const (
 )
 
 // Setup sets up the testnet configuration.
-//
-//nolint:gocyclo // Just many sequential steps.
 func Setup(ctx context.Context, def Definition, depCfg DeployConfig) error {
 	log.Info(ctx, "Setup testnet", "dir", def.Testnet.Dir)
 
@@ -65,10 +63,6 @@ func Setup(ctx context.Context, def Definition, depCfg DeployConfig) error {
 
 	if err := os.MkdirAll(def.Testnet.Dir, os.ModePerm); err != nil {
 		return errors.Wrap(err, "mkdir")
-	}
-
-	if def.Manifest.OnlyMonitor {
-		return SetupOnlyMonitor(ctx, def)
 	}
 
 	// Setup geth execution genesis
@@ -208,25 +202,6 @@ func Setup(ctx context.Context, def Definition, depCfg DeployConfig) error {
 		return errors.Wrap(err, "marshal endpoints")
 	} else if err := os.WriteFile(filepath.Join(def.Testnet.Dir, "endpoints.json"), endpointBytes, 0o644); err != nil {
 		return errors.Wrap(err, "write endpoints")
-	}
-
-	if def.Testnet.Prometheus {
-		if err := agent.WriteConfig(ctx, def.Testnet, def.Cfg.AgentSecrets); err != nil {
-			return errors.Wrap(err, "write prom config")
-		}
-	}
-
-	if err := def.Infra.Setup(); err != nil {
-		return errors.Wrap(err, "setup provider")
-	}
-
-	return nil
-}
-
-func SetupOnlyMonitor(ctx context.Context, def Definition) error {
-	logCfg := logConfig(def)
-	if err := writeMonitorConfig(ctx, def, logCfg, nil); err != nil {
-		return err
 	}
 
 	if def.Testnet.Prometheus {

--- a/e2e/docker/docker.go
+++ b/e2e/docker/docker.go
@@ -302,11 +302,6 @@ func additionalServices(testnet types.Testnet) []string {
 
 	resp = append(resp, "monitor")
 
-	// In monitor only mode, we only start monitor and prometheus.
-	if testnet.OnlyMonitor {
-		return resp
-	}
-
 	for _, omniEVM := range testnet.OmniEVMs {
 		resp = append(resp, omniEVM.InstanceName)
 	}

--- a/e2e/netman/manager.go
+++ b/e2e/netman/manager.go
@@ -27,16 +27,6 @@ type Manager interface {
 }
 
 func NewManager(testnet types.Testnet, backends ethbackend.Backends) (Manager, error) {
-	if testnet.OnlyMonitor {
-		if !netconf.IsAny(testnet.Network, netconf.Mainnet) {
-			return nil, errors.New("monitor-only only supported for mainnet")
-		}
-
-		return &manager{
-			backends: backends,
-		}, nil
-	}
-
 	return &manager{
 		backends: backends,
 		network:  testnet.Network,

--- a/e2e/types/manifest.go
+++ b/e2e/types/manifest.go
@@ -88,9 +88,6 @@ type Manifest struct {
 	// MultiOmniEVMs defines whether to deploy one or multiple Omni EVMs.
 	MultiOmniEVMs bool `toml:"multi_omni_evms"`
 
-	// OnlyMonitor indicates that the monitor is the only thing that we deploy in this network.
-	OnlyMonitor bool `toml:"only_monitor"`
-
 	// PingPongN defines the number of ping pong messages to send. Defaults 3 if 0.
 	PingPongN uint64 `toml:"pingpong_n"`
 

--- a/e2e/types/testnet.go
+++ b/e2e/types/testnet.go
@@ -27,7 +27,6 @@ type Testnet struct {
 	OmniEVMs     []OmniEVM
 	AnvilChains  []AnvilChain
 	PublicChains []PublicChain
-	OnlyMonitor  bool
 	Perturb      map[string][]Perturb
 }
 


### PR DESCRIPTION
Removes some old used to deploy the monitor without a live network. Now that mainnet is live we can remove it.

issue: none