### PR TITLE
fix(ci): increase the nightly-join test timeout

### DIFF
--- a/.github/workflows/ci-join.yml
+++ b/.github/workflows/ci-join.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Run join test
         run: |
           cd scripts/join
-          go test . -v --integration --logs_file=docker_logs.txt
+          go test . -v --integration --logs_file=docker_logs.txt -timeout 8h
 
       - name: Upload docker logs
         uses: actions/upload-artifact@v4

--- a/.github/workflows/ci-join.yml
+++ b/.github/workflows/ci-join.yml
@@ -4,7 +4,7 @@ name: join omega nightly
 on:
   workflow_dispatch:
   schedule:
-    - cron: "0 4 * * 1-5" # Weekdays at 4am UTC
+    - cron: "0 1 * * 1-5" # Weekdays at 1am UTC
 
 permissions:
   contents: read
@@ -31,7 +31,7 @@ jobs:
       - name: Run join test
         run: |
           cd scripts/join
-          go test . -v --integration --logs_file=docker_logs.txt -timeout 8h
+          go test . -v --integration --logs_file=docker_logs.txt -timeout 0
 
       - name: Upload docker logs
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
By default, a Go test times out after 10m. But the syncing is expected to take much longer, so we disable the time out because the test has a built in timeout of 6h.

issue: none