### PR TITLE
fix(halo/app): do not override the http status header

### DIFF
--- a/halo/app/monitor.go
+++ b/halo/app/monitor.go
@@ -231,24 +231,19 @@ func startMonitoringAPI(
 
 	// Serve readiness status json at `/ready`, returning 503 if not ready.
 	mux.HandleFunc("/ready", func(w http.ResponseWriter, _ *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-
-		// We do not serialize `status` directly to the http writer, because even if
-		// it can be serialized without errors, we might need to set a different http status
-		// code than the one set by default on a successful write.
-		var buf bytes.Buffer
-		if ready, err := status.serialize(&buf); err != nil {
+		var body bytes.Buffer
+		statusCode := http.StatusOK
+		if ready, err := status.serialize(&body); err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return
 		} else if !ready {
-			w.WriteHeader(http.StatusServiceUnavailable)
-			return
+			statusCode = http.StatusServiceUnavailable
 		}
 
-		_, err := w.Write(buf.Bytes())
-		if err != nil {
-			http.Error(w, err.Error(), http.StatusInternalServerError)
-		}
+		// Do writes in correct order
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(statusCode)
+		_, _ = w.Write(body.Bytes())
 	})
 
 	server := &http.Server{


### PR DESCRIPTION
We're currently setting the http status code twice when the server is unhealthy.

issue: none