### PR TITLE
POC stream cache

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -294,6 +294,8 @@ require (
 	sigs.k8s.io/yaml v1.4.0 // indirect
 )
 
+require github.com/maypok86/otter v1.2.3
+
 require (
 	buf.build/gen/go/bufbuild/bufplugin/protocolbuffers/go v1.34.2-20240928190436-5e8abcfd7a7e.2 // indirect
 	buf.build/gen/go/pluginrpc/pluginrpc/protocolbuffers/go v1.34.2-20240828222655-5345c0a56177.2 // indirect
@@ -309,6 +311,8 @@ require (
 	github.com/containerd/platforms v0.2.1 // indirect
 	github.com/containerd/ttrpc v1.2.5 // indirect
 	github.com/containerd/typeurl/v2 v2.2.0 // indirect
+	github.com/dolthub/maphash v0.1.0 // indirect
+	github.com/gammazero/deque v0.2.1 // indirect
 	github.com/go-task/slim-sprig/v3 v3.0.0 // indirect
 	github.com/moby/locker v1.0.1 // indirect
 	github.com/moby/patternmatcher v0.6.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -501,6 +501,8 @@ github.com/docker/go-connections v0.5.0 h1:USnMq7hx7gwdVZq1L49hLXaFtUdTADjXGp+uj
 github.com/docker/go-connections v0.5.0/go.mod h1:ov60Kzw0kKElRwhNs9UlUHAE/F9Fe6GLaXnqyDdmEXc=
 github.com/docker/go-units v0.5.0 h1:69rxXcBk27SvSaaxTtLh/8llcHD8vYHT7WSdRZ/jvr4=
 github.com/docker/go-units v0.5.0/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
+github.com/dolthub/maphash v0.1.0 h1:bsQ7JsF4FkkWyrP3oCnFJgrCUAFbFf3kOl4L/QxPDyQ=
+github.com/dolthub/maphash v0.1.0/go.mod h1:gkg4Ch4CdCDu5h6PMriVLawB7koZ+5ijb9puGMV50a4=
 github.com/dustin/go-humanize v0.0.0-20171111073723-bb3d318650d4/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=
@@ -552,6 +554,8 @@ github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMo
 github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
 github.com/fsnotify/fsnotify v1.7.0 h1:8JEhPFa5W2WU7YfeZzPNqzMP6Lwt7L2715Ggo0nosvA=
 github.com/fsnotify/fsnotify v1.7.0/go.mod h1:40Bi/Hjc2AVfZrqy+aj+yEI+/bRxZnMJyTJwOpGvigM=
+github.com/gammazero/deque v0.2.1 h1:qSdsbG6pgp6nL7A0+K/B7s12mcCY/5l5SIUpMOl+dC0=
+github.com/gammazero/deque v0.2.1/go.mod h1:LFroj8x4cMYCukHJDbxFCkT+r9AndaJnFMuZDV34tuU=
 github.com/gballet/go-libpcsclite v0.0.0-20190607065134-2772fd86a8ff h1:tY80oXqGNY4FhTFhk+o9oFHGINQ/+vhlm8HFzi6znCI=
 github.com/gballet/go-libpcsclite v0.0.0-20190607065134-2772fd86a8ff/go.mod h1:x7DCsMOv1taUwEWCzT4cmDeAkigA5/QCwUodaVOe8Ww=
 github.com/getsentry/sentry-go v0.27.0 h1:Pv98CIbtB3LkMWmXi4Joa5OOcwbmnX88sF5qbK3r3Ps=
@@ -966,6 +970,8 @@ github.com/mattn/go-runewidth v0.0.12/go.mod h1:RAqKPSqVFrSLVXbA8x7dzmKdmGzieGRC
 github.com/mattn/go-runewidth v0.0.15 h1:UNAjwbU9l54TA3KzvqLGxwWjHmMgBUVhBiTjelZgg3U=
 github.com/mattn/go-runewidth v0.0.15/go.mod h1:Jdepj2loyihRzMpdS35Xk/zdY8IAYHsh153qUoGf23w=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
+github.com/maypok86/otter v1.2.3 h1:jxyPD4ofCwtrQM5is5JNrdAs+6+JQkf/PREZd7JCVgg=
+github.com/maypok86/otter v1.2.3/go.mod h1:mKLfoI7v1HOmQMwFgX4QkRk23mX6ge3RDvjdHOWG4R4=
 github.com/mgutz/ansi v0.0.0-20170206155736-9520e82c474b h1:j7+1HpAFS1zy5+Q4qx1fWh90gTKwiN4QCGoY9TWyyO4=
 github.com/mgutz/ansi v0.0.0-20170206155736-9520e82c474b/go.mod h1:01TrycV0kFyexm33Z7vhZRXopbI8J3TDReVlkTgMUxE=
 github.com/miekg/dns v1.0.14/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=

--- a/lib/cchain/provider/provider.go
+++ b/lib/cchain/provider/provider.go
@@ -180,6 +180,7 @@ func (p Provider) stream(
 	srcChain := p.chainNamer(chainVer)
 	ctx := log.WithCtx(in, "src_chain", srcChain, "worker", workerName)
 
+	// note: see the note from cache, this is poc
 	key := func(height uint64) string {
 		return fmt.Sprintf("%d-%d", chainVer.ConfLevel, height)
 	}

--- a/lib/cchain/provider/provider.go
+++ b/lib/cchain/provider/provider.go
@@ -3,6 +3,7 @@ package provider
 
 import (
 	"context"
+	"fmt"
 	"path"
 	"strings"
 	"testing"
@@ -179,7 +180,12 @@ func (p Provider) stream(
 	srcChain := p.chainNamer(chainVer)
 	ctx := log.WithCtx(in, "src_chain", srcChain, "worker", workerName)
 
-	cache, err := stream.NewCache[xchain.Attestation]()
+	key := func(height uint64) string {
+		return fmt.Sprintf("%d-%d", chainVer.ConfLevel, height)
+	}
+	cache, err := stream.NewCache[xchain.Attestation](
+		stream.WithKeyFunc[xchain.Attestation](key),
+	)
 	if err != nil {
 		return errors.Wrap(err, "cache fail [BUG]")
 	}

--- a/lib/stream/cache.go
+++ b/lib/stream/cache.go
@@ -1,0 +1,93 @@
+package stream
+
+import (
+	"strconv"
+	"time"
+
+	"github.com/omni-network/omni/lib/errors"
+
+	"github.com/maypok86/otter"
+)
+
+// Cacher defines the cache type for caching stream items.
+// Stream uses height as stream cursor so our cache implementation
+// relies on the height for calculating the key.
+//
+// The key implementation can vary based on the context and is up
+// to the implementor.
+type Cacher[K any, E any] interface {
+	// Get cached item at the height (stream cursor)
+	// as well as a boolean indicating a cache hit or miss.
+	// If item is not found nil and false is returned.
+	Get(height uint64) ([]E, bool)
+	// Set item in the cache at the height and return true.
+	// If item is failed to store, returns false.
+	Set(height uint64, value []E) bool
+}
+
+const cacheSize = 100_000
+
+type Opt[E any] func(*Cache[E])
+
+// WithKeyFunc sets a custom key function for the Cache.
+func WithKeyFunc[E any](keyFunc func(uint64) string) Opt[E] {
+	return func(c *Cache[E]) {
+		c.key = keyFunc
+	}
+}
+
+// WithTTL sets a custom key function for the Cache.
+func WithTTL[E any](ttl time.Duration) Opt[E] {
+	return func(c *Cache[E]) {
+		c.ttl = ttl
+	}
+}
+
+// Cache is a default cache implementation that uses
+// otter Cache as an underlying cache. It assumes keys
+// as strings.
+// note: the key is string type for POC, in production we would probably want to do
+// variable length encoding (e.g. VLQ or similar/simpler) due to the nature of the
+// keys, for example chain ID is a small set of keys we support, and heights, although
+// they can reach 64 bytes they are growing slowly so no need to keep the key big initially.
+type Cache[E any] struct {
+	cache *otter.Cache[string, []E]
+	key   func(uint64) string
+	ttl   time.Duration
+}
+
+func NewCache[E any](opts ...Opt[E]) (*Cache[E], error) {
+	cache := &Cache[E]{
+		// default implementation for key
+		key: func(height uint64) string {
+			return strconv.FormatUint(height, 10)
+		},
+	}
+
+	for _, opt := range opts {
+		opt(cache)
+	}
+
+	builder := otter.MustBuilder[string, []E](cacheSize)
+
+	if cache.ttl != 0 {
+		builder.WithTTL(cache.ttl)
+	}
+
+	otterCache, err := builder.Build()
+	if err != nil {
+		return nil, errors.Wrap(err, "cache build [BUG]", "size", cacheSize)
+	}
+	cache.cache = &otterCache
+
+	return cache, nil
+}
+
+func (c *Cache[E]) Get(height uint64) ([]E, bool) {
+	// todo report hit/miss metrics
+	return c.cache.Get(c.key(height))
+}
+
+func (c *Cache[E]) Set(height uint64, value []E) bool {
+	return c.cache.Set(c.key(height), value)
+}

--- a/lib/stream/stream.go
+++ b/lib/stream/stream.go
@@ -3,7 +3,6 @@ package stream
 
 import (
 	"context"
-	"fmt"
 	"math"
 	"sync"
 	"time"
@@ -63,7 +62,6 @@ func Stream[E any](ctx context.Context, deps Deps[E], srcChainID uint64, startHe
 	// It only returns an empty list if the context is canceled.
 	// It retries forever on error or if no elements found.
 	fetchFunc := func(ctx context.Context, height uint64) []E {
-		cacheKey := fmt.Sprintf("%d-%d", srcChainID, height) // note: this is POC
 		if deps.Cache != nil {
 			elements, ok := deps.Cache.Get(height)
 			if ok {
@@ -114,7 +112,7 @@ func Stream[E any](ctx context.Context, deps Deps[E], srcChainID uint64, startHe
 
 			if deps.Cache != nil {
 				if ok := deps.Cache.Set(height, elems); !ok {
-					log.Debug(ctx, "Cache drop", "key", cacheKey)
+					log.Debug(ctx, "Cache drop", "height", height)
 				}
 			}
 


### PR DESCRIPTION
POC for https://www.notion.so/omni-network/Dedup-relayer-streams-12769a99643a80c7b78cea02dbea35ba

My take doesn't change the workers it just minimise the overhead of having more workers. I believe having more workers with sufficient caching this PR introduces is a benefit because a blast radius in case something goes wrong or is held up of current workers setup is as minimal as it can get. Beside minimising fetching same data this also minimises the cost of doing a bisections when searching for offests. However this will still be done on a cold cache.

This approach also makes the changes minimal and well isolated to a seperate component which can and should be unit tested in the next step. The added complexity is small, but impact is big, because this should also be used with xprovider and would have even bigger impact (TODO).

issue: none