### PR TITLE
feat(cchain/provider): add attest stream cache

### DIFF
--- a/cli/cmd/initnodes.go
+++ b/cli/cmd/initnodes.go
@@ -18,7 +18,6 @@ import (
 	"github.com/omni-network/omni/lib/errors"
 	"github.com/omni-network/omni/lib/log"
 	"github.com/omni-network/omni/lib/netconf"
-	"github.com/omni-network/omni/lib/xchain"
 
 	cmtconfig "github.com/cometbft/cometbft/config"
 	k1 "github.com/cometbft/cometbft/crypto/secp256k1"
@@ -170,8 +169,7 @@ func maybeDownloadGenesis(ctx context.Context, network netconf.ID) error {
 	if err != nil {
 		return errors.Wrap(err, "create rpc client")
 	}
-	stubNamer := func(xchain.ChainVersion) string { return "" }
-	cprov := cprovider.NewABCI(rpcCl, network, stubNamer)
+	cprov := cprovider.NewABCI(rpcCl, network)
 
 	execution, consensus, err := cprov.GenesisFiles(ctx)
 	if err != nil {

--- a/cli/cmd/staking.go
+++ b/cli/cmd/staking.go
@@ -487,7 +487,7 @@ func setupClients(
 		return nil, nil, nil, errors.Wrap(err, "new tendermint client")
 	}
 
-	cprov := provider.NewABCI(cl, conf.Network, netconf.ChainVersionNamer(conf.Network))
+	cprov := provider.NewABCI(cl, conf.Network)
 
 	eth, err := ethclient.Dial(chainMeta.Name, conf.ExecutionRPC)
 	if err != nil {

--- a/e2e/app/monitor.go
+++ b/e2e/app/monitor.go
@@ -44,7 +44,7 @@ func StartMonitoringReceipts(ctx context.Context, def Definition) func() error {
 	}
 
 	network := NetworkFromDef(def) // Safe to call NetworkFromDef since this after netman.DeployContracts
-	cProvider := cprovider.NewABCI(client, def.Testnet.Network, netconf.ChainVersionNamer(def.Testnet.Network))
+	cProvider := cprovider.NewABCI(client, def.Testnet.Network)
 	xProvider := xprovider.New(network, def.Backends().RPCClients(), cProvider)
 	cChainID := def.Testnet.Network.Static().OmniConsensusChainIDUint64()
 
@@ -153,7 +153,7 @@ func MonitorCProvider(ctx context.Context, node *e2e.Node, network netconf.Netwo
 		return errors.Wrap(err, "getting client")
 	}
 
-	cprov := cprovider.NewABCI(client, network.ID, netconf.ChainVersionNamer(network.ID))
+	cprov := cprovider.NewABCI(client, network.ID)
 
 	for _, chain := range network.Chains {
 		for _, chainVer := range chain.ChainVersions() {

--- a/e2e/test/attestations_test.go
+++ b/e2e/test/attestations_test.go
@@ -30,7 +30,7 @@ func TestApprovedAttestations(t *testing.T) {
 
 		client, err := node.Client()
 		require.NoError(t, err)
-		cprov := provider.NewABCI(client, network.ID, netconf.ChainVersionNamer(netconf.Simnet))
+		cprov := provider.NewABCI(client, network.ID)
 
 		ctx := context.Background()
 		for _, portal := range portals {
@@ -80,7 +80,7 @@ func TestApprovedValUpdates(t *testing.T) {
 
 		client, err := node.Client()
 		require.NoError(t, err)
-		cprov := provider.NewABCI(client, network.ID, netconf.ChainVersionNamer(netconf.Simnet))
+		cprov := provider.NewABCI(client, network.ID)
 
 		addr, err := k1util.PubKeyToAddress(node.PrivvalKey.PubKey())
 		require.NoError(t, err)

--- a/e2e/test/cli_test.go
+++ b/e2e/test/cli_test.go
@@ -89,7 +89,7 @@ func TestCLIOperator(t *testing.T) {
 		cl, err := http.New(testnet.Network.Static().ConsensusRPC(), "/websocket")
 		require.NoError(t, err)
 
-		cprov := provider.NewABCI(cl, network.ID, netconf.ChainVersionNamer(network.ID))
+		cprov := provider.NewABCI(cl, network.ID)
 
 		// wait for validator to be created
 		const valChangeWait = 15 * time.Second

--- a/halo/app/pruning_test.go
+++ b/halo/app/pruning_test.go
@@ -48,7 +48,7 @@ func TestPruningHistory(t *testing.T) {
 	cl, err := rpchttp.New(cfg.Comet.RPC.ListenAddress, "/websocket")
 	require.NoError(t, err)
 
-	cprov := cprovider.NewABCI(cl, netconf.Simnet, netconf.ChainVersionNamer(netconf.Simnet))
+	cprov := cprovider.NewABCI(cl, netconf.Simnet)
 
 	// Wait until we get to block 1.
 	waitUntilHeight := uint64(1)

--- a/halo/app/start.go
+++ b/halo/app/start.go
@@ -249,10 +249,10 @@ func Start(ctx context.Context, cfg Config) (<-chan error, func(context.Context)
 
 func newCProvider(rpcClient *rpclocal.Local, cfg Config) (cchain.Provider, error) {
 	if cfg.SDKGRPC.Enable {
-		return cprovider.NewGRPC(cfg.SDKGRPC.Address, cfg.Network, netconf.ChainVersionNamer(cfg.Network))
+		return cprovider.NewGRPC(cfg.SDKGRPC.Address, cfg.Network)
 	}
 
-	return cprovider.NewABCI(rpcClient, cfg.Network, netconf.ChainVersionNamer(cfg.Network)), nil
+	return cprovider.NewABCI(rpcClient, cfg.Network), nil
 }
 
 // startRPCServers starts the Cosmos REST and gRPC servers.

--- a/halo/app/start_test.go
+++ b/halo/app/start_test.go
@@ -52,8 +52,8 @@ func TestSmoke(t *testing.T) {
 	cl, err := rpchttp.New(cfg.Comet.RPC.ListenAddress, "/websocket")
 	require.NoError(t, err)
 
-	cprov := cprovider.NewABCI(cl, netconf.Simnet, netconf.ChainVersionNamer(netconf.Simnet))
-	cprovGRPC, err := cprovider.NewGRPC(cfg.SDKGRPC.Address, netconf.Simnet, netconf.ChainVersionNamer(netconf.Simnet))
+	cprov := cprovider.NewABCI(cl, netconf.Simnet)
+	cprovGRPC, err := cprovider.NewGRPC(cfg.SDKGRPC.Address, netconf.Simnet)
 	require.NoError(t, err)
 
 	// Wait until we get to block 3.

--- a/lib/cchain/provider/metrics.go
+++ b/lib/cchain/provider/metrics.go
@@ -67,6 +67,20 @@ var (
 		Buckets:   []float64{0, 1, 2, 4, 8, 16, 32, 64, 128, 256},
 		Help:      "Number of steps in the binary search process to find the right height",
 	}, []string{"chain_version"})
+
+	cacheHits = promauto.NewCounterVec(prometheus.CounterOpts{
+		Namespace: "lib",
+		Subsystem: "cprovider",
+		Name:      "cache_hits_total",
+		Help:      "Total number of cache hits per source chain version.",
+	}, []string{"chain_version"})
+
+	cacheMisses = promauto.NewCounterVec(prometheus.CounterOpts{
+		Namespace: "lib",
+		Subsystem: "cprovider",
+		Name:      "cache_misses_total",
+		Help:      "Total number of cache misses per source chain version.",
+	}, []string{"chain_version"})
 )
 
 func fetchStepsMetrics(chainName string, lookbackSteps, binarySearchSteps uint64) {

--- a/lib/cchain/provider/provider.go
+++ b/lib/cchain/provider/provider.go
@@ -54,24 +54,25 @@ type valSetResponse struct {
 
 // Provider implements cchain.Provider.
 type Provider struct {
-	fetch       fetchFunc
-	allAtts     allAttsFunc
-	latest      latestFunc
-	window      windowFunc
-	valset      valsetFunc
-	val         valFunc
-	signing     signingFunc
-	vals        valsFunc
-	rewards     rewardsFunc
-	chainID     chainIDFunc
-	portalBlock portalBlockFunc
-	networkFunc networkFunc
-	genesisFunc genesisFunc
-	plannedFunc planedUpgradeFunc
-	appliedFunc appliedUpgradeFunc
-	backoffFunc func(context.Context) func()
-	chainNamer  func(xchain.ChainVersion) string
-	network     netconf.ID
+	fetch         fetchFunc
+	allAtts       allAttsFunc
+	latest        latestFunc
+	window        windowFunc
+	valset        valsetFunc
+	val           valFunc
+	signing       signingFunc
+	vals          valsFunc
+	rewards       rewardsFunc
+	chainID       chainIDFunc
+	portalBlock   portalBlockFunc
+	networkFunc   networkFunc
+	genesisFunc   genesisFunc
+	plannedFunc   planedUpgradeFunc
+	appliedFunc   appliedUpgradeFunc
+	backoffFunc   func(context.Context) func()
+	chainNamer    func(xchain.ChainVersion) string
+	network       netconf.ID
+	cacheProvider attestCacheProvider
 }
 
 // NewProviderForT creates a new provider for testing.
@@ -79,11 +80,12 @@ func NewProviderForT(_ *testing.T, fetch fetchFunc, latest latestFunc, window wi
 	backoffFunc func(context.Context) func(),
 ) Provider {
 	return Provider{
-		latest:      latest,
-		fetch:       fetch,
-		window:      window,
-		backoffFunc: backoffFunc,
-		chainNamer:  func(xchain.ChainVersion) string { return "" },
+		latest:        latest,
+		fetch:         fetch,
+		window:        window,
+		backoffFunc:   backoffFunc,
+		chainNamer:    func(xchain.ChainVersion) string { return "" },
+		cacheProvider: nopCacheProvider,
 	}
 }
 
@@ -183,6 +185,7 @@ func (p Provider) stream(
 		FetchBatch: func(ctx context.Context, _ uint64, offset uint64) ([]xchain.Attestation, error) {
 			return p.fetch(ctx, chainVer, offset)
 		},
+		Cache:         p.cacheProvider(chainVer),
 		Backoff:       p.backoffFunc,
 		ElemLabel:     "attestation",
 		HeightLabel:   "offset",
@@ -208,6 +211,12 @@ func (p Provider) stream(
 		},
 		IncCallbackErr: func() {
 			callbackErrTotal.WithLabelValues(workerName, srcChain).Inc()
+		},
+		IncCacheHit: func() {
+			cacheHits.WithLabelValues(srcChain).Inc()
+		},
+		IncCacheMiss: func() {
+			cacheMisses.WithLabelValues(srcChain).Inc()
 		},
 		SetStreamHeight: func(h uint64) {
 			streamHeight.WithLabelValues(workerName, srcChain).Set(float64(h))

--- a/lib/stream/cache.go
+++ b/lib/stream/cache.go
@@ -1,0 +1,82 @@
+package stream
+
+import (
+	"math"
+	"sync"
+)
+
+// NewNopCache returns a cache that does nothing.
+func NewNopCache[E any]() Cache[E] {
+	return new(nopCache[E])
+}
+
+type nopCache[E any] struct{}
+
+func (nopCache[E]) Get(uint64) []E  { return nil }
+func (nopCache[E]) Set(uint64, []E) {}
+
+// NewCache returns a new map based cache using the provided limit.
+func NewCache[E any](limit int) Cache[E] {
+	return &mapCache[E]{
+		limit: limit,
+		elems: make(map[uint64]E),
+		floor: math.MaxUint64,
+	}
+}
+
+// mapCache implements Cache storing elements in a map.
+// It will only retain the highest `limit` elements.
+// It assumes elements are roughly sequential and that heights are not sparse.
+type mapCache[E any] struct {
+	limit int // Immutable
+
+	// Mutable fields
+	mu    sync.RWMutex
+	elems map[uint64]E
+	floor uint64 // floor is equaled to or lower than the lowest height in elems. It is MaxUint64 if elems is empty.
+}
+
+// Get returns all strictly sequential elements in the cache from the provided height (inclusive).
+func (c *mapCache[E]) Get(from uint64) []E {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	var resp []E
+	for height := from; ; height++ {
+		elem, ok := c.elems[height]
+		if !ok {
+			break
+		}
+
+		resp = append(resp, elem)
+	}
+
+	return resp
+}
+
+// Set adds the provided elements to the cache starting from the provided height (inclusive).
+// Elements are assumed to be in strictly sequential order.
+func (c *mapCache[E]) Set(from uint64, elems []E) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	for i, elem := range elems {
+		height := from + uint64(i)
+
+		if len(c.elems) >= c.limit && height < c.floor {
+			// Don't add too low elements when cache is full, they will just be deleted below.
+			continue
+		}
+
+		c.elems[height] = elem
+
+		if height < c.floor {
+			c.floor = height // Update floor
+		}
+	}
+
+	for len(c.elems) > c.limit {
+		delete(c.elems, c.floor)
+		c.floor++
+	}
+}

--- a/lib/stream/cache_internal_test.go
+++ b/lib/stream/cache_internal_test.go
@@ -1,0 +1,21 @@
+package stream
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func EnsureFloor[E any](t *testing.T, cache Cache[E]) {
+	t.Helper()
+
+	mc, ok := cache.(*mapCache[E])
+	require.True(t, ok)
+
+	mc.mu.RLock()
+	defer mc.mu.RUnlock()
+
+	for k := range mc.elems {
+		require.GreaterOrEqual(t, k, mc.floor)
+	}
+}

--- a/lib/stream/cache_test.go
+++ b/lib/stream/cache_test.go
@@ -1,0 +1,165 @@
+package stream_test
+
+import (
+	"math/rand/v2"
+	"sync"
+	"testing"
+
+	"github.com/omni-network/omni/lib/stream"
+
+	"github.com/stretchr/testify/require"
+)
+
+//go:generate go test . -run=TestFloor -count=100
+
+func TestFloor(t *testing.T) {
+	t.Parallel()
+
+	const total = 100
+	toAdd := make(map[int]struct{})
+	for i := range total {
+		toAdd[i] = struct{}{}
+	}
+
+	cache := stream.NewCache[int](total)
+	// Add in random order
+	for i := range toAdd {
+		cache.Set(uint64(i), []int{i})
+		stream.EnsureFloor(t, cache)
+	}
+	// Add in random order
+	for i := range toAdd {
+		i += total
+		cache.Set(uint64(i), []int{i})
+		stream.EnsureFloor(t, cache)
+	}
+}
+
+//go:generate go test . -run=TestCache -count=100
+
+func TestCache(t *testing.T) {
+	t.Parallel()
+
+	const limit = 100
+	cache := stream.NewCache[int](limit)
+
+	// Helper function ensuring length of returned elements
+	requireGetLen := func(t *testing.T, from uint64, l int) {
+		t.Helper()
+		require.Len(t, cache.Get(from), l)
+	}
+
+	var wg sync.WaitGroup
+	added := make(chan []int)
+
+	// Ensure it is empty
+	requireGetLen(t, 0, 0)
+	requireGetLen(t, 1, 0)
+	requireGetLen(t, limit, 0)
+
+	// Concurrently add elements to the cache
+	const writers = 10
+	for i := range writers {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			count := limit / writers
+			start := count * i
+
+			var elems []int
+			for j := 0; j < count; j++ {
+				elems = append(elems, start+j)
+			}
+
+			cache.Set(uint64(start), elems)
+			added <- elems
+		}(i)
+	}
+
+	// Wait for all elements to be added
+	go func() {
+		wg.Wait()
+		close(added)
+	}()
+
+	for elems := range added {
+		// Ensure these are all added
+		for i, elem := range elems {
+			got := cache.Get(uint64(elem))
+			// Ensure they are in order
+			for j, e := range got {
+				if j == 0 {
+					continue
+				}
+				require.Equal(t, e, got[j-1]+1)
+			}
+
+			for _, expect := range elems[i:] {
+				require.Contains(t, got, expect)
+			}
+		}
+	}
+
+	// Ensure the cache is full
+	requireGetLen(t, 0, limit)
+	cache.Set(limit, []int{limit, limit + 1}) // Add two more elements
+	requireGetLen(t, 0, 0)                    // Ensure the oldest element is removed
+	requireGetLen(t, 1, 0)                    // Ensure the second-oldest element is removed
+	requireGetLen(t, 2, limit)                // Ensure the second-oldest element is removed
+
+	// Add a new element with a gap at limit+2
+	cache.Set(limit+3, []int{limit + 3})
+	requireGetLen(t, 2, 0)       // Ensure the third-oldest element is removed
+	requireGetLen(t, 3, limit-1) // The rest should still be there (before gap)
+	requireGetLen(t, limit+3, 1) // The new element should be there (after gap
+}
+
+func Benchmark(b *testing.B) {
+	const limit = 1000
+
+	benchmarks := []struct {
+		name  string
+		cache stream.Cache[int]
+	}{
+		{
+			name:  "nop",
+			cache: stream.NewNopCache[int](),
+		},
+		//{
+		//	name:  "slice",
+		//	cache: stream.NewSliceCache[int](limit),
+		// },
+		{
+			name:  "map",
+			cache: stream.NewCache[int](limit),
+		},
+	}
+	for _, bm := range benchmarks {
+		b.Run(bm.name, func(b *testing.B) {
+			var wg sync.WaitGroup
+			r := rand.New(rand.NewPCG(uint64(b.N), uint64(b.N)))
+
+			// Concurrently run Get and Set operations
+			for i := 0; i < b.N; i++ {
+				wg.Add(2)
+
+				// Perform Set operations concurrently
+				go func() {
+					defer wg.Done()
+					height := r.Uint64N(limit)
+					elems := make([]int, 10)
+					for j := range elems {
+						elems[j] = rand.IntN(100)
+					}
+					bm.cache.Set(height, elems)
+				}()
+
+				// Perform Get operations concurrently
+				go func() {
+					defer wg.Done()
+					_ = bm.cache.Get(rand.Uint64N(limit))
+				}()
+			}
+		})
+	}
+}

--- a/lib/xchain/connect/connect.go
+++ b/lib/xchain/connect/connect.go
@@ -178,7 +178,7 @@ func New(ctx context.Context, netID netconf.ID, opts ...option) (Connector, erro
 		return Connector{}, errors.Wrap(err, "comet rpc client")
 	}
 
-	cprov := cprovider.NewABCI(cometCl, netID, netconf.ChainVersionNamer(netID))
+	cprov := cprovider.NewABCI(cometCl, netID)
 
 	xprov := xprovider.New(network, ethClients, cprov)
 

--- a/lib/xchain/provider/provider.go
+++ b/lib/xchain/provider/provider.go
@@ -167,6 +167,7 @@ func (p *Provider) stream(
 
 			return nil, lastErr
 		},
+		Cache:         stream.NewNopCache[xchain.Block](),
 		Backoff:       p.backoffFunc,
 		ElemLabel:     "block",
 		HeightLabel:   "height",
@@ -189,6 +190,8 @@ func (p *Provider) stream(
 		IncCallbackErr: func() {
 			callbackErrTotal.WithLabelValues(chainVersionName).Inc()
 		},
+		IncCacheHit:  func() {}, // Caching not required for xprovider
+		IncCacheMiss: func() {}, // Caching not required for xprovider
 		SetStreamHeight: func(h uint64) {
 			streamHeight.WithLabelValues(chainVersionName).Set(float64(h))
 		},

--- a/monitor/app/app.go
+++ b/monitor/app/app.go
@@ -68,7 +68,7 @@ func Run(ctx context.Context, cfg Config) error {
 		return err
 	}
 
-	cprov := cprovider.NewABCI(tmClient, network.ID, netconf.ChainVersionNamer(cfg.Network))
+	cprov := cprovider.NewABCI(tmClient, network.ID)
 
 	xprov := xprovider.New(network, ethClients, cprov)
 

--- a/relayer/app/app.go
+++ b/relayer/app/app.go
@@ -21,6 +21,13 @@ import (
 	ethcrypto "github.com/ethereum/go-ethereum/crypto"
 )
 
+// attestCacheLimit defines the attest stream cache limit per chain version.
+// - 10k attestations per chain version
+// - 10 chain versions (4 public chains with 2 versions, 2 omni chains with 1 version)
+// - 1KB per attestation (with 10 validator signatures)
+// - Total size ~= 1KB * 10k * 10 ~= 100MB.
+const attestCacheLimit = 10000
+
 func Run(ctx context.Context, cfg Config) error {
 	log.Info(ctx, "Starting relayer")
 
@@ -54,7 +61,7 @@ func Run(ctx context.Context, cfg Config) error {
 		return err
 	}
 
-	cprov := cprovider.NewABCI(tmClient, network.ID, netconf.ChainVersionNamer(cfg.Network))
+	cprov := cprovider.NewABCI(tmClient, network.ID, cprovider.WithAttestCache(attestCacheLimit))
 	xprov := xprovider.New(network, rpcClientPerChain, cprov)
 
 	pricer := newTokenPricer(ctx)


### PR DESCRIPTION
Add support for cache in `stream` package. Implement a map based cache and wire it as part of cprovider.

issue: #2321
