### PR TITLE
chore(ci): add zodomo to codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,7 +4,7 @@
 /relayer @corverroos @sideninja @chmllr @kc1116
 /octane @corverroos @sideninja @chmllr @kc1116
 
-/contracts @kevinhalliday @ttarsi
+/contracts @kevinhalliday @zodomo
 
 /monitor @corverroos @sideninja @chmllr @kc1116 @kevinhalliday
 /e2e @corverroos @sideninja @chmllr @kc1116 @kevinhalliday


### PR DESCRIPTION
see title

issue: none
