### PR TITLE
refactor(lib/ethclient): make syncprogress safe

### DIFF
--- a/halo/app/monitor.go
+++ b/halo/app/monitor.go
@@ -146,12 +146,11 @@ func monitorEVMOnce(ctx context.Context, ethCl ethclient.Client, status *readine
 		status.setExecutionP2PPeers(peers)
 	}
 
-	if syncing, err := ethCl.SyncProgress(ctx); err != nil {
+	if progress, syncing, err := ethCl.ProgressIfSyncing(ctx); err != nil {
 		return errors.Wrap(err, "sync progress")
-	} else if syncing != nil && !syncing.Done() {
-		// SyncProgress returns nil of not syncing.
+	} else if syncing && !progress.Done() {
 		evmSynced.Set(0)
-		log.Warn(ctx, "Attached omni evm is syncing", nil, "highest_block", syncing.HighestBlock, "current_block", syncing.CurrentBlock, "tx_indexing", syncing.TxIndexRemainingBlocks)
+		log.Warn(ctx, "Attached omni evm is syncing", nil, "highest_block", progress.HighestBlock, "current_block", progress.CurrentBlock, "tx_indexing", progress.TxIndexRemainingBlocks)
 		status.setExecutionSynced(false)
 	} else {
 		evmSynced.Set(1)

--- a/lib/ethclient/enginemock.go
+++ b/lib/ethclient/enginemock.go
@@ -240,8 +240,8 @@ func (*engineMock) PeerCount(context.Context) (uint64, error) {
 	return 1, nil
 }
 
-func (*engineMock) SyncProgress(context.Context) (*ethereum.SyncProgress, error) {
-	return nil, nil //nolint:nilnil // nil-nil return means not syncing.
+func (*engineMock) ProgressIfSyncing(context.Context) (*ethereum.SyncProgress, bool, error) {
+	return nil, false, nil // False == synced
 }
 
 func (m *engineMock) FilterLogs(_ context.Context, q ethereum.FilterQuery) ([]types.Log, error) {

--- a/lib/ethclient/ethbackend/backend.go
+++ b/lib/ethclient/ethbackend/backend.go
@@ -246,17 +246,17 @@ func (b *Backend) SendTransaction(ctx context.Context, in *ethtypes.Transaction)
 
 // EnsureSynced returns an error if the backend is not synced.
 func (b *Backend) EnsureSynced(ctx context.Context) error {
-	syncing, err := b.SyncProgress(ctx)
+	progress, syncing, err := b.ProgressIfSyncing(ctx)
 	if ethclient.IsErrMethodNotAvailable(err) {
 		return nil // Assume synced if method not available.
 	} else if err != nil {
 		return err
-	} else if syncing == nil {
-		return nil // Syncing is nil if node is not syncing.
-	} else if !syncing.Done() {
+	} else if !syncing {
+		return nil
+	} else if !progress.Done() {
 		return errors.New("backend not synced",
-			"lag", umath.SubtractOrZero(syncing.HighestBlock, syncing.CurrentBlock),
-			"indexing", syncing.TxIndexRemainingBlocks,
+			"lag", umath.SubtractOrZero(progress.HighestBlock, progress.CurrentBlock),
+			"indexing", progress.TxIndexRemainingBlocks,
 		)
 	}
 

--- a/lib/ethclient/ethclient_gen.go
+++ b/lib/ethclient/ethclient_gen.go
@@ -19,7 +19,6 @@ type Client interface {
 	ethereum.ChainIDReader
 	ethereum.ChainReader
 	ethereum.ChainStateReader
-	ethereum.ChainSyncReader
 	ethereum.ContractCaller
 	ethereum.GasEstimator
 	ethereum.GasPricer
@@ -32,6 +31,7 @@ type Client interface {
 	EtherBalanceAt(ctx context.Context, addr common.Address) (float64, error)
 	PeerCount(ctx context.Context) (uint64, error)
 	SetHead(ctx context.Context, height uint64) error
+	ProgressIfSyncing(ctx context.Context) (*ethereum.SyncProgress, bool, error)
 	Address() string
 	Close()
 }
@@ -248,22 +248,6 @@ func (w Wrapper) NonceAt(ctx context.Context, account common.Address, blockNumbe
 	defer span.End()
 
 	res0, err := w.cl.NonceAt(ctx, account, blockNumber)
-	if err != nil {
-		incError(w.chain, endpoint)
-		err = errors.Wrap(err, "json-rpc", "endpoint", endpoint)
-	}
-
-	return res0, err
-}
-
-func (w Wrapper) SyncProgress(ctx context.Context) (*ethereum.SyncProgress, error) {
-	const endpoint = "sync_progress"
-	defer latency(w.chain, endpoint)()
-
-	ctx, span := tracer.Start(ctx, spanName(endpoint))
-	defer span.End()
-
-	res0, err := w.cl.SyncProgress(ctx)
 	if err != nil {
 		incError(w.chain, endpoint)
 		err = errors.Wrap(err, "json-rpc", "endpoint", endpoint)

--- a/lib/ethclient/genwrap/genwrap.go
+++ b/lib/ethclient/genwrap/genwrap.go
@@ -48,6 +48,7 @@ type Client interface {
 	EtherBalanceAt(ctx context.Context, addr common.Address) (float64, error)
 	PeerCount(ctx context.Context) (uint64, error)
 	SetHead(ctx context.Context, height uint64) error
+	ProgressIfSyncing(ctx context.Context) (*ethereum.SyncProgress, bool, error)
 	Address() string
 	Close()
 }
@@ -77,7 +78,6 @@ type Client interface {
 		"ChainReader":        true,
 		"TransactionReader":  true,
 		"ChainStateReader":   true,
-		"ChainSyncReader":    true,
 		"ContractCaller":     true,
 		"LogFilterer":        true,
 		"TransactionSender":  true,

--- a/lib/ethclient/mock/mock_interfaces.go
+++ b/lib/ethclient/mock/mock_interfaces.go
@@ -106,7 +106,7 @@ func (mr *MockClientMockRecorder) BlockByNumber(ctx, number any) *gomock.Call {
 // BlockNumber mocks base method.
 func (m *MockClient) BlockNumber(ctx context.Context) (uint64, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "BlockHeight", ctx)
+	ret := m.ctrl.Call(m, "BlockNumber", ctx)
 	ret0, _ := ret[0].(uint64)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
@@ -115,7 +115,7 @@ func (m *MockClient) BlockNumber(ctx context.Context) (uint64, error) {
 // BlockNumber indicates an expected call of BlockNumber.
 func (mr *MockClientMockRecorder) BlockNumber(ctx any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BlockHeight", reflect.TypeOf((*MockClient)(nil).BlockNumber), ctx)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BlockNumber", reflect.TypeOf((*MockClient)(nil).BlockNumber), ctx)
 }
 
 // CallContract mocks base method.
@@ -263,6 +263,22 @@ func (m *MockClient) HeaderByType(ctx context.Context, typ ethclient.HeadType) (
 func (mr *MockClientMockRecorder) HeaderByType(ctx, typ any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HeaderByType", reflect.TypeOf((*MockClient)(nil).HeaderByType), ctx, typ)
+}
+
+// ProgressIfSyncing mocks base method.
+func (m *MockClient) ProgressIfSyncing(ctx context.Context) (*ethereum.SyncProgress, bool, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ProgressIfSyncing", ctx)
+	ret0, _ := ret[0].(*ethereum.SyncProgress)
+	ret1, _ := ret[1].(bool)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
+}
+
+// ProgressIfSyncing indicates an expected call of ProgressIfSyncing.
+func (mr *MockClientMockRecorder) ProgressIfSyncing(ctx any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ProgressIfSyncing", reflect.TypeOf((*MockClient)(nil).ProgressIfSyncing), ctx)
 }
 
 // NonceAt mocks base method.
@@ -471,21 +487,6 @@ func (m *MockClient) SuggestGasTipCap(ctx context.Context) (*big.Int, error) {
 func (mr *MockClientMockRecorder) SuggestGasTipCap(ctx any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SuggestGasTipCap", reflect.TypeOf((*MockClient)(nil).SuggestGasTipCap), ctx)
-}
-
-// SyncProgress mocks base method.
-func (m *MockClient) SyncProgress(ctx context.Context) (*ethereum.SyncProgress, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SyncProgress", ctx)
-	ret0, _ := ret[0].(*ethereum.SyncProgress)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// SyncProgress indicates an expected call of SyncProgress.
-func (mr *MockClientMockRecorder) SyncProgress(ctx any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SyncProgress", reflect.TypeOf((*MockClient)(nil).SyncProgress), ctx)
 }
 
 // TransactionByHash mocks base method.

--- a/lib/txmgr/txmgr.go
+++ b/lib/txmgr/txmgr.go
@@ -81,15 +81,15 @@ func (m *simple) ReserveNextNonce(ctx context.Context) (uint64, error) {
 
 	if m.nonce == nil {
 		// Ensure the node is synced before fetching the nonce
-		syncing, err := m.backend.SyncProgress(ctx)
+		progress, syncing, err := m.backend.ProgressIfSyncing(ctx)
 		if ethclient.IsErrMethodNotAvailable(err) { //nolint:revive // Empty block skips error handling below.
 			// Skip if method not available.
 		} else if err != nil {
 			return 0, errors.Wrap(err, "sync progress")
-		} else if syncing != nil && !syncing.Done() { // Note syncing is nil if node is not syncing.
+		} else if syncing && !progress.Done() {
 			return 0, errors.New("backend not synced",
-				"lag", umath.SubtractOrZero(syncing.HighestBlock, syncing.CurrentBlock),
-				"indexing", syncing.TxIndexRemainingBlocks,
+				"lag", umath.SubtractOrZero(progress.HighestBlock, progress.CurrentBlock),
+				"indexing", progress.TxIndexRemainingBlocks,
 			)
 		}
 

--- a/lib/txmgr/txmgr_internal_test.go
+++ b/lib/txmgr/txmgr_internal_test.go
@@ -213,12 +213,11 @@ func (b *mockBackend) BlockNumber(ctx context.Context) (uint64, error) {
 	return b.blockHeight, nil
 }
 
-// SyncProgress returns the nil syncing progress; i.e. not syncing.
-func (b *mockBackend) SyncProgress(ctx context.Context) (*ethereum.SyncProgress, error) {
+func (b *mockBackend) ProgressIfSyncing(ctx context.Context) (*ethereum.SyncProgress, bool, error) {
 	b.mu.RLock()
 	defer b.mu.RUnlock()
 
-	return nil, nil //nolint:nilnil // This is how geth does it.
+	return nil, false, nil // False == synced.
 }
 
 func (b *mockBackend) HeaderByNumber(ctx context.Context, number *big.Int) (*types.Header, error) {

--- a/monitor/app/public_rpc.go
+++ b/monitor/app/public_rpc.go
@@ -53,17 +53,17 @@ func monitorPublicRPCForever(
 }
 
 func monitorPublicRPCOnce(ctx context.Context, omniNodeRPC, publicRPC ethclient.Client) error {
-	omniNodeProgress, err := omniNodeRPC.SyncProgress(ctx)
+	omniNodeHeight, err := omniNodeRPC.BlockNumber(ctx)
 	if err != nil {
-		return errors.Wrap(err, "omni node sync progress")
+		return errors.Wrap(err, "omni node height")
 	}
 
-	publicRPCProgress, err := publicRPC.SyncProgress(ctx)
+	publicRPCHeight, err := publicRPC.BlockNumber(ctx)
 	if err != nil {
-		return errors.Wrap(err, "public RPC sync progress")
+		return errors.Wrap(err, "public RPC height")
 	}
 
-	heightDiff := float64(omniNodeProgress.HighestBlock) - float64(publicRPCProgress.HighestBlock)
+	heightDiff := float64(omniNodeHeight) - float64(publicRPCHeight)
 	publicRPCSyncDiff.Set(heightDiff)
 
 	return nil


### PR DESCRIPTION
Replace `ethclient.SyncProgress` which is prone to panics with a safe version `ethclient.ProgressIfSyncing` which returns `pointer, bool, error`.

issue: none