### PR TITLE
ci(github): add mainnet join nightly

### DIFF
--- a/.github/workflows/ci-join.yml
+++ b/.github/workflows/ci-join.yml
@@ -10,7 +10,7 @@ on:
         options:
           - omega
           - mainnet
-        default: "mainnet" # this value will be picked by the cron job
+        default: "omega"
   schedule:
     - cron: "0 1 * * 1-5" # Weekdays at 1am UTC
 
@@ -39,7 +39,7 @@ jobs:
       - name: Run join test
         run: |
           cd scripts/join
-          go test . -v --integration --logs_file=docker_logs.txt --network=${github.event.inputs.network} -timeout 0
+          go test . -v --integration --logs_file=docker_logs.txt --network="${{github.event.inputs.network || 'mainnet'}}" -timeout 0
 
       - name: Upload docker logs
         uses: actions/upload-artifact@v4

--- a/.github/workflows/ci-join.yml
+++ b/.github/workflows/ci-join.yml
@@ -1,8 +1,16 @@
-name: join omega nightly
-# Nightly action that tests joining omega as a full node.
+name: join networks nightly
+# Nightly action that tests joining network as a full node.
 
 on:
   workflow_dispatch:
+    inputs:
+      network:
+        type: choice
+        description: Network
+        options:
+          - omega
+          - mainnet
+        default: "mainnet" # this value will be picked by the cron job
   schedule:
     - cron: "0 1 * * 1-5" # Weekdays at 1am UTC
 
@@ -31,7 +39,7 @@ jobs:
       - name: Run join test
         run: |
           cd scripts/join
-          go test . -v --integration --logs_file=docker_logs.txt -timeout 0
+          go test . -v --integration --logs_file=docker_logs.txt --network=${github.event.inputs.network} -timeout 0
 
       - name: Upload docker logs
         uses: actions/upload-artifact@v4

--- a/scripts/join/join_test.go
+++ b/scripts/join/join_test.go
@@ -30,14 +30,15 @@ import (
 
 var (
 	logsFile    = flag.String("logs_file", "join_test.log", "File to write docker logs to")
+	network     = flag.String("network", "omega", "Network to join (default: omega)")
 	integration = flag.Bool("integration", false, "Run integration tests")
 )
 
-// TestJoinOmega starts a local node (using omni operator init-nodes)
+// TestJoinNetwork starts a local node (using omni operator init-nodes)
 // and waits for it to sync.
 //
 //nolint:paralleltest // Parallel tests not supported since we start docker containers.
-func TestJoinOmega(t *testing.T) {
+func TestJoinNetwork(t *testing.T) {
 	if !*integration {
 		t.Skip("skipping integration test")
 	}
@@ -47,7 +48,6 @@ func TestJoinOmega(t *testing.T) {
 		minDuration = time.Minute * 30
 	)
 
-	network := netconf.Omega
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	home := t.TempDir()
@@ -57,7 +57,7 @@ func TestJoinOmega(t *testing.T) {
 	require.NoError(t, err)
 
 	cfg := clicmd.InitConfig{
-		Network: network,
+		Network: netconf.ID(*network),
 		Home:    home,
 		Moniker: t.Name(),
 		HaloTag: getGitCommit7(t),

--- a/scripts/join/join_test.go
+++ b/scripts/join/join_test.go
@@ -56,8 +56,9 @@ func TestJoinNetwork(t *testing.T) {
 	output, err := os.OpenFile(logsPath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0644)
 	require.NoError(t, err)
 
+	networkID := netconf.ID(*network)
 	cfg := clicmd.InitConfig{
-		Network: netconf.ID(*network),
+		Network: networkID,
 		Home:    home,
 		Moniker: t.Name(),
 		HaloTag: getGitCommit7(t),
@@ -65,7 +66,7 @@ func TestJoinNetwork(t *testing.T) {
 
 	require.NoError(t, ensureHaloImage(cfg.HaloTag))
 
-	log.Info(ctx, "Exec: omni operator init-nodes")
+	log.Info(ctx, "Exec: omni operator init-nodes", "network", networkID)
 	require.NoError(t, clicmd.InitNodes(log.WithNoopLogger(ctx), cfg))
 
 	t0 := time.Now()


### PR DESCRIPTION
- Disable omega nightly join until the sync timeout is understood
- Enable mainnet nightly sync (syncs in 10m on a Macbook)
- Allow to run the action manually both for test and mainnet

issue: #2314