### PR TITLE
fix(ci): fix timer for local join of mainnet

### DIFF
--- a/scripts/join/join_test.go
+++ b/scripts/join/join_test.go
@@ -45,7 +45,7 @@ func TestJoinNetwork(t *testing.T) {
 
 	const (
 		timeout     = time.Hour * 10
-		minDuration = time.Minute * 30
+		minDuration = time.Minute * 10
 	)
 
 	ctx, cancel := context.WithCancel(context.Background())


### PR DESCRIPTION
Reduce the internal timer to 10m (otherwise it fails locally on joining mainnet).

issue: none