### PR TITLE
fix(ci): run with sudo

### DIFF
--- a/.github/workflows/ci-join.yml
+++ b/.github/workflows/ci-join.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Run join test
         run: |
           cd scripts/join
-          go test . -v --integration --logs_file=docker_logs.txt --network="${{github.event.inputs.network || 'mainnet'}}" -timeout 0
+          sudo go test . -v --integration --logs_file=docker_logs.txt --network="${{github.event.inputs.network || 'mainnet'}}" -timeout 0
 
       - name: Upload docker logs
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
Run the test with sudo do avoid dealing with file permissions of the geth state. (See [GitHub docs](https://docs.github.com/en/actions/using-github-hosted-runners/using-github-hosted-runners/about-github-hosted-runners#administrative-privileges))

issue: none