### PR TITLE
fix(monitor/cmd): rename coingecko flag

### DIFF
--- a/monitor/app/config_test.go
+++ b/monitor/app/config_test.go
@@ -7,8 +7,10 @@ import (
 
 	"github.com/omni-network/omni/lib/log"
 	"github.com/omni-network/omni/lib/tutil"
+	"github.com/omni-network/omni/lib/xchain"
 	monitor "github.com/omni-network/omni/monitor/app"
 	"github.com/omni-network/omni/monitor/loadgen"
+	"github.com/omni-network/omni/monitor/xfeemngr"
 
 	"github.com/stretchr/testify/require"
 )
@@ -22,6 +24,10 @@ func TestDefaultConfigReference(t *testing.T) {
 	cfg := monitor.DefaultConfig()
 	cfg.LoadGen = loadgen.Config{
 		ValidatorKeysGlob: "path/*/1",
+	}
+	cfg.XFeeMngr = xfeemngr.Config{
+		RPCEndpoints:    xchain.RPCEndpoints{"test_chain": "http://localhost:8545"},
+		CoinGeckoAPIKey: "secret",
 	}
 
 	path := filepath.Join(tempDir, "monitor.toml")

--- a/monitor/app/testdata/default_monitor.toml
+++ b/monitor/app/testdata/default_monitor.toml
@@ -41,12 +41,11 @@ halo-url = ""
 [xfeemngr]
 
 # The CoinGecko API key to use for fetching token prices.
-coingecko-apikey = ""
+coingecko-apikey = "secret"
 
 # EVM RPC endpoints to use in xfeemngr. This may include out-of-network rpcs.
 [xfeemngr.rpc-endpoints]
-# ethereum = "http://my-ethreum-node:8545"
-# optimism = "https://my-op-node.com"
+test_chain = "http://localhost:8545"
 
 
 

--- a/monitor/cmd/flags.go
+++ b/monitor/cmd/flags.go
@@ -25,5 +25,5 @@ func bindLoadGenFlags(flags *pflag.FlagSet, cfg *loadgen.Config) {
 
 func bindXFeeMngrFlags(flags *pflag.FlagSet, cfg *xfeemngr.Config) {
 	flags.StringToStringVar((*map[string]string)(&cfg.RPCEndpoints), "xfeemngr-rpc-endpoints", cfg.RPCEndpoints, "Cross-chain EVM RPC endpoints. e.g. \"ethereum=http://geth:8545,optimism=https://optimism.io\"")
-	flags.StringVar(&cfg.CoinGeckoAPIKey, "coingecko-apikey", cfg.CoinGeckoAPIKey, "The CoinGecko API key to use for fetching token prices")
+	flags.StringVar(&cfg.CoinGeckoAPIKey, "xfeemngr-coingecko-apikey", cfg.CoinGeckoAPIKey, "The CoinGecko API key to use for fetching token prices")
 }


### PR DESCRIPTION
Fixes incorrect coingecko flag name that didn't route viper to cobra.

issue: #1839 