### PR TITLE
fix(attest/voter): reset to available if not included

### DIFF
--- a/halo/attest/voter/voter.go
+++ b/halo/attest/voter/voter.go
@@ -438,11 +438,6 @@ func (v *Voter) GetAvailable() []*types.Vote {
 // SetProposed sets the votes as proposed.
 func (v *Voter) SetProposed(headers []*types.AttestHeader) error {
 	proposedPerBlock.Observe(float64(len(headers)))
-
-	if len(headers) == 0 {
-		return nil
-	}
-
 	proposed := headerMap(headers)
 
 	v.mu.Lock()
@@ -470,11 +465,6 @@ func (v *Voter) SetProposed(headers []*types.AttestHeader) error {
 // SetCommitted sets the votes as committed. Persisting the result to disk.
 func (v *Voter) SetCommitted(headers []*types.AttestHeader) error {
 	committedPerBlock.Observe(float64(len(headers)))
-
-	if len(headers) == 0 {
-		return nil
-	}
-
 	committed := headerMap(headers)
 
 	v.mu.Lock()


### PR DESCRIPTION
Currently, if a validator prosed a vote(s) but they are not included in the next rounds proposed block, they will only be reset to available if that (or once subsequent) proposed blocks contain another vote from the same validator. This creates an inefficiency, where votes are only rebroadcasted once subsequent votes are included. This could delay voting by up to `AttestInterval` (1 hour).

It is better to rebroadcast if even no votes from the validator is included in the next proposal.

issue: none