### PR TITLE
chore(lib/contracts): reduced gas pump max swap init

### DIFF
--- a/lib/contracts/gaspump/deploy.go
+++ b/lib/contracts/gaspump/deploy.go
@@ -137,8 +137,8 @@ func Deploy(ctx context.Context, network netconf.ID, backend *ethbackend.Backend
 		Portal:          addrs.Portal,
 		GasStation:      addrs.GasStation,
 		Oracle:          oracle,
-		MaxSwap:         big.NewInt(20000000000000000), // 0.02 ETH
-		Toll:            big.NewInt(100),               // 100 / 1000 = 0.1 = 10% (1000 = GasPump.TOLL_DENOM),
+		MaxSwap:         big.NewInt(1000000000000000), // 0.001 ETH
+		Toll:            big.NewInt(100),              // 100 / 1000 = 0.1 = 10% (1000 = GasPump.TOLL_DENOM),
 		ExpectedAddr:    addrs.GasPump,
 	}
 


### PR DESCRIPTION
0.02 ETH was far too much, reduced it to 0.001 ETH. Gas Pump is not a DEX.

issue: #2206 
