### PR TITLE
refactor(xchain/provider): use ref with get submitted cursor

### DIFF
--- a/halo/attest/voter/voter_test.go
+++ b/halo/attest/voter/voter_test.go
@@ -549,7 +549,7 @@ func (stubProvider) GetBlock(context.Context, xchain.ProviderRequest) (xchain.Bl
 	panic("unexpected")
 }
 
-func (stubProvider) GetSubmittedCursor(context.Context, xchain.StreamID) (xchain.SubmitCursor, bool, error) {
+func (stubProvider) GetSubmittedCursor(context.Context, xchain.Ref, xchain.StreamID) (xchain.SubmitCursor, bool, error) {
 	panic("unexpected")
 }
 

--- a/halo/attest/voter/voter_test.go
+++ b/halo/attest/voter/voter_test.go
@@ -553,7 +553,7 @@ func (stubProvider) GetSubmittedCursor(context.Context, xchain.StreamID) (xchain
 	panic("unexpected")
 }
 
-func (stubProvider) GetEmittedCursor(context.Context, xchain.EmitRef, xchain.StreamID) (xchain.EmitCursor, bool, error) {
+func (stubProvider) GetEmittedCursor(context.Context, xchain.Ref, xchain.StreamID) (xchain.EmitCursor, bool, error) {
 	panic("unexpected")
 }
 

--- a/lib/xchain/provider.go
+++ b/lib/xchain/provider.go
@@ -72,7 +72,7 @@ type Provider interface {
 	// or false if not available, or an error.
 	// Calls the destination chain portal InXStreamOffset method.
 	// Note this is only supported for EVM chains, no the consensus chain.
-	GetSubmittedCursor(ctx context.Context, stream StreamID) (SubmitCursor, bool, error)
+	GetSubmittedCursor(ctx context.Context, ref Ref, stream StreamID) (SubmitCursor, bool, error)
 
 	// GetEmittedCursor returns the emitted cursor for the provided stream,
 	// or false if not available, or an error.
@@ -115,7 +115,9 @@ func HeightRef(height uint64) Ref {
 	}
 }
 
-// LatestRef returns a Ref with the latest confirmation level.
-func LatestRef() Ref {
-	return ConfRef(ConfLatest)
-}
+var (
+	// LatestRef references the latest confirmation level.
+	LatestRef = ConfRef(ConfLatest)
+	// FinalizedRef references the latest confirmation level.
+	FinalizedRef = ConfRef(ConfFinalized)
+)

--- a/lib/xchain/provider.go
+++ b/lib/xchain/provider.go
@@ -80,7 +80,7 @@ type Provider interface {
 	//
 	// Note that the AttestOffset field is not populated for emit cursors, since it isn't stored on-chain
 	// but tracked off-chain.
-	GetEmittedCursor(ctx context.Context, ref EmitRef, stream StreamID) (EmitCursor, bool, error)
+	GetEmittedCursor(ctx context.Context, ref Ref, stream StreamID) (EmitCursor, bool, error)
 
 	// ChainVersionHeight returns the height for the provided chain version.
 	ChainVersionHeight(ctx context.Context, chainVer ChainVersion) (uint64, error)
@@ -89,33 +89,33 @@ type Provider interface {
 	GetSubmission(ctx context.Context, chainID uint64, txHash common.Hash) (Submission, error)
 }
 
-// EmitRef specifies which block to query for emit cursors.
-type EmitRef struct {
+// Ref specifies which block to query for cursors.
+type Ref struct {
 	// Height specifies an absolute height to query; if non-nil.
 	Height *uint64
 	// ConfLevel specifies a relative-to-head block to query; if non-nil.
 	ConfLevel *ConfLevel
 }
 
-func (r EmitRef) Valid() bool {
+func (r Ref) Valid() bool {
 	return r.Height != nil || r.ConfLevel != nil
 }
 
-// ConfEmitRef returns a EmitRef with the provided confirmation level.
-func ConfEmitRef(level ConfLevel) EmitRef {
-	return EmitRef{
+// ConfRef returns a Ref with the provided confirmation level.
+func ConfRef(level ConfLevel) Ref {
+	return Ref{
 		ConfLevel: &level,
 	}
 }
 
-// HeightEmitRef returns a EmitRef with the provided confirmation level.
-func HeightEmitRef(height uint64) EmitRef {
-	return EmitRef{
+// HeightRef returns a Ref with the provided confirmation level.
+func HeightRef(height uint64) Ref {
+	return Ref{
 		Height: &height,
 	}
 }
 
-// LatestEmitRef returns a EmitRef with the latest confirmation level.
-func LatestEmitRef() EmitRef {
-	return ConfEmitRef(ConfLatest)
+// LatestRef returns a Ref with the latest confirmation level.
+func LatestRef() Ref {
+	return ConfRef(ConfLatest)
 }

--- a/lib/xchain/provider/fetch.go
+++ b/lib/xchain/provider/fetch.go
@@ -59,7 +59,7 @@ func (p *Provider) ChainVersionHeight(ctx context.Context, chainVer xchain.Chain
 //
 // Note that the AttestOffset field is not populated for emit cursors, since it isn't stored on-chain
 // but tracked off-chain.
-func (p *Provider) GetEmittedCursor(ctx context.Context, ref xchain.EmitRef, stream xchain.StreamID,
+func (p *Provider) GetEmittedCursor(ctx context.Context, ref xchain.Ref, stream xchain.StreamID,
 ) (xchain.EmitCursor, bool, error) {
 	if !ref.Valid() {
 		return xchain.EmitCursor{}, false, errors.New("invalid emit ref")
@@ -443,7 +443,7 @@ func parseXReceipt(filterer *bindings.OmniPortalFilterer, event types.Log, chain
 	}, nil
 }
 
-func getConsXBlock(ctx context.Context, ref xchain.EmitRef, cprov cchain.Provider) (xchain.Block, error) {
+func getConsXBlock(ctx context.Context, ref xchain.Ref, cprov cchain.Provider) (xchain.Block, error) {
 	var height uint64
 	var latest bool
 	if ref.Height != nil {

--- a/lib/xchain/provider/mock.go
+++ b/lib/xchain/provider/mock.go
@@ -152,7 +152,7 @@ func (m *Mock) GetBlock(_ context.Context, req xchain.ProviderRequest) (xchain.B
 	return block, ok, nil
 }
 
-func (*Mock) GetSubmittedCursor(_ context.Context, stream xchain.StreamID,
+func (*Mock) GetSubmittedCursor(_ context.Context, _ xchain.Ref, stream xchain.StreamID,
 ) (xchain.SubmitCursor, bool, error) {
 	return xchain.SubmitCursor{StreamID: stream}, true, nil
 }

--- a/lib/xchain/provider/mock.go
+++ b/lib/xchain/provider/mock.go
@@ -157,7 +157,7 @@ func (*Mock) GetSubmittedCursor(_ context.Context, stream xchain.StreamID,
 	return xchain.SubmitCursor{StreamID: stream}, true, nil
 }
 
-func (*Mock) GetEmittedCursor(_ context.Context, _ xchain.EmitRef, stream xchain.StreamID,
+func (*Mock) GetEmittedCursor(_ context.Context, _ xchain.Ref, stream xchain.StreamID,
 ) (xchain.EmitCursor, bool, error) {
 	return xchain.EmitCursor{StreamID: stream}, true, nil
 }

--- a/monitor/routerecon/recon.go
+++ b/monitor/routerecon/recon.go
@@ -64,7 +64,7 @@ func reconStreamOnce(
 	ethCls map[uint64]ethclient.Client,
 	stream xchain.StreamID,
 ) error {
-	cursor, ok, err := xprov.GetSubmittedCursor(ctx, stream)
+	cursor, ok, err := xprov.GetSubmittedCursor(ctx, xchain.LatestRef, stream)
 	if err != nil {
 		return err
 	} else if !ok {

--- a/monitor/routerecon/recon_internal_test.go
+++ b/monitor/routerecon/recon_internal_test.go
@@ -111,7 +111,7 @@ func TestBasicHistorical(t *testing.T) {
 
 		log.Info(ctx, "Max routescan offset", "stream", streamName, "offset", maxOffset, "src_timestamp", fmtTime(maxCrossTx.SrcTimestamp), "dst_timestamp", fmtTime(maxCrossTx.DstTimestamp))
 
-		sub, ok, err := conn.XProvider.GetSubmittedCursor(ctx, streamID)
+		sub, ok, err := conn.XProvider.GetSubmittedCursor(ctx, xchain.LatestRef, streamID)
 		log.Info(ctx, "Max onchain offset", "stream", streamName, "offset", sub.MsgOffset, "ok", ok, "err", err)
 		log.Info(ctx, "Missing routescan offsets", "stream", streamName, "indexed", len(offsets), "indexed_gaps", gaps, "unindexed", umath.SubtractOrZero(sub.MsgOffset, maxOffset))
 	}

--- a/monitor/routerecon/routescan_internal_test.go
+++ b/monitor/routerecon/routescan_internal_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/omni-network/omni/lib/evmchain"
 	"github.com/omni-network/omni/lib/log"
 	"github.com/omni-network/omni/lib/netconf"
+	"github.com/omni-network/omni/lib/xchain"
 	"github.com/omni-network/omni/lib/xchain/connect"
 
 	"github.com/stretchr/testify/require"
@@ -36,7 +37,7 @@ func TestReconLag(t *testing.T) {
 
 		streamName := conn.Network.StreamName(stream)
 
-		cursor, ok, err := conn.XProvider.GetSubmittedCursor(ctx, stream)
+		cursor, ok, err := conn.XProvider.GetSubmittedCursor(ctx, xchain.LatestRef, stream)
 		require.NoError(t, err, streamName)
 		if !ok {
 			// Skip streams without submissions

--- a/monitor/xmonitor/monitor.go
+++ b/monitor/xmonitor/monitor.go
@@ -85,7 +85,7 @@ func monitorConsOffsetOnce(ctx context.Context, network netconf.Network, xprovid
 
 	// Consensus chain messages are broadcast, so query for each EVM chain.
 	for _, stream := range network.StreamsFrom(cChain.ID) {
-		ref := xchain.Ref{ConfLevel: ptr(stream.ConfLevel())}
+		ref := xchain.ConfRef(stream.ConfLevel())
 		emitted, ok, err := xprovider.GetEmittedCursor(ctx, ref, stream)
 		if err != nil {
 			return errors.Wrap(err, "get emit cursor", "stream", network.StreamName(stream))
@@ -172,7 +172,7 @@ func monitorAttestedForever(
 
 				streamName := network.StreamName(stream)
 
-				cursor, _, err := xprovider.GetEmittedCursor(ctx, xchain.Ref{Height: &att.BlockHeight}, stream)
+				cursor, _, err := xprovider.GetEmittedCursor(ctx, xchain.HeightRef(att.BlockHeight), stream)
 				if err != nil {
 					log.Warn(ctx, "Attest offset monitor failed getting emit cursor", err, "stream", streamName)
 					continue
@@ -267,7 +267,7 @@ func monitorOffsetsOnce(
 		}
 
 		confLevel := stream.ConfLevel()
-		emitted, _, err := xprovider.GetEmittedCursor(ctx, xchain.Ref{ConfLevel: &confLevel}, stream)
+		emitted, _, err := xprovider.GetEmittedCursor(ctx, xchain.ConfRef(confLevel), stream)
 		if err != nil {
 			lastErr = errors.Wrap(err, "get emit cursor", "stream", stream)
 			continue
@@ -286,8 +286,4 @@ func monitorOffsetsOnce(
 	}
 
 	return lastErr
-}
-
-func ptr[T any](t T) *T {
-	return &t
 }

--- a/monitor/xmonitor/monitor.go
+++ b/monitor/xmonitor/monitor.go
@@ -96,7 +96,7 @@ func monitorConsOffsetOnce(ctx context.Context, network netconf.Network, xprovid
 		streamName := network.StreamName(stream)
 		emitMsgOffset.WithLabelValues(streamName).Set(float64(emitted.MsgOffset))
 
-		submitted, ok, err := xprovider.GetSubmittedCursor(ctx, stream)
+		submitted, ok, err := xprovider.GetSubmittedCursor(ctx, xchain.LatestRef, stream)
 		if err != nil {
 			return errors.Wrap(err, "get submit cursor", "stream", network.StreamName(stream))
 		} else if !ok {
@@ -273,7 +273,7 @@ func monitorOffsetsOnce(
 			continue
 		}
 
-		submitted, _, err := xprovider.GetSubmittedCursor(ctx, stream)
+		submitted, _, err := xprovider.GetSubmittedCursor(ctx, xchain.LatestRef, stream)
 		if err != nil {
 			lastErr = errors.Wrap(err, "get submit cursor", "stream", network.StreamName(stream), "height", height)
 			continue

--- a/monitor/xmonitor/monitor.go
+++ b/monitor/xmonitor/monitor.go
@@ -85,7 +85,7 @@ func monitorConsOffsetOnce(ctx context.Context, network netconf.Network, xprovid
 
 	// Consensus chain messages are broadcast, so query for each EVM chain.
 	for _, stream := range network.StreamsFrom(cChain.ID) {
-		ref := xchain.EmitRef{ConfLevel: ptr(stream.ConfLevel())}
+		ref := xchain.Ref{ConfLevel: ptr(stream.ConfLevel())}
 		emitted, ok, err := xprovider.GetEmittedCursor(ctx, ref, stream)
 		if err != nil {
 			return errors.Wrap(err, "get emit cursor", "stream", network.StreamName(stream))
@@ -172,7 +172,7 @@ func monitorAttestedForever(
 
 				streamName := network.StreamName(stream)
 
-				cursor, _, err := xprovider.GetEmittedCursor(ctx, xchain.EmitRef{Height: &att.BlockHeight}, stream)
+				cursor, _, err := xprovider.GetEmittedCursor(ctx, xchain.Ref{Height: &att.BlockHeight}, stream)
 				if err != nil {
 					log.Warn(ctx, "Attest offset monitor failed getting emit cursor", err, "stream", streamName)
 					continue
@@ -267,7 +267,7 @@ func monitorOffsetsOnce(
 		}
 
 		confLevel := stream.ConfLevel()
-		emitted, _, err := xprovider.GetEmittedCursor(ctx, xchain.EmitRef{ConfLevel: &confLevel}, stream)
+		emitted, _, err := xprovider.GetEmittedCursor(ctx, xchain.Ref{ConfLevel: &confLevel}, stream)
 		if err != nil {
 			lastErr = errors.Wrap(err, "get emit cursor", "stream", stream)
 			continue

--- a/relayer/app/cursors.go
+++ b/relayer/app/cursors.go
@@ -20,7 +20,7 @@ func getSubmittedCursors(ctx context.Context, network netconf.Network, dstChainI
 ) ([]xchain.SubmitCursor, error) {
 	var cursors []xchain.SubmitCursor //nolint:prealloc // Not worth it.
 	for _, stream := range network.StreamsTo(dstChainID) {
-		cursor, ok, err := xClient.GetSubmittedCursor(ctx, stream)
+		cursor, ok, err := xClient.GetSubmittedCursor(ctx, xchain.FinalizedRef, stream)
 		if err != nil {
 			return nil, errors.Wrap(err, "failed to get submitted cursors", "src_chain", stream.SourceChainID)
 		} else if !ok {

--- a/relayer/app/cursors_internal_test.go
+++ b/relayer/app/cursors_internal_test.go
@@ -97,7 +97,7 @@ var (
 type mockXChainClient struct {
 	GetBlockFn           func(context.Context, xchain.ProviderRequest) (xchain.Block, bool, error)
 	GetSubmittedCursorFn func(context.Context, xchain.StreamID) (xchain.SubmitCursor, bool, error)
-	GetEmittedCursorFn   func(context.Context, xchain.EmitRef, xchain.StreamID) (xchain.EmitCursor, bool, error)
+	GetEmittedCursorFn   func(context.Context, xchain.Ref, xchain.StreamID) (xchain.EmitCursor, bool, error)
 }
 
 func (*mockXChainClient) GetSubmission(context.Context, uint64, common.Hash) (xchain.Submission, error) {
@@ -129,7 +129,7 @@ func (m *mockXChainClient) GetSubmittedCursor(ctx context.Context, stream xchain
 	return m.GetSubmittedCursorFn(ctx, stream)
 }
 
-func (m *mockXChainClient) GetEmittedCursor(ctx context.Context, ref xchain.EmitRef, stream xchain.StreamID,
+func (m *mockXChainClient) GetEmittedCursor(ctx context.Context, ref xchain.Ref, stream xchain.StreamID,
 ) (xchain.EmitCursor, bool, error) {
 	return m.GetEmittedCursorFn(ctx, ref, stream)
 }

--- a/relayer/app/cursors_internal_test.go
+++ b/relayer/app/cursors_internal_test.go
@@ -96,7 +96,7 @@ var (
 
 type mockXChainClient struct {
 	GetBlockFn           func(context.Context, xchain.ProviderRequest) (xchain.Block, bool, error)
-	GetSubmittedCursorFn func(context.Context, xchain.StreamID) (xchain.SubmitCursor, bool, error)
+	GetSubmittedCursorFn func(context.Context, xchain.Ref, xchain.StreamID) (xchain.SubmitCursor, bool, error)
 	GetEmittedCursorFn   func(context.Context, xchain.Ref, xchain.StreamID) (xchain.EmitCursor, bool, error)
 }
 
@@ -124,9 +124,9 @@ func (m *mockXChainClient) GetBlock(ctx context.Context, req xchain.ProviderRequ
 	return m.GetBlockFn(ctx, req)
 }
 
-func (m *mockXChainClient) GetSubmittedCursor(ctx context.Context, stream xchain.StreamID,
+func (m *mockXChainClient) GetSubmittedCursor(ctx context.Context, ref xchain.Ref, stream xchain.StreamID,
 ) (xchain.SubmitCursor, bool, error) {
-	return m.GetSubmittedCursorFn(ctx, stream)
+	return m.GetSubmittedCursorFn(ctx, ref, stream)
 }
 
 func (m *mockXChainClient) GetEmittedCursor(ctx context.Context, ref xchain.Ref, stream xchain.StreamID,

--- a/relayer/app/worker_internal_test.go
+++ b/relayer/app/worker_internal_test.go
@@ -60,7 +60,7 @@ func TestWorker_Run(t *testing.T) {
 				},
 			}, true, nil
 		},
-		GetSubmittedCursorFn: func(_ context.Context, stream xchain.StreamID) (xchain.SubmitCursor, bool, error) {
+		GetSubmittedCursorFn: func(_ context.Context, ref xchain.Ref, stream xchain.StreamID) (xchain.SubmitCursor, bool, error) {
 			resp, ok := cursors[stream]
 			return resp, ok, nil
 		},


### PR DESCRIPTION
Use ref with submitted cursors so we can get finalized cursors. 

issue: none