### PR TITLE
ci(e2e/docker): switch to local logging driver

### DIFF
--- a/e2e/docker/compose.yaml.tmpl
+++ b/e2e/docker/compose.yaml.tmpl
@@ -31,6 +31,8 @@ services:
     - 6060 # Pprof
     volumes:
     - ./{{ .Name }}:/halo
+    logging:
+      driver: local
     networks:
       {{ $.NetworkName }}:
         {{ if $.Network }}ipv4_address: {{ .InternalIP }}{{ end }}
@@ -56,6 +58,8 @@ services:
     {{ if .LoadState }}
     volumes:
       - {{ .LoadState }}:/anvil/state.json
+    logging:
+      driver: local
     {{ end }}
 {{- end}}
 
@@ -90,6 +94,8 @@ services:
       retries: 30
     volumes:
       - ./{{ .InstanceName }}:/geth
+    logging:
+      driver: local
     networks:
       {{ $.NetworkName }}:
         {{ if $.Network }}ipv4_address: {{ .AdvertisedIP }}{{ end }}
@@ -106,6 +112,8 @@ services:
       - 26660 # Prometheus and pprof
     volumes:
       - ./relayer:/relayer
+    logging:
+      driver: local
     networks:
       {{ $.NetworkName }}:
         {{ if $.Network }}ipv4_address: 10.186.73.200{{ end }}
@@ -122,6 +130,8 @@ services:
       - 26660 # Prometheus and pprof
     volumes:
       - ./monitor:/monitor
+    logging:
+      driver: local
     networks:
       {{ $.NetworkName }}:
         {{ if $.Network }}ipv4_address: 10.186.73.201{{ end }}
@@ -138,6 +148,8 @@ services:
       - 26660 # Prometheus and pprof
     volumes:
       - ./solver:/solver
+    logging:
+      driver: local
     networks:
       {{ $.NetworkName }}:
         {{ if $.Network }}ipv4_address: 10.186.73.203{{ end }}
@@ -158,6 +170,8 @@ services:
     restart: unless-stopped
     volumes:
       - ./prometheus/prometheus.yaml:/etc/prometheus/prometheus.yaml
+    logging:
+      driver: local
     networks:
       {{ $.NetworkName }}:
         {{ if $.Network }}ipv4_address: 10.186.73.202{{ end }}

--- a/e2e/docker/testdata/TestComposeTemplate_commit.golden
+++ b/e2e/docker/testdata/TestComposeTemplate_commit.golden
@@ -25,6 +25,8 @@ services:
     - 6060 # Pprof
     volumes:
     - ./node0:/halo
+    logging:
+      driver: local
     networks:
       test:
         ipv4_address: 10.186.73.0
@@ -65,6 +67,8 @@ services:
     
     volumes:
       - path/to/anvil/state.json:/anvil/state.json
+    logging:
+      driver: local
     
 
   # Use geth as the omni EVMs.
@@ -97,6 +101,8 @@ services:
       retries: 30
     volumes:
       - ./omni_evm_0:/geth
+    logging:
+      driver: local
     networks:
       test:
         ipv4_address: 10.186.73.0
@@ -111,6 +117,8 @@ services:
       - 26660 # Prometheus and pprof
     volumes:
       - ./relayer:/relayer
+    logging:
+      driver: local
     networks:
       test:
         ipv4_address: 10.186.73.200
@@ -125,6 +133,8 @@ services:
       - 26660 # Prometheus and pprof
     volumes:
       - ./monitor:/monitor
+    logging:
+      driver: local
     networks:
       test:
         ipv4_address: 10.186.73.201
@@ -139,6 +149,8 @@ services:
       - 26660 # Prometheus and pprof
     volumes:
       - ./solver:/solver
+    logging:
+      driver: local
     networks:
       test:
         ipv4_address: 10.186.73.203
@@ -157,6 +169,8 @@ services:
     restart: unless-stopped
     volumes:
       - ./prometheus/prometheus.yaml:/etc/prometheus/prometheus.yaml
+    logging:
+      driver: local
     networks:
       test:
         ipv4_address: 10.186.73.202

--- a/e2e/docker/testdata/TestComposeTemplate_empheral_network.golden
+++ b/e2e/docker/testdata/TestComposeTemplate_empheral_network.golden
@@ -25,6 +25,8 @@ services:
     - 6060 # Pprof
     volumes:
     - ./node0:/halo
+    logging:
+      driver: local
     networks:
       test:
         ipv4_address: 10.186.73.0
@@ -65,6 +67,8 @@ services:
     
     volumes:
       - path/to/anvil/state.json:/anvil/state.json
+    logging:
+      driver: local
     
 
   # Use geth as the omni EVMs.
@@ -97,6 +101,8 @@ services:
       retries: 30
     volumes:
       - ./omni_evm_0:/geth
+    logging:
+      driver: local
     networks:
       test:
         ipv4_address: 10.186.73.0
@@ -111,6 +117,8 @@ services:
       - 26660 # Prometheus and pprof
     volumes:
       - ./relayer:/relayer
+    logging:
+      driver: local
     networks:
       test:
         ipv4_address: 10.186.73.200
@@ -125,6 +133,8 @@ services:
       - 26660 # Prometheus and pprof
     volumes:
       - ./monitor:/monitor
+    logging:
+      driver: local
     networks:
       test:
         ipv4_address: 10.186.73.201
@@ -139,6 +149,8 @@ services:
       - 26660 # Prometheus and pprof
     volumes:
       - ./solver:/solver
+    logging:
+      driver: local
     networks:
       test:
         ipv4_address: 10.186.73.203
@@ -157,6 +169,8 @@ services:
     restart: unless-stopped
     volumes:
       - ./prometheus/prometheus.yaml:/etc/prometheus/prometheus.yaml
+    logging:
+      driver: local
     networks:
       test:
         ipv4_address: 10.186.73.202

--- a/e2e/docker/testdata/TestComposeTemplate_empheral_network_upgrade.golden
+++ b/e2e/docker/testdata/TestComposeTemplate_empheral_network_upgrade.golden
@@ -25,6 +25,8 @@ services:
     - 6060 # Pprof
     volumes:
     - ./node0:/halo
+    logging:
+      driver: local
     networks:
       test:
         ipv4_address: 10.186.73.0
@@ -65,6 +67,8 @@ services:
     
     volumes:
       - path/to/anvil/state.json:/anvil/state.json
+    logging:
+      driver: local
     
 
   # Use geth as the omni EVMs.
@@ -97,6 +101,8 @@ services:
       retries: 30
     volumes:
       - ./omni_evm_0:/geth
+    logging:
+      driver: local
     networks:
       test:
         ipv4_address: 10.186.73.0
@@ -111,6 +117,8 @@ services:
       - 26660 # Prometheus and pprof
     volumes:
       - ./relayer:/relayer
+    logging:
+      driver: local
     networks:
       test:
         ipv4_address: 10.186.73.200
@@ -125,6 +133,8 @@ services:
       - 26660 # Prometheus and pprof
     volumes:
       - ./monitor:/monitor
+    logging:
+      driver: local
     networks:
       test:
         ipv4_address: 10.186.73.201
@@ -139,6 +149,8 @@ services:
       - 26660 # Prometheus and pprof
     volumes:
       - ./solver:/solver
+    logging:
+      driver: local
     networks:
       test:
         ipv4_address: 10.186.73.203
@@ -157,6 +169,8 @@ services:
     restart: unless-stopped
     volumes:
       - ./prometheus/prometheus.yaml:/etc/prometheus/prometheus.yaml
+    logging:
+      driver: local
     networks:
       test:
         ipv4_address: 10.186.73.202

--- a/e2e/vmcompose/testdata/TestSetup_127-0-0-1-compose.yaml.golden
+++ b/e2e/vmcompose/testdata/TestSetup_127-0-0-1-compose.yaml.golden
@@ -21,6 +21,8 @@ services:
     - 6060 # Pprof
     volumes:
     - ./validator01:/halo
+    logging:
+      driver: local
     networks:
       test:
         
@@ -56,6 +58,8 @@ services:
       retries: 30
     volumes:
       - ./validator01_evm:/geth
+    logging:
+      driver: local
     networks:
       test:
         

--- a/e2e/vmcompose/testdata/TestSetup_127-0-0-2-compose.yaml.golden
+++ b/e2e/vmcompose/testdata/TestSetup_127-0-0-2-compose.yaml.golden
@@ -21,6 +21,8 @@ services:
     - 6060 # Pprof
     volumes:
     - ./validator02:/halo
+    logging:
+      driver: local
     networks:
       test:
         
@@ -56,6 +58,8 @@ services:
       retries: 30
     volumes:
       - ./validator02_evm:/geth
+    logging:
+      driver: local
     networks:
       test:
         

--- a/e2e/vmcompose/testdata/TestSetup_127-0-0-3-compose.yaml.golden
+++ b/e2e/vmcompose/testdata/TestSetup_127-0-0-3-compose.yaml.golden
@@ -25,6 +25,8 @@ services:
     
     volumes:
       - ./anvil/state.json:/anvil/state.json
+    logging:
+      driver: local
     
 
   # Use geth as the omni EVMs.
@@ -38,6 +40,8 @@ services:
       - 26660 # Prometheus and pprof
     volumes:
       - ./relayer:/relayer
+    logging:
+      driver: local
     networks:
       test:
         

--- a/e2e/vmcompose/testdata/TestSetup_127-0-0-4-compose.yaml.golden
+++ b/e2e/vmcompose/testdata/TestSetup_127-0-0-4-compose.yaml.golden
@@ -21,6 +21,8 @@ services:
     - 6060 # Pprof
     volumes:
     - ./seed01:/halo
+    logging:
+      driver: local
     networks:
       test:
         
@@ -56,6 +58,8 @@ services:
       retries: 30
     volumes:
       - ./seed01_evm:/geth
+    logging:
+      driver: local
     networks:
       test:
         

--- a/e2e/vmcompose/testdata/TestSetup_127-0-0-5-compose.yaml.golden
+++ b/e2e/vmcompose/testdata/TestSetup_127-0-0-5-compose.yaml.golden
@@ -21,6 +21,8 @@ services:
     - 6060 # Pprof
     volumes:
     - ./fullnode01:/halo
+    logging:
+      driver: local
     networks:
       test:
         
@@ -56,6 +58,8 @@ services:
       retries: 30
     volumes:
       - ./fullnode01_evm:/geth
+    logging:
+      driver: local
     networks:
       test:
         


### PR DESCRIPTION
The [default](https://docs.docker.com/engine/logging/configure/) docker logging driver doesn't do log rotation. Switch to `local` instead which does.

issue: none