### PR TITLE
fix(lib/k1util): always verify pubkeys

### DIFF
--- a/lib/k1util/k1util.go
+++ b/lib/k1util/k1util.go
@@ -117,6 +117,10 @@ func PubKeyBytesToCosmos(pubkey []byte) (cosmoscrypto.PubKey, error) {
 		return nil, errors.New("invalid pubkey length", "length", len(pubkey))
 	}
 
+	if _, err := ethcrypto.DecompressPubkey(pubkey); err != nil {
+		return nil, errors.Wrap(err, "invalid pubkey")
+	}
+
 	return &cosmosk1.PubKey{
 		Key: pubkey,
 	}, nil
@@ -125,6 +129,10 @@ func PubKeyBytesToCosmos(pubkey []byte) (cosmoscrypto.PubKey, error) {
 func PBPubKeyFromBytes(pubkey []byte) (cryptopb.PublicKey, error) {
 	if len(pubkey) != pubkeyCompressedLen {
 		return cryptopb.PublicKey{}, errors.New("invalid pubkey length", "length", len(pubkey))
+	}
+
+	if _, err := ethcrypto.DecompressPubkey(pubkey); err != nil {
+		return cryptopb.PublicKey{}, errors.Wrap(err, "invalid pubkey")
 	}
 
 	return cryptopb.PublicKey{Sum: &cryptopb.PublicKey_Secp256K1{Secp256K1: pubkey}}, nil

--- a/lib/k1util/k1util_test.go
+++ b/lib/k1util/k1util_test.go
@@ -7,6 +7,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/omni-network/omni/lib/k1util"
@@ -115,6 +116,18 @@ func TestCometBFT(t *testing.T) {
 
 	require.Equal(t, votePB1.Signature, votePB2.Signature)
 	require.Equal(t, votePB1.ExtensionSignature, votePB2.ExtensionSignature)
+}
+
+func TestPubKeyBytesToCosmos(t *testing.T) {
+	t.Parallel()
+
+	invalid := fromHex(t, strings.ReplaceAll(pubKey1, "c9c7d50d", "00112233"))
+
+	_, err := k1util.PubKeyBytesToCosmos(invalid)
+	require.Error(t, err)
+
+	_, err = k1util.PBPubKeyFromBytes(invalid)
+	require.Error(t, err)
 }
 
 func TestPubkey64(t *testing.T) {


### PR DESCRIPTION
Verify pubkey are valid when converting types. This prevent invalid pubkeys being registered in evmstaking. Which will halt the chain.

issue: #2430