### PR TITLE
ci(e2e): support canary upgrade regex

### DIFF
--- a/e2e/types/infra.go
+++ b/e2e/types/infra.go
@@ -2,10 +2,31 @@ package types
 
 import (
 	"context"
+	"regexp"
+	"strings"
 
 	e2e "github.com/cometbft/cometbft/test/e2e/pkg"
 	"github.com/cometbft/cometbft/test/e2e/pkg/infra"
 )
+
+const (
+	// regexpCanary is a convenient way to specify canary upgrades.
+	regexpCanary = "canary"
+	// regexpNonCanary is a convenient way to specify non-canary upgrades.
+	regexpNonCanary = "non-canary"
+)
+
+// canaries define services included in canary upgrades
+// and excluded from non-canary upgrades.
+var canaries = map[string]bool{
+	"validator01": true,
+	"fullnode01":  true,
+	"archive01":   true,
+	"seed01":      true,
+	"relayer":     true,
+	"monitor":     true,
+	"solver":      true,
+}
 
 func DefaultServiceConfig() ServiceConfig {
 	return ServiceConfig{
@@ -16,6 +37,33 @@ func DefaultServiceConfig() ServiceConfig {
 type ServiceConfig struct {
 	// Regexp to match the service names.
 	Regexp string
+}
+
+// MatchService returns true if the service matches the regexp config.
+func (c ServiceConfig) MatchService(service string) bool {
+	if c.Regexp == "" {
+		return true
+	}
+
+	isCanary := func() bool {
+		for canary := range canaries {
+			if strings.HasPrefix(service, canary) {
+				return true
+			}
+		}
+
+		return false
+	}
+
+	if c.Regexp == regexpCanary {
+		return isCanary()
+	} else if c.Regexp == regexpNonCanary {
+		return !isCanary()
+	}
+
+	ok, _ := regexp.MatchString(c.Regexp, service) // Nothing matches invalid regex
+
+	return ok
 }
 
 type InfraProvider interface {

--- a/e2e/types/infra_test.go
+++ b/e2e/types/infra_test.go
@@ -1,0 +1,44 @@
+package types_test
+
+import (
+	"testing"
+
+	"github.com/omni-network/omni/e2e/types"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCanaryRegex(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		Service string
+		Canary  bool
+	}{
+		{"validator01", true},
+		{"validator01_evm", true},
+		{"validator02", false},
+		{"validator02_evm", false},
+		{"fullnode01", true},
+		{"fullnode01_evm", true},
+		{"fullnode02", false},
+		{"fullnode02_evm", false},
+		{"archive01", true},
+		{"archive01_evm", true},
+		{"archive02", false},
+		{"archive02_evm", false},
+		{"relayer", true},
+		{"monitor", true},
+		{"solver", true},
+	}
+	for _, test := range tests {
+		t.Run(test.Service, func(t *testing.T) {
+			t.Parallel()
+			ok := types.ServiceConfig{Regexp: "canary"}.MatchService(test.Service)
+			require.Equal(t, test.Canary, ok)
+
+			ok = types.ServiceConfig{Regexp: "non-canary"}.MatchService(test.Service)
+			require.Equal(t, !test.Canary, ok)
+		})
+	}
+}

--- a/e2e/vmcompose/provider.go
+++ b/e2e/vmcompose/provider.go
@@ -6,7 +6,6 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"regexp"
 	"strings"
 	"sync"
 	"time"
@@ -277,12 +276,8 @@ func (p *Provider) Upgrade(ctx context.Context, cfg types.ServiceConfig) error {
 // matchAny returns true if the pattern matches any of the services in the services map.
 // An empty pattern returns true, matching anything.
 func matchAny(cfg types.ServiceConfig, services map[string]bool) bool {
-	if cfg.Regexp == "" {
-		return true
-	}
-
 	for service := range services {
-		matched, _ := regexp.MatchString(cfg.Regexp, service)
+		matched := cfg.MatchService(service)
 		if matched {
 			return true
 		}


### PR DESCRIPTION
Make canary upgrades simple and consistent by specifying a special "service regex"
- `canary` will upgrade canary services.
- `non-canary` will upgrade all other services.

issue: none