### PR TITLE
chore(docs): add syncing duration explanation

### DIFF
--- a/docs/content/operate/faq.md
+++ b/docs/content/operate/faq.md
@@ -19,13 +19,14 @@
 
 ### How long does syncing take?
 
-The time it takes for a validator to sync from genesis depends largely on your disk write throughput.
+The time it takes for Geth to do a fullsync (snapsync is not supported yet) depends largely on your disk write throughput.
 Syncing speed is directly proportional to write performance.
 We observed the following numbers in practice:
 - 200 MB/s disk write speed achieves approximately 40 blocks per second.
 - 1.5 GB/s disk write speed achieves around 460 blocks per second.
 
-To estimate your full sync time, check the current chain height and divide this number by your blocks-per-second rate to get a rough duration in seconds.
+To estimate your full sync time, check the current chain height (see [omniscan.network](https://omniscan.network)) and divide this number by your blocks-per-second rate to get a rough duration in seconds.
+You can estimate your blocks-per-second rate by monitoring the Geth logs: the log line starting with `Imported new potential chain segment` contains the `number` parameter denoting the last imported block height.
 
 ### How to check if the validator is ready?
 A node is considered ready when it is healthy and functions as intended.


### PR DESCRIPTION
Extends the FAQ with how to calculate the approximate syncing duration of a node.

issue: #2329 