### PR TITLE
fix(octane/evmengine): handle engine errors

### DIFF
--- a/lib/ethclient/client_test.go
+++ b/lib/ethclient/client_test.go
@@ -19,23 +19,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestGetPayloadV2(t *testing.T) {
-	t.Parallel()
-	fuzzer := fuzz.New().NilChance(0)
-
-	var param1 engine.PayloadID
-	fuzzer.Fuzz(&param1)
-
-	var resp engine.ExecutionPayloadEnvelope
-	fuzzer.Fuzz(&resp)
-
-	call := func(ctx context.Context, engineCl ethclient.EngineClient) (any, error) {
-		return engineCl.GetPayloadV2(ctx, param1)
-	}
-
-	testEndpoint(t, call, resp, param1)
-}
-
 func TestGetPayloadV3(t *testing.T) {
 	t.Parallel()
 	fuzzer := fuzz.New().NilChance(0)
@@ -48,23 +31,6 @@ func TestGetPayloadV3(t *testing.T) {
 
 	call := func(ctx context.Context, engineCl ethclient.EngineClient) (any, error) {
 		return engineCl.GetPayloadV3(ctx, param1)
-	}
-
-	testEndpoint(t, call, resp, param1)
-}
-
-func TestNewPayloadV2(t *testing.T) {
-	t.Parallel()
-	fuzzer := fuzz.New().NilChance(0)
-
-	var param1 engine.ExecutableData
-	fuzzer.Fuzz(&param1)
-
-	var resp engine.PayloadStatusV1
-	fuzzer.Fuzz(&resp)
-
-	call := func(ctx context.Context, engineCl ethclient.EngineClient) (any, error) {
-		return engineCl.NewPayloadV2(ctx, param1)
 	}
 
 	testEndpoint(t, call, resp, param1)
@@ -85,32 +51,13 @@ func TestNewPayloadV3(t *testing.T) {
 
 	var resp engine.PayloadStatusV1
 	fuzzer.Fuzz(&resp)
+	resp.Status = engine.VALID
 
 	call := func(ctx context.Context, engineCl ethclient.EngineClient) (any, error) {
 		return engineCl.NewPayloadV3(ctx, param1, param2, &param3)
 	}
 
 	testEndpoint(t, call, resp, param1, param2, param3)
-}
-
-func TestForkchoiceUpdatedV2(t *testing.T) {
-	t.Parallel()
-	fuzzer := fuzz.New().NilChance(0)
-
-	var param1 engine.ForkchoiceStateV1
-	fuzzer.Fuzz(&param1)
-
-	var param2 engine.PayloadAttributes
-	fuzzer.Fuzz(&param2)
-
-	var resp engine.ForkChoiceResponse
-	fuzzer.Fuzz(&resp)
-
-	call := func(ctx context.Context, engineCl ethclient.EngineClient) (any, error) {
-		return engineCl.ForkchoiceUpdatedV2(ctx, param1, &param2)
-	}
-
-	testEndpoint(t, call, resp, param1, param2)
 }
 
 func TestForkchoiceUpdatedV3(t *testing.T) {
@@ -125,6 +72,7 @@ func TestForkchoiceUpdatedV3(t *testing.T) {
 
 	var resp engine.ForkChoiceResponse
 	fuzzer.Fuzz(&resp)
+	resp.PayloadStatus.Status = engine.VALID
 
 	call := func(ctx context.Context, engineCl ethclient.EngineClient) (any, error) {
 		return engineCl.ForkchoiceUpdatedV3(ctx, param1, &param2)

--- a/lib/ethclient/engineclient.go
+++ b/lib/ethclient/engineclient.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/omni-network/omni/lib/errors"
+	"github.com/omni-network/omni/lib/log"
 
 	"github.com/ethereum/go-ethereum/beacon/engine"
 	"github.com/ethereum/go-ethereum/common"
@@ -30,25 +31,14 @@ const (
 type EngineClient interface {
 	Client
 
-	// NewPayloadV2 creates an Eth1 block, inserts it in the chain, and returns the status of the chain.
-	NewPayloadV2(ctx context.Context, params engine.ExecutableData) (engine.PayloadStatusV1, error)
 	// NewPayloadV3 creates an Eth1 block, inserts it in the chain, and returns the status of the chain.
 	NewPayloadV3(ctx context.Context, params engine.ExecutableData, versionedHashes []common.Hash,
 		beaconRoot *common.Hash) (engine.PayloadStatusV1, error)
-
-	// ForkchoiceUpdatedV2 has several responsibilities:
-	//  - It sets the chain the head.
-	//  - And/or it sets the chain's finalized block hash.
-	//  - And/or it starts assembling (async) a block with the payload attributes.
-	ForkchoiceUpdatedV2(ctx context.Context, update engine.ForkchoiceStateV1,
-		payloadAttributes *engine.PayloadAttributes) (engine.ForkChoiceResponse, error)
 
 	// ForkchoiceUpdatedV3 is equivalent to V2 with the addition of parent beacon block root in the payload attributes.
 	ForkchoiceUpdatedV3(ctx context.Context, update engine.ForkchoiceStateV1,
 		payloadAttributes *engine.PayloadAttributes) (engine.ForkChoiceResponse, error)
 
-	// GetPayloadV2 returns a cached payload by id.
-	GetPayloadV2(ctx context.Context, payloadID engine.PayloadID) (*engine.ExecutionPayloadEnvelope, error)
 	// GetPayloadV3 returns a cached payload by id.
 	GetPayloadV3(ctx context.Context, payloadID engine.PayloadID) (*engine.ExecutionPayloadEnvelope, error)
 }
@@ -77,50 +67,39 @@ func NewAuthClient(ctx context.Context, urlAddr string, jwtSecret []byte) (Engin
 	}, nil
 }
 
-func (c engineClient) NewPayloadV2(ctx context.Context, params engine.ExecutableData) (engine.PayloadStatusV1, error) {
-	const endpoint = "new_payload_v2"
-	defer latency(c.chain, endpoint)()
-
-	var resp engine.PayloadStatusV1
-	err := c.cl.Client().CallContext(ctx, &resp, newPayloadV2, params)
-	if err != nil {
-		incError(c.chain, endpoint)
-		return engine.PayloadStatusV1{}, errors.Wrap(err, "rpc new payload v2")
-	}
-
-	return resp, nil
-}
-
 func (c engineClient) NewPayloadV3(ctx context.Context, params engine.ExecutableData, versionedHashes []common.Hash,
 	beaconRoot *common.Hash,
 ) (engine.PayloadStatusV1, error) {
 	const endpoint = "new_payload_v3"
 	defer latency(c.chain, endpoint)()
 
+	// isStatusOk returns true if the response status is valid.
+	isStatusOk := func(status engine.PayloadStatusV1) bool {
+		return map[string]bool{
+			engine.VALID:    true,
+			engine.INVALID:  true,
+			engine.SYNCING:  true,
+			engine.ACCEPTED: true,
+		}[status.Status]
+	}
+
 	var resp engine.PayloadStatusV1
 	err := c.cl.Client().CallContext(ctx, &resp, newPayloadV3, params, versionedHashes, beaconRoot)
-	if err != nil {
+	if isStatusOk(resp) {
+		// Swallow errors when geth returns errors along with proper responses (but at least log it).
+		if err != nil {
+			log.Warn(ctx, "Ignoring new_payload_v3 error with proper response", err, "status", resp.Status)
+		}
+
+		return resp, nil
+	} else if err != nil {
 		incError(c.chain, endpoint)
-		return engine.PayloadStatusV1{}, errors.Wrap(err, "rpc new payload v3")
-	}
+		return engine.PayloadStatusV1{}, errors.Wrap(err, "rpc new payload")
+	} /* else err==nil && status!=ok */
 
-	return resp, nil
-}
+	incError(c.chain, endpoint)
 
-func (c engineClient) ForkchoiceUpdatedV2(ctx context.Context, update engine.ForkchoiceStateV1,
-	payloadAttributes *engine.PayloadAttributes,
-) (engine.ForkChoiceResponse, error) {
-	const endpoint = "forkchoice_updated_v2"
-	defer latency(c.chain, endpoint)()
-
-	var resp engine.ForkChoiceResponse
-	err := c.cl.Client().CallContext(ctx, &resp, forkchoiceUpdatedV2, update, payloadAttributes)
-	if err != nil {
-		incError(c.chain, endpoint)
-		return engine.ForkChoiceResponse{}, errors.Wrap(err, "rpc forkchoice updated v2")
-	}
-
-	return resp, nil
+	return engine.PayloadStatusV1{}, errors.New("nil error and unknown status", "status", resp.Status)
 }
 
 func (c engineClient) ForkchoiceUpdatedV3(ctx context.Context, update engine.ForkchoiceStateV1,
@@ -129,30 +108,33 @@ func (c engineClient) ForkchoiceUpdatedV3(ctx context.Context, update engine.For
 	const endpoint = "forkchoice_updated_v3"
 	defer latency(c.chain, endpoint)()
 
+	// isStatusOk returns true if the response status is valid.
+	isStatusOk := func(resp engine.ForkChoiceResponse) bool {
+		return map[string]bool{
+			engine.VALID:    true,
+			engine.INVALID:  true,
+			engine.SYNCING:  true,
+			engine.ACCEPTED: false, // Unexpected in ForkchoiceUpdated
+		}[resp.PayloadStatus.Status]
+	}
+
 	var resp engine.ForkChoiceResponse
 	err := c.cl.Client().CallContext(ctx, &resp, forkchoiceUpdatedV3, update, payloadAttributes)
-	if err != nil {
+	if isStatusOk(resp) {
+		// Swallow errors when geth returns errors along with proper responses (but at least log it).
+		if err != nil {
+			log.Warn(ctx, "Ignoring forkchoice_updated_v3 error with proper response", err, "status", resp.PayloadStatus.Status)
+		}
+
+		return resp, nil
+	} else if err != nil {
 		incError(c.chain, endpoint)
 		return engine.ForkChoiceResponse{}, errors.Wrap(err, "rpc forkchoice updated v3")
-	}
+	} /* else err==nil && status!=ok */
 
-	return resp, nil
-}
+	incError(c.chain, endpoint)
 
-func (c engineClient) GetPayloadV2(ctx context.Context, payloadID engine.PayloadID) (
-	*engine.ExecutionPayloadEnvelope, error,
-) {
-	const endpoint = "get_payload_v2"
-	defer latency(c.chain, endpoint)()
-
-	var resp engine.ExecutionPayloadEnvelope
-	err := c.cl.Client().CallContext(ctx, &resp, getPayloadV2, payloadID)
-	if err != nil {
-		incError(c.chain, endpoint)
-		return nil, errors.Wrap(err, "rpc get payload v2")
-	}
-
-	return &resp, nil
+	return engine.ForkChoiceResponse{}, errors.New("nil error and unknown status", "status", resp.PayloadStatus.Status)
 }
 
 func (c engineClient) GetPayloadV3(ctx context.Context, payloadID engine.PayloadID) (

--- a/octane/evmengine/keeper/abci_internal_test.go
+++ b/octane/evmengine/keeper/abci_internal_test.go
@@ -84,7 +84,7 @@ func TestKeeper_PrepareProposal(t *testing.T) {
 				wantErr: true,
 			},
 			{
-				name: "forkchoiceUpdateV2  not valid",
+				name: "forkchoiceUpdateV3  not valid",
 				mockEngine: mockEngineAPI{
 					headerByTypeFunc: func(context.Context, ethclient.HeadType) (*types.Header, error) {
 						fuzzer := ethclient.NewFuzzer(0)
@@ -502,10 +502,6 @@ func (m *mockEngineAPI) HeaderByType(ctx context.Context, typ ethclient.HeadType
 	return m.mock.HeaderByType(ctx, typ)
 }
 
-func (m *mockEngineAPI) NewPayloadV2(ctx context.Context, params eengine.ExecutableData) (eengine.PayloadStatusV1, error) {
-	return m.mock.NewPayloadV2(ctx, params)
-}
-
 //nolint:nonamedreturns // Required for defer
 func (m *mockEngineAPI) NewPayloadV3(ctx context.Context, params eengine.ExecutableData, versionedHashes []common.Hash, beaconRoot *common.Hash) (resp eengine.PayloadStatusV1, err error) {
 	if status, ok := m.maybeSync(); ok {
@@ -540,7 +536,7 @@ func (m *mockEngineAPI) GetPayloadV3(ctx context.Context, payloadID eengine.Payl
 	return m.mock.GetPayloadV3(ctx, payloadID)
 }
 
-// pushPayload - invokes the ForkchoiceUpdatedV2 method on the mock engine and returns the payload ID.
+// pushPayload - invokes the ForkchoiceUpdatedV3 method on the mock engine and returns the payload ID.
 func (m *mockEngineAPI) pushPayload(t *testing.T, ctx context.Context, feeRecipient common.Address, blockHash common.Hash, ts time.Time, appHash common.Hash) *eengine.PayloadID {
 	t.Helper()
 	state := eengine.ForkchoiceStateV1{

--- a/octane/evmengine/keeper/msg_server.go
+++ b/octane/evmengine/keeper/msg_server.go
@@ -36,10 +36,9 @@ func (s msgServer) ExecutionPayload(ctx context.Context, msg *types.MsgExecution
 
 	err = retryForever(ctx, func(ctx context.Context) (bool, error) {
 		status, err := pushPayload(ctx, s.engineCl, payload)
-		if err != nil || isUnknown(status) {
+		if err != nil {
 			// We need to retry forever on networking errors, but can't easily identify them, so retry all errors.
-			log.Warn(ctx, "Processing finalized payload failed: push new payload to evm (will retry)", err,
-				"status", status.Status)
+			log.Warn(ctx, "Processing finalized payload failed: push new payload to evm (will retry)", err)
 
 			return false, nil // Retry
 		} else if invalid, err := isInvalid(status); invalid {
@@ -50,7 +49,7 @@ func (s msgServer) ExecutionPayload(ctx context.Context, msg *types.MsgExecution
 		} else if isSyncing(status) {
 			// Payload pushed, but EVM syncing continue to ForkChoiceUpdate below
 			log.Warn(ctx, "Processing finalized payload; evm syncing", nil)
-		}
+		} /* else isValid(status) */
 
 		return true, nil // Done
 	})
@@ -67,10 +66,9 @@ func (s msgServer) ExecutionPayload(ctx context.Context, msg *types.MsgExecution
 
 	err = retryForever(ctx, func(ctx context.Context) (bool, error) {
 		fcr, err := s.engineCl.ForkchoiceUpdatedV3(ctx, fcs, nil)
-		if err != nil || isUnknown(fcr.PayloadStatus) {
+		if err != nil {
 			// We need to retry forever on networking errors, but can't easily identify them, so retry all errors.
-			log.Warn(ctx, "Processing finalized payload failed: evm fork choice update (will retry)", err,
-				"status", fcr.PayloadStatus.Status)
+			log.Warn(ctx, "Processing finalized payload failed: evm fork choice update (will retry)", err)
 
 			return false, nil // Retry
 		} else if isSyncing(fcr.PayloadStatus) {
@@ -83,7 +81,7 @@ func (s msgServer) ExecutionPayload(ctx context.Context, msg *types.MsgExecution
 				"payload_height", payload.Number)
 
 			return false, err // Abort, don't retry
-		}
+		} /* else isValid(status) */
 
 		return true, nil // Done
 	})
@@ -187,17 +185,6 @@ func NewMsgServerImpl(keeper *Keeper) types.MsgServiceServer {
 }
 
 var _ types.MsgServiceServer = msgServer{}
-
-func isUnknown(status engine.PayloadStatusV1) bool {
-	if status.Status == engine.VALID ||
-		status.Status == engine.INVALID ||
-		status.Status == engine.SYNCING ||
-		status.Status == engine.ACCEPTED {
-		return false
-	}
-
-	return true
-}
 
 func isSyncing(status engine.PayloadStatusV1) bool {
 	return status.Status == engine.SYNCING || status.Status == engine.ACCEPTED

--- a/octane/evmengine/keeper/proposal_server.go
+++ b/octane/evmengine/keeper/proposal_server.go
@@ -26,10 +26,9 @@ func (s proposalServer) ExecutionPayload(ctx context.Context, msg *types.MsgExec
 	// Push the payload to the EVM.
 	err = retryForever(ctx, func(ctx context.Context) (bool, error) {
 		status, err := pushPayload(ctx, s.engineCl, payload)
-		if err != nil || isUnknown(status) {
+		if err != nil {
 			// We need to retry forever on networking errors, but can't easily identify them, so retry all errors.
-			log.Warn(ctx, "Verifying proposal failed: push new payload to evm (will retry)", err,
-				"status", status.Status)
+			log.Warn(ctx, "Verifying proposal failed: push new payload to evm (will retry)", err)
 
 			return false, nil // Retry
 		} else if invalid, err := isInvalid(status); invalid {
@@ -38,7 +37,7 @@ func (s proposalServer) ExecutionPayload(ctx context.Context, msg *types.MsgExec
 			// If this is initial sync, we need to continue and set a target head to sync to, so don't retry.
 			log.Warn(ctx, "Can't properly verifying proposal: evm syncing", err,
 				"payload_height", payload.Number)
-		}
+		} /* else isValid(status) */
 
 		return true, nil // Done
 	})


### PR DESCRIPTION
Improve EngineAPI error handling:
 - Geth returns `status:INVALID` AND errors, so swallow errors if known status is returned.
 - Remaining errors (with unknown status) should only be temporary networking (or some unexpected geth error).
 - Timeout PrepareProposal after 10s, proposing an empty consensus block rather (other validators probably already moved on in any case.)
 - Timeout ProcessProposal after 1min, prevent blocking forever

issue: #2461 