### PR TITLE
feat(e2e): create FeeOracleV2 deployer

### DIFF
--- a/contracts/Makefile
+++ b/contracts/Makefile
@@ -35,7 +35,7 @@ all: install-deps build bindings allocs ## Build contracts, generate bindings an
 CORE_CONTRACTS := OmniPortal FeeOracleV1 Create3 TransparentUpgradeableProxy \
 			Staking Slashing OmniBridgeL1 OmniBridgeNative Omni WOmni \
 			PortalRegistry AllocPredeploys PingPong ProxyAdmin Admin \
-			OmniGasPump OmniGasStation
+			OmniGasPump OmniGasStation FeeOracleV2
 
 SOLVE_CONTRACTS := SolveInbox SolveOutbox MockToken MockVault
 

--- a/contracts/bindings/feeoraclev2.go
+++ b/contracts/bindings/feeoraclev2.go
@@ -1,0 +1,1993 @@
+// Code generated - DO NOT EDIT.
+// This file is a generated binding and any manual changes will be lost.
+
+package bindings
+
+import (
+	"errors"
+	"math/big"
+	"strings"
+
+	ethereum "github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/event"
+)
+
+// Reference imports to suppress errors if they are not otherwise used.
+var (
+	_ = errors.New
+	_ = big.NewInt
+	_ = strings.NewReader
+	_ = ethereum.NotFound
+	_ = bind.Bind
+	_ = common.Big1
+	_ = types.BloomLookup
+	_ = event.NewSubscription
+	_ = abi.ConvertType
+)
+
+// IFeeOracleV2FeeParams is an auto generated low-level Go binding around an user-defined struct.
+type IFeeOracleV2FeeParams struct {
+	ChainId      uint64
+	ExecGasPrice uint64
+	DataGasPrice uint64
+	ToNativeRate uint64
+}
+
+// FeeOracleV2MetaData contains all meta data concerning the FeeOracleV2 contract.
+var FeeOracleV2MetaData = &bind.MetaData{
+	ABI: "[{\"type\":\"constructor\",\"inputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"CONVERSION_RATE_DENOM\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"baseGasLimit\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"uint24\",\"internalType\":\"uint24\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"bulkSetFeeParams\",\"inputs\":[{\"name\":\"params\",\"type\":\"tuple[]\",\"internalType\":\"structIFeeOracleV2.FeeParams[]\",\"components\":[{\"name\":\"chainId\",\"type\":\"uint64\",\"internalType\":\"uint64\"},{\"name\":\"execGasPrice\",\"type\":\"uint64\",\"internalType\":\"uint64\"},{\"name\":\"dataGasPrice\",\"type\":\"uint64\",\"internalType\":\"uint64\"},{\"name\":\"toNativeRate\",\"type\":\"uint64\",\"internalType\":\"uint64\"}]}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"dataGasPrice\",\"inputs\":[{\"name\":\"chainId\",\"type\":\"uint64\",\"internalType\":\"uint64\"}],\"outputs\":[{\"name\":\"\",\"type\":\"uint64\",\"internalType\":\"uint64\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"execGasPrice\",\"inputs\":[{\"name\":\"chainId\",\"type\":\"uint64\",\"internalType\":\"uint64\"}],\"outputs\":[{\"name\":\"\",\"type\":\"uint64\",\"internalType\":\"uint64\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"feeFor\",\"inputs\":[{\"name\":\"destChainId\",\"type\":\"uint64\",\"internalType\":\"uint64\"},{\"name\":\"data\",\"type\":\"bytes\",\"internalType\":\"bytes\"},{\"name\":\"gasLimit\",\"type\":\"uint64\",\"internalType\":\"uint64\"}],\"outputs\":[{\"name\":\"\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"feeParams\",\"inputs\":[{\"name\":\"chainId\",\"type\":\"uint64\",\"internalType\":\"uint64\"}],\"outputs\":[{\"name\":\"\",\"type\":\"tuple\",\"internalType\":\"structIFeeOracleV2.FeeParams\",\"components\":[{\"name\":\"chainId\",\"type\":\"uint64\",\"internalType\":\"uint64\"},{\"name\":\"execGasPrice\",\"type\":\"uint64\",\"internalType\":\"uint64\"},{\"name\":\"dataGasPrice\",\"type\":\"uint64\",\"internalType\":\"uint64\"},{\"name\":\"toNativeRate\",\"type\":\"uint64\",\"internalType\":\"uint64\"}]}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"initialize\",\"inputs\":[{\"name\":\"owner_\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"manager_\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"baseGasLimit_\",\"type\":\"uint24\",\"internalType\":\"uint24\"},{\"name\":\"protocolFee_\",\"type\":\"uint72\",\"internalType\":\"uint72\"},{\"name\":\"params\",\"type\":\"tuple[]\",\"internalType\":\"structIFeeOracleV2.FeeParams[]\",\"components\":[{\"name\":\"chainId\",\"type\":\"uint64\",\"internalType\":\"uint64\"},{\"name\":\"execGasPrice\",\"type\":\"uint64\",\"internalType\":\"uint64\"},{\"name\":\"dataGasPrice\",\"type\":\"uint64\",\"internalType\":\"uint64\"},{\"name\":\"toNativeRate\",\"type\":\"uint64\",\"internalType\":\"uint64\"}]}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"manager\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"address\",\"internalType\":\"address\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"owner\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"address\",\"internalType\":\"address\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"protocolFee\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"uint72\",\"internalType\":\"uint72\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"renounceOwnership\",\"inputs\":[],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"setBaseGasLimit\",\"inputs\":[{\"name\":\"gasLimit\",\"type\":\"uint24\",\"internalType\":\"uint24\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"setDataGasPrice\",\"inputs\":[{\"name\":\"chainId\",\"type\":\"uint64\",\"internalType\":\"uint64\"},{\"name\":\"gasPrice\",\"type\":\"uint64\",\"internalType\":\"uint64\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"setExecGasPrice\",\"inputs\":[{\"name\":\"chainId\",\"type\":\"uint64\",\"internalType\":\"uint64\"},{\"name\":\"gasPrice\",\"type\":\"uint64\",\"internalType\":\"uint64\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"setManager\",\"inputs\":[{\"name\":\"manager_\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"setProtocolFee\",\"inputs\":[{\"name\":\"fee\",\"type\":\"uint72\",\"internalType\":\"uint72\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"setToNativeRate\",\"inputs\":[{\"name\":\"chainId\",\"type\":\"uint64\",\"internalType\":\"uint64\"},{\"name\":\"rate\",\"type\":\"uint64\",\"internalType\":\"uint64\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"toNativeRate\",\"inputs\":[{\"name\":\"chainId\",\"type\":\"uint64\",\"internalType\":\"uint64\"}],\"outputs\":[{\"name\":\"\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"transferOwnership\",\"inputs\":[{\"name\":\"newOwner\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"version\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"uint64\",\"internalType\":\"uint64\"}],\"stateMutability\":\"pure\"},{\"type\":\"event\",\"name\":\"BaseGasLimitSet\",\"inputs\":[{\"name\":\"baseGasLimit\",\"type\":\"uint24\",\"indexed\":false,\"internalType\":\"uint24\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"DataGasPriceSet\",\"inputs\":[{\"name\":\"chainId\",\"type\":\"uint64\",\"indexed\":false,\"internalType\":\"uint64\"},{\"name\":\"gasPrice\",\"type\":\"uint64\",\"indexed\":false,\"internalType\":\"uint64\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"ExecGasPriceSet\",\"inputs\":[{\"name\":\"chainId\",\"type\":\"uint64\",\"indexed\":false,\"internalType\":\"uint64\"},{\"name\":\"gasPrice\",\"type\":\"uint64\",\"indexed\":false,\"internalType\":\"uint64\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"FeeParamsSet\",\"inputs\":[{\"name\":\"chainId\",\"type\":\"uint64\",\"indexed\":false,\"internalType\":\"uint64\"},{\"name\":\"execGasPrice\",\"type\":\"uint64\",\"indexed\":false,\"internalType\":\"uint64\"},{\"name\":\"dataGasPrice\",\"type\":\"uint64\",\"indexed\":false,\"internalType\":\"uint64\"},{\"name\":\"toNativeRate\",\"type\":\"uint64\",\"indexed\":false,\"internalType\":\"uint64\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"Initialized\",\"inputs\":[{\"name\":\"version\",\"type\":\"uint64\",\"indexed\":false,\"internalType\":\"uint64\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"ManagerSet\",\"inputs\":[{\"name\":\"manager\",\"type\":\"address\",\"indexed\":false,\"internalType\":\"address\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"OwnershipTransferred\",\"inputs\":[{\"name\":\"previousOwner\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"newOwner\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"ProtocolFeeSet\",\"inputs\":[{\"name\":\"protocolFee\",\"type\":\"uint72\",\"indexed\":false,\"internalType\":\"uint72\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"ToNativeRateSet\",\"inputs\":[{\"name\":\"chainId\",\"type\":\"uint64\",\"indexed\":false,\"internalType\":\"uint64\"},{\"name\":\"toNativeRate\",\"type\":\"uint64\",\"indexed\":false,\"internalType\":\"uint64\"}],\"anonymous\":false},{\"type\":\"error\",\"name\":\"InvalidInitialization\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"NotInitializing\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"OwnableInvalidOwner\",\"inputs\":[{\"name\":\"owner\",\"type\":\"address\",\"internalType\":\"address\"}]},{\"type\":\"error\",\"name\":\"OwnableUnauthorizedAccount\",\"inputs\":[{\"name\":\"account\",\"type\":\"address\",\"internalType\":\"address\"}]}]",
+	Bin: "0x608060405234801561001057600080fd5b5061001961001e565b6100d0565b7ff0c57e16840df040f15088dc2f81fe391c3923bec73e23a9662efc9c229c6a00805468010000000000000000900460ff161561006e5760405163f92ee8a960e01b815260040160405180910390fd5b80546001600160401b03908116146100cd5780546001600160401b0319166001600160401b0390811782556040519081527fc7f505b2f371ae2175ee4913f4499e1f2633a7b5936321eed1cdaeb6115181d29060200160405180910390a15b50565b6114a2806100df6000396000f3fe608060405234801561001057600080fd5b50600436106101375760003560e01c80638df66e34116100b8578063c1af080b1161007c578063c1af080b146103d4578063d0ebdbe7146103e7578063e21497b9146103fa578063f16fd2871461042d578063f2fde38b14610440578063fcb1deb11461045357600080fd5b80638df66e341461034b5780638f9d6ace14610375578063a8d8216f1461037f578063b0e21e8a14610392578063b9923e1c146103c157600080fd5b80635e837ee7116100ff5780635e837ee7146102ac578063715018a6146102bf5780638b7bfd70146102c75780638da5cb5b146103085780638dd9523c1461033857600080fd5b80632d4634a41461013c578063415070af14610213578063481c6a751461025e57806354fd4d50146102905780635d3acee214610297575b600080fd5b6101c761014a366004610fe0565b60408051608080820183526000808352602080840182905283850182905260609384018290526001600160401b039586168252600181529084902084519283018552548086168352600160401b8104861691830191909152600160801b8104851693820193909352600160c01b9092049092169181019190915290565b60405161020a919081516001600160401b039081168252602080840151821690830152604080840151821690830152606092830151169181019190915260800190565b60405180910390f35b610246610221366004610fe0565b6001600160401b03908116600090815260016020526040902054600160801b90041690565b6040516001600160401b03909116815260200161020a565b60005461027890600160601b90046001600160a01b031681565b6040516001600160a01b03909116815260200161020a565b6002610246565b6102aa6102a5366004611002565b610466565b005b6102aa6102ba366004611002565b6104ae565b6102aa6104e9565b6102fa6102d5366004610fe0565b6001600160401b03908116600090815260016020526040902054600160c01b90041690565b60405190815260200161020a565b7f9016d09d72d40fdae2fd8ceac6b6234c7706214fd39c1cd1e609a0528c199300546001600160a01b0316610278565b6102fa610346366004611035565b6104fd565b60005461036190600160481b900462ffffff1681565b60405162ffffff909116815260200161020a565b6102fa620f424081565b6102aa61038d3660046110db565b6106ad565b6000546103a79068ffffffffffffffffff1681565b60405168ffffffffffffffffff909116815260200161020a565b6102aa6103cf366004611002565b6106c1565b6102aa6103e2366004611141565b6106fc565b6102aa6103f5366004611199565b610737565b610246610408366004610fe0565b6001600160401b03908116600090815260016020526040902054600160401b90041690565b6102aa61043b3660046111cd565b61079e565b6102aa61044e366004611199565b6108d6565b6102aa610461366004611252565b610911565b600054600160601b90046001600160a01b031633146104a05760405162461bcd60e51b81526004016104979061126d565b60405180910390fd5b6104aa8282610922565b5050565b600054600160601b90046001600160a01b031633146104df5760405162461bcd60e51b81526004016104979061126d565b6104aa82826109ea565b6104f1610ad1565b6104fb6000610b2c565b565b6001600160401b0380851660009081526001602052604081208054919290918391620f42409161053e91600160c01b8204811691600160401b9004166112ba565b6001600160401b031661055191906112e5565b8254909150600090620f424090610581906001600160401b03600160c01b8204811691600160801b9004166112ba565b6001600160401b031661059491906112e5565b9050600082116105e65760405162461bcd60e51b815260206004820152601a60248201527f4665654f7261636c6556323a206e6f2066656520706172616d730000000000006044820152606401610497565b600081116106365760405162461bcd60e51b815260206004820152601a60248201527f4665654f7261636c6556323a206e6f2066656520706172616d730000000000006044820152606401610497565b6000610643876010611307565b905061064f8282611307565b600054849061066b908990600160481b900462ffffff16611324565b6001600160401b031661067e9190611307565b600054610696919068ffffffffffffffffff1661134b565b6106a0919061134b565b9998505050505050505050565b6106b5610ad1565b6106be81610b9d565b50565b600054600160601b90046001600160a01b031633146106f25760405162461bcd60e51b81526004016104979061126d565b6104aa8282610bfc565b600054600160601b90046001600160a01b0316331461072d5760405162461bcd60e51b81526004016104979061126d565b6104aa8282610cc1565b61073f610ad1565b6001600160a01b0381166107955760405162461bcd60e51b815260206004820152601c60248201527f4665654f7261636c6556323a206e6f207a65726f206d616e61676572000000006044820152606401610497565b6106be81610eb5565b7ff0c57e16840df040f15088dc2f81fe391c3923bec73e23a9662efc9c229c6a008054600160401b810460ff1615906001600160401b03166000811580156107e35750825b90506000826001600160401b031660011480156107ff5750303b155b90508115801561080d575080155b1561082b5760405163f92ee8a960e01b815260040160405180910390fd5b845467ffffffffffffffff19166001178555831561085557845460ff60401b1916600160401b1785555b61085e8b610f10565b6108678a610eb5565b61087089610b9d565b61087988610f21565b6108838787610cc1565b83156108c957845460ff60401b19168555604051600181527fc7f505b2f371ae2175ee4913f4499e1f2633a7b5936321eed1cdaeb6115181d29060200160405180910390a15b5050505050505050505050565b6108de610ad1565b6001600160a01b03811661090857604051631e4fbdf760e01b815260006004820152602401610497565b6106be81610b2c565b610919610ad1565b6106be81610f21565b6000816001600160401b03161161094b5760405162461bcd60e51b81526004016104979061135e565b816001600160401b03166000036109745760405162461bcd60e51b815260040161049790611395565b6001600160401b03828116600081815260016020908152604091829020805467ffffffffffffffff60801b1916600160801b95871695860217905581519283528201929092527fd7d8dd5a956a8bd500e02d52d0a9dd8a0e2955ec48771a8c9da485e6706c66fb91015b60405180910390a15050565b6000816001600160401b031611610a3f5760405162461bcd60e51b81526020600482015260196024820152784665654f7261636c6556323a206e6f207a65726f207261746560381b6044820152606401610497565b816001600160401b0316600003610a685760405162461bcd60e51b815260040161049790611395565b6001600160401b0382811660008181526001602090815260409182902080546001600160c01b0316600160c01b95871695860217905581519283528201929092527fb4eba3689ad3ae3c17af326b345f7ac3d1f996301aab3598d7dd6cece2666e4d91016109de565b33610b037f9016d09d72d40fdae2fd8ceac6b6234c7706214fd39c1cd1e609a0528c199300546001600160a01b031690565b6001600160a01b0316146104fb5760405163118cdaa760e01b8152336004820152602401610497565b7f9016d09d72d40fdae2fd8ceac6b6234c7706214fd39c1cd1e609a0528c19930080546001600160a01b031981166001600160a01b03848116918217845560405192169182907f8be0079c531659141344cd1fd0a4f28419497f9722a3daafe3b4186f6b6457e090600090a3505050565b600080546bffffff0000000000000000001916600160481b62ffffff8416908102919091179091556040519081527fb2497d19702e6a33eb2a5487a9ad5977a0284bfe1ccad332e31b8a81a8c5ebaf906020015b60405180910390a150565b6000816001600160401b031611610c255760405162461bcd60e51b81526004016104979061135e565b816001600160401b0316600003610c4e5760405162461bcd60e51b815260040161049790611395565b6001600160401b0382811660008181526001602090815260409182902080546fffffffffffffffff00000000000000001916600160401b95871695860217905581519283528201929092527fe0e5abb8929e27a69d77f47a4e3f9575411a5be1fa596e5b55078d7850f358db91016109de565b60005b81811015610eb0576000838383818110610ce057610ce06113cc565b905060800201803603810190610cf691906113e2565b9050600081602001516001600160401b031611610d255760405162461bcd60e51b81526004016104979061135e565b600081604001516001600160401b031611610d525760405162461bcd60e51b81526004016104979061135e565b600081606001516001600160401b031611610dab5760405162461bcd60e51b81526020600482015260196024820152784665654f7261636c6556323a206e6f207a65726f207261746560381b6044820152606401610497565b80516001600160401b0316600003610dd55760405162461bcd60e51b815260040161049790611395565b80516001600160401b039081166000908152600160209081526040918290208451815483870151858801516060808a01519489166fffffffffffffffffffffffffffffffff199094168417600160401b938a16938402176fffffffffffffffffffffffffffffffff16600160801b928a169283026001600160c01b031617600160c01b959099169485029890981790945585519182529381019390935292820152918201527fe71d0f9609b0d14693633a9bdbc9c8b24a957f4141779d70de5c51913ce2d53d9060800160405180910390a150600101610cc4565b505050565b600080546bffffffffffffffffffffffff16600160601b6001600160a01b038416908102919091179091556040519081527f60a0f5b9f9e81e98216071b85826681c796256fe3d1354ecb675580fba64fa6990602001610bf1565b610f18610f73565b6106be81610fbc565b6000805468ffffffffffffffffff191668ffffffffffffffffff83169081179091556040519081527f92c98513056b0d0d263b0f7153c99e1651791a983e75fc558b424b3aa0b623f790602001610bf1565b7ff0c57e16840df040f15088dc2f81fe391c3923bec73e23a9662efc9c229c6a0054600160401b900460ff166104fb57604051631afcd79f60e31b815260040160405180910390fd5b6108de610f73565b80356001600160401b0381168114610fdb57600080fd5b919050565b600060208284031215610ff257600080fd5b610ffb82610fc4565b9392505050565b6000806040838503121561101557600080fd5b61101e83610fc4565b915061102c60208401610fc4565b90509250929050565b6000806000806060858703121561104b57600080fd5b61105485610fc4565b935060208501356001600160401b038082111561107057600080fd5b818701915087601f83011261108457600080fd5b81358181111561109357600080fd5b8860208285010111156110a557600080fd5b6020830195508094505050506110bd60408601610fc4565b905092959194509250565b803562ffffff81168114610fdb57600080fd5b6000602082840312156110ed57600080fd5b610ffb826110c8565b60008083601f84011261110857600080fd5b5081356001600160401b0381111561111f57600080fd5b6020830191508360208260071b850101111561113a57600080fd5b9250929050565b6000806020838503121561115457600080fd5b82356001600160401b0381111561116a57600080fd5b611176858286016110f6565b90969095509350505050565b80356001600160a01b0381168114610fdb57600080fd5b6000602082840312156111ab57600080fd5b610ffb82611182565b803568ffffffffffffffffff81168114610fdb57600080fd5b60008060008060008060a087890312156111e657600080fd5b6111ef87611182565b95506111fd60208801611182565b945061120b604088016110c8565b9350611219606088016111b4565b925060808701356001600160401b0381111561123457600080fd5b61124089828a016110f6565b979a9699509497509295939492505050565b60006020828403121561126457600080fd5b610ffb826111b4565b60208082526018908201527f4665654f7261636c6556323a206e6f74206d616e616765720000000000000000604082015260600190565b634e487b7160e01b600052601160045260246000fd5b6001600160401b038181168382160280821691908281146112dd576112dd6112a4565b505092915050565b60008261130257634e487b7160e01b600052601260045260246000fd5b500490565b808202811582820484141761131e5761131e6112a4565b92915050565b6001600160401b03818116838216019080821115611344576113446112a4565b5092915050565b8082018082111561131e5761131e6112a4565b6020808252601e908201527f4665654f7261636c6556323a206e6f207a65726f206761732070726963650000604082015260600190565b6020808252601d908201527f4665654f7261636c6556323a206e6f207a65726f20636861696e206964000000604082015260600190565b634e487b7160e01b600052603260045260246000fd5b6000608082840312156113f457600080fd5b604051608081018181106001600160401b038211171561142457634e487b7160e01b600052604160045260246000fd5b60405261143083610fc4565b815261143e60208401610fc4565b602082015261144f60408401610fc4565b604082015261146060608401610fc4565b6060820152939250505056fea2646970667358221220e06b55f5ef6f57c1a669387c37c882339abf517a641005f9f4d25c615022ee7764736f6c63430008180033",
+}
+
+// FeeOracleV2ABI is the input ABI used to generate the binding from.
+// Deprecated: Use FeeOracleV2MetaData.ABI instead.
+var FeeOracleV2ABI = FeeOracleV2MetaData.ABI
+
+// FeeOracleV2Bin is the compiled bytecode used for deploying new contracts.
+// Deprecated: Use FeeOracleV2MetaData.Bin instead.
+var FeeOracleV2Bin = FeeOracleV2MetaData.Bin
+
+// DeployFeeOracleV2 deploys a new Ethereum contract, binding an instance of FeeOracleV2 to it.
+func DeployFeeOracleV2(auth *bind.TransactOpts, backend bind.ContractBackend) (common.Address, *types.Transaction, *FeeOracleV2, error) {
+	parsed, err := FeeOracleV2MetaData.GetAbi()
+	if err != nil {
+		return common.Address{}, nil, nil, err
+	}
+	if parsed == nil {
+		return common.Address{}, nil, nil, errors.New("GetABI returned nil")
+	}
+
+	address, tx, contract, err := bind.DeployContract(auth, *parsed, common.FromHex(FeeOracleV2Bin), backend)
+	if err != nil {
+		return common.Address{}, nil, nil, err
+	}
+	return address, tx, &FeeOracleV2{FeeOracleV2Caller: FeeOracleV2Caller{contract: contract}, FeeOracleV2Transactor: FeeOracleV2Transactor{contract: contract}, FeeOracleV2Filterer: FeeOracleV2Filterer{contract: contract}}, nil
+}
+
+// FeeOracleV2 is an auto generated Go binding around an Ethereum contract.
+type FeeOracleV2 struct {
+	FeeOracleV2Caller     // Read-only binding to the contract
+	FeeOracleV2Transactor // Write-only binding to the contract
+	FeeOracleV2Filterer   // Log filterer for contract events
+}
+
+// FeeOracleV2Caller is an auto generated read-only Go binding around an Ethereum contract.
+type FeeOracleV2Caller struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// FeeOracleV2Transactor is an auto generated write-only Go binding around an Ethereum contract.
+type FeeOracleV2Transactor struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// FeeOracleV2Filterer is an auto generated log filtering Go binding around an Ethereum contract events.
+type FeeOracleV2Filterer struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// FeeOracleV2Session is an auto generated Go binding around an Ethereum contract,
+// with pre-set call and transact options.
+type FeeOracleV2Session struct {
+	Contract     *FeeOracleV2      // Generic contract binding to set the session for
+	CallOpts     bind.CallOpts     // Call options to use throughout this session
+	TransactOpts bind.TransactOpts // Transaction auth options to use throughout this session
+}
+
+// FeeOracleV2CallerSession is an auto generated read-only Go binding around an Ethereum contract,
+// with pre-set call options.
+type FeeOracleV2CallerSession struct {
+	Contract *FeeOracleV2Caller // Generic contract caller binding to set the session for
+	CallOpts bind.CallOpts      // Call options to use throughout this session
+}
+
+// FeeOracleV2TransactorSession is an auto generated write-only Go binding around an Ethereum contract,
+// with pre-set transact options.
+type FeeOracleV2TransactorSession struct {
+	Contract     *FeeOracleV2Transactor // Generic contract transactor binding to set the session for
+	TransactOpts bind.TransactOpts      // Transaction auth options to use throughout this session
+}
+
+// FeeOracleV2Raw is an auto generated low-level Go binding around an Ethereum contract.
+type FeeOracleV2Raw struct {
+	Contract *FeeOracleV2 // Generic contract binding to access the raw methods on
+}
+
+// FeeOracleV2CallerRaw is an auto generated low-level read-only Go binding around an Ethereum contract.
+type FeeOracleV2CallerRaw struct {
+	Contract *FeeOracleV2Caller // Generic read-only contract binding to access the raw methods on
+}
+
+// FeeOracleV2TransactorRaw is an auto generated low-level write-only Go binding around an Ethereum contract.
+type FeeOracleV2TransactorRaw struct {
+	Contract *FeeOracleV2Transactor // Generic write-only contract binding to access the raw methods on
+}
+
+// NewFeeOracleV2 creates a new instance of FeeOracleV2, bound to a specific deployed contract.
+func NewFeeOracleV2(address common.Address, backend bind.ContractBackend) (*FeeOracleV2, error) {
+	contract, err := bindFeeOracleV2(address, backend, backend, backend)
+	if err != nil {
+		return nil, err
+	}
+	return &FeeOracleV2{FeeOracleV2Caller: FeeOracleV2Caller{contract: contract}, FeeOracleV2Transactor: FeeOracleV2Transactor{contract: contract}, FeeOracleV2Filterer: FeeOracleV2Filterer{contract: contract}}, nil
+}
+
+// NewFeeOracleV2Caller creates a new read-only instance of FeeOracleV2, bound to a specific deployed contract.
+func NewFeeOracleV2Caller(address common.Address, caller bind.ContractCaller) (*FeeOracleV2Caller, error) {
+	contract, err := bindFeeOracleV2(address, caller, nil, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &FeeOracleV2Caller{contract: contract}, nil
+}
+
+// NewFeeOracleV2Transactor creates a new write-only instance of FeeOracleV2, bound to a specific deployed contract.
+func NewFeeOracleV2Transactor(address common.Address, transactor bind.ContractTransactor) (*FeeOracleV2Transactor, error) {
+	contract, err := bindFeeOracleV2(address, nil, transactor, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &FeeOracleV2Transactor{contract: contract}, nil
+}
+
+// NewFeeOracleV2Filterer creates a new log filterer instance of FeeOracleV2, bound to a specific deployed contract.
+func NewFeeOracleV2Filterer(address common.Address, filterer bind.ContractFilterer) (*FeeOracleV2Filterer, error) {
+	contract, err := bindFeeOracleV2(address, nil, nil, filterer)
+	if err != nil {
+		return nil, err
+	}
+	return &FeeOracleV2Filterer{contract: contract}, nil
+}
+
+// bindFeeOracleV2 binds a generic wrapper to an already deployed contract.
+func bindFeeOracleV2(address common.Address, caller bind.ContractCaller, transactor bind.ContractTransactor, filterer bind.ContractFilterer) (*bind.BoundContract, error) {
+	parsed, err := FeeOracleV2MetaData.GetAbi()
+	if err != nil {
+		return nil, err
+	}
+	return bind.NewBoundContract(address, *parsed, caller, transactor, filterer), nil
+}
+
+// Call invokes the (constant) contract method with params as input values and
+// sets the output to result. The result type might be a single field for simple
+// returns, a slice of interfaces for anonymous returns and a struct for named
+// returns.
+func (_FeeOracleV2 *FeeOracleV2Raw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
+	return _FeeOracleV2.Contract.FeeOracleV2Caller.contract.Call(opts, result, method, params...)
+}
+
+// Transfer initiates a plain transaction to move funds to the contract, calling
+// its default method if one is available.
+func (_FeeOracleV2 *FeeOracleV2Raw) Transfer(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _FeeOracleV2.Contract.FeeOracleV2Transactor.contract.Transfer(opts)
+}
+
+// Transact invokes the (paid) contract method with params as input values.
+func (_FeeOracleV2 *FeeOracleV2Raw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (*types.Transaction, error) {
+	return _FeeOracleV2.Contract.FeeOracleV2Transactor.contract.Transact(opts, method, params...)
+}
+
+// Call invokes the (constant) contract method with params as input values and
+// sets the output to result. The result type might be a single field for simple
+// returns, a slice of interfaces for anonymous returns and a struct for named
+// returns.
+func (_FeeOracleV2 *FeeOracleV2CallerRaw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
+	return _FeeOracleV2.Contract.contract.Call(opts, result, method, params...)
+}
+
+// Transfer initiates a plain transaction to move funds to the contract, calling
+// its default method if one is available.
+func (_FeeOracleV2 *FeeOracleV2TransactorRaw) Transfer(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _FeeOracleV2.Contract.contract.Transfer(opts)
+}
+
+// Transact invokes the (paid) contract method with params as input values.
+func (_FeeOracleV2 *FeeOracleV2TransactorRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (*types.Transaction, error) {
+	return _FeeOracleV2.Contract.contract.Transact(opts, method, params...)
+}
+
+// CONVERSIONRATEDENOM is a free data retrieval call binding the contract method 0x8f9d6ace.
+//
+// Solidity: function CONVERSION_RATE_DENOM() view returns(uint256)
+func (_FeeOracleV2 *FeeOracleV2Caller) CONVERSIONRATEDENOM(opts *bind.CallOpts) (*big.Int, error) {
+	var out []interface{}
+	err := _FeeOracleV2.contract.Call(opts, &out, "CONVERSION_RATE_DENOM")
+
+	if err != nil {
+		return *new(*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+
+	return out0, err
+
+}
+
+// CONVERSIONRATEDENOM is a free data retrieval call binding the contract method 0x8f9d6ace.
+//
+// Solidity: function CONVERSION_RATE_DENOM() view returns(uint256)
+func (_FeeOracleV2 *FeeOracleV2Session) CONVERSIONRATEDENOM() (*big.Int, error) {
+	return _FeeOracleV2.Contract.CONVERSIONRATEDENOM(&_FeeOracleV2.CallOpts)
+}
+
+// CONVERSIONRATEDENOM is a free data retrieval call binding the contract method 0x8f9d6ace.
+//
+// Solidity: function CONVERSION_RATE_DENOM() view returns(uint256)
+func (_FeeOracleV2 *FeeOracleV2CallerSession) CONVERSIONRATEDENOM() (*big.Int, error) {
+	return _FeeOracleV2.Contract.CONVERSIONRATEDENOM(&_FeeOracleV2.CallOpts)
+}
+
+// BaseGasLimit is a free data retrieval call binding the contract method 0x8df66e34.
+//
+// Solidity: function baseGasLimit() view returns(uint24)
+func (_FeeOracleV2 *FeeOracleV2Caller) BaseGasLimit(opts *bind.CallOpts) (*big.Int, error) {
+	var out []interface{}
+	err := _FeeOracleV2.contract.Call(opts, &out, "baseGasLimit")
+
+	if err != nil {
+		return *new(*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+
+	return out0, err
+
+}
+
+// BaseGasLimit is a free data retrieval call binding the contract method 0x8df66e34.
+//
+// Solidity: function baseGasLimit() view returns(uint24)
+func (_FeeOracleV2 *FeeOracleV2Session) BaseGasLimit() (*big.Int, error) {
+	return _FeeOracleV2.Contract.BaseGasLimit(&_FeeOracleV2.CallOpts)
+}
+
+// BaseGasLimit is a free data retrieval call binding the contract method 0x8df66e34.
+//
+// Solidity: function baseGasLimit() view returns(uint24)
+func (_FeeOracleV2 *FeeOracleV2CallerSession) BaseGasLimit() (*big.Int, error) {
+	return _FeeOracleV2.Contract.BaseGasLimit(&_FeeOracleV2.CallOpts)
+}
+
+// DataGasPrice is a free data retrieval call binding the contract method 0x415070af.
+//
+// Solidity: function dataGasPrice(uint64 chainId) view returns(uint64)
+func (_FeeOracleV2 *FeeOracleV2Caller) DataGasPrice(opts *bind.CallOpts, chainId uint64) (uint64, error) {
+	var out []interface{}
+	err := _FeeOracleV2.contract.Call(opts, &out, "dataGasPrice", chainId)
+
+	if err != nil {
+		return *new(uint64), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(uint64)).(*uint64)
+
+	return out0, err
+
+}
+
+// DataGasPrice is a free data retrieval call binding the contract method 0x415070af.
+//
+// Solidity: function dataGasPrice(uint64 chainId) view returns(uint64)
+func (_FeeOracleV2 *FeeOracleV2Session) DataGasPrice(chainId uint64) (uint64, error) {
+	return _FeeOracleV2.Contract.DataGasPrice(&_FeeOracleV2.CallOpts, chainId)
+}
+
+// DataGasPrice is a free data retrieval call binding the contract method 0x415070af.
+//
+// Solidity: function dataGasPrice(uint64 chainId) view returns(uint64)
+func (_FeeOracleV2 *FeeOracleV2CallerSession) DataGasPrice(chainId uint64) (uint64, error) {
+	return _FeeOracleV2.Contract.DataGasPrice(&_FeeOracleV2.CallOpts, chainId)
+}
+
+// ExecGasPrice is a free data retrieval call binding the contract method 0xe21497b9.
+//
+// Solidity: function execGasPrice(uint64 chainId) view returns(uint64)
+func (_FeeOracleV2 *FeeOracleV2Caller) ExecGasPrice(opts *bind.CallOpts, chainId uint64) (uint64, error) {
+	var out []interface{}
+	err := _FeeOracleV2.contract.Call(opts, &out, "execGasPrice", chainId)
+
+	if err != nil {
+		return *new(uint64), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(uint64)).(*uint64)
+
+	return out0, err
+
+}
+
+// ExecGasPrice is a free data retrieval call binding the contract method 0xe21497b9.
+//
+// Solidity: function execGasPrice(uint64 chainId) view returns(uint64)
+func (_FeeOracleV2 *FeeOracleV2Session) ExecGasPrice(chainId uint64) (uint64, error) {
+	return _FeeOracleV2.Contract.ExecGasPrice(&_FeeOracleV2.CallOpts, chainId)
+}
+
+// ExecGasPrice is a free data retrieval call binding the contract method 0xe21497b9.
+//
+// Solidity: function execGasPrice(uint64 chainId) view returns(uint64)
+func (_FeeOracleV2 *FeeOracleV2CallerSession) ExecGasPrice(chainId uint64) (uint64, error) {
+	return _FeeOracleV2.Contract.ExecGasPrice(&_FeeOracleV2.CallOpts, chainId)
+}
+
+// FeeFor is a free data retrieval call binding the contract method 0x8dd9523c.
+//
+// Solidity: function feeFor(uint64 destChainId, bytes data, uint64 gasLimit) view returns(uint256)
+func (_FeeOracleV2 *FeeOracleV2Caller) FeeFor(opts *bind.CallOpts, destChainId uint64, data []byte, gasLimit uint64) (*big.Int, error) {
+	var out []interface{}
+	err := _FeeOracleV2.contract.Call(opts, &out, "feeFor", destChainId, data, gasLimit)
+
+	if err != nil {
+		return *new(*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+
+	return out0, err
+
+}
+
+// FeeFor is a free data retrieval call binding the contract method 0x8dd9523c.
+//
+// Solidity: function feeFor(uint64 destChainId, bytes data, uint64 gasLimit) view returns(uint256)
+func (_FeeOracleV2 *FeeOracleV2Session) FeeFor(destChainId uint64, data []byte, gasLimit uint64) (*big.Int, error) {
+	return _FeeOracleV2.Contract.FeeFor(&_FeeOracleV2.CallOpts, destChainId, data, gasLimit)
+}
+
+// FeeFor is a free data retrieval call binding the contract method 0x8dd9523c.
+//
+// Solidity: function feeFor(uint64 destChainId, bytes data, uint64 gasLimit) view returns(uint256)
+func (_FeeOracleV2 *FeeOracleV2CallerSession) FeeFor(destChainId uint64, data []byte, gasLimit uint64) (*big.Int, error) {
+	return _FeeOracleV2.Contract.FeeFor(&_FeeOracleV2.CallOpts, destChainId, data, gasLimit)
+}
+
+// FeeParams is a free data retrieval call binding the contract method 0x2d4634a4.
+//
+// Solidity: function feeParams(uint64 chainId) view returns((uint64,uint64,uint64,uint64))
+func (_FeeOracleV2 *FeeOracleV2Caller) FeeParams(opts *bind.CallOpts, chainId uint64) (IFeeOracleV2FeeParams, error) {
+	var out []interface{}
+	err := _FeeOracleV2.contract.Call(opts, &out, "feeParams", chainId)
+
+	if err != nil {
+		return *new(IFeeOracleV2FeeParams), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(IFeeOracleV2FeeParams)).(*IFeeOracleV2FeeParams)
+
+	return out0, err
+
+}
+
+// FeeParams is a free data retrieval call binding the contract method 0x2d4634a4.
+//
+// Solidity: function feeParams(uint64 chainId) view returns((uint64,uint64,uint64,uint64))
+func (_FeeOracleV2 *FeeOracleV2Session) FeeParams(chainId uint64) (IFeeOracleV2FeeParams, error) {
+	return _FeeOracleV2.Contract.FeeParams(&_FeeOracleV2.CallOpts, chainId)
+}
+
+// FeeParams is a free data retrieval call binding the contract method 0x2d4634a4.
+//
+// Solidity: function feeParams(uint64 chainId) view returns((uint64,uint64,uint64,uint64))
+func (_FeeOracleV2 *FeeOracleV2CallerSession) FeeParams(chainId uint64) (IFeeOracleV2FeeParams, error) {
+	return _FeeOracleV2.Contract.FeeParams(&_FeeOracleV2.CallOpts, chainId)
+}
+
+// Manager is a free data retrieval call binding the contract method 0x481c6a75.
+//
+// Solidity: function manager() view returns(address)
+func (_FeeOracleV2 *FeeOracleV2Caller) Manager(opts *bind.CallOpts) (common.Address, error) {
+	var out []interface{}
+	err := _FeeOracleV2.contract.Call(opts, &out, "manager")
+
+	if err != nil {
+		return *new(common.Address), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(common.Address)).(*common.Address)
+
+	return out0, err
+
+}
+
+// Manager is a free data retrieval call binding the contract method 0x481c6a75.
+//
+// Solidity: function manager() view returns(address)
+func (_FeeOracleV2 *FeeOracleV2Session) Manager() (common.Address, error) {
+	return _FeeOracleV2.Contract.Manager(&_FeeOracleV2.CallOpts)
+}
+
+// Manager is a free data retrieval call binding the contract method 0x481c6a75.
+//
+// Solidity: function manager() view returns(address)
+func (_FeeOracleV2 *FeeOracleV2CallerSession) Manager() (common.Address, error) {
+	return _FeeOracleV2.Contract.Manager(&_FeeOracleV2.CallOpts)
+}
+
+// Owner is a free data retrieval call binding the contract method 0x8da5cb5b.
+//
+// Solidity: function owner() view returns(address)
+func (_FeeOracleV2 *FeeOracleV2Caller) Owner(opts *bind.CallOpts) (common.Address, error) {
+	var out []interface{}
+	err := _FeeOracleV2.contract.Call(opts, &out, "owner")
+
+	if err != nil {
+		return *new(common.Address), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(common.Address)).(*common.Address)
+
+	return out0, err
+
+}
+
+// Owner is a free data retrieval call binding the contract method 0x8da5cb5b.
+//
+// Solidity: function owner() view returns(address)
+func (_FeeOracleV2 *FeeOracleV2Session) Owner() (common.Address, error) {
+	return _FeeOracleV2.Contract.Owner(&_FeeOracleV2.CallOpts)
+}
+
+// Owner is a free data retrieval call binding the contract method 0x8da5cb5b.
+//
+// Solidity: function owner() view returns(address)
+func (_FeeOracleV2 *FeeOracleV2CallerSession) Owner() (common.Address, error) {
+	return _FeeOracleV2.Contract.Owner(&_FeeOracleV2.CallOpts)
+}
+
+// ProtocolFee is a free data retrieval call binding the contract method 0xb0e21e8a.
+//
+// Solidity: function protocolFee() view returns(uint72)
+func (_FeeOracleV2 *FeeOracleV2Caller) ProtocolFee(opts *bind.CallOpts) (*big.Int, error) {
+	var out []interface{}
+	err := _FeeOracleV2.contract.Call(opts, &out, "protocolFee")
+
+	if err != nil {
+		return *new(*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+
+	return out0, err
+
+}
+
+// ProtocolFee is a free data retrieval call binding the contract method 0xb0e21e8a.
+//
+// Solidity: function protocolFee() view returns(uint72)
+func (_FeeOracleV2 *FeeOracleV2Session) ProtocolFee() (*big.Int, error) {
+	return _FeeOracleV2.Contract.ProtocolFee(&_FeeOracleV2.CallOpts)
+}
+
+// ProtocolFee is a free data retrieval call binding the contract method 0xb0e21e8a.
+//
+// Solidity: function protocolFee() view returns(uint72)
+func (_FeeOracleV2 *FeeOracleV2CallerSession) ProtocolFee() (*big.Int, error) {
+	return _FeeOracleV2.Contract.ProtocolFee(&_FeeOracleV2.CallOpts)
+}
+
+// ToNativeRate is a free data retrieval call binding the contract method 0x8b7bfd70.
+//
+// Solidity: function toNativeRate(uint64 chainId) view returns(uint256)
+func (_FeeOracleV2 *FeeOracleV2Caller) ToNativeRate(opts *bind.CallOpts, chainId uint64) (*big.Int, error) {
+	var out []interface{}
+	err := _FeeOracleV2.contract.Call(opts, &out, "toNativeRate", chainId)
+
+	if err != nil {
+		return *new(*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+
+	return out0, err
+
+}
+
+// ToNativeRate is a free data retrieval call binding the contract method 0x8b7bfd70.
+//
+// Solidity: function toNativeRate(uint64 chainId) view returns(uint256)
+func (_FeeOracleV2 *FeeOracleV2Session) ToNativeRate(chainId uint64) (*big.Int, error) {
+	return _FeeOracleV2.Contract.ToNativeRate(&_FeeOracleV2.CallOpts, chainId)
+}
+
+// ToNativeRate is a free data retrieval call binding the contract method 0x8b7bfd70.
+//
+// Solidity: function toNativeRate(uint64 chainId) view returns(uint256)
+func (_FeeOracleV2 *FeeOracleV2CallerSession) ToNativeRate(chainId uint64) (*big.Int, error) {
+	return _FeeOracleV2.Contract.ToNativeRate(&_FeeOracleV2.CallOpts, chainId)
+}
+
+// Version is a free data retrieval call binding the contract method 0x54fd4d50.
+//
+// Solidity: function version() pure returns(uint64)
+func (_FeeOracleV2 *FeeOracleV2Caller) Version(opts *bind.CallOpts) (uint64, error) {
+	var out []interface{}
+	err := _FeeOracleV2.contract.Call(opts, &out, "version")
+
+	if err != nil {
+		return *new(uint64), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(uint64)).(*uint64)
+
+	return out0, err
+
+}
+
+// Version is a free data retrieval call binding the contract method 0x54fd4d50.
+//
+// Solidity: function version() pure returns(uint64)
+func (_FeeOracleV2 *FeeOracleV2Session) Version() (uint64, error) {
+	return _FeeOracleV2.Contract.Version(&_FeeOracleV2.CallOpts)
+}
+
+// Version is a free data retrieval call binding the contract method 0x54fd4d50.
+//
+// Solidity: function version() pure returns(uint64)
+func (_FeeOracleV2 *FeeOracleV2CallerSession) Version() (uint64, error) {
+	return _FeeOracleV2.Contract.Version(&_FeeOracleV2.CallOpts)
+}
+
+// BulkSetFeeParams is a paid mutator transaction binding the contract method 0xc1af080b.
+//
+// Solidity: function bulkSetFeeParams((uint64,uint64,uint64,uint64)[] params) returns()
+func (_FeeOracleV2 *FeeOracleV2Transactor) BulkSetFeeParams(opts *bind.TransactOpts, params []IFeeOracleV2FeeParams) (*types.Transaction, error) {
+	return _FeeOracleV2.contract.Transact(opts, "bulkSetFeeParams", params)
+}
+
+// BulkSetFeeParams is a paid mutator transaction binding the contract method 0xc1af080b.
+//
+// Solidity: function bulkSetFeeParams((uint64,uint64,uint64,uint64)[] params) returns()
+func (_FeeOracleV2 *FeeOracleV2Session) BulkSetFeeParams(params []IFeeOracleV2FeeParams) (*types.Transaction, error) {
+	return _FeeOracleV2.Contract.BulkSetFeeParams(&_FeeOracleV2.TransactOpts, params)
+}
+
+// BulkSetFeeParams is a paid mutator transaction binding the contract method 0xc1af080b.
+//
+// Solidity: function bulkSetFeeParams((uint64,uint64,uint64,uint64)[] params) returns()
+func (_FeeOracleV2 *FeeOracleV2TransactorSession) BulkSetFeeParams(params []IFeeOracleV2FeeParams) (*types.Transaction, error) {
+	return _FeeOracleV2.Contract.BulkSetFeeParams(&_FeeOracleV2.TransactOpts, params)
+}
+
+// Initialize is a paid mutator transaction binding the contract method 0xf16fd287.
+//
+// Solidity: function initialize(address owner_, address manager_, uint24 baseGasLimit_, uint72 protocolFee_, (uint64,uint64,uint64,uint64)[] params) returns()
+func (_FeeOracleV2 *FeeOracleV2Transactor) Initialize(opts *bind.TransactOpts, owner_ common.Address, manager_ common.Address, baseGasLimit_ *big.Int, protocolFee_ *big.Int, params []IFeeOracleV2FeeParams) (*types.Transaction, error) {
+	return _FeeOracleV2.contract.Transact(opts, "initialize", owner_, manager_, baseGasLimit_, protocolFee_, params)
+}
+
+// Initialize is a paid mutator transaction binding the contract method 0xf16fd287.
+//
+// Solidity: function initialize(address owner_, address manager_, uint24 baseGasLimit_, uint72 protocolFee_, (uint64,uint64,uint64,uint64)[] params) returns()
+func (_FeeOracleV2 *FeeOracleV2Session) Initialize(owner_ common.Address, manager_ common.Address, baseGasLimit_ *big.Int, protocolFee_ *big.Int, params []IFeeOracleV2FeeParams) (*types.Transaction, error) {
+	return _FeeOracleV2.Contract.Initialize(&_FeeOracleV2.TransactOpts, owner_, manager_, baseGasLimit_, protocolFee_, params)
+}
+
+// Initialize is a paid mutator transaction binding the contract method 0xf16fd287.
+//
+// Solidity: function initialize(address owner_, address manager_, uint24 baseGasLimit_, uint72 protocolFee_, (uint64,uint64,uint64,uint64)[] params) returns()
+func (_FeeOracleV2 *FeeOracleV2TransactorSession) Initialize(owner_ common.Address, manager_ common.Address, baseGasLimit_ *big.Int, protocolFee_ *big.Int, params []IFeeOracleV2FeeParams) (*types.Transaction, error) {
+	return _FeeOracleV2.Contract.Initialize(&_FeeOracleV2.TransactOpts, owner_, manager_, baseGasLimit_, protocolFee_, params)
+}
+
+// RenounceOwnership is a paid mutator transaction binding the contract method 0x715018a6.
+//
+// Solidity: function renounceOwnership() returns()
+func (_FeeOracleV2 *FeeOracleV2Transactor) RenounceOwnership(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _FeeOracleV2.contract.Transact(opts, "renounceOwnership")
+}
+
+// RenounceOwnership is a paid mutator transaction binding the contract method 0x715018a6.
+//
+// Solidity: function renounceOwnership() returns()
+func (_FeeOracleV2 *FeeOracleV2Session) RenounceOwnership() (*types.Transaction, error) {
+	return _FeeOracleV2.Contract.RenounceOwnership(&_FeeOracleV2.TransactOpts)
+}
+
+// RenounceOwnership is a paid mutator transaction binding the contract method 0x715018a6.
+//
+// Solidity: function renounceOwnership() returns()
+func (_FeeOracleV2 *FeeOracleV2TransactorSession) RenounceOwnership() (*types.Transaction, error) {
+	return _FeeOracleV2.Contract.RenounceOwnership(&_FeeOracleV2.TransactOpts)
+}
+
+// SetBaseGasLimit is a paid mutator transaction binding the contract method 0xa8d8216f.
+//
+// Solidity: function setBaseGasLimit(uint24 gasLimit) returns()
+func (_FeeOracleV2 *FeeOracleV2Transactor) SetBaseGasLimit(opts *bind.TransactOpts, gasLimit *big.Int) (*types.Transaction, error) {
+	return _FeeOracleV2.contract.Transact(opts, "setBaseGasLimit", gasLimit)
+}
+
+// SetBaseGasLimit is a paid mutator transaction binding the contract method 0xa8d8216f.
+//
+// Solidity: function setBaseGasLimit(uint24 gasLimit) returns()
+func (_FeeOracleV2 *FeeOracleV2Session) SetBaseGasLimit(gasLimit *big.Int) (*types.Transaction, error) {
+	return _FeeOracleV2.Contract.SetBaseGasLimit(&_FeeOracleV2.TransactOpts, gasLimit)
+}
+
+// SetBaseGasLimit is a paid mutator transaction binding the contract method 0xa8d8216f.
+//
+// Solidity: function setBaseGasLimit(uint24 gasLimit) returns()
+func (_FeeOracleV2 *FeeOracleV2TransactorSession) SetBaseGasLimit(gasLimit *big.Int) (*types.Transaction, error) {
+	return _FeeOracleV2.Contract.SetBaseGasLimit(&_FeeOracleV2.TransactOpts, gasLimit)
+}
+
+// SetDataGasPrice is a paid mutator transaction binding the contract method 0x5d3acee2.
+//
+// Solidity: function setDataGasPrice(uint64 chainId, uint64 gasPrice) returns()
+func (_FeeOracleV2 *FeeOracleV2Transactor) SetDataGasPrice(opts *bind.TransactOpts, chainId uint64, gasPrice uint64) (*types.Transaction, error) {
+	return _FeeOracleV2.contract.Transact(opts, "setDataGasPrice", chainId, gasPrice)
+}
+
+// SetDataGasPrice is a paid mutator transaction binding the contract method 0x5d3acee2.
+//
+// Solidity: function setDataGasPrice(uint64 chainId, uint64 gasPrice) returns()
+func (_FeeOracleV2 *FeeOracleV2Session) SetDataGasPrice(chainId uint64, gasPrice uint64) (*types.Transaction, error) {
+	return _FeeOracleV2.Contract.SetDataGasPrice(&_FeeOracleV2.TransactOpts, chainId, gasPrice)
+}
+
+// SetDataGasPrice is a paid mutator transaction binding the contract method 0x5d3acee2.
+//
+// Solidity: function setDataGasPrice(uint64 chainId, uint64 gasPrice) returns()
+func (_FeeOracleV2 *FeeOracleV2TransactorSession) SetDataGasPrice(chainId uint64, gasPrice uint64) (*types.Transaction, error) {
+	return _FeeOracleV2.Contract.SetDataGasPrice(&_FeeOracleV2.TransactOpts, chainId, gasPrice)
+}
+
+// SetExecGasPrice is a paid mutator transaction binding the contract method 0xb9923e1c.
+//
+// Solidity: function setExecGasPrice(uint64 chainId, uint64 gasPrice) returns()
+func (_FeeOracleV2 *FeeOracleV2Transactor) SetExecGasPrice(opts *bind.TransactOpts, chainId uint64, gasPrice uint64) (*types.Transaction, error) {
+	return _FeeOracleV2.contract.Transact(opts, "setExecGasPrice", chainId, gasPrice)
+}
+
+// SetExecGasPrice is a paid mutator transaction binding the contract method 0xb9923e1c.
+//
+// Solidity: function setExecGasPrice(uint64 chainId, uint64 gasPrice) returns()
+func (_FeeOracleV2 *FeeOracleV2Session) SetExecGasPrice(chainId uint64, gasPrice uint64) (*types.Transaction, error) {
+	return _FeeOracleV2.Contract.SetExecGasPrice(&_FeeOracleV2.TransactOpts, chainId, gasPrice)
+}
+
+// SetExecGasPrice is a paid mutator transaction binding the contract method 0xb9923e1c.
+//
+// Solidity: function setExecGasPrice(uint64 chainId, uint64 gasPrice) returns()
+func (_FeeOracleV2 *FeeOracleV2TransactorSession) SetExecGasPrice(chainId uint64, gasPrice uint64) (*types.Transaction, error) {
+	return _FeeOracleV2.Contract.SetExecGasPrice(&_FeeOracleV2.TransactOpts, chainId, gasPrice)
+}
+
+// SetManager is a paid mutator transaction binding the contract method 0xd0ebdbe7.
+//
+// Solidity: function setManager(address manager_) returns()
+func (_FeeOracleV2 *FeeOracleV2Transactor) SetManager(opts *bind.TransactOpts, manager_ common.Address) (*types.Transaction, error) {
+	return _FeeOracleV2.contract.Transact(opts, "setManager", manager_)
+}
+
+// SetManager is a paid mutator transaction binding the contract method 0xd0ebdbe7.
+//
+// Solidity: function setManager(address manager_) returns()
+func (_FeeOracleV2 *FeeOracleV2Session) SetManager(manager_ common.Address) (*types.Transaction, error) {
+	return _FeeOracleV2.Contract.SetManager(&_FeeOracleV2.TransactOpts, manager_)
+}
+
+// SetManager is a paid mutator transaction binding the contract method 0xd0ebdbe7.
+//
+// Solidity: function setManager(address manager_) returns()
+func (_FeeOracleV2 *FeeOracleV2TransactorSession) SetManager(manager_ common.Address) (*types.Transaction, error) {
+	return _FeeOracleV2.Contract.SetManager(&_FeeOracleV2.TransactOpts, manager_)
+}
+
+// SetProtocolFee is a paid mutator transaction binding the contract method 0xfcb1deb1.
+//
+// Solidity: function setProtocolFee(uint72 fee) returns()
+func (_FeeOracleV2 *FeeOracleV2Transactor) SetProtocolFee(opts *bind.TransactOpts, fee *big.Int) (*types.Transaction, error) {
+	return _FeeOracleV2.contract.Transact(opts, "setProtocolFee", fee)
+}
+
+// SetProtocolFee is a paid mutator transaction binding the contract method 0xfcb1deb1.
+//
+// Solidity: function setProtocolFee(uint72 fee) returns()
+func (_FeeOracleV2 *FeeOracleV2Session) SetProtocolFee(fee *big.Int) (*types.Transaction, error) {
+	return _FeeOracleV2.Contract.SetProtocolFee(&_FeeOracleV2.TransactOpts, fee)
+}
+
+// SetProtocolFee is a paid mutator transaction binding the contract method 0xfcb1deb1.
+//
+// Solidity: function setProtocolFee(uint72 fee) returns()
+func (_FeeOracleV2 *FeeOracleV2TransactorSession) SetProtocolFee(fee *big.Int) (*types.Transaction, error) {
+	return _FeeOracleV2.Contract.SetProtocolFee(&_FeeOracleV2.TransactOpts, fee)
+}
+
+// SetToNativeRate is a paid mutator transaction binding the contract method 0x5e837ee7.
+//
+// Solidity: function setToNativeRate(uint64 chainId, uint64 rate) returns()
+func (_FeeOracleV2 *FeeOracleV2Transactor) SetToNativeRate(opts *bind.TransactOpts, chainId uint64, rate uint64) (*types.Transaction, error) {
+	return _FeeOracleV2.contract.Transact(opts, "setToNativeRate", chainId, rate)
+}
+
+// SetToNativeRate is a paid mutator transaction binding the contract method 0x5e837ee7.
+//
+// Solidity: function setToNativeRate(uint64 chainId, uint64 rate) returns()
+func (_FeeOracleV2 *FeeOracleV2Session) SetToNativeRate(chainId uint64, rate uint64) (*types.Transaction, error) {
+	return _FeeOracleV2.Contract.SetToNativeRate(&_FeeOracleV2.TransactOpts, chainId, rate)
+}
+
+// SetToNativeRate is a paid mutator transaction binding the contract method 0x5e837ee7.
+//
+// Solidity: function setToNativeRate(uint64 chainId, uint64 rate) returns()
+func (_FeeOracleV2 *FeeOracleV2TransactorSession) SetToNativeRate(chainId uint64, rate uint64) (*types.Transaction, error) {
+	return _FeeOracleV2.Contract.SetToNativeRate(&_FeeOracleV2.TransactOpts, chainId, rate)
+}
+
+// TransferOwnership is a paid mutator transaction binding the contract method 0xf2fde38b.
+//
+// Solidity: function transferOwnership(address newOwner) returns()
+func (_FeeOracleV2 *FeeOracleV2Transactor) TransferOwnership(opts *bind.TransactOpts, newOwner common.Address) (*types.Transaction, error) {
+	return _FeeOracleV2.contract.Transact(opts, "transferOwnership", newOwner)
+}
+
+// TransferOwnership is a paid mutator transaction binding the contract method 0xf2fde38b.
+//
+// Solidity: function transferOwnership(address newOwner) returns()
+func (_FeeOracleV2 *FeeOracleV2Session) TransferOwnership(newOwner common.Address) (*types.Transaction, error) {
+	return _FeeOracleV2.Contract.TransferOwnership(&_FeeOracleV2.TransactOpts, newOwner)
+}
+
+// TransferOwnership is a paid mutator transaction binding the contract method 0xf2fde38b.
+//
+// Solidity: function transferOwnership(address newOwner) returns()
+func (_FeeOracleV2 *FeeOracleV2TransactorSession) TransferOwnership(newOwner common.Address) (*types.Transaction, error) {
+	return _FeeOracleV2.Contract.TransferOwnership(&_FeeOracleV2.TransactOpts, newOwner)
+}
+
+// FeeOracleV2BaseGasLimitSetIterator is returned from FilterBaseGasLimitSet and is used to iterate over the raw logs and unpacked data for BaseGasLimitSet events raised by the FeeOracleV2 contract.
+type FeeOracleV2BaseGasLimitSetIterator struct {
+	Event *FeeOracleV2BaseGasLimitSet // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *FeeOracleV2BaseGasLimitSetIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(FeeOracleV2BaseGasLimitSet)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(FeeOracleV2BaseGasLimitSet)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *FeeOracleV2BaseGasLimitSetIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *FeeOracleV2BaseGasLimitSetIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// FeeOracleV2BaseGasLimitSet represents a BaseGasLimitSet event raised by the FeeOracleV2 contract.
+type FeeOracleV2BaseGasLimitSet struct {
+	BaseGasLimit *big.Int
+	Raw          types.Log // Blockchain specific contextual infos
+}
+
+// FilterBaseGasLimitSet is a free log retrieval operation binding the contract event 0xb2497d19702e6a33eb2a5487a9ad5977a0284bfe1ccad332e31b8a81a8c5ebaf.
+//
+// Solidity: event BaseGasLimitSet(uint24 baseGasLimit)
+func (_FeeOracleV2 *FeeOracleV2Filterer) FilterBaseGasLimitSet(opts *bind.FilterOpts) (*FeeOracleV2BaseGasLimitSetIterator, error) {
+
+	logs, sub, err := _FeeOracleV2.contract.FilterLogs(opts, "BaseGasLimitSet")
+	if err != nil {
+		return nil, err
+	}
+	return &FeeOracleV2BaseGasLimitSetIterator{contract: _FeeOracleV2.contract, event: "BaseGasLimitSet", logs: logs, sub: sub}, nil
+}
+
+// WatchBaseGasLimitSet is a free log subscription operation binding the contract event 0xb2497d19702e6a33eb2a5487a9ad5977a0284bfe1ccad332e31b8a81a8c5ebaf.
+//
+// Solidity: event BaseGasLimitSet(uint24 baseGasLimit)
+func (_FeeOracleV2 *FeeOracleV2Filterer) WatchBaseGasLimitSet(opts *bind.WatchOpts, sink chan<- *FeeOracleV2BaseGasLimitSet) (event.Subscription, error) {
+
+	logs, sub, err := _FeeOracleV2.contract.WatchLogs(opts, "BaseGasLimitSet")
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(FeeOracleV2BaseGasLimitSet)
+				if err := _FeeOracleV2.contract.UnpackLog(event, "BaseGasLimitSet", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseBaseGasLimitSet is a log parse operation binding the contract event 0xb2497d19702e6a33eb2a5487a9ad5977a0284bfe1ccad332e31b8a81a8c5ebaf.
+//
+// Solidity: event BaseGasLimitSet(uint24 baseGasLimit)
+func (_FeeOracleV2 *FeeOracleV2Filterer) ParseBaseGasLimitSet(log types.Log) (*FeeOracleV2BaseGasLimitSet, error) {
+	event := new(FeeOracleV2BaseGasLimitSet)
+	if err := _FeeOracleV2.contract.UnpackLog(event, "BaseGasLimitSet", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// FeeOracleV2DataGasPriceSetIterator is returned from FilterDataGasPriceSet and is used to iterate over the raw logs and unpacked data for DataGasPriceSet events raised by the FeeOracleV2 contract.
+type FeeOracleV2DataGasPriceSetIterator struct {
+	Event *FeeOracleV2DataGasPriceSet // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *FeeOracleV2DataGasPriceSetIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(FeeOracleV2DataGasPriceSet)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(FeeOracleV2DataGasPriceSet)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *FeeOracleV2DataGasPriceSetIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *FeeOracleV2DataGasPriceSetIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// FeeOracleV2DataGasPriceSet represents a DataGasPriceSet event raised by the FeeOracleV2 contract.
+type FeeOracleV2DataGasPriceSet struct {
+	ChainId  uint64
+	GasPrice uint64
+	Raw      types.Log // Blockchain specific contextual infos
+}
+
+// FilterDataGasPriceSet is a free log retrieval operation binding the contract event 0xd7d8dd5a956a8bd500e02d52d0a9dd8a0e2955ec48771a8c9da485e6706c66fb.
+//
+// Solidity: event DataGasPriceSet(uint64 chainId, uint64 gasPrice)
+func (_FeeOracleV2 *FeeOracleV2Filterer) FilterDataGasPriceSet(opts *bind.FilterOpts) (*FeeOracleV2DataGasPriceSetIterator, error) {
+
+	logs, sub, err := _FeeOracleV2.contract.FilterLogs(opts, "DataGasPriceSet")
+	if err != nil {
+		return nil, err
+	}
+	return &FeeOracleV2DataGasPriceSetIterator{contract: _FeeOracleV2.contract, event: "DataGasPriceSet", logs: logs, sub: sub}, nil
+}
+
+// WatchDataGasPriceSet is a free log subscription operation binding the contract event 0xd7d8dd5a956a8bd500e02d52d0a9dd8a0e2955ec48771a8c9da485e6706c66fb.
+//
+// Solidity: event DataGasPriceSet(uint64 chainId, uint64 gasPrice)
+func (_FeeOracleV2 *FeeOracleV2Filterer) WatchDataGasPriceSet(opts *bind.WatchOpts, sink chan<- *FeeOracleV2DataGasPriceSet) (event.Subscription, error) {
+
+	logs, sub, err := _FeeOracleV2.contract.WatchLogs(opts, "DataGasPriceSet")
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(FeeOracleV2DataGasPriceSet)
+				if err := _FeeOracleV2.contract.UnpackLog(event, "DataGasPriceSet", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseDataGasPriceSet is a log parse operation binding the contract event 0xd7d8dd5a956a8bd500e02d52d0a9dd8a0e2955ec48771a8c9da485e6706c66fb.
+//
+// Solidity: event DataGasPriceSet(uint64 chainId, uint64 gasPrice)
+func (_FeeOracleV2 *FeeOracleV2Filterer) ParseDataGasPriceSet(log types.Log) (*FeeOracleV2DataGasPriceSet, error) {
+	event := new(FeeOracleV2DataGasPriceSet)
+	if err := _FeeOracleV2.contract.UnpackLog(event, "DataGasPriceSet", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// FeeOracleV2ExecGasPriceSetIterator is returned from FilterExecGasPriceSet and is used to iterate over the raw logs and unpacked data for ExecGasPriceSet events raised by the FeeOracleV2 contract.
+type FeeOracleV2ExecGasPriceSetIterator struct {
+	Event *FeeOracleV2ExecGasPriceSet // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *FeeOracleV2ExecGasPriceSetIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(FeeOracleV2ExecGasPriceSet)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(FeeOracleV2ExecGasPriceSet)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *FeeOracleV2ExecGasPriceSetIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *FeeOracleV2ExecGasPriceSetIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// FeeOracleV2ExecGasPriceSet represents a ExecGasPriceSet event raised by the FeeOracleV2 contract.
+type FeeOracleV2ExecGasPriceSet struct {
+	ChainId  uint64
+	GasPrice uint64
+	Raw      types.Log // Blockchain specific contextual infos
+}
+
+// FilterExecGasPriceSet is a free log retrieval operation binding the contract event 0xe0e5abb8929e27a69d77f47a4e3f9575411a5be1fa596e5b55078d7850f358db.
+//
+// Solidity: event ExecGasPriceSet(uint64 chainId, uint64 gasPrice)
+func (_FeeOracleV2 *FeeOracleV2Filterer) FilterExecGasPriceSet(opts *bind.FilterOpts) (*FeeOracleV2ExecGasPriceSetIterator, error) {
+
+	logs, sub, err := _FeeOracleV2.contract.FilterLogs(opts, "ExecGasPriceSet")
+	if err != nil {
+		return nil, err
+	}
+	return &FeeOracleV2ExecGasPriceSetIterator{contract: _FeeOracleV2.contract, event: "ExecGasPriceSet", logs: logs, sub: sub}, nil
+}
+
+// WatchExecGasPriceSet is a free log subscription operation binding the contract event 0xe0e5abb8929e27a69d77f47a4e3f9575411a5be1fa596e5b55078d7850f358db.
+//
+// Solidity: event ExecGasPriceSet(uint64 chainId, uint64 gasPrice)
+func (_FeeOracleV2 *FeeOracleV2Filterer) WatchExecGasPriceSet(opts *bind.WatchOpts, sink chan<- *FeeOracleV2ExecGasPriceSet) (event.Subscription, error) {
+
+	logs, sub, err := _FeeOracleV2.contract.WatchLogs(opts, "ExecGasPriceSet")
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(FeeOracleV2ExecGasPriceSet)
+				if err := _FeeOracleV2.contract.UnpackLog(event, "ExecGasPriceSet", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseExecGasPriceSet is a log parse operation binding the contract event 0xe0e5abb8929e27a69d77f47a4e3f9575411a5be1fa596e5b55078d7850f358db.
+//
+// Solidity: event ExecGasPriceSet(uint64 chainId, uint64 gasPrice)
+func (_FeeOracleV2 *FeeOracleV2Filterer) ParseExecGasPriceSet(log types.Log) (*FeeOracleV2ExecGasPriceSet, error) {
+	event := new(FeeOracleV2ExecGasPriceSet)
+	if err := _FeeOracleV2.contract.UnpackLog(event, "ExecGasPriceSet", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// FeeOracleV2FeeParamsSetIterator is returned from FilterFeeParamsSet and is used to iterate over the raw logs and unpacked data for FeeParamsSet events raised by the FeeOracleV2 contract.
+type FeeOracleV2FeeParamsSetIterator struct {
+	Event *FeeOracleV2FeeParamsSet // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *FeeOracleV2FeeParamsSetIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(FeeOracleV2FeeParamsSet)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(FeeOracleV2FeeParamsSet)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *FeeOracleV2FeeParamsSetIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *FeeOracleV2FeeParamsSetIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// FeeOracleV2FeeParamsSet represents a FeeParamsSet event raised by the FeeOracleV2 contract.
+type FeeOracleV2FeeParamsSet struct {
+	ChainId      uint64
+	ExecGasPrice uint64
+	DataGasPrice uint64
+	ToNativeRate uint64
+	Raw          types.Log // Blockchain specific contextual infos
+}
+
+// FilterFeeParamsSet is a free log retrieval operation binding the contract event 0xe71d0f9609b0d14693633a9bdbc9c8b24a957f4141779d70de5c51913ce2d53d.
+//
+// Solidity: event FeeParamsSet(uint64 chainId, uint64 execGasPrice, uint64 dataGasPrice, uint64 toNativeRate)
+func (_FeeOracleV2 *FeeOracleV2Filterer) FilterFeeParamsSet(opts *bind.FilterOpts) (*FeeOracleV2FeeParamsSetIterator, error) {
+
+	logs, sub, err := _FeeOracleV2.contract.FilterLogs(opts, "FeeParamsSet")
+	if err != nil {
+		return nil, err
+	}
+	return &FeeOracleV2FeeParamsSetIterator{contract: _FeeOracleV2.contract, event: "FeeParamsSet", logs: logs, sub: sub}, nil
+}
+
+// WatchFeeParamsSet is a free log subscription operation binding the contract event 0xe71d0f9609b0d14693633a9bdbc9c8b24a957f4141779d70de5c51913ce2d53d.
+//
+// Solidity: event FeeParamsSet(uint64 chainId, uint64 execGasPrice, uint64 dataGasPrice, uint64 toNativeRate)
+func (_FeeOracleV2 *FeeOracleV2Filterer) WatchFeeParamsSet(opts *bind.WatchOpts, sink chan<- *FeeOracleV2FeeParamsSet) (event.Subscription, error) {
+
+	logs, sub, err := _FeeOracleV2.contract.WatchLogs(opts, "FeeParamsSet")
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(FeeOracleV2FeeParamsSet)
+				if err := _FeeOracleV2.contract.UnpackLog(event, "FeeParamsSet", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseFeeParamsSet is a log parse operation binding the contract event 0xe71d0f9609b0d14693633a9bdbc9c8b24a957f4141779d70de5c51913ce2d53d.
+//
+// Solidity: event FeeParamsSet(uint64 chainId, uint64 execGasPrice, uint64 dataGasPrice, uint64 toNativeRate)
+func (_FeeOracleV2 *FeeOracleV2Filterer) ParseFeeParamsSet(log types.Log) (*FeeOracleV2FeeParamsSet, error) {
+	event := new(FeeOracleV2FeeParamsSet)
+	if err := _FeeOracleV2.contract.UnpackLog(event, "FeeParamsSet", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// FeeOracleV2InitializedIterator is returned from FilterInitialized and is used to iterate over the raw logs and unpacked data for Initialized events raised by the FeeOracleV2 contract.
+type FeeOracleV2InitializedIterator struct {
+	Event *FeeOracleV2Initialized // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *FeeOracleV2InitializedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(FeeOracleV2Initialized)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(FeeOracleV2Initialized)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *FeeOracleV2InitializedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *FeeOracleV2InitializedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// FeeOracleV2Initialized represents a Initialized event raised by the FeeOracleV2 contract.
+type FeeOracleV2Initialized struct {
+	Version uint64
+	Raw     types.Log // Blockchain specific contextual infos
+}
+
+// FilterInitialized is a free log retrieval operation binding the contract event 0xc7f505b2f371ae2175ee4913f4499e1f2633a7b5936321eed1cdaeb6115181d2.
+//
+// Solidity: event Initialized(uint64 version)
+func (_FeeOracleV2 *FeeOracleV2Filterer) FilterInitialized(opts *bind.FilterOpts) (*FeeOracleV2InitializedIterator, error) {
+
+	logs, sub, err := _FeeOracleV2.contract.FilterLogs(opts, "Initialized")
+	if err != nil {
+		return nil, err
+	}
+	return &FeeOracleV2InitializedIterator{contract: _FeeOracleV2.contract, event: "Initialized", logs: logs, sub: sub}, nil
+}
+
+// WatchInitialized is a free log subscription operation binding the contract event 0xc7f505b2f371ae2175ee4913f4499e1f2633a7b5936321eed1cdaeb6115181d2.
+//
+// Solidity: event Initialized(uint64 version)
+func (_FeeOracleV2 *FeeOracleV2Filterer) WatchInitialized(opts *bind.WatchOpts, sink chan<- *FeeOracleV2Initialized) (event.Subscription, error) {
+
+	logs, sub, err := _FeeOracleV2.contract.WatchLogs(opts, "Initialized")
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(FeeOracleV2Initialized)
+				if err := _FeeOracleV2.contract.UnpackLog(event, "Initialized", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseInitialized is a log parse operation binding the contract event 0xc7f505b2f371ae2175ee4913f4499e1f2633a7b5936321eed1cdaeb6115181d2.
+//
+// Solidity: event Initialized(uint64 version)
+func (_FeeOracleV2 *FeeOracleV2Filterer) ParseInitialized(log types.Log) (*FeeOracleV2Initialized, error) {
+	event := new(FeeOracleV2Initialized)
+	if err := _FeeOracleV2.contract.UnpackLog(event, "Initialized", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// FeeOracleV2ManagerSetIterator is returned from FilterManagerSet and is used to iterate over the raw logs and unpacked data for ManagerSet events raised by the FeeOracleV2 contract.
+type FeeOracleV2ManagerSetIterator struct {
+	Event *FeeOracleV2ManagerSet // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *FeeOracleV2ManagerSetIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(FeeOracleV2ManagerSet)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(FeeOracleV2ManagerSet)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *FeeOracleV2ManagerSetIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *FeeOracleV2ManagerSetIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// FeeOracleV2ManagerSet represents a ManagerSet event raised by the FeeOracleV2 contract.
+type FeeOracleV2ManagerSet struct {
+	Manager common.Address
+	Raw     types.Log // Blockchain specific contextual infos
+}
+
+// FilterManagerSet is a free log retrieval operation binding the contract event 0x60a0f5b9f9e81e98216071b85826681c796256fe3d1354ecb675580fba64fa69.
+//
+// Solidity: event ManagerSet(address manager)
+func (_FeeOracleV2 *FeeOracleV2Filterer) FilterManagerSet(opts *bind.FilterOpts) (*FeeOracleV2ManagerSetIterator, error) {
+
+	logs, sub, err := _FeeOracleV2.contract.FilterLogs(opts, "ManagerSet")
+	if err != nil {
+		return nil, err
+	}
+	return &FeeOracleV2ManagerSetIterator{contract: _FeeOracleV2.contract, event: "ManagerSet", logs: logs, sub: sub}, nil
+}
+
+// WatchManagerSet is a free log subscription operation binding the contract event 0x60a0f5b9f9e81e98216071b85826681c796256fe3d1354ecb675580fba64fa69.
+//
+// Solidity: event ManagerSet(address manager)
+func (_FeeOracleV2 *FeeOracleV2Filterer) WatchManagerSet(opts *bind.WatchOpts, sink chan<- *FeeOracleV2ManagerSet) (event.Subscription, error) {
+
+	logs, sub, err := _FeeOracleV2.contract.WatchLogs(opts, "ManagerSet")
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(FeeOracleV2ManagerSet)
+				if err := _FeeOracleV2.contract.UnpackLog(event, "ManagerSet", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseManagerSet is a log parse operation binding the contract event 0x60a0f5b9f9e81e98216071b85826681c796256fe3d1354ecb675580fba64fa69.
+//
+// Solidity: event ManagerSet(address manager)
+func (_FeeOracleV2 *FeeOracleV2Filterer) ParseManagerSet(log types.Log) (*FeeOracleV2ManagerSet, error) {
+	event := new(FeeOracleV2ManagerSet)
+	if err := _FeeOracleV2.contract.UnpackLog(event, "ManagerSet", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// FeeOracleV2OwnershipTransferredIterator is returned from FilterOwnershipTransferred and is used to iterate over the raw logs and unpacked data for OwnershipTransferred events raised by the FeeOracleV2 contract.
+type FeeOracleV2OwnershipTransferredIterator struct {
+	Event *FeeOracleV2OwnershipTransferred // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *FeeOracleV2OwnershipTransferredIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(FeeOracleV2OwnershipTransferred)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(FeeOracleV2OwnershipTransferred)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *FeeOracleV2OwnershipTransferredIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *FeeOracleV2OwnershipTransferredIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// FeeOracleV2OwnershipTransferred represents a OwnershipTransferred event raised by the FeeOracleV2 contract.
+type FeeOracleV2OwnershipTransferred struct {
+	PreviousOwner common.Address
+	NewOwner      common.Address
+	Raw           types.Log // Blockchain specific contextual infos
+}
+
+// FilterOwnershipTransferred is a free log retrieval operation binding the contract event 0x8be0079c531659141344cd1fd0a4f28419497f9722a3daafe3b4186f6b6457e0.
+//
+// Solidity: event OwnershipTransferred(address indexed previousOwner, address indexed newOwner)
+func (_FeeOracleV2 *FeeOracleV2Filterer) FilterOwnershipTransferred(opts *bind.FilterOpts, previousOwner []common.Address, newOwner []common.Address) (*FeeOracleV2OwnershipTransferredIterator, error) {
+
+	var previousOwnerRule []interface{}
+	for _, previousOwnerItem := range previousOwner {
+		previousOwnerRule = append(previousOwnerRule, previousOwnerItem)
+	}
+	var newOwnerRule []interface{}
+	for _, newOwnerItem := range newOwner {
+		newOwnerRule = append(newOwnerRule, newOwnerItem)
+	}
+
+	logs, sub, err := _FeeOracleV2.contract.FilterLogs(opts, "OwnershipTransferred", previousOwnerRule, newOwnerRule)
+	if err != nil {
+		return nil, err
+	}
+	return &FeeOracleV2OwnershipTransferredIterator{contract: _FeeOracleV2.contract, event: "OwnershipTransferred", logs: logs, sub: sub}, nil
+}
+
+// WatchOwnershipTransferred is a free log subscription operation binding the contract event 0x8be0079c531659141344cd1fd0a4f28419497f9722a3daafe3b4186f6b6457e0.
+//
+// Solidity: event OwnershipTransferred(address indexed previousOwner, address indexed newOwner)
+func (_FeeOracleV2 *FeeOracleV2Filterer) WatchOwnershipTransferred(opts *bind.WatchOpts, sink chan<- *FeeOracleV2OwnershipTransferred, previousOwner []common.Address, newOwner []common.Address) (event.Subscription, error) {
+
+	var previousOwnerRule []interface{}
+	for _, previousOwnerItem := range previousOwner {
+		previousOwnerRule = append(previousOwnerRule, previousOwnerItem)
+	}
+	var newOwnerRule []interface{}
+	for _, newOwnerItem := range newOwner {
+		newOwnerRule = append(newOwnerRule, newOwnerItem)
+	}
+
+	logs, sub, err := _FeeOracleV2.contract.WatchLogs(opts, "OwnershipTransferred", previousOwnerRule, newOwnerRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(FeeOracleV2OwnershipTransferred)
+				if err := _FeeOracleV2.contract.UnpackLog(event, "OwnershipTransferred", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseOwnershipTransferred is a log parse operation binding the contract event 0x8be0079c531659141344cd1fd0a4f28419497f9722a3daafe3b4186f6b6457e0.
+//
+// Solidity: event OwnershipTransferred(address indexed previousOwner, address indexed newOwner)
+func (_FeeOracleV2 *FeeOracleV2Filterer) ParseOwnershipTransferred(log types.Log) (*FeeOracleV2OwnershipTransferred, error) {
+	event := new(FeeOracleV2OwnershipTransferred)
+	if err := _FeeOracleV2.contract.UnpackLog(event, "OwnershipTransferred", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// FeeOracleV2ProtocolFeeSetIterator is returned from FilterProtocolFeeSet and is used to iterate over the raw logs and unpacked data for ProtocolFeeSet events raised by the FeeOracleV2 contract.
+type FeeOracleV2ProtocolFeeSetIterator struct {
+	Event *FeeOracleV2ProtocolFeeSet // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *FeeOracleV2ProtocolFeeSetIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(FeeOracleV2ProtocolFeeSet)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(FeeOracleV2ProtocolFeeSet)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *FeeOracleV2ProtocolFeeSetIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *FeeOracleV2ProtocolFeeSetIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// FeeOracleV2ProtocolFeeSet represents a ProtocolFeeSet event raised by the FeeOracleV2 contract.
+type FeeOracleV2ProtocolFeeSet struct {
+	ProtocolFee *big.Int
+	Raw         types.Log // Blockchain specific contextual infos
+}
+
+// FilterProtocolFeeSet is a free log retrieval operation binding the contract event 0x92c98513056b0d0d263b0f7153c99e1651791a983e75fc558b424b3aa0b623f7.
+//
+// Solidity: event ProtocolFeeSet(uint72 protocolFee)
+func (_FeeOracleV2 *FeeOracleV2Filterer) FilterProtocolFeeSet(opts *bind.FilterOpts) (*FeeOracleV2ProtocolFeeSetIterator, error) {
+
+	logs, sub, err := _FeeOracleV2.contract.FilterLogs(opts, "ProtocolFeeSet")
+	if err != nil {
+		return nil, err
+	}
+	return &FeeOracleV2ProtocolFeeSetIterator{contract: _FeeOracleV2.contract, event: "ProtocolFeeSet", logs: logs, sub: sub}, nil
+}
+
+// WatchProtocolFeeSet is a free log subscription operation binding the contract event 0x92c98513056b0d0d263b0f7153c99e1651791a983e75fc558b424b3aa0b623f7.
+//
+// Solidity: event ProtocolFeeSet(uint72 protocolFee)
+func (_FeeOracleV2 *FeeOracleV2Filterer) WatchProtocolFeeSet(opts *bind.WatchOpts, sink chan<- *FeeOracleV2ProtocolFeeSet) (event.Subscription, error) {
+
+	logs, sub, err := _FeeOracleV2.contract.WatchLogs(opts, "ProtocolFeeSet")
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(FeeOracleV2ProtocolFeeSet)
+				if err := _FeeOracleV2.contract.UnpackLog(event, "ProtocolFeeSet", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseProtocolFeeSet is a log parse operation binding the contract event 0x92c98513056b0d0d263b0f7153c99e1651791a983e75fc558b424b3aa0b623f7.
+//
+// Solidity: event ProtocolFeeSet(uint72 protocolFee)
+func (_FeeOracleV2 *FeeOracleV2Filterer) ParseProtocolFeeSet(log types.Log) (*FeeOracleV2ProtocolFeeSet, error) {
+	event := new(FeeOracleV2ProtocolFeeSet)
+	if err := _FeeOracleV2.contract.UnpackLog(event, "ProtocolFeeSet", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// FeeOracleV2ToNativeRateSetIterator is returned from FilterToNativeRateSet and is used to iterate over the raw logs and unpacked data for ToNativeRateSet events raised by the FeeOracleV2 contract.
+type FeeOracleV2ToNativeRateSetIterator struct {
+	Event *FeeOracleV2ToNativeRateSet // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *FeeOracleV2ToNativeRateSetIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(FeeOracleV2ToNativeRateSet)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(FeeOracleV2ToNativeRateSet)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *FeeOracleV2ToNativeRateSetIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *FeeOracleV2ToNativeRateSetIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// FeeOracleV2ToNativeRateSet represents a ToNativeRateSet event raised by the FeeOracleV2 contract.
+type FeeOracleV2ToNativeRateSet struct {
+	ChainId      uint64
+	ToNativeRate uint64
+	Raw          types.Log // Blockchain specific contextual infos
+}
+
+// FilterToNativeRateSet is a free log retrieval operation binding the contract event 0xb4eba3689ad3ae3c17af326b345f7ac3d1f996301aab3598d7dd6cece2666e4d.
+//
+// Solidity: event ToNativeRateSet(uint64 chainId, uint64 toNativeRate)
+func (_FeeOracleV2 *FeeOracleV2Filterer) FilterToNativeRateSet(opts *bind.FilterOpts) (*FeeOracleV2ToNativeRateSetIterator, error) {
+
+	logs, sub, err := _FeeOracleV2.contract.FilterLogs(opts, "ToNativeRateSet")
+	if err != nil {
+		return nil, err
+	}
+	return &FeeOracleV2ToNativeRateSetIterator{contract: _FeeOracleV2.contract, event: "ToNativeRateSet", logs: logs, sub: sub}, nil
+}
+
+// WatchToNativeRateSet is a free log subscription operation binding the contract event 0xb4eba3689ad3ae3c17af326b345f7ac3d1f996301aab3598d7dd6cece2666e4d.
+//
+// Solidity: event ToNativeRateSet(uint64 chainId, uint64 toNativeRate)
+func (_FeeOracleV2 *FeeOracleV2Filterer) WatchToNativeRateSet(opts *bind.WatchOpts, sink chan<- *FeeOracleV2ToNativeRateSet) (event.Subscription, error) {
+
+	logs, sub, err := _FeeOracleV2.contract.WatchLogs(opts, "ToNativeRateSet")
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(FeeOracleV2ToNativeRateSet)
+				if err := _FeeOracleV2.contract.UnpackLog(event, "ToNativeRateSet", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseToNativeRateSet is a log parse operation binding the contract event 0xb4eba3689ad3ae3c17af326b345f7ac3d1f996301aab3598d7dd6cece2666e4d.
+//
+// Solidity: event ToNativeRateSet(uint64 chainId, uint64 toNativeRate)
+func (_FeeOracleV2 *FeeOracleV2Filterer) ParseToNativeRateSet(log types.Log) (*FeeOracleV2ToNativeRateSet, error) {
+	event := new(FeeOracleV2ToNativeRateSet)
+	if err := _FeeOracleV2.contract.UnpackLog(event, "ToNativeRateSet", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}

--- a/e2e/app/feeoraclev2.go
+++ b/e2e/app/feeoraclev2.go
@@ -1,0 +1,45 @@
+package app
+
+import (
+	"context"
+
+	"github.com/omni-network/omni/lib/contracts/feeoraclev2"
+	"github.com/omni-network/omni/lib/errors"
+	"github.com/omni-network/omni/lib/log"
+)
+
+func DeployFeeOracleV2(ctx context.Context, def Definition) error {
+	if err := deployFeeOracleV2(ctx, def); err != nil {
+		return errors.Wrap(err, "deploy fee oracle v2")
+	}
+
+	return nil
+}
+
+func deployFeeOracleV2(ctx context.Context, def Definition) error {
+	_, ok := def.Testnet.OmniEVMChain()
+	if !ok {
+		return errors.New("no omni evm chain")
+	}
+
+	allChains := def.Testnet.EVMChains()
+	for _, chain := range allChains {
+		backends := def.Backends()
+
+		destChainIDs := make([]uint64, 0, len(allChains)-1)
+		for _, destChain := range allChains {
+			if destChain.ChainID != chain.ChainID {
+				destChainIDs = append(destChainIDs, destChain.ChainID)
+			}
+		}
+
+		addr, receipt, err := feeoraclev2.DeployIfNeeded(ctx, def.Testnet.Network, chain.ChainID, destChainIDs, backends)
+		if err != nil {
+			return errors.Wrap(err, "deploy", "chain", chain.Name, "tx", maybeTxHash(receipt))
+		}
+
+		log.Info(ctx, "FeeOracleV2 deployed", "chain", chain.Name, "address", addr.Hex(), "tx", maybeTxHash(receipt))
+	}
+
+	return nil
+}

--- a/e2e/cmd/cmd.go
+++ b/e2e/cmd/cmd.go
@@ -83,6 +83,7 @@ func New() *cobra.Command {
 		newERC20FaucetCmd(&def),
 		newDeployGasAppCmd(&def),
 		newDeployBridgeCmd(&def),
+		newDeployFeeOracleV2Cmd(&def),
 		fundAccounts(&def),
 	)
 
@@ -269,6 +270,18 @@ func newDeployBridgeCmd(def *app.Definition) *cobra.Command {
 		Short: "Deploys l1 bridge, setups native bridge.",
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			return app.DeployBridge(cmd.Context(), *def)
+		},
+	}
+
+	return cmd
+}
+
+func newDeployFeeOracleV2Cmd(def *app.Definition) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "deploy-feeoraclev2",
+		Short: "Deploys the FeeOracleV2 contract",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return app.DeployFeeOracleV2(cmd.Context(), *def)
 		},
 	}
 

--- a/lib/contracts/address.go
+++ b/lib/contracts/address.go
@@ -86,6 +86,7 @@ type Addresses struct {
 	Token          common.Address
 	SolveOutbox    common.Address
 	SolveInbox     common.Address
+	FeeOracleV2    common.Address
 }
 
 type Salts struct {
@@ -97,6 +98,7 @@ type Salts struct {
 	Token       string
 	SolveOutbox string
 	SolveInbox  string
+	FeeOracleV2 string
 }
 
 type cache[T any] struct {
@@ -141,6 +143,7 @@ func GetAddresses(ctx context.Context, network netconf.ID) (Addresses, error) {
 		GasStation:     gasStation(network, ver),
 		SolveInbox:     solveInbox(network, ver),
 		SolveOutbox:    solveOutbox(network, ver),
+		FeeOracleV2:    feeOracleV2(network, ver),
 	}
 
 	addrsCache.cache[network] = addrs
@@ -232,6 +235,10 @@ func solveOutbox(network netconf.ID, version string) common.Address {
 	return create3.Address(Create3Factory(network), solveOutboxSalt(network, version), eoa.MustAddress(network, eoa.RoleDeployer))
 }
 
+func feeOracleV2(network netconf.ID, version string) common.Address {
+	return create3.Address(Create3Factory(network), feeOracleV2Salt(network, version), eoa.MustAddress(network, eoa.RoleDeployer))
+}
+
 //
 // Salts.
 //
@@ -267,6 +274,10 @@ func solveInboxSalt(network netconf.ID, version string) string {
 
 func solveOutboxSalt(network netconf.ID, version string) string {
 	return salt(network, "solve-outbox-"+version)
+}
+
+func feeOracleV2Salt(network netconf.ID, version string) string {
+	return salt(network, "fee-oracle-v2-"+version)
 }
 
 //

--- a/lib/contracts/feeoraclev2/deploy.go
+++ b/lib/contracts/feeoraclev2/deploy.go
@@ -1,0 +1,209 @@
+package feeoraclev2
+
+import (
+	"context"
+	"math/big"
+
+	"github.com/omni-network/omni/contracts/bindings"
+	"github.com/omni-network/omni/e2e/app/eoa"
+	"github.com/omni-network/omni/lib/contracts"
+	"github.com/omni-network/omni/lib/create3"
+	"github.com/omni-network/omni/lib/errors"
+	"github.com/omni-network/omni/lib/ethclient/ethbackend"
+	"github.com/omni-network/omni/lib/netconf"
+	"github.com/omni-network/omni/lib/tokens/coingecko"
+
+	"github.com/ethereum/go-ethereum/common"
+	ethtypes "github.com/ethereum/go-ethereum/core/types"
+)
+
+type DeploymentConfig struct {
+	Create3Salt     string
+	Create3Factory  common.Address
+	ExpectedAddr    common.Address
+	ProxyAdminOwner common.Address
+	Owner           common.Address
+	Deployer        common.Address
+	Manager         common.Address // manager is the address that can set fee parameters (gas price, conversion rates)
+	BaseGasLimit    uint32         // must fit in uint24 (max: 16,777,215)
+	ProtocolFee     *big.Int       // must fit in uint72 (max: 4,722,366,482,869,645,213,695)
+}
+
+func isEmpty(addr common.Address) bool {
+	return addr == common.Address{}
+}
+
+var maxUint72 = new(big.Int).Sub(new(big.Int).Lsh(big.NewInt(1), 72), big.NewInt(1))
+
+func (cfg DeploymentConfig) Validate() error {
+	if cfg.Create3Salt == "" {
+		return errors.New("create3 salt is empty")
+	}
+	if isEmpty(cfg.Create3Factory) {
+		return errors.New("create3 factory is zero")
+	}
+	if isEmpty(cfg.ExpectedAddr) {
+		return errors.New("expected address is zero")
+	}
+	if isEmpty(cfg.ProxyAdminOwner) {
+		return errors.New("proxy admin is zero")
+	}
+	if isEmpty(cfg.Owner) {
+		return errors.New("owner is zero")
+	}
+	if isEmpty(cfg.Deployer) {
+		return errors.New("deployer is zero")
+	}
+	if isEmpty(cfg.Manager) {
+		return errors.New("manager is zero")
+	}
+	if cfg.BaseGasLimit > (1<<24 - 1) {
+		return errors.New("base gas limit too high")
+	}
+	if cfg.ProtocolFee.Cmp(maxUint72) > 0 {
+		return errors.New("protocol fee too high")
+	}
+
+	return nil
+}
+
+// isDeployed returns true if the oracle contract is already deployed to its expected address.
+func isDeployed(ctx context.Context, network netconf.ID, backend *ethbackend.Backend) (bool, common.Address, error) {
+	addrs, err := contracts.GetAddresses(ctx, network)
+	if err != nil {
+		return false, common.Address{}, errors.Wrap(err, "get addrs")
+	}
+
+	code, err := backend.CodeAt(ctx, addrs.FeeOracleV2, nil)
+	if err != nil {
+		return false, addrs.FeeOracleV2, errors.Wrap(err, "code at", "address", addrs.FeeOracleV2)
+	}
+
+	if len(code) == 0 {
+		return false, addrs.FeeOracleV2, nil
+	}
+
+	return true, addrs.FeeOracleV2, nil
+}
+
+// DeployIfNeeded deploys a new oracle contract if it is not already deployed.
+// If the contract is already deployed, the receipt is nil.
+func DeployIfNeeded(ctx context.Context, network netconf.ID, chainID uint64, destChainIDs []uint64, backends ethbackend.Backends) (common.Address, *ethtypes.Receipt, error) {
+	backend, err := backends.Backend(chainID)
+	if err != nil {
+		return common.Address{}, nil, errors.Wrap(err, "get backend")
+	}
+
+	deployed, addr, err := isDeployed(ctx, network, backend)
+	if err != nil {
+		return common.Address{}, nil, errors.Wrap(err, "is deployed")
+	}
+	if deployed {
+		return addr, nil, nil
+	}
+
+	return Deploy(ctx, network, chainID, destChainIDs, backend, backends)
+}
+
+// Deploy deploys a new FeeOracleV2 contract and returns the address and receipt.
+func Deploy(ctx context.Context, network netconf.ID, chainID uint64, destChainIDs []uint64, backend *ethbackend.Backend, backends ethbackend.Backends) (common.Address, *ethtypes.Receipt, error) {
+	addrs, err := contracts.GetAddresses(ctx, network)
+	if err != nil {
+		return common.Address{}, nil, errors.Wrap(err, "get addresses")
+	}
+
+	salts, err := contracts.GetSalts(ctx, network)
+	if err != nil {
+		return common.Address{}, nil, errors.Wrap(err, "get salts")
+	}
+
+	cfg := DeploymentConfig{
+		Create3Salt:     salts.FeeOracleV2,
+		Create3Factory:  addrs.Create3Factory,
+		ExpectedAddr:    addrs.FeeOracleV2,
+		ProxyAdminOwner: eoa.MustAddress(network, eoa.RoleUpgrader),
+		Owner:           eoa.MustAddress(network, eoa.RoleManager),
+		Deployer:        eoa.MustAddress(network, eoa.RoleDeployer),
+		Manager:         eoa.MustAddress(network, eoa.RoleMonitor), // NOTE: monitor is owner of fee oracle contracts, because monitor manages on chain gas prices / conversion rates
+		BaseGasLimit:    50_000,
+		ProtocolFee:     big.NewInt(0),
+	}
+
+	return deploy(ctx, chainID, destChainIDs, cfg, backend, backends)
+}
+
+func deploy(ctx context.Context, chainID uint64, destChainIDs []uint64, cfg DeploymentConfig, backend *ethbackend.Backend, backends ethbackend.Backends) (common.Address, *ethtypes.Receipt, error) {
+	if err := cfg.Validate(); err != nil {
+		return common.Address{}, nil, errors.Wrap(err, "validate config")
+	}
+
+	txOpts, err := backend.BindOpts(ctx, cfg.Deployer)
+	if err != nil {
+		return common.Address{}, nil, errors.Wrap(err, "bind opts")
+	}
+
+	factory, err := bindings.NewCreate3(cfg.Create3Factory, backend)
+	if err != nil {
+		return common.Address{}, nil, errors.Wrap(err, "new create3")
+	}
+
+	salt := create3.HashSalt(cfg.Create3Salt)
+
+	addr, err := factory.GetDeployed(nil, txOpts.From, salt)
+	if err != nil {
+		return common.Address{}, nil, errors.Wrap(err, "get deployed")
+	} else if (cfg.ExpectedAddr != common.Address{}) && addr != cfg.ExpectedAddr {
+		return common.Address{}, nil, errors.New("unexpected address", "expected", cfg.ExpectedAddr, "actual", addr)
+	}
+
+	impl, tx, _, err := bindings.DeployFeeOracleV2(txOpts, backend)
+	if err != nil {
+		return common.Address{}, nil, errors.Wrap(err, "deploy implementation")
+	}
+
+	_, err = backend.WaitMined(ctx, tx)
+	if err != nil {
+		return common.Address{}, nil, errors.Wrap(err, "wait mined implementation")
+	}
+
+	initCode, err := packInitCode(ctx, chainID, destChainIDs, cfg, backends, impl)
+	if err != nil {
+		return common.Address{}, nil, errors.Wrap(err, "pack init code")
+	}
+
+	tx, err = factory.DeployWithRetry(txOpts, salt, initCode) //nolint:contextcheck // Context is txOpts
+	if err != nil {
+		return common.Address{}, nil, errors.Wrap(err, "deploy proxy")
+	}
+
+	receipt, err := backend.WaitMined(ctx, tx)
+	if err != nil {
+		return common.Address{}, nil, errors.Wrap(err, "wait mined proxy")
+	}
+
+	return addr, receipt, nil
+}
+
+func packInitCode(ctx context.Context, chainID uint64, destChainIDs []uint64, cfg DeploymentConfig, backends ethbackend.Backends, impl common.Address) ([]byte, error) {
+	feeOracleAbi, err := bindings.FeeOracleV2MetaData.GetAbi()
+	if err != nil {
+		return nil, errors.Wrap(err, "get fee oracle abi")
+	}
+
+	proxyAbi, err := bindings.TransparentUpgradeableProxyMetaData.GetAbi()
+	if err != nil {
+		return nil, errors.Wrap(err, "get proxy abi")
+	}
+
+	feeparams, err := feeParams(ctx, chainID, destChainIDs, backends, coingecko.New())
+	if err != nil {
+		return nil, errors.Wrap(err, "fee params")
+	}
+
+	initializer, err := feeOracleAbi.Pack("initialize", cfg.Owner, cfg.Manager, cfg.BaseGasLimit, cfg.ProtocolFee, feeparams)
+	if err != nil {
+		return nil, errors.Wrap(err, "pack initialize")
+	}
+
+	return contracts.PackInitCode(proxyAbi, bindings.TransparentUpgradeableProxyBin, impl, cfg.ProxyAdminOwner, initializer)
+}

--- a/lib/contracts/feeoraclev2/deploy.go
+++ b/lib/contracts/feeoraclev2/deploy.go
@@ -125,7 +125,7 @@ func Deploy(ctx context.Context, network netconf.ID, chainID uint64, destChainID
 		Owner:           eoa.MustAddress(network, eoa.RoleManager),
 		Deployer:        eoa.MustAddress(network, eoa.RoleDeployer),
 		Manager:         eoa.MustAddress(network, eoa.RoleMonitor), // NOTE: monitor is owner of fee oracle contracts, because monitor manages on chain gas prices / conversion rates
-		BaseGasLimit:    50_000,
+		BaseGasLimit:    100_000,
 		ProtocolFee:     big.NewInt(0),
 	}
 

--- a/lib/contracts/feeoraclev2/feeparams.go
+++ b/lib/contracts/feeoraclev2/feeparams.go
@@ -1,0 +1,141 @@
+package feeoraclev2
+
+import (
+	"context"
+	"math/big"
+
+	"github.com/omni-network/omni/contracts/bindings"
+	"github.com/omni-network/omni/lib/errors"
+	"github.com/omni-network/omni/lib/ethclient/ethbackend"
+	"github.com/omni-network/omni/lib/evmchain"
+	"github.com/omni-network/omni/lib/log"
+	"github.com/omni-network/omni/lib/tokens"
+	"github.com/omni-network/omni/monitor/xfeemngr"
+
+	"github.com/ethereum/go-ethereum/params"
+)
+
+func feeParams(ctx context.Context, srcChainID uint64, destChainIDs []uint64, backends ethbackend.Backends, pricer tokens.Pricer,
+) ([]bindings.IFeeOracleV2FeeParams, error) {
+	// used cached pricer, to avoid multiple price requests for same token
+	pricer = tokens.NewCachedPricer(pricer)
+
+	srcChain, ok := evmchain.MetadataByID(srcChainID)
+	if !ok {
+		return nil, errors.New("meta by chain id", "chain_id", srcChainID)
+	}
+
+	var resp []bindings.IFeeOracleV2FeeParams
+	for _, destChainID := range destChainIDs {
+		destChain, ok := evmchain.MetadataByID(destChainID)
+		if !ok {
+			return nil, errors.New("meta by chain id", "dest_chain", destChain.Name)
+		}
+
+		ps, err := destFeeParams(ctx, srcChain, destChain, backends, pricer)
+		if err != nil {
+			return nil, err
+		}
+
+		resp = append(resp, ps)
+
+		// Add postsTo rates if not already present
+		if destChain.PostsTo != 0 && !contains(resp, destChain.PostsTo) {
+			resp = append(resp, bindings.IFeeOracleV2FeeParams{
+				ChainId:      destChain.PostsTo,
+				ExecGasPrice: uint64(params.GWei),
+				DataGasPrice: uint64(params.GWei),
+				ToNativeRate: rateToNumerator(1), // Stub native rates for now
+			})
+		}
+	}
+
+	return resp, nil
+}
+
+// feeParams returns the fee parameters for the given source token and destination chains.
+func destFeeParams(ctx context.Context, srcChain evmchain.Metadata, destChain evmchain.Metadata, backends ethbackend.Backends, pricer tokens.Pricer,
+) (bindings.IFeeOracleV2FeeParams, error) {
+	backend, err := backends.Backend(destChain.ChainID)
+	if err != nil {
+		return bindings.IFeeOracleV2FeeParams{}, errors.Wrap(err, "get backend", "dest_chain", destChain.Name)
+	}
+
+	// conversion rate from "dest token" to "src token"
+	// ex if dest chain is ETH, and src chain is OMNI, we need to know the rate of ETH to OMNI.
+	toNativeRate, err := conversionRate(ctx, pricer, destChain.NativeToken, srcChain.NativeToken)
+	if err != nil {
+		log.Warn(ctx, "Failed fetching conversion rate, using default 1", err, "dest_chain", destChain.Name, "src_chain", srcChain.Name)
+		toNativeRate = 1
+	}
+
+	gasPrice, err := backend.SuggestGasPrice(ctx)
+	if err != nil {
+		log.Warn(ctx, "Failed fetching gas price, using default 1 Gwei", err, "dest_chain", destChain.Name)
+		gasPrice = big.NewInt(params.GWei)
+	}
+
+	return bindings.IFeeOracleV2FeeParams{
+		ChainId:      destChain.ChainID,
+		ExecGasPrice: withGasPriceShield(float64(gasPrice.Uint64())),
+		DataGasPrice: withGasPriceShield(float64(gasPrice.Uint64())),
+		ToNativeRate: rateToNumerator(toNativeRate),
+	}, nil
+}
+
+// conversionRate returns the conversion rate C from token F to token T, where C = price(F) / price(T).
+// Ex. We want to convert from ETH to OMNI. We need to know the what X OMNI = 1 ETH.
+// If the price of OMNI is 10, the price of ETH is 1000. The conversion rate C is price(ETH) / price(OMNI) = 1000 / 10 = 100.
+func conversionRate(ctx context.Context, pricer tokens.Pricer, from, to tokens.Token) (float64, error) {
+	if from == to {
+		return 1, nil
+	}
+
+	prices, err := pricer.Price(ctx, from, to)
+	if err != nil {
+		return 0, errors.Wrap(err, "get price", "ids", "from", from, "to", to)
+	}
+
+	has := func(t tokens.Token) bool {
+		p, ok := prices[t]
+		return ok && p > 0
+	}
+	if !has(to) {
+		return 0, errors.New("missing to token price", "to", to)
+	} else if !has(from) {
+		return 0, errors.New("missing from token price", "from", from)
+	}
+
+	return prices[from] / prices[to], nil
+}
+
+// conversionRateDenom matches the CONVERSION_RATE_DENOM on the FeeOracleV1 contract.
+// This denominator helps convert between token amounts in solidity, in which there are no floating point numbers.
+//
+//	ex. (amt A) * (rate R) / CONVERSION_RATE_DENOM = (amt B)
+var conversionRateDenom = big.NewInt(1_000_000)
+
+// rateToNumerator translates a float rate (ex 0.1) to numerator / CONVERSION_RATE_DENOM (ex 100_000).
+// This rate-as-numerator representation is used in FeeOracleV1 contracts.
+func rateToNumerator(r float64) uint64 {
+	denom := new(big.Float).SetInt64(conversionRateDenom.Int64())
+	numer := new(big.Float).SetFloat64(r)
+	norm, _ := new(big.Float).Mul(numer, denom).Uint64()
+
+	return norm
+}
+
+// withGasPriceShield returns the gas price with an added xfeemngr.GasPriceShield pct offset.
+func withGasPriceShield(gasPrice float64) uint64 {
+	return uint64(gasPrice + (xfeemngr.GasPriceShield * gasPrice))
+}
+
+func contains(params []bindings.IFeeOracleV2FeeParams, chainID uint64) bool {
+	for _, param := range params {
+		if param.ChainId == chainID {
+			return true
+		}
+	}
+
+	return false
+}


### PR DESCRIPTION
Created a FeeOracleV2 deployment routine that uses Create3. We cannot upgrade FeeOracleV1 as V2 has a different storage layout. This routine does not currently include upgrade logic.

issue: #1951 