### PR TITLE
fix(halo/attest): verify votes before proposing

### DIFF
--- a/halo/attest/keeper/valaddr.go
+++ b/halo/attest/keeper/valaddr.go
@@ -11,8 +11,6 @@ import (
 	"github.com/cometbft/cometbft/crypto"
 
 	"github.com/ethereum/go-ethereum/common"
-
-	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
 // valAddrCache is a simple read-through cache for validator comet-to-eth address lookups.
@@ -63,8 +61,8 @@ func (c *valAddrCache) SetAll(vals []vtypes.Validator) error {
 
 // getValEthAddr returns the validator's ethereum address via reverse lookup using the provided validator cometBFT address.
 // It uses the validator read-through-cache to avoid querying the underlying validator set provider.
-// Note it assumes the provided validator is inside the current set. It doesn't ensure this.
-func (k *Keeper) getValEthAddr(ctx context.Context, cmtAddr []byte) (common.Address, error) {
+// Note it assumes the provided validator is inside the provided set. It doesn't ensure this.
+func (k *Keeper) getValEthAddr(ctx context.Context, cmtAddr []byte, setHeight uint64) (common.Address, error) {
 	addr, err := cast.Array20(cmtAddr)
 	if err != nil {
 		return common.Address{}, errors.Wrap(err, "invalid comet address length [BUG]")
@@ -76,8 +74,7 @@ func (k *Keeper) getValEthAddr(ctx context.Context, cmtAddr []byte) (common.Addr
 	}
 
 	// Cache is stale, rehydrate it.
-	sdkCtx := sdk.UnwrapSDKContext(ctx)
-	valset, err := k.valProvider.ActiveSetByHeight(ctx, uint64(sdkCtx.BlockHeight()))
+	valset, err := k.valProvider.ActiveSetByHeight(ctx, setHeight)
 	if err != nil {
 		return common.Address{}, errors.Wrap(err, "get active set")
 	}

--- a/octane/evmengine/keeper/abci.go
+++ b/octane/evmengine/keeper/abci.go
@@ -121,7 +121,7 @@ func (k *Keeper) PrepareProposal(ctx sdk.Context, req *abci.RequestPreparePropos
 	}
 
 	// First, collect all vote extension msgs from the vote provider.
-	voteMsgs, err := k.voteProvider.PrepareVotes(ctx, req.LocalLastCommit)
+	voteMsgs, err := k.voteProvider.PrepareVotes(ctx, req.LocalLastCommit, uint64(req.Height-1))
 	if err != nil {
 		return nil, errors.Wrap(err, "prepare votes")
 	}

--- a/octane/evmengine/keeper/abci_internal_test.go
+++ b/octane/evmengine/keeper/abci_internal_test.go
@@ -436,7 +436,7 @@ type mockAddressProvider struct {
 
 type mockVEProvider struct{}
 
-func (m mockVEProvider) PrepareVotes(_ context.Context, _ abci.ExtendedCommitInfo) ([]sdk.Msg, error) {
+func (mockVEProvider) PrepareVotes(context.Context, abci.ExtendedCommitInfo, uint64) ([]sdk.Msg, error) {
 	coin := sdk.NewInt64Coin("stake", 100)
 	msg := stypes.NewMsgDelegate("addr", "addr", coin)
 

--- a/octane/evmengine/types/cpayload.go
+++ b/octane/evmengine/types/cpayload.go
@@ -17,7 +17,7 @@ import (
 // EVMEngine calls this during PreparePayload to collect all vote extensions msgs to include in
 // the consensus block.
 type VoteExtensionProvider interface {
-	PrepareVotes(ctx context.Context, commit abci.ExtendedCommitInfo) ([]sdk.Msg, error)
+	PrepareVotes(ctx context.Context, commit abci.ExtendedCommitInfo, commitHeight uint64) ([]sdk.Msg, error)
 }
 
 // EvmEventProcessor abstracts logic that processes EVM log events of the


### PR DESCRIPTION
Verify (and discard) invalid votes before proposing. This is required since VerifyVoteExtension isn't always called, so LastLocalCommit may contain invalid votes.

issue: #2460 