### PR TITLE
chore(monitor/xfeemngr): add gas price buffer updates counter metric

### DIFF
--- a/monitor/xfeemngr/gasprice/buffer.go
+++ b/monitor/xfeemngr/gasprice/buffer.go
@@ -154,6 +154,7 @@ func guageLive(chainID uint64, price uint64) {
 // guageBuffered updates "buffered" guages for a chain's gas price.
 func guageBuffered(chainID uint64, price uint64) {
 	bufferedGasPrice.WithLabelValues(chainName(chainID)).Set(float64(price))
+	bufferUpdates.WithLabelValues(chainName(chainID)).Inc()
 }
 
 // setPrice sets the buffered gas price for the given chainID.

--- a/monitor/xfeemngr/gasprice/metrics.go
+++ b/monitor/xfeemngr/gasprice/metrics.go
@@ -13,6 +13,13 @@ var (
 		Help:      "Live gas price",
 	}, []string{"chain"})
 
+	bufferUpdates = promauto.NewCounterVec(prometheus.CounterOpts{
+		Namespace: "monitor",
+		Subsystem: "xfeemngr",
+		Name:      "buffer_updates_total",
+		Help:      "The total number of buffer updates",
+	}, []string{"chain"})
+
 	bufferedGasPrice = promauto.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: "monitor",
 		Subsystem: "xfeemngr",


### PR DESCRIPTION
Track number of times gas price buffer is updated per chain.

issue: none