### PR TITLE
ci(e2e): support devnet chaos slashing

### DIFF
--- a/e2e/app/setup.go
+++ b/e2e/app/setup.go
@@ -163,6 +163,7 @@ func Setup(ctx context.Context, def Definition, depCfg DeployConfig) error {
 			node.Mode,
 			omniEVM.InstanceName,
 			endpoints,
+			def.Testnet.Manifest.HaloChaos,
 		); err != nil {
 			return err
 		}
@@ -396,6 +397,7 @@ func writeHaloConfig(
 	mode e2e.Mode,
 	evmInstance string,
 	endpoints xchain.RPCEndpoints,
+	devnetChaos bool,
 ) error {
 	cfg := halocfg.DefaultConfig()
 
@@ -412,6 +414,7 @@ func writeHaloConfig(
 	cfg.EngineJWTFile = "/halo/config/jwtsecret"                    // Absolute path inside docker container
 	cfg.Tracer.Endpoint = defCfg.TracingEndpoint
 	cfg.Tracer.Headers = defCfg.TracingHeaders
+	cfg.DevnetChaos = devnetChaos
 
 	if testCfg {
 		cfg.SnapshotInterval = 1   // Write snapshots each block in e2e tests

--- a/e2e/manifests/ci.toml
+++ b/e2e/manifests/ci.toml
@@ -4,6 +4,7 @@ anvil_chains = ["mock_l2", "mock_l1"]
 multi_omni_evms = true
 network_upgrade_height = 15
 pingpong_n = 5 # Increased ping pong to span validator updates
+halo_chaos = true
 
 [node.validator01]
 [node.validator02]

--- a/e2e/types/manifest.go
+++ b/e2e/types/manifest.go
@@ -58,8 +58,6 @@ const (
 	PerturbStopStart Perturb = "stopstart"
 	// PerturbRollback defines a perturbation that stops a halo node, performs a rollback, then starts it again.
 	PerturbRollback Perturb = "rollback"
-	// PerturbUpgrade defines a perturbation that upgrades a halo node to the latest image tag.
-	PerturbUpgrade Perturb = "upgrade"
 
 	// PerturbFuzzyHeadDropBlocks defines a perturbation that enables fuzzyhead dropping xblock for a while.
 	PerturbFuzzyHeadDropBlocks Perturb = "fuzzyhead_dropblocks"
@@ -72,8 +70,6 @@ const (
 )
 
 // Manifest wraps e2e.Manifest with additional omni-specific fields.
-//
-
 type Manifest struct {
 	e2e.Manifest
 
@@ -118,6 +114,9 @@ type Manifest struct {
 	// NetworkUpgradeHeight defines the network upgrade height, default is genesis, negative is disabled.
 	// Note that it might be scheduled at a later height.
 	NetworkUpgradeHeight int64 `toml:"network_upgrade_height"`
+
+	// HaloChaos defines whether to enable chaos testing in halo.
+	HaloChaos bool `toml:"halo_chaos"`
 }
 
 // Seeds returns a map of seed nodes by name.

--- a/halo/attest/keeper/cpayload.go
+++ b/halo/attest/keeper/cpayload.go
@@ -18,7 +18,6 @@ import (
 	"github.com/cosmos/cosmos-sdk/baseapp"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
-	"github.com/cosmos/gogoproto/proto"
 )
 
 var _ evmenginetypes.VoteExtensionProvider = (*Keeper)(nil)
@@ -26,8 +25,8 @@ var _ evmenginetypes.VoteExtensionProvider = (*Keeper)(nil)
 // PrepareVotes returns the cosmosSDK transaction MsgAddVotes that will include all the validator votes included
 // in the previous block's vote extensions into the attest module.
 //
-// Note that the commit is assumed to be valid and only contains valid VEs from the previous block as
-// provided by a trusted cometBFT. Some votes (contained inside VE) may however be invalid, they are discarded.
+// Note that the commit is expected to be valid and only contains valid VEs from the previous block as
+// provided by a trusted cometBFT. Some votes (contained inside VEs) may however be invalid, they are discarded.
 func (k *Keeper) PrepareVotes(ctx context.Context, commit abci.ExtendedCommitInfo, commitHeight uint64) ([]sdk.Msg, error) {
 	sdkCtx := sdk.UnwrapSDKContext(ctx)
 	// The VEs in LastLocalCommit is expected to be valid
@@ -113,18 +112,4 @@ func sortAggregates(aggs []*types.AggVote) []*types.AggVote {
 	})
 
 	return aggs
-}
-
-// votesFromExtension returns the attestations contained in the vote extension, or false if none or an error.
-func votesFromExtension(voteExtension []byte) (*types.Votes, bool, error) {
-	if len(voteExtension) == 0 {
-		return nil, false, nil
-	}
-
-	resp := new(types.Votes)
-	if err := proto.Unmarshal(voteExtension, resp); err != nil {
-		return nil, false, errors.Wrap(err, "decode vote extension")
-	}
-
-	return resp, true, nil
 }

--- a/halo/attest/keeper/keeper.go
+++ b/halo/attest/keeper/keeper.go
@@ -769,7 +769,7 @@ func (k *Keeper) parseAndVerifyVoteExtension(
 		return nil, false, err // This error should never occur
 	}
 
-	votes, ok, err := votesFromExtension(voteExt)
+	votes, ok, err := types.VotesFromExtension(voteExt)
 	if err != nil {
 		return nil, false, errors.Wrap(err, "votes from extension")
 	} else if !ok {

--- a/halo/attest/types/helper.go
+++ b/halo/attest/types/helper.go
@@ -5,7 +5,10 @@ import (
 	"log/slog"
 	"strconv"
 
+	"github.com/omni-network/omni/lib/errors"
 	"github.com/omni-network/omni/lib/xchain"
+
+	"github.com/cosmos/gogoproto/proto"
 )
 
 const logLimit = 5
@@ -44,4 +47,18 @@ func AttLogs(headers []*AttestHeader) []any {
 	}
 
 	return attrs
+}
+
+// VotesFromExtension returns the attestations contained in the vote extension, or false if none or an error.
+func VotesFromExtension(voteExtension []byte) (*Votes, bool, error) {
+	if len(voteExtension) == 0 {
+		return nil, false, nil
+	}
+
+	resp := new(Votes)
+	if err := proto.Unmarshal(voteExtension, resp); err != nil {
+		return nil, false, errors.Wrap(err, "decode vote extension")
+	}
+
+	return resp, true, nil
 }

--- a/halo/cmd/cmd_internal_test.go
+++ b/halo/cmd/cmd_internal_test.go
@@ -145,6 +145,7 @@ func TestTomlConfig(t *testing.T) {
 	var expect halocfg.Config
 	fuzzer.Fuzz(&expect)
 	expect.HomeDir = dir
+	expect.DevnetChaos = false // Chaos not included in toml
 
 	// The Toml library converts map keys to lower case. So do this so expect==actual.
 	for k := range expect.RPCEndpoints {

--- a/halo/cmd/flags.go
+++ b/halo/cmd/flags.go
@@ -35,6 +35,7 @@ func bindRunFlags(cmd *cobra.Command, cfg *halocfg.Config) {
 	flags.DurationVar(&cfg.EVMBuildDelay, "evm-build-delay", cfg.EVMBuildDelay, "Minimum delay between triggering and fetching a EVM payload build")
 	flags.BoolVar(&cfg.EVMBuildOptimistic, "evm-build-optimistic", cfg.EVMBuildOptimistic, "Enables optimistic building of EVM payloads on previous block finalize")
 	flags.IntSliceVar(&cfg.UnsafeSkipUpgrades, sdkserver.FlagUnsafeSkipUpgrades, cfg.UnsafeSkipUpgrades, "Skip a set of upgrade heights to continue the old binary")
+	flags.BoolVar(&cfg.DevnetChaos, "devnet-chaos-test", cfg.DevnetChaos, "Enable chaos testing (only applicable to devnet)")
 }
 
 func bindRollbackFlags(flags *pflag.FlagSet, cfg *app.RollbackConfig) {

--- a/halo/cmd/testdata/TestCLIReference_rollback.golden
+++ b/halo/cmd/testdata/TestCLIReference_rollback.golden
@@ -14,6 +14,7 @@ Flags:
       --api-address string                        Address defines the API server to listen on (default "tcp://0.0.0.0:1317")
       --api-enable                                Enable defines if the API server should be enabled. (default true)
       --app-db-backend string                     The type of database for application and snapshots databases (default "goleveldb")
+      --devnet-chaos-test                         Enable chaos testing (only applicable to devnet)
       --engine-endpoint string                    An EVM execution client Engine API http endpoint
       --engine-jwt-file string                    The path to the Engine API JWT file
       --evm-build-delay duration                  Minimum delay between triggering and fetching a EVM payload build (default 600ms)

--- a/halo/cmd/testdata/TestCLIReference_run.golden
+++ b/halo/cmd/testdata/TestCLIReference_run.golden
@@ -7,6 +7,7 @@ Flags:
       --api-address string                        Address defines the API server to listen on (default "tcp://0.0.0.0:1317")
       --api-enable                                Enable defines if the API server should be enabled. (default true)
       --app-db-backend string                     The type of database for application and snapshots databases (default "goleveldb")
+      --devnet-chaos-test                         Enable chaos testing (only applicable to devnet)
       --engine-endpoint string                    An EVM execution client Engine API http endpoint
       --engine-jwt-file string                    The path to the Engine API JWT file
       --evm-build-delay duration                  Minimum delay between triggering and fetching a EVM payload build (default 600ms)

--- a/halo/cmd/testdata/TestRunCmd_defaults.golden
+++ b/halo/cmd/testdata/TestRunCmd_defaults.golden
@@ -24,6 +24,7 @@
   "Enable": true,
   "Address": "0.0.0.0:9090"
  },
+ "DevnetChaos": false,
  "Comet": {
   "Version": "0.38.15",
   "RootDir": "./halo",

--- a/halo/cmd/testdata/TestRunCmd_flags.golden
+++ b/halo/cmd/testdata/TestRunCmd_flags.golden
@@ -24,6 +24,7 @@
   "Enable": true,
   "Address": "0.0.0.0:9090"
  },
+ "DevnetChaos": false,
  "Comet": {
   "Version": "0.38.15",
   "RootDir": "foo",

--- a/halo/cmd/testdata/TestRunCmd_json_files.golden
+++ b/halo/cmd/testdata/TestRunCmd_json_files.golden
@@ -24,6 +24,7 @@
   "Enable": true,
   "Address": "0.0.0.0:9090"
  },
+ "DevnetChaos": false,
  "Comet": {
   "Version": "0.38.15",
   "RootDir": "testinput/input2",

--- a/halo/cmd/testdata/TestRunCmd_toml_files.golden
+++ b/halo/cmd/testdata/TestRunCmd_toml_files.golden
@@ -27,6 +27,7 @@
   "Enable": true,
   "Address": "grpc/toml"
  },
+ "DevnetChaos": false,
  "Comet": {
   "Version": "0.38.15",
   "RootDir": "testinput/input1",

--- a/halo/config/config.go
+++ b/halo/config/config.go
@@ -86,6 +86,7 @@ type Config struct {
 	UnsafeSkipUpgrades []int
 	SDKAPI             RPCConfig `mapstructure:"api"`
 	SDKGRPC            RPCConfig `mapstructure:"grpc"`
+	DevnetChaos        bool
 }
 
 // RPCConfig is an abridged version of CosmosSDK srvconfig.API/GRPCConfig.


### PR DESCRIPTION
Support slash testing in e2e:
- Enable it via `halo_chaos = true` in e2e manifest.
- This results in `--devnet-chaos-test=true` flag in halo.
- Which results in halo injecting deterministic double sign evidence once

The aim is to improve the edge-case testing when slashing occurs.

issue: none