### PR TITLE
fix(lib/contracts): correct deployment of feeoraclev2

### DIFF
--- a/lib/contracts/feeoraclev2/deploy.go
+++ b/lib/contracts/feeoraclev2/deploy.go
@@ -130,10 +130,10 @@ func Deploy(ctx context.Context, network netconf.ID, chainID uint64, destChainID
 		ProtocolFee:     big.NewInt(0),
 	}
 
-	return deploy(ctx, network, chainID, destChainIDs, cfg, backend, backends)
+	return deploy(ctx, chainID, destChainIDs, cfg, backend, backends)
 }
 
-func deploy(ctx context.Context, network netconf.ID, chainID uint64, destChainIDs []uint64, cfg DeploymentConfig, backend *ethbackend.Backend, backends ethbackend.Backends) (common.Address, *ethtypes.Receipt, error) {
+func deploy(ctx context.Context, chainID uint64, destChainIDs []uint64, cfg DeploymentConfig, backend *ethbackend.Backend, backends ethbackend.Backends) (common.Address, *ethtypes.Receipt, error) {
 	if err := cfg.Validate(); err != nil {
 		return common.Address{}, nil, errors.Wrap(err, "validate config")
 	}
@@ -167,7 +167,7 @@ func deploy(ctx context.Context, network netconf.ID, chainID uint64, destChainID
 		return common.Address{}, nil, errors.Wrap(err, "wait mined implementation")
 	}
 
-	initCode, err := packInitCode(ctx, network, chainID, destChainIDs, cfg, backends, impl)
+	initCode, err := packInitCode(ctx, chainID, destChainIDs, cfg, backends, impl)
 	if err != nil {
 		return common.Address{}, nil, errors.Wrap(err, "pack init code")
 	}
@@ -185,7 +185,7 @@ func deploy(ctx context.Context, network netconf.ID, chainID uint64, destChainID
 	return addr, receipt, nil
 }
 
-func packInitCode(ctx context.Context, network netconf.ID, chainID uint64, destChainIDs []uint64, cfg DeploymentConfig, backends ethbackend.Backends, impl common.Address) ([]byte, error) {
+func packInitCode(ctx context.Context, chainID uint64, destChainIDs []uint64, cfg DeploymentConfig, backends ethbackend.Backends, impl common.Address) ([]byte, error) {
 	feeOracleAbi, err := bindings.FeeOracleV2MetaData.GetAbi()
 	if err != nil {
 		return nil, errors.Wrap(err, "get fee oracle abi")
@@ -196,7 +196,7 @@ func packInitCode(ctx context.Context, network netconf.ID, chainID uint64, destC
 		return nil, errors.Wrap(err, "get proxy abi")
 	}
 
-	feeparams, err := feeParams(ctx, network, chainID, destChainIDs, backends, coingecko.New())
+	feeparams, err := feeParams(ctx, chainID, destChainIDs, backends, coingecko.New())
 	if err != nil {
 		return nil, errors.Wrap(err, "fee params")
 	}

--- a/lib/contracts/feeoraclev2/feeparams.go
+++ b/lib/contracts/feeoraclev2/feeparams.go
@@ -9,13 +9,14 @@ import (
 	"github.com/omni-network/omni/lib/ethclient/ethbackend"
 	"github.com/omni-network/omni/lib/evmchain"
 	"github.com/omni-network/omni/lib/log"
+	"github.com/omni-network/omni/lib/netconf"
 	"github.com/omni-network/omni/lib/tokens"
 	"github.com/omni-network/omni/monitor/xfeemngr/gasprice"
 
 	"github.com/ethereum/go-ethereum/params"
 )
 
-func feeParams(ctx context.Context, srcChainID uint64, destChainIDs []uint64, backends ethbackend.Backends, pricer tokens.Pricer,
+func feeParams(ctx context.Context, network netconf.ID, srcChainID uint64, destChainIDs []uint64, backends ethbackend.Backends, pricer tokens.Pricer,
 ) ([]bindings.IFeeOracleV2FeeParams, error) {
 	// used cached pricer, to avoid multiple price requests for same token
 	pricer = tokens.NewCachedPricer(pricer)
@@ -32,9 +33,20 @@ func feeParams(ctx context.Context, srcChainID uint64, destChainIDs []uint64, ba
 			return nil, errors.New("meta by chain id", "dest_chain", destChain.Name)
 		}
 
-		ps, err := destFeeParams(ctx, srcChain, destChain, backends, pricer)
-		if err != nil {
-			return nil, err
+		var ps bindings.IFeeOracleV2FeeParams
+		if network == netconf.Mainnet {
+			var err error
+			ps, err = destFeeParams(ctx, srcChain, destChain, backends, pricer)
+			if err != nil {
+				return nil, err
+			}
+		} else {
+			ps = bindings.IFeeOracleV2FeeParams{
+				ChainId:      destChain.ChainID,
+				ExecGasPrice: params.GWei,
+				DataGasPrice: params.GWei,
+				ToNativeRate: 1_000_000,
+			}
 		}
 
 		resp = append(resp, ps)


### PR DESCRIPTION
Generation of FeeParams for L2 Sepolia testnets was failing as Sepolia isn't in the manifests for staging or omega. Default gas prices to 1 gwei for non-mainnet manifests.

issue: #1951 