### PR TITLE
fix(octane/evmengine): graceful post finalize errors

### DIFF
--- a/octane/evmengine/keeper/abci.go
+++ b/octane/evmengine/keeper/abci.go
@@ -184,7 +184,10 @@ func (k *Keeper) PostFinalize(ctx sdk.Context) error {
 	// Maybe start building the next block if we are the next proposer.
 	isNext, err := k.isNextProposer(ctx, proposer, height)
 	if err != nil {
-		return errors.Wrap(err, "next proposer")
+		// IsNextProposer does non-deterministic cometBFT queries, don't stall node due to errors.
+		log.Warn(ctx, "Next proposer failed, skipping optimistic EVM payload build", err)
+
+		return nil
 	} else if !isNext {
 		return nil // Nothing to do if we are not next proposer.
 	}


### PR DESCRIPTION
Don't error (stall node) in `PostFinalize` if `CometBFT.Validators` returns an error, rather handle it graacefully and skip optimisic build. `CometBFT.Validators` is non-deterministic and may return unexpected errors in edge cases.

issue: #2480