### PR TITLE
feat(lib/chaos): add chaos errors to relayer workers

### DIFF
--- a/lib/chaos/chaos.go
+++ b/lib/chaos/chaos.go
@@ -1,0 +1,39 @@
+// Package chaos provides a simple API to inject errors into applications to test error handling in-the-wild.
+package chaos
+
+import (
+	"context"
+	"math/rand/v2"
+
+	"github.com/omni-network/omni/lib/errors"
+	"github.com/omni-network/omni/lib/netconf"
+)
+
+var (
+	networkErrorProb = map[netconf.ID]float64{
+		netconf.Devnet:  0.001,  // 0.1% error rate in devnet (1 in 1_000)
+		netconf.Omega:   0.0001, // 0.01% error rate in omega (1 in 10_000)
+		netconf.Mainnet: 0.00,   // No chaos errors in mainnet
+	}
+
+	// ErrChaos is the error returned my MaybeError. It supports checking for chaos errors via: errors.Is(err, chaos.ErrChaos).
+	ErrChaos = errors.NewSentinel("chaos error")
+)
+
+type key struct{}
+
+// WithErrProbability sets the chaos error probability for the given network in the context.
+func WithErrProbability(ctx context.Context, network netconf.ID) context.Context {
+	return context.WithValue(ctx, key{}, networkErrorProb[network])
+}
+
+// MaybeError sometimes returns an error based on the probability set in the context.
+func MaybeError(ctx context.Context) error {
+	if prob, ok := ctx.Value(key{}).(float64); ok && prob > 0 {
+		if rand.Float64() < prob { //nolint:gosec // Weak randomness isn't a problem here.
+			return errors.Wrap(ErrChaos, "maybe error") // Wrap error for proper stack traces.
+		}
+	}
+
+	return nil
+}

--- a/lib/chaos/chaos_test.go
+++ b/lib/chaos/chaos_test.go
@@ -1,0 +1,26 @@
+package chaos_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/omni-network/omni/lib/chaos"
+	"github.com/omni-network/omni/lib/log"
+	"github.com/omni-network/omni/lib/netconf"
+)
+
+func TestMaybeError(t *testing.T) {
+	t.Parallel()
+	ctx := chaos.WithErrProbability(context.Background(), netconf.Devnet)
+
+	for i := 0; ; i++ {
+		err := chaos.MaybeError(ctx)
+		if err == nil {
+			continue
+		}
+
+		log.Warn(ctx, "Got chaos errors", err, "i", i) // Manually confirm stack trace is correct.
+
+		return
+	}
+}

--- a/lib/errors/errors.go
+++ b/lib/errors/errors.go
@@ -4,16 +4,38 @@
 package errors
 
 import (
+	stderrors "errors"
+
 	pkgerrors "github.com/pkg/errors"
 )
 
 // New returns an error that formats as the given text and
-// contains the structured (slog) attributes.
+// contains the structured (slog) attributes and stack trace.
 func New(msg string, attrs ...any) error {
 	return structured{
 		err:   pkgerrors.New(msg),
 		attrs: attrs,
 	}
+}
+
+// NewSentinel returns a new error that formats as the given text.
+// It doesn't contain a stack trace.
+// This can be used to support error checking with proper runtime stack traces.
+//
+//	// ErrNotFound is a sentinel error, it doesn't have a stack trace.
+//	var ErrNotFound = errors.NewSentinel("not found")
+//
+//	// Foo returns a sentinel error with runtime stack trace of this function
+//	// instead of the stack trace of ErrNotFound initialization.
+//	func Foo() error {
+//	  return errors.Wrap(ErrNotFound, "foo failed")
+//	}
+//
+//	// Usage
+//	if errors.Is(Foo(), ErrNotFound) {
+//	  // Handle ErrNotFound or log it with proper runtime stack traces.
+func NewSentinel(msg string) error {
+	return stderrors.New(msg) //nolint:wrapcheck // This is explicitly not wrapped.
 }
 
 // Wrap returns a new error wrapping the provided with additional

--- a/lib/errors/errors_test.go
+++ b/lib/errors/errors_test.go
@@ -12,6 +12,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+var errSentinel = errors.NewSentinel("test sentinel")
+
 func TestComparable(t *testing.T) {
 	t.Parallel()
 	require.False(t, reflect.TypeOf(errors.New("x")).Comparable())
@@ -24,11 +26,13 @@ func TestIs(t *testing.T) {
 	err1 := errors.New("1", "1", "1")
 	err11 := errors.Wrap(err1, "w1")
 	err111 := errors.Wrap(err11, "w2")
+	errWrapSent := errors.Wrap(errSentinel, "w1")
 
 	require.Equal(t, "x", errX.Error())
 	require.Equal(t, "1", err1.Error())
 	require.Equal(t, "w1: 1", err11.Error())
 	require.Equal(t, "w2: w1: 1", err111.Error())
+	require.Equal(t, "w1: test sentinel", errWrapSent.Error())
 
 	require.True(t, errors.Is(err1, err1))
 	require.True(t, errors.Is(err11, err1))
@@ -39,8 +43,7 @@ func TestIs(t *testing.T) {
 	require.False(t, errors.Is(err1, err111))
 	require.False(t, errors.Is(err11, err111))
 	require.True(t, errors.Is(err111, err11))
-
-	require.False(t, errors.Is(err111, errX))
+	require.True(t, errors.Is(errWrapSent, errSentinel))
 
 	errIO1 := errors.Wrap(io.EOF, "w1")
 	errIO11 := errors.Wrap(errIO1, "w2")

--- a/relayer/app/buffer.go
+++ b/relayer/app/buffer.go
@@ -3,6 +3,7 @@ package relayer
 import (
 	"context"
 
+	"github.com/omni-network/omni/lib/chaos"
 	"github.com/omni-network/omni/lib/errors"
 	"github.com/omni-network/omni/lib/xchain"
 
@@ -75,6 +76,11 @@ func (b *activeBuffer) Run(ctx context.Context) error {
 				mempoolLen.WithLabelValues(b.chainName).Dec()
 				sema.Release(1)
 			}()
+
+			// Chaos test this worker with random errors.
+			if err := chaos.MaybeError(ctx); err != nil {
+				return err
+			}
 		}
 	}
 }

--- a/relayer/app/worker.go
+++ b/relayer/app/worker.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/omni-network/omni/contracts/bindings"
 	"github.com/omni-network/omni/lib/cchain"
+	"github.com/omni-network/omni/lib/chaos"
 	"github.com/omni-network/omni/lib/errors"
 	"github.com/omni-network/omni/lib/expbackoff"
 	"github.com/omni-network/omni/lib/log"
@@ -63,9 +64,11 @@ func (w *Worker) Run(ctx context.Context) {
 		err := w.runOnce(ctx)
 		if ctx.Err() != nil {
 			return
+		} else if errors.Is(err, chaos.ErrChaos) {
+			log.Info(ctx, "Worker failed due to chaos testing, resetting", err)
+		} else {
+			log.Warn(ctx, "Worker failed, resetting", err)
 		}
-
-		log.Error(ctx, "Worker failed, resetting", err)
 
 		workerResets.WithLabelValues(w.destChain.Name).Inc()
 		backoff()


### PR DESCRIPTION
Adds chaos testing to relayer workers such that they regularly reset. This helps to ensure that the cursor store are working as expected as it is only read when workers bootstrap.

issue: none