### PR TITLE
chore(monitor/xfeemngr): tweak low gas price tiers to reflect real chains

### DIFF
--- a/monitor/xfeemngr/gasprice/tiers.go
+++ b/monitor/xfeemngr/gasprice/tiers.go
@@ -2,7 +2,8 @@ package gasprice
 
 // buffer will be the lowest tier that is higher than the live gas price.
 var tiers = []uint64{
-	gwei(0.001),
+	gwei(0.0015), // op stack chains generally maintain 0.001+epsilon.
+	gwei(0.05),   // arb generally maintains 0.01 - 0.05.
 	gwei(0.1),
 	gwei(0.5),
 	gwei(1),


### PR DESCRIPTION
Update lower gas price tiers to match arb / op real values.

issue: none