### PR TITLE
fix(lib/contracts): proper default toNativeRate values

### DIFF
--- a/lib/contracts/feeoraclev1/feeparams.go
+++ b/lib/contracts/feeoraclev1/feeparams.go
@@ -65,8 +65,14 @@ func destFeeParams(ctx context.Context, srcChain evmchain.Metadata, destChain ev
 	// ex if dest chain is ETH, and src chain is OMNI, we need to know the rate of ETH to OMNI.
 	toNativeRate, err := conversionRate(ctx, pricer, destChain.NativeToken, srcChain.NativeToken)
 	if err != nil {
-		log.Warn(ctx, "Failed fetching conversion rate, using default 1", err, "dest_chain", destChain.Name, "src_chain", srcChain.Name)
-		toNativeRate = 1
+		if srcChain.NativeToken == destChain.NativeToken {
+			toNativeRate = 1 // 1 ETH = 1 ETH || 1 OMNI = 1 OMNI
+		} else if destChain.NativeToken == tokens.OMNI {
+			toNativeRate = 0.0025 // 1 OMNI = 0.0025 ETH
+		} else {
+			toNativeRate = 400 // 1 ETH = 400 OMNI
+		}
+		log.Warn(ctx, "Failed fetching conversion rate, using default", err, "dest_chain", destChain.Name, "src_chain", srcChain.Name, "to_native_rate", toNativeRate)
 	}
 
 	gasPrice, err := backend.SuggestGasPrice(ctx)

--- a/lib/contracts/feeoraclev2/feeparams.go
+++ b/lib/contracts/feeoraclev2/feeparams.go
@@ -47,8 +47,14 @@ func destFeeParams(ctx context.Context, srcChain evmchain.Metadata, destChain ev
 	// ex if dest chain is ETH, and src chain is OMNI, we need to know the rate of ETH to OMNI.
 	toNativeRate, err := conversionRate(ctx, pricer, destChain.NativeToken, srcChain.NativeToken)
 	if err != nil {
-		log.Warn(ctx, "Failed fetching conversion rate, using default 1", err, "dest_chain", destChain.Name, "src_chain", srcChain.Name)
-		toNativeRate = 1
+		if srcChain.NativeToken == destChain.NativeToken {
+			toNativeRate = 1 // 1 ETH = 1 ETH || 1 OMNI = 1 OMNI
+		} else if destChain.NativeToken == tokens.OMNI {
+			toNativeRate = 0.0025 // 1 OMNI = 0.0025 ETH
+		} else {
+			toNativeRate = 400 // 1 ETH = 400 OMNI
+		}
+		log.Warn(ctx, "Failed fetching conversion rate, using default", err, "dest_chain", destChain.Name, "src_chain", srcChain.Name, "to_native_rate", toNativeRate)
 	}
 
 	// Get execution gas price, defaulting to 1 Gwei if any error occurs.


### PR DESCRIPTION
Occasionally the CoinGecko API fails during our CI tests, triggering the default toNativeRate assignment. 1 was improper for certain routes, causing gas pump errors to occur. I've assigned correct placeholder values taking all native token conversions (ETH->ETH, ETH->OMNI, OMNI->ETH) into account.

issue: none