### PR TITLE
ci(lib/chaos): enable chaos errors in staging

### DIFF
--- a/lib/chaos/chaos.go
+++ b/lib/chaos/chaos.go
@@ -12,6 +12,7 @@ import (
 var (
 	networkErrorProb = map[netconf.ID]float64{
 		netconf.Devnet:  0.001,  // 0.1% error rate in devnet (1 in 1_000)
+		netconf.Staging: 0.001,  // 0.1% error rate in staging (1 in 1_000)
 		netconf.Omega:   0.0001, // 0.01% error rate in omega (1 in 10_000)
 		netconf.Mainnet: 0.00,   // No chaos errors in mainnet
 	}


### PR DESCRIPTION
Fix missing chaos probability in staging, set equaled to devnet chaos.

issue: none