### PR TITLE
feat(lib/feature): add support for feature flags

### DIFF
--- a/e2e/types/manifest.go
+++ b/e2e/types/manifest.go
@@ -2,6 +2,7 @@ package types
 
 import (
 	"github.com/omni-network/omni/e2e/app/key"
+	"github.com/omni-network/omni/lib/feature"
 	"github.com/omni-network/omni/lib/netconf"
 
 	e2e "github.com/cometbft/cometbft/test/e2e/pkg"
@@ -118,6 +119,9 @@ type Manifest struct {
 	// NetworkUpgradeHeight defines the network upgrade height, default is genesis, negative is disabled.
 	// Note that it might be scheduled at a later height.
 	NetworkUpgradeHeight int64 `toml:"network_upgrade_height"`
+
+	// FeatureFlags defines the feature flags to enable.
+	FeatureFlags feature.Flags `toml:"feature_flags"`
 }
 
 // Seeds returns a map of seed nodes by name.

--- a/halo/app/start.go
+++ b/halo/app/start.go
@@ -14,6 +14,7 @@ import (
 	cprovider "github.com/omni-network/omni/lib/cchain/provider"
 	"github.com/omni-network/omni/lib/errors"
 	"github.com/omni-network/omni/lib/ethclient"
+	"github.com/omni-network/omni/lib/feature"
 	"github.com/omni-network/omni/lib/log"
 	"github.com/omni-network/omni/lib/netconf"
 	"github.com/omni-network/omni/lib/tracer"
@@ -101,6 +102,8 @@ func Start(ctx context.Context, cfg Config) (<-chan error, func(context.Context)
 	}
 
 	buildinfo.Instrument(ctx)
+
+	ctx = feature.WithFlags(ctx, cfg.FeatureFlags)
 
 	tracerIDs := tracer.Identifiers{Network: cfg.Network, Service: "halo", Instance: cfg.Comet.Moniker}
 	stopTracer, err := tracer.Init(ctx, tracerIDs, cfg.Tracer)

--- a/halo/cmd/flags.go
+++ b/halo/cmd/flags.go
@@ -7,6 +7,7 @@ import (
 	"github.com/omni-network/omni/halo/app"
 	halocfg "github.com/omni-network/omni/halo/config"
 	libcmd "github.com/omni-network/omni/lib/cmd"
+	"github.com/omni-network/omni/lib/feature"
 	"github.com/omni-network/omni/lib/netconf"
 	"github.com/omni-network/omni/lib/tracer"
 	"github.com/omni-network/omni/lib/xchain"
@@ -23,6 +24,7 @@ func bindRunFlags(cmd *cobra.Command, cfg *halocfg.Config) {
 	tracer.BindFlags(flags, &cfg.Tracer)
 	xchain.BindFlags(flags, &cfg.RPCEndpoints)
 	netconf.BindFlag(flags, &cfg.Network)
+	feature.BindFlag(flags, &cfg.FeatureFlags)
 	bindRPCFlags(flags, "api", &cfg.SDKAPI)
 	bindRPCFlags(flags, "grpc", &cfg.SDKGRPC)
 	flags.StringVar(&cfg.EngineEndpoint, "engine-endpoint", cfg.EngineEndpoint, "An EVM execution client Engine API http endpoint")

--- a/halo/cmd/testdata/TestCLIReference_rollback.golden
+++ b/halo/cmd/testdata/TestCLIReference_rollback.golden
@@ -18,6 +18,7 @@ Flags:
       --engine-jwt-file string                    The path to the Engine API JWT file
       --evm-build-delay duration                  Minimum delay between triggering and fetching a EVM payload build (default 600ms)
       --evm-build-optimistic                      Enables optimistic building of EVM payloads on previous block finalize (default true)
+      --feature-flags strings                     Comma separated list of enabled feature flags
       --grpc-address string                       Address defines the GRPC server to listen on (default "0.0.0.0:9090")
       --grpc-enable                               Enable defines if the GRPC server should be enabled. (default true)
       --hard                                      Remove last block as well as state

--- a/halo/cmd/testdata/TestCLIReference_run.golden
+++ b/halo/cmd/testdata/TestCLIReference_run.golden
@@ -11,6 +11,7 @@ Flags:
       --engine-jwt-file string                    The path to the Engine API JWT file
       --evm-build-delay duration                  Minimum delay between triggering and fetching a EVM payload build (default 600ms)
       --evm-build-optimistic                      Enables optimistic building of EVM payloads on previous block finalize (default true)
+      --feature-flags strings                     Comma separated list of enabled feature flags
       --grpc-address string                       Address defines the GRPC server to listen on (default "0.0.0.0:9090")
       --grpc-enable                               Enable defines if the GRPC server should be enabled. (default true)
   -h, --help                                      help for run

--- a/halo/cmd/testdata/TestRunCmd_defaults.golden
+++ b/halo/cmd/testdata/TestRunCmd_defaults.golden
@@ -24,6 +24,7 @@
   "Enable": true,
   "Address": "0.0.0.0:9090"
  },
+ "FeatureFlags": [],
  "Comet": {
   "Version": "0.38.15",
   "RootDir": "./halo",

--- a/halo/cmd/testdata/TestRunCmd_flags.golden
+++ b/halo/cmd/testdata/TestRunCmd_flags.golden
@@ -24,6 +24,7 @@
   "Enable": true,
   "Address": "0.0.0.0:9090"
  },
+ "FeatureFlags": [],
  "Comet": {
   "Version": "0.38.15",
   "RootDir": "foo",

--- a/halo/cmd/testdata/TestRunCmd_json_files.golden
+++ b/halo/cmd/testdata/TestRunCmd_json_files.golden
@@ -24,6 +24,7 @@
   "Enable": true,
   "Address": "0.0.0.0:9090"
  },
+ "FeatureFlags": [],
  "Comet": {
   "Version": "0.38.15",
   "RootDir": "testinput/input2",

--- a/halo/cmd/testdata/TestRunCmd_toml_files.golden
+++ b/halo/cmd/testdata/TestRunCmd_toml_files.golden
@@ -27,6 +27,10 @@
   "Enable": true,
   "Address": "grpc/toml"
  },
+ "FeatureFlags": [
+  "a",
+  "b"
+ ],
  "Comet": {
   "Version": "0.38.15",
   "RootDir": "testinput/input1",

--- a/halo/cmd/testinput/input1/config/halo.toml
+++ b/halo/cmd/testinput/input1/config/halo.toml
@@ -1,6 +1,6 @@
 engine-jwt-file="jwt.toml"
 
-
+feature-flags=["a","b"]
 
 snapshot-interval=999
 

--- a/halo/config/config.go
+++ b/halo/config/config.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/omni-network/omni/lib/buildinfo"
 	"github.com/omni-network/omni/lib/errors"
+	"github.com/omni-network/omni/lib/feature"
 	"github.com/omni-network/omni/lib/log"
 	"github.com/omni-network/omni/lib/netconf"
 	"github.com/omni-network/omni/lib/tracer"
@@ -65,6 +66,7 @@ func DefaultConfig() Config {
 		Tracer:             tracer.DefaultConfig(),
 		SDKAPI:             RPCConfig{Enable: defaultAPIEnable, Address: defaultAPIAddress},
 		SDKGRPC:            RPCConfig{Enable: defaultGRPCEnable, Address: defaultGRPCAddress},
+		FeatureFlags:       feature.Flags{}, // Zero enabled flags by default (note not nil).
 	}
 }
 
@@ -86,6 +88,7 @@ type Config struct {
 	UnsafeSkipUpgrades []int
 	SDKAPI             RPCConfig `mapstructure:"api"`
 	SDKGRPC            RPCConfig `mapstructure:"grpc"`
+	FeatureFlags       feature.Flags
 }
 
 // RPCConfig is an abridged version of CosmosSDK srvconfig.API/GRPCConfig.

--- a/halo/config/config.toml.tmpl
+++ b/halo/config/config.toml.tmpl
@@ -8,6 +8,8 @@ version = "{{ .Version }}"
 # Omni network to participate in: mainnet, testnet, or devnet.
 network = "{{ .Network }}"
 
+{{ if .FeatureFlags }}feature-flags = {{ .FeatureFlags.FormatToml }}
+{{ end -}}
 #######################################################################
 ###                       Halo Octane Options                       ###
 #######################################################################

--- a/halo/config/config_test.go
+++ b/halo/config/config_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	halocfg "github.com/omni-network/omni/halo/config"
+	"github.com/omni-network/omni/lib/feature"
 	"github.com/omni-network/omni/lib/log"
 	"github.com/omni-network/omni/lib/netconf"
 	"github.com/omni-network/omni/lib/tutil"
@@ -37,6 +38,7 @@ func TestDefaultConfigReference(t *testing.T) {
 					"mock": "http://mock_rpc:8545",
 				}
 				cfg.UnsafeSkipUpgrades = []int{1, 2, 3}
+				cfg.FeatureFlags = feature.Flags{"a", "b"}
 
 				return cfg
 			},

--- a/halo/config/testdata/test_halo.toml
+++ b/halo/config/testdata/test_halo.toml
@@ -8,6 +8,7 @@ version = "main"
 # Omni network to participate in: mainnet, testnet, or devnet.
 network = "omega"
 
+feature-flags = ["a","b"]
 #######################################################################
 ###                       Halo Octane Options                       ###
 #######################################################################

--- a/halo/evmstaking/evmstaking.go
+++ b/halo/evmstaking/evmstaking.go
@@ -1,4 +1,5 @@
 // Package evmstaking monitors the Staking pre-deploy contract and converts
+// Package evmstaking monitors the Staking pre-deploy contract and converts
 // its log events to cosmosSDK x/staking logic.
 package evmstaking
 

--- a/lib/feature/feature.go
+++ b/lib/feature/feature.go
@@ -1,0 +1,70 @@
+package feature
+
+import (
+	"context"
+
+	"github.com/omni-network/omni/lib/log"
+)
+
+const (
+	// FlagEVMStakingModule enables the wip EVM Staking Module feature.
+	FlagEVMStakingModule Flag = "evm-staking-module"
+)
+
+var allFlags = map[Flag]bool{
+	FlagEVMStakingModule: true,
+}
+
+// Flag is a feature flag.
+type Flag string
+
+// Enabled returns true if the flag is enabled in the context.
+func (f Flag) Enabled(ctx context.Context) bool {
+	return enabled(ctx, f)
+}
+
+type key struct{}
+
+// WithFlags returns a copy of the context with the given flags enabled.
+// Note that this should only be called once on app startup.
+// Multiple calls will overwrite the existing flags.
+func WithFlags(ctx context.Context, flags Flags) context.Context {
+	var enabled []Flag
+	for _, f := range flags.Typed() {
+		if !allFlags[f] {
+			// Don't error, just log, this ensures flags can be safely removed.
+			log.Warn(ctx, "Ignoring unknown feature flag", nil, "flag", f)
+			continue
+		}
+		enabled = append(enabled, f)
+	}
+
+	if len(enabled) == 0 {
+		return ctx
+	}
+
+	log.Info(ctx, "Enabling feature flags", "flags", enabled)
+
+	return context.WithValue(ctx, key{}, enabled)
+}
+
+// WithFlag is a convenience function for testing to enable single flags.
+func WithFlag(ctx context.Context, flag Flag) context.Context {
+	return WithFlags(ctx, Flags{string(flag)})
+}
+
+// enabled returns true if the given flag is enabled in the context.
+func enabled(ctx context.Context, flag Flag) bool {
+	flags, ok := ctx.Value(key{}).([]Flag)
+	if !ok {
+		return false
+	}
+
+	for _, f := range flags {
+		if f == flag {
+			return true
+		}
+	}
+
+	return false
+}

--- a/lib/feature/feature_test.go
+++ b/lib/feature/feature_test.go
@@ -1,0 +1,25 @@
+package feature_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/omni-network/omni/lib/feature"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestFlags(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	// No flags enabled
+	require.False(t, feature.FlagEVMStakingModule.Enabled(ctx))
+
+	// Single flag enabled
+	ctx = feature.WithFlag(ctx, feature.FlagEVMStakingModule)
+	require.True(t, feature.FlagEVMStakingModule.Enabled(ctx))
+
+	// Unknown flags are ignored (and don't overwrite existing)
+	ctx = feature.WithFlags(ctx, feature.Flags{"ignore", "us"})
+	require.True(t, feature.FlagEVMStakingModule.Enabled(ctx))
+}

--- a/lib/feature/flags.go
+++ b/lib/feature/flags.go
@@ -1,0 +1,33 @@
+package feature
+
+import (
+	"strings"
+
+	"github.com/spf13/pflag"
+)
+
+// Flags is a convenience type for a slice of flags providing easy formatting to TOML and usage with spf13 flags.
+type Flags []string
+
+func (f Flags) FormatToml() string {
+	var resp []string
+	for _, flag := range f {
+		resp = append(resp, `"`+flag+`"`)
+	}
+
+	return "[" + strings.Join(resp, ",") + "]"
+}
+
+func (f Flags) Typed() []Flag {
+	var resp []Flag
+	for _, flag := range f {
+		resp = append(resp, Flag(flag))
+	}
+
+	return resp
+}
+
+// BindFlag binds the network identifier flag.
+func BindFlag(set *pflag.FlagSet, flags *Flags) {
+	set.StringSliceVar((*[]string)(flags), "feature-flags", *flags, "Comma separated list of enabled feature flags")
+}


### PR DESCRIPTION
Add support for feature flags via a new `feature` package. Also add support to enable feature flags in manifests with the aim of having dedicated manifests with WIP features so that CI tests them.

issue: none