### PR TITLE
fix(halo/attest): delete empty attestations on double-sign detection

### DIFF
--- a/halo/attest/keeper/keeper_test.go
+++ b/halo/attest/keeper/keeper_test.go
@@ -196,12 +196,7 @@ func TestKeeper_Add(t *testing.T) {
 			want: want{
 				atts: []*keeper.Attestation{
 					expectPendingAtt(1, defaultOffset, 1), // Default agg vote resulting in pending attestation.
-					update( // Update agg vote resulting in second att with different root
-						expectPendingAtt(2, defaultOffset, 1),
-						func(att *keeper.Attestation) {
-							att.MsgRoot = common.BytesToHash([]byte("different root")).Bytes()
-						},
-					),
+					// Second att not added, since no valid sigs added
 				},
 				sigs: []*keeper.Signature{
 					expectValSig(1, 1, val1, defaultOffset),


### PR DESCRIPTION
- Issue: Attestations were created even if double signing was detected, allowing malicious validators to spam the database with invalid data.
- Cause: Attestation creation was not rolled back if no valid signature was stored due to double sign detection.
- Solution: Added logic to delete the attestation if it was created but no signatures were added, preventing the spam of invalid data in the DB as suggested by @corverroos in https://github.com/omni-network/omni/issues/2488#:~:text=Proposed%20Solution-,In%20addOne%2C%20delete%20the%20attestation%20if%20it%20was%20created%20but%20signatures%20were%20inserted.,-corverroos%20added%20the

issue: fixes #2488 
