### PR TITLE
fix(octane/evmengine): reject payloads with deposits

### DIFF
--- a/octane/evmengine/keeper/keeper.go
+++ b/octane/evmengine/keeper/keeper.go
@@ -122,6 +122,11 @@ func (k *Keeper) parseAndVerifyProposedPayload(ctx context.Context, msg *types.M
 		return engine.ExecutableData{}, errors.New("withdrawals not allowed in payload")
 	}
 
+	// Ensure no deposits are included in the payload.
+	if len(payload.Deposits) > 0 {
+		return engine.ExecutableData{}, errors.New("deposits not allowed in payload")
+	}
+
 	// Ensure fee recipient using provider
 	if err := k.feeRecProvider.VerifyFeeRecipient(payload.FeeRecipient); err != nil {
 		return engine.ExecutableData{}, errors.Wrap(err, "verify proposed fee recipient")


### PR DESCRIPTION
Reject execution payloads with deposits since they are not supported.

issue: #2481