### PR TITLE
ci(e2e): explicit supported geth versions

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,7 @@ repos:
     rev: v4.6.0
     hooks:
       - id: check-added-large-files # No large files
-        exclude: "(lib/netconf/.*/.*|contracts/allocs/.*)"
+        exclude: "(lib/netconf/.*/.*|contracts/allocs/.*|halo/genutil/evm/testdata/.*)"
       - id: trailing-whitespace # trims trailing whitespace
         exclude: "testdata"
       - id: end-of-file-fixer # ensures that a file is either empty, or ends with one newline

--- a/e2e/app/geth/config.go
+++ b/e2e/app/geth/config.go
@@ -2,12 +2,12 @@ package geth
 
 import (
 	"encoding/hex"
-	"encoding/json"
 	"os"
 	"path/filepath"
 	"time"
 
 	"github.com/omni-network/omni/e2e/types"
+	evmgenutil "github.com/omni-network/omni/halo/genutil/evm"
 	"github.com/omni-network/omni/lib/errors"
 
 	"github.com/ethereum/go-ethereum/core"
@@ -22,7 +22,7 @@ const snapshotCacheMB = 1024
 
 // WriteAllConfig writes all the geth config files for all omniEVMs.
 func WriteAllConfig(testnet types.Testnet, genesis core.Genesis) error {
-	gethGenesisBz, err := json.MarshalIndent(genesis, "", "  ")
+	gethGenesisBz, err := evmgenutil.MarshallBackwardsCompatible(genesis)
 	if err != nil {
 		return errors.Wrap(err, "marshal genesis")
 	}

--- a/e2e/app/geth/types.go
+++ b/e2e/app/geth/types.go
@@ -16,6 +16,15 @@ import (
 // Version defines the geth version deployed to all networks.
 const Version = "v1.14.12"
 
+// SupportedVersions are the supported older geth versions.
+// These are tested in backwards.toml.
+var SupportedVersions = []string{
+	"v1.14.11",
+	"v1.14.8",
+	"v1.14.7",
+	"v1.14.6",
+}
+
 // Config is the configurable options for the standard omni geth config.
 type Config struct {
 	// Moniker is the p2p node name.

--- a/e2e/app/geth/types_test.go
+++ b/e2e/app/geth/types_test.go
@@ -1,0 +1,15 @@
+package geth_test
+
+import (
+	"testing"
+
+	"github.com/omni-network/omni/e2e/app/geth"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestVersions(t *testing.T) {
+	t.Parallel()
+	require.Len(t, geth.SupportedVersions, 4) // Only support (max) 4 versions
+	require.NotContains(t, geth.SupportedVersions, geth.Version)
+}

--- a/e2e/app/perturb.go
+++ b/e2e/app/perturb.go
@@ -73,6 +73,16 @@ func perturbService(ctx context.Context, service string, testnetDir string, pert
 		if err := docker.ExecCompose(ctx, testnetDir, "exec", service, "wget", "-O-", "localhost:8545/fuzzy_disable"); err != nil {
 			return errors.Wrap(err, "disable fuzzy head")
 		}
+	case types.PerturbUpgrade:
+		if err := docker.ExecCompose(ctx, testnetDir, "down", service); err != nil {
+			return errors.Wrap(err, "down service")
+		}
+		if err := docker.ReplaceUpgradeImage(testnetDir, service); err != nil {
+			return errors.Wrap(err, "upgrade service")
+		}
+		if err := docker.ExecCompose(ctx, testnetDir, "up", "-d", service); err != nil {
+			return errors.Wrap(err, "up service")
+		}
 	default:
 		return errors.New("unknown service perturbation")
 	}

--- a/e2e/app/setup.go
+++ b/e2e/app/setup.go
@@ -73,7 +73,7 @@ func Setup(ctx context.Context, def Definition, depCfg DeployConfig) error {
 	if err != nil {
 		return errors.Wrap(err, "make genesis")
 	}
-	gethGenesisBz, err := json.MarshalIndent(gethGenesis, "", "  ")
+	gethGenesisBz, err := evmgenutil.MarshallBackwardsCompatible(gethGenesis)
 	if err != nil {
 		return errors.Wrap(err, "marshal genesis")
 	}

--- a/e2e/docker/compose.yaml.tmpl
+++ b/e2e/docker/compose.yaml.tmpl
@@ -64,12 +64,12 @@ services:
 {{- end}}
 
   # Use geth as the omni EVMs.
-{{- range .OmniEVMs }}
+{{- range $i, $v := .OmniEVMs }}
   {{ .InstanceName }}:
     labels:
       e2e: true
     container_name: {{ .InstanceName }}
-    image: "ethereum/client-go:{{ $.GethTag }}"
+    image: ethereum/client-go:{{ $.InitialGethTag $i }}{{if $.UpgradeGeth $i}} # Upgrade {{ .InstanceName }}:ethereum/client-go:{{ $.UpgradeGethTag }}{{end}}
     restart: unless-stopped
     command:
       - --config=/geth/config.toml

--- a/e2e/docker/docker_test.go
+++ b/e2e/docker/docker_test.go
@@ -56,6 +56,7 @@ func TestComposeTemplate(t *testing.T) {
 			en := enode.NewV4(&key.PublicKey, ipNet.IP, 30303, 30303)
 
 			const node0 = "node0"
+			const evm0 = "omni_evm_0"
 			dir := t.TempDir()
 			testnet := types.Testnet{
 				Manifest: types.Manifest{
@@ -78,7 +79,7 @@ func TestComposeTemplate(t *testing.T) {
 				OmniEVMs: []types.OmniEVM{
 					{
 						Chain:        types.OmniEVMByNetwork(netconf.Simnet),
-						InstanceName: "omni_evm_0",
+						InstanceName: evm0,
 						AdvertisedIP: ipNet.IP,
 						ProxyPort:    8000,
 						NodeKey:      key,
@@ -116,6 +117,7 @@ func TestComposeTemplate(t *testing.T) {
 
 			if test.upgrade != "" {
 				testnet.UpgradeVersion = test.upgrade
+				testnet.Manifest.Perturb = map[string][]types.Perturb{evm0: {types.PerturbUpgrade}}
 			}
 
 			p := docker.NewProvider(testnet, types.InfrastructureData{}, test.tag)
@@ -136,6 +138,8 @@ func TestComposeTemplate(t *testing.T) {
 					return
 				}
 				require.NoError(t, err)
+
+				require.NoError(t, docker.ReplaceUpgradeImage(dir, evm0))
 
 				bz, err := os.ReadFile(filepath.Join(dir, "docker-compose.yaml"))
 				require.NoError(t, err)

--- a/e2e/docker/testdata/TestComposeTemplate_commit.golden
+++ b/e2e/docker/testdata/TestComposeTemplate_commit.golden
@@ -76,7 +76,7 @@ services:
     labels:
       e2e: true
     container_name: omni_evm_0
-    image: "ethereum/client-go:v1.14.12"
+    image: ethereum/client-go:v1.14.12
     restart: unless-stopped
     command:
       - --config=/geth/config.toml

--- a/e2e/docker/testdata/TestComposeTemplate_empheral_network.golden
+++ b/e2e/docker/testdata/TestComposeTemplate_empheral_network.golden
@@ -76,7 +76,7 @@ services:
     labels:
       e2e: true
     container_name: omni_evm_0
-    image: "ethereum/client-go:v1.14.12"
+    image: ethereum/client-go:v1.14.11 # Upgrade omni_evm_0:ethereum/client-go:v1.14.12
     restart: unless-stopped
     command:
       - --config=/geth/config.toml

--- a/e2e/docker/testdata/TestComposeTemplate_empheral_network_upgrade.golden
+++ b/e2e/docker/testdata/TestComposeTemplate_empheral_network_upgrade.golden
@@ -76,7 +76,7 @@ services:
     labels:
       e2e: true
     container_name: omni_evm_0
-    image: "ethereum/client-go:v1.14.12"
+    image: ethereum/client-go:v1.14.12
     restart: unless-stopped
     command:
       - --config=/geth/config.toml

--- a/e2e/manifests/backwards.toml
+++ b/e2e/manifests/backwards.toml
@@ -15,3 +15,9 @@ perturb = ["upgrade"]
 [node.validator04]
 version="omniops/halovisor:v0.9.0"
 perturb = ["upgrade"]
+
+[perturb]
+validator01_evm = ["upgrade"]
+validator02_evm = ["upgrade"]
+validator03_evm = ["upgrade"]
+validator04_evm = ["upgrade"]

--- a/e2e/types/manifest.go
+++ b/e2e/types/manifest.go
@@ -59,7 +59,8 @@ const (
 	PerturbStopStart Perturb = "stopstart"
 	// PerturbRollback defines a perturbation that stops a halo node, performs a rollback, then starts it again.
 	PerturbRollback Perturb = "rollback"
-	// PerturbUpgrade defines a perturbation that upgrades a halo node to the latest image tag.
+	// PerturbUpgrade defines a perturbation that upgrades a geth node to the latest version.
+	// Note that halo upgrades are handled by CometBFT perturbations.
 	PerturbUpgrade Perturb = "upgrade"
 
 	// PerturbFuzzyHeadDropBlocks defines a perturbation that enables fuzzyhead dropping xblock for a while.

--- a/e2e/vmcompose/testdata/TestSetup_127-0-0-1-compose.yaml.golden
+++ b/e2e/vmcompose/testdata/TestSetup_127-0-0-1-compose.yaml.golden
@@ -33,7 +33,7 @@ services:
     labels:
       e2e: true
     container_name: validator01_evm
-    image: "ethereum/client-go:v1.14.12"
+    image: ethereum/client-go:v1.14.12
     restart: unless-stopped
     command:
       - --config=/geth/config.toml

--- a/e2e/vmcompose/testdata/TestSetup_127-0-0-2-compose.yaml.golden
+++ b/e2e/vmcompose/testdata/TestSetup_127-0-0-2-compose.yaml.golden
@@ -33,7 +33,7 @@ services:
     labels:
       e2e: true
     container_name: validator02_evm
-    image: "ethereum/client-go:v1.14.12"
+    image: ethereum/client-go:v1.14.12
     restart: unless-stopped
     command:
       - --config=/geth/config.toml

--- a/e2e/vmcompose/testdata/TestSetup_127-0-0-4-compose.yaml.golden
+++ b/e2e/vmcompose/testdata/TestSetup_127-0-0-4-compose.yaml.golden
@@ -33,7 +33,7 @@ services:
     labels:
       e2e: true
     container_name: seed01_evm
-    image: "ethereum/client-go:v1.14.12"
+    image: ethereum/client-go:v1.14.12
     restart: unless-stopped
     command:
       - --config=/geth/config.toml

--- a/e2e/vmcompose/testdata/TestSetup_127-0-0-5-compose.yaml.golden
+++ b/e2e/vmcompose/testdata/TestSetup_127-0-0-5-compose.yaml.golden
@@ -33,7 +33,7 @@ services:
     labels:
       e2e: true
     container_name: fullnode01_evm
-    image: "ethereum/client-go:v1.14.12"
+    image: ethereum/client-go:v1.14.12
     restart: unless-stopped
     command:
       - --config=/geth/config.toml

--- a/halo/genutil/evm/evm_test.go
+++ b/halo/genutil/evm/evm_test.go
@@ -20,4 +20,11 @@ func TestMakeEVMGenesis(t *testing.T) {
 	genesis, err := evm.MakeGenesis(netconf.Staging)
 	require.NoError(t, err)
 	tutil.RequireGoldenJSON(t, genesis)
+
+	t.Run("backwards", func(t *testing.T) {
+		t.Parallel()
+		backwards, err := evm.MarshallBackwardsCompatible(genesis)
+		require.NoError(t, err)
+		tutil.RequireGoldenBytes(t, backwards)
+	})
 }


### PR DESCRIPTION
Add explicit supported geth versions. Ensure backwards compatibility in backwards.toml.

issue: none