### PR TITLE
test(e2e): fix tests

### DIFF
--- a/halo/genutil/evm/evm_test.go
+++ b/halo/genutil/evm/evm_test.go
@@ -23,6 +23,7 @@ func TestMakeEVMGenesis(t *testing.T) {
 
 	t.Run("backwards", func(t *testing.T) {
 		t.Parallel()
+		genesis.Alloc = nil // Clear allocs since it is HUGE and not important for this test.
 		backwards, err := evm.MarshallBackwardsCompatible(genesis)
 		require.NoError(t, err)
 		tutil.RequireGoldenBytes(t, backwards)


### PR DESCRIPTION
Backwards tests restarts all geths. This causes txmgr to fail submitting portalregistrations since it doesn't return a network error but EOF, catch and handle this.

EVM genesis test golden wasn't updated in recent PR, also make it smaller.

issue: none