### PR TITLE
chore(lib/ethclient): remove holesky wait delay

### DIFF
--- a/lib/ethclient/ethbackend/backend.go
+++ b/lib/ethclient/ethbackend/backend.go
@@ -12,7 +12,6 @@ import (
 	"github.com/omni-network/omni/lib/anvil"
 	"github.com/omni-network/omni/lib/errors"
 	"github.com/omni-network/omni/lib/ethclient"
-	"github.com/omni-network/omni/lib/evmchain"
 	"github.com/omni-network/omni/lib/fireblocks"
 	"github.com/omni-network/omni/lib/k1util"
 	"github.com/omni-network/omni/lib/log"
@@ -176,12 +175,6 @@ func (b *Backend) WaitMined(ctx context.Context, tx *ethtypes.Transaction) (*eth
 		return nil, errors.Wrap(err, "wait mined", "chain", b.chainName)
 	} else if rec.Status != ethtypes.ReceiptStatusSuccessful {
 		return rec, errors.New("receipt status unsuccessful", "status", rec.Status, "tx", tx.Hash())
-	}
-
-	// If b.chainID == holesky, wait a little longer for the tx to be indexed.
-	if b.chainID == evmchain.IDHolesky {
-		log.Debug(ctx, "Waiting extra 12 seconds (~1 block) for tx to be indexed on Holesky")
-		time.Sleep(time.Second * 12)
 	}
 
 	return rec, nil


### PR DESCRIPTION
The 12 second wait applied to Holesky contract deployments did not solve the issues we're seeing in Staging deployments.

issue: none