### PR TITLE
feat(halo/evmstaking2): integrate delegation delivery code

### DIFF
--- a/halo/evmstaking2/keeper/helpers.go
+++ b/halo/evmstaking2/keeper/helpers.go
@@ -1,8 +1,13 @@
 package keeper
 
 import (
+	"math/big"
+
 	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+
+	"cosmossdk.io/math"
+	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
 // mustGetABI returns the metadata's ABI as an abi.ABI type.
@@ -25,4 +30,11 @@ func mustGetEvent(abi *abi.ABI, name string) abi.Event {
 	}
 
 	return event
+}
+
+// omniToBondCoin converts the $OMNI amount into a $STAKE coin.
+// TODO(corver): At this point, it is 1-to1, but this might change in the future.
+func omniToBondCoin(amount *big.Int) (sdk.Coin, sdk.Coins) {
+	coin := sdk.NewCoin(sdk.DefaultBondDenom, math.NewIntFromBigInt(amount))
+	return coin, sdk.NewCoins(coin)
 }

--- a/halo/evmstaking2/keeper/helpers.go
+++ b/halo/evmstaking2/keeper/helpers.go
@@ -3,6 +3,8 @@ package keeper
 import (
 	"math/big"
 
+	"github.com/omni-network/omni/lib/errors"
+
 	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 
@@ -37,4 +39,15 @@ func mustGetEvent(abi *abi.ABI, name string) abi.Event {
 func omniToBondCoin(amount *big.Int) (sdk.Coin, sdk.Coins) {
 	coin := sdk.NewCoin(sdk.DefaultBondDenom, math.NewIntFromBigInt(amount))
 	return coin, sdk.NewCoins(coin)
+}
+
+// catch executes the function, returning an error if it panics.
+func catch(fn func() error) (err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			err = errors.New("recovered", "panic", r)
+		}
+	}()
+
+	return fn()
 }

--- a/halo/evmstaking2/keeper/keeper_internal_test.go
+++ b/halo/evmstaking2/keeper/keeper_internal_test.go
@@ -93,7 +93,14 @@ func setupKeeper(t *testing.T, submissionDelay int64) (*Keeper, sdk.Context) {
 	ctx = ctx.WithBlockHeight(1)
 	ctx = ctx.WithChainID(netconf.Simnet.Static().OmniConsensusChainIDStr())
 
-	k, err := NewKeeper(storeSvc, nil, submissionDelay)
+	k, err := NewKeeper(
+		storeSvc,
+		nil,
+		nil,
+		nil,
+		nil,
+		submissionDelay,
+	)
 	require.NoError(t, err, "new keeper")
 
 	return k, ctx

--- a/halo/evmstaking2/module/module.go
+++ b/halo/evmstaking2/module/module.go
@@ -14,6 +14,9 @@ import (
 	"github.com/cosmos/cosmos-sdk/codec"
 	cdctypes "github.com/cosmos/cosmos-sdk/codec/types"
 	"github.com/cosmos/cosmos-sdk/types/module"
+	accountkeeper "github.com/cosmos/cosmos-sdk/x/auth/keeper"
+	bankkeeper "github.com/cosmos/cosmos-sdk/x/bank/keeper"
+	stakingkeeper "github.com/cosmos/cosmos-sdk/x/staking/keeper"
 	"github.com/grpc-ecosystem/grpc-gateway/runtime"
 )
 
@@ -113,6 +116,9 @@ type ModuleInputs struct {
 
 	StoreService store.KVStoreService
 	EthCl        ethclient.Client
+	AKeeper      accountkeeper.AccountKeeperI
+	BKeeper      bankkeeper.Keeper
+	SKeeper      *stakingkeeper.Keeper
 	Cdc          codec.Codec
 	Config       *Module
 }
@@ -128,6 +134,9 @@ func ProvideModule(in ModuleInputs) (ModuleOutputs, error) {
 	k, err := keeper.NewKeeper(
 		in.StoreService,
 		in.EthCl,
+		in.AKeeper,
+		in.BKeeper,
+		in.SKeeper,
 		in.Config.GetDeliverInterval(),
 	)
 	if err != nil {


### PR DESCRIPTION
- Introduces a new method `processBufferedEvent` that clones the state and tries to deliver the passed EVM event
- Integrates the implementation of `deliverDelegate` function from `evmstaking` package

issue: #2525