### PR TITLE
feat(cli): add AVS operator deregistration cmd

### DIFF
--- a/cli/cmd/cmd.go
+++ b/cli/cmd/cmd.go
@@ -29,6 +29,7 @@ func newOperatorCmds() *cobra.Command {
 
 	cmd.AddCommand(
 		newRegisterCmd(),
+		newDeregisterCmd(),
 		newInitCmd(),
 		newCreateValCmd(),
 		newCreateOperatorKeyCmd(),
@@ -55,6 +56,32 @@ Note the operator must already be registered with Eigen-Layer.`,
 			err := Register(cmd.Context(), cfg)
 			if err != nil {
 				return errors.Wrap(err, "registration failed")
+			}
+
+			return nil
+		},
+	}
+
+	bindRegConfig(cmd, &cfg)
+
+	return cmd
+}
+
+func newDeregisterCmd() *cobra.Command {
+	var cfg RegConfig
+
+	cmd := &cobra.Command{
+		Use:   "deregister",
+		Short: "Deregister an operator from the Omni AVS contract",
+		Long: `Deregister command expects a EigenLayer yaml config file as an argument
+to successfully deregister an operator from the Omni AVS contract.
+
+Note the operator must already be registered on the Omni AVS contract.`,
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			err := Deregister(cmd.Context(), cfg)
+			if err != nil {
+				return errors.Wrap(err, "deregistration failed")
 			}
 
 			return nil

--- a/lib/contracts/avs/register.go
+++ b/lib/contracts/avs/register.go
@@ -98,3 +98,27 @@ func verifyRegisterOperator(ctx context.Context, avs *bindings.OmniAVS, operator
 
 	return nil
 }
+
+func DeregisterOperatorFromAVS(ctx context.Context, addr common.Address, backend *ethbackend.Backend, operator common.Address) error {
+	avs, err := bindings.NewOmniAVS(addr, backend)
+	if err != nil {
+		return errors.Wrap(err, "new avs")
+	}
+
+	txOpts, err := backend.BindOpts(ctx, operator)
+	if err != nil {
+		return err
+	}
+
+	tx, err := avs.DeregisterOperator(txOpts)
+	if err != nil {
+		return errors.Wrap(err, "deregister operator")
+	}
+
+	_, err = backend.WaitMined(ctx, tx)
+	if err != nil {
+		return errors.Wrap(err, "wait mined")
+	}
+
+	return nil
+}


### PR DESCRIPTION
Added a CLI command to deregister an operator from the AVS contracts.

issue: https://github.com/omni-network/ops/issues/601