### PR TITLE
fix(relayer/cursor): dont overwrite existing

### DIFF
--- a/relayer/app/cursor/cursors_internal_test.go
+++ b/relayer/app/cursor/cursors_internal_test.go
@@ -65,9 +65,13 @@ func TestStore(t *testing.T) {
 		if msgOffset != 0 {
 			msgs = append(msgs, xchain.Msg{MsgID: xchain.MsgID{StreamID: stream, StreamOffset: msgOffset}})
 		}
-		err := store.Save(ctx, stream.ChainVersion(), stream.DestChainID, attOffset, map[xchain.StreamID][]xchain.Msg{
+		err := store.Insert(ctx, stream.ChainVersion(), stream.DestChainID, attOffset, map[xchain.StreamID][]xchain.Msg{
 			stream: msgs,
 		})
+		require.NoError(t, err)
+
+		// Subsequent insert should be no-op
+		err = store.Insert(ctx, stream.ChainVersion(), stream.DestChainID, attOffset, map[xchain.StreamID][]xchain.Msg{})
 		require.NoError(t, err)
 	}
 

--- a/relayer/app/worker.go
+++ b/relayer/app/worker.go
@@ -134,6 +134,8 @@ func (w *Worker) runOnce(ctx context.Context) error {
 				"bootstrap", stored[chainVer],
 			)
 			attestOffsets[chainVer] = stored[chainVer]
+			// Note that technically, we could start streaming from storedOffset+1,
+			// Since confirmed cursors are fully finalized, so no need to reprocess partial submissions.
 		}
 	}
 
@@ -244,7 +246,7 @@ func (w *Worker) newCallback(
 
 	return func(ctx context.Context, att xchain.Attestation) error {
 		saveCursors := func(streamMsgs map[xchain.StreamID][]xchain.Msg) error {
-			return w.cursors.Save(ctx, streamerChainVer, w.destChain.ID, att.AttestOffset, streamMsgs)
+			return w.cursors.Insert(ctx, streamerChainVer, w.destChain.ID, att.AttestOffset, streamMsgs)
 		}
 
 		block, ok, err := fetchXBlock(ctx, w.xProvider, att)


### PR DESCRIPTION
Don't overwrite existing cursors. Just check if offsets are identical.

This fixes the following problem:
- Cursor X is inserted into the DB
- Cursor X is confirmed (so it is the only cursor for this streamer).
- Worker resets, starts streaming from X (inclusive)
- Cursor X is overwritten (resetting it to unconfirmed).
- Worker resets (before cursor can be confirmed). In this case, there are no confirmed cursors.
- So worker starts streaming from MUCH lower height (overloading archive node).
- MUCH lower cursors become new confirmed height.

We could also start streaming from X+1 instead, since confirmed cursors are fully finalized, so no need to reprocess to handle partial submissions.

issue: none