### PR TITLE
ci(e2e/geth): limit omni evm gas tips

### DIFF
--- a/e2e/app/geth/config.go
+++ b/e2e/app/geth/config.go
@@ -2,6 +2,7 @@ package geth
 
 import (
 	"encoding/hex"
+	"math/big"
 	"os"
 	"path/filepath"
 	"time"
@@ -13,6 +14,7 @@ import (
 	"github.com/ethereum/go-ethereum/core"
 	ethcrypto "github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/eth/downloader"
+	"github.com/ethereum/go-ethereum/params"
 )
 
 // snapshotCacheMB increases the default snapshot cache size of 102MB.
@@ -79,7 +81,7 @@ func WriteConfigTOML(conf Config, path string) error {
 // MakeGethConfig returns the full omni geth config for the provided custom config.
 func MakeGethConfig(conf Config) FullConfig {
 	cfg := defaultGethConfig()
-	cfg.Eth.RPCTxFeeCap = 100 // 100 OMNI
+	cfg.Eth.GPO.MaxPrice = big.NewInt(params.GWei) // Very low gas tip cap (1gwei), blocks are far from half full.
 	cfg.Eth.NetworkId = conf.ChainID
 	cfg.Node.DataDir = "/geth" // Mount inside docker container
 	cfg.Node.IPCPath = "/geth/geth.ipc"

--- a/e2e/app/geth/testdata/TestWriteConfigTOML_archive.golden
+++ b/e2e/app/geth/testdata/TestWriteConfigTOML_archive.golden
@@ -21,7 +21,7 @@ VMTrace = ""
 VMTraceJsonConfig = ""
 RPCGasCap = 50000000
 RPCEVMTimeout = 5000000000
-RPCTxFeeCap = 1e+02
+RPCTxFeeCap = 1e+00
 
 [Eth.Miner]
 GasCeil = 30000000
@@ -51,7 +51,7 @@ Blocks = 20
 Percentile = 60
 MaxHeaderHistory = 1024
 MaxBlockHistory = 1024
-MaxPrice = 500000000000
+MaxPrice = 1000000000
 IgnorePrice = 2
 
 [Node]

--- a/e2e/app/geth/testdata/TestWriteConfigTOML_full.golden
+++ b/e2e/app/geth/testdata/TestWriteConfigTOML_full.golden
@@ -21,7 +21,7 @@ VMTrace = ""
 VMTraceJsonConfig = ""
 RPCGasCap = 50000000
 RPCEVMTimeout = 5000000000
-RPCTxFeeCap = 1e+02
+RPCTxFeeCap = 1e+00
 
 [Eth.Miner]
 GasCeil = 30000000
@@ -51,7 +51,7 @@ Blocks = 20
 Percentile = 60
 MaxHeaderHistory = 1024
 MaxBlockHistory = 1024
-MaxPrice = 500000000000
+MaxPrice = 1000000000
 IgnorePrice = 2
 
 [Node]

--- a/e2e/app/geth/testdata/default_config.toml
+++ b/e2e/app/geth/testdata/default_config.toml
@@ -21,7 +21,7 @@ VMTrace = ""
 VMTraceJsonConfig = ""
 RPCGasCap = 50000000
 RPCEVMTimeout = 5000000000
-RPCTxFeeCap = 1e+02
+RPCTxFeeCap = 1e+00
 
 [Eth.Miner]
 GasCeil = 30000000
@@ -51,7 +51,7 @@ Blocks = 20
 Percentile = 60
 MaxHeaderHistory = 1024
 MaxBlockHistory = 1024
-MaxPrice = 500000000000
+MaxPrice = 1000000000
 IgnorePrice = 2
 
 [Node]


### PR DESCRIPTION
Limit `SuggestGasTipCap` (max 1 gwei) of omni's own nodes, since relayer is currently driving the price up bidding against itself since there are very few other txs. Blocks are also pretty much empty. So tips are not required.

issue: #2200 