### PR TITLE
chore(docs): more SolverNet

### DIFF
--- a/docs/content/solvernet/how.md
+++ b/docs/content/solvernet/how.md
@@ -1,4 +1,4 @@
-# How SolverNet Works
+# How It Works
 
 ## An Intent-Based Architecture
 

--- a/docs/content/solvernet/problem.md
+++ b/docs/content/solvernet/problem.md
@@ -1,0 +1,19 @@
+# Problem We're Solving
+
+## The Challenge of Cross-Chain Applications
+
+Building cross-chain applications is hard. Building on top of a cross-chain messaging protocol introduces many challenges, and in the long run of smart contract development will primarily be used by infrastucture providers and sophistacted actors like solvers rather than apps for end users.
+
+In particular, cross chain app development introduces challenges like:
+
+1. **Complexity**: Cross-chain applications require more complex smart contracts, which are more vulnerable to hacks.
+2. **Finality Risks**: Developers of cross-chain applications need to consider chain reorgs, finality risks, and other issues that do not exist on a single chain.
+3. **Extended Development Timelines**: Building cross chain applications simply takes way longer than building on a single chain. In a fast-evolving industry where most applications are still pursuing product-market fit, this long development cycle is impractical.
+4. **Platform Risk**: App developers need to bet the success of their protocol on the success of a cross-chain messaging protocol, in addition to each of the chains they're built on.
+
+_**SolverNet fixes this.**_
+
+1. Build applications on a single chain.
+2. Don't worry about finality, solvers do that.
+3. Build on a single chain.
+4. Omni brings users and capital to you, without you needing to integrate it into your smart contracts (just your frontend!).

--- a/docs/website/sidebars.ts
+++ b/docs/website/sidebars.ts
@@ -47,6 +47,7 @@ const sidebars: SidebarsConfig = {
       label: 'Build with SolverNet',
       items: [
         'solvernet/intro',
+        'solvernet/problem',
         'solvernet/how',
       ],
       collapsed: true,


### PR DESCRIPTION
Adds more context about the problem we're solving to the SolverNet section, so users coming to that section have full context and don't need to read through the `Learn` section as well. Don't change the learn section though, it's good to have it there too.

issue: none
