### PR TITLE
chore(e2e/types): remove unused pinned manifest tags

### DIFF
--- a/e2e/app/definition.go
+++ b/e2e/app/definition.go
@@ -219,11 +219,6 @@ func adaptNode(ctx context.Context, manifest types.Manifest, node *e2e.Node, tag
 		return nil, err
 	}
 
-	// Pinned tag overrides the cli --omni-image-tag flag.
-	if manifest.PinnedHaloTag != "" {
-		tag = manifest.PinnedHaloTag
-	}
-
 	// Override default comet version with our own, see github.com/cometbft/cometbft@v0.38.11/test/e2e/pkg/testnet.go:36
 	const cometLocalVersion = "cometbft/e2e-node:local-version"
 	if node.Version == cometLocalVersion {

--- a/e2e/docker/docker.go
+++ b/e2e/docker/docker.go
@@ -101,8 +101,11 @@ func (p *Provider) Setup() error {
 		Solver:         true,
 		GethVerbosity:  3, // Info
 		GethInitTags:   gethInitTags,
+		AnvilProxyTag:  p.omniTag,
+		MonitorTag:     p.omniTag,
+		RelayerTag:     p.omniTag,
+		SolverTag:      p.omniTag,
 	}
-	def = SetImageTags(def, p.testnet.Manifest, p.omniTag)
 
 	bz, err := GenerateComposeFile(def)
 	if err != nil {
@@ -235,30 +238,6 @@ func (c ComposeDef) NodeOmniEVMs() map[string]string {
 	}
 
 	return resp
-}
-
-// SetImageTags returns a new ComposeDef with the image tags set.
-// This is a convenience function to avoid setting the tags manually.
-func SetImageTags(def ComposeDef, manifest types.Manifest, omniImgTag string) ComposeDef {
-	anvilProxyTag := omniImgTag
-
-	// TODO(corver): Remove pinned tags since they are not used.
-	monitorTag := omniImgTag
-	if manifest.PinnedMonitorTag != "" {
-		monitorTag = manifest.PinnedMonitorTag
-	}
-
-	relayerTag := omniImgTag
-	if manifest.PinnedRelayerTag != "" {
-		relayerTag = manifest.PinnedRelayerTag
-	}
-
-	def.AnvilProxyTag = anvilProxyTag
-	def.MonitorTag = monitorTag
-	def.RelayerTag = relayerTag
-	def.SolverTag = omniImgTag
-
-	return def
 }
 
 func GenerateComposeFile(def ComposeDef) ([]byte, error) {

--- a/e2e/docker/docker_test.go
+++ b/e2e/docker/docker_test.go
@@ -59,10 +59,6 @@ func TestComposeTemplate(t *testing.T) {
 			const evm0 = "omni_evm_0"
 			dir := t.TempDir()
 			testnet := types.Testnet{
-				Manifest: types.Manifest{
-					PinnedRelayerTag: "v2",
-					PinnedMonitorTag: "v3",
-				},
 				Testnet: &e2e.Testnet{
 					Name:       "test",
 					IP:         ipNet,

--- a/e2e/docker/testdata/TestComposeTemplate_commit.golden
+++ b/e2e/docker/testdata/TestComposeTemplate_commit.golden
@@ -115,7 +115,7 @@ services:
     labels:
       e2e: true
     container_name: relayer
-    image: omniops/relayer:v2
+    image: omniops/relayer:7d1ae53
     restart: unless-stopped
     ports:
       - 26660 # Prometheus and pprof
@@ -131,7 +131,7 @@ services:
     labels:
       e2e: true
     container_name: monitor
-    image: omniops/monitor:v3
+    image: omniops/monitor:7d1ae53
     restart: unless-stopped
     ports:
       - 26660 # Prometheus and pprof

--- a/e2e/docker/testdata/TestComposeTemplate_empheral_network.golden
+++ b/e2e/docker/testdata/TestComposeTemplate_empheral_network.golden
@@ -115,7 +115,7 @@ services:
     labels:
       e2e: true
     container_name: relayer
-    image: omniops/relayer:v2
+    image: omniops/relayer:main
     restart: unless-stopped
     ports:
       - 26660 # Prometheus and pprof
@@ -131,7 +131,7 @@ services:
     labels:
       e2e: true
     container_name: monitor
-    image: omniops/monitor:v3
+    image: omniops/monitor:main
     restart: unless-stopped
     ports:
       - 26660 # Prometheus and pprof

--- a/e2e/docker/testdata/TestComposeTemplate_empheral_network_upgrade.golden
+++ b/e2e/docker/testdata/TestComposeTemplate_empheral_network_upgrade.golden
@@ -115,7 +115,7 @@ services:
     labels:
       e2e: true
     container_name: relayer
-    image: omniops/relayer:v2
+    image: omniops/relayer:main
     restart: unless-stopped
     ports:
       - 26660 # Prometheus and pprof
@@ -131,7 +131,7 @@ services:
     labels:
       e2e: true
     container_name: monitor
-    image: omniops/monitor:v3
+    image: omniops/monitor:main
     restart: unless-stopped
     ports:
       - 26660 # Prometheus and pprof

--- a/e2e/types/manifest.go
+++ b/e2e/types/manifest.go
@@ -106,21 +106,6 @@ type Manifest struct {
 	// Perturb defines additional (non-cometBFT) perturbations by service name.
 	Perturb map[string][]Perturb `json:"perturb"`
 
-	// PinnedHaloTag defines the pinned halo docker image tag.
-	// This allows source code defined versions for protected networks.
-	// This overrides the --omni-image-tag if non-empty.
-	PinnedHaloTag string `toml:"pinned_halo_tag"`
-
-	// PinnedMonitorTag defines the pinned monitor docker image tag.
-	// This allows source code defined versions for protected networks.
-	// This overrides the --omni-image-tag if non-empty.
-	PinnedMonitorTag string `toml:"pinned_monitor_tag"`
-
-	// PinnedRelayerTag defines the pinned relayer docker image tag.
-	// This allows source code defined versions for protected networks.
-	// This overrides the --omni-image-tag if non-empty.
-	PinnedRelayerTag string `toml:"pinned_relayer_tag"`
-
 	// NetworkUpgradeHeight defines the network upgrade height, default is genesis, negative is disabled.
 	// Note that it might be scheduled at a later height.
 	NetworkUpgradeHeight int64 `toml:"network_upgrade_height"`

--- a/e2e/vmcompose/provider.go
+++ b/e2e/vmcompose/provider.go
@@ -97,8 +97,11 @@ func (p *Provider) Setup() error {
 			Solver:         services["solver"],
 			Prometheus:     p.Testnet.Prometheus,
 			GethVerbosity:  gethVerbosity,
+			AnvilProxyTag:  p.omniTag,
+			MonitorTag:     p.omniTag,
+			RelayerTag:     p.omniTag,
+			SolverTag:      p.omniTag,
 		}
-		def = docker.SetImageTags(def, p.Testnet.Manifest, p.omniTag)
 
 		compose, err := docker.GenerateComposeFile(def)
 		if err != nil {


### PR DESCRIPTION
Remove unused manifest `Pinned*` fields.

issue: none