### PR TITLE
fix(cli): add flag for rpc server URL

### DIFF
--- a/cli/cmd/flags.go
+++ b/cli/cmd/flags.go
@@ -30,7 +30,7 @@ func bindInitConfig(cmd *cobra.Command, cfg *InitConfig) {
 	netconf.BindFlag(cmd.Flags(), &cfg.Network)
 	cmd.Flags().StringVar(&cfg.Moniker, "moniker", "", "Human-readable node name used in p2p networking")
 	cmd.Flags().StringVar(&cfg.Home, "home", "", "Home directory. If empty, defaults to: $HOME/.omni/<network>/")
-	cmd.Flags().StringVar(&cfg.RPCServerURL, "rpc-server", "", "RPC server url to use when querying")
+	cmd.Flags().StringVar(&cfg.RPCServerURL, "consensus-rpc", "", "RPC server url to use when querying")
 	cmd.Flags().BoolVar(&cfg.Clean, "clean", cfg.Clean, "Delete contents of home directory")
 	cmd.Flags().BoolVar(&cfg.Archive, "archive", cfg.Archive, "Enable archive mode. Note this requires more disk space")
 	cmd.Flags().BoolVar(&cfg.Debug, "debug", cfg.Debug, "Configure nodes with debug log level")

--- a/cli/cmd/flags.go
+++ b/cli/cmd/flags.go
@@ -1,9 +1,9 @@
 package cmd
 
 import (
-	"github.com/omni-network/omni/lib/netconf"
-
 	"github.com/spf13/cobra"
+
+	"github.com/omni-network/omni/lib/netconf"
 )
 
 const (
@@ -30,6 +30,7 @@ func bindInitConfig(cmd *cobra.Command, cfg *InitConfig) {
 	netconf.BindFlag(cmd.Flags(), &cfg.Network)
 	cmd.Flags().StringVar(&cfg.Moniker, "moniker", "", "Human-readable node name used in p2p networking")
 	cmd.Flags().StringVar(&cfg.Home, "home", "", "Home directory. If empty, defaults to: $HOME/.omni/<network>/")
+	cmd.Flags().StringVar(&cfg.RPCServerURL, "rpc-server", "", "RPC server url to use when querying")
 	cmd.Flags().BoolVar(&cfg.Clean, "clean", cfg.Clean, "Delete contents of home directory")
 	cmd.Flags().BoolVar(&cfg.Archive, "archive", cfg.Archive, "Enable archive mode. Note this requires more disk space")
 	cmd.Flags().BoolVar(&cfg.Debug, "debug", cfg.Debug, "Configure nodes with debug log level")

--- a/cli/cmd/initnodes.go
+++ b/cli/cmd/initnodes.go
@@ -130,11 +130,12 @@ func InitNodes(ctx context.Context, cfg InitConfig) error {
 	}
 
 	err = halocmd.InitFiles(ctx, halocmd.InitConfig{
-		HomeDir:     filepath.Join(cfg.Home, "halo"),
-		Moniker:     cfg.Moniker,
-		Network:     cfg.Network,
-		TrustedSync: !cfg.Archive, // Don't state sync if archive
-		AddrBook:    true,
+		HomeDir:      filepath.Join(cfg.Home, "halo"),
+		Moniker:      cfg.Moniker,
+		Network:      cfg.Network,
+		RPCServerURL: cfg.RPCServerURL,
+		TrustedSync:  !cfg.Archive, // Don't state sync if archive
+		AddrBook:     true,
 		HaloCfgFunc: func(haloCfg *halocfg.Config) {
 			haloCfg.EngineEndpoint = "http://omni_evm:8551"
 			haloCfg.EngineJWTFile = "/geth/jwtsecret"


### PR DESCRIPTION
Currently, the CLI relies on static consensus URLs. This morning, we disabled one of these URLs, which caused the _operator init-nodes_ command to fail because the static URL was no longer reachable. As a result, the instructions in our live documentation ([Run a Full Node - Quick Start](https://docs.omni.network/operate/run-full-node#quick-start)) are now broken. This PR introduces the ability for users to override the static consensus URL.

```
omni operator init-nodes --network=omega --moniker=foo --rpc-server=https://omega.omni.network --home=./temp
```

issue: none