### PR TITLE
feat(contracts/portal): refund xcall fee overpayment

### DIFF
--- a/contracts/core/src/xchain/OmniPortal.sol
+++ b/contracts/core/src/xchain/OmniPortal.sol
@@ -146,9 +146,11 @@ contract OmniPortal is
         uint256 fee = feeFor(destChainId, data, gasLimit);
         require(msg.value >= fee, "OmniPortal: insufficient fee");
 
-        outXMsgOffset[destChainId][shardId] += 1;
+        uint256 refund = msg.value - fee;
 
-        emit XMsg(destChainId, shardId, outXMsgOffset[destChainId][shardId], msg.sender, to, data, gasLimit, fee);
+        emit XMsg(destChainId, shardId, ++outXMsgOffset[destChainId][shardId], msg.sender, to, data, gasLimit, fee);
+
+        if (refund > 0) msg.sender.call{ value: refund }("");
     }
 
     /**


### PR DESCRIPTION
Added a refund on fee overpayment & made a small optimization that removes the second SSLOAD & is imo cleaner

Requesting feedback because there is a needless warning on unused low level return value