### PR TITLE
ci(e2e): fix pinned halo image

### DIFF
--- a/e2e/app/definition.go
+++ b/e2e/app/definition.go
@@ -196,6 +196,9 @@ func adaptCometTestnet(ctx context.Context, manifest types.Manifest, testnet *e2
 	testnet.Dir = runsDir(testnet.File)
 	testnet.VoteExtensionsEnableHeight = 1
 	testnet.UpgradeVersion = "omniops/halovisor:" + imgTag // Currently only support upgrading to "latest" version
+	if manifest.PinnedHaloTag != "" {
+		testnet.UpgradeVersion = "omniops/halovisor:" + manifest.PinnedHaloTag // Pinned tag overrides the cli --omni-image-tag flag.
+	}
 
 	for i := range testnet.Nodes {
 		var err error

--- a/e2e/vmcompose/provider.go
+++ b/e2e/vmcompose/provider.go
@@ -49,7 +49,10 @@ func (p *Provider) Setup() error {
 		var halos []string
 		for _, node := range p.Testnet.Nodes {
 			if node.Version != p.Testnet.UpgradeVersion {
-				return errors.New("upgrades not supported for vmcompose")
+				return errors.New("node upgrades not supported for vmcompose",
+					"node_version", node.Version,
+					"upgrade_version", p.Testnet.UpgradeVersion,
+				)
 			}
 
 			if services[node.Name] {


### PR DESCRIPTION
Align `testnet.UpgradeNodeVersion` with `PinnedHaloTag` so fix errors on deploying omage.

issue: none