### PR TITLE
ci(e2e): retry scp on permission denied

### DIFF
--- a/lib/expbackoff/expbackoff.go
+++ b/lib/expbackoff/expbackoff.go
@@ -29,8 +29,8 @@ type Config struct {
 	// MaxDelay is the upper bound of backoff delay.
 	MaxDelay time.Duration
 
-	// retryCount defines the number of retries. Note this is only applicable to Retry.
-	retryCount int
+	// retryConfig only applicable to Retry.
+	retryConfig retryConfig
 }
 
 // DefaultConfig is a backoff configuration with the default values specified
@@ -41,19 +41,20 @@ type Config struct {
 //
 // Copied from google.golang.org/grpc@v1.48.0/backoff/backoff.go.
 var DefaultConfig = Config{
-	BaseDelay:  1.0 * time.Second,
-	Multiplier: 1.6,
-	Jitter:     0.2,
-	MaxDelay:   120 * time.Second,
-	retryCount: defaultRetries,
+	BaseDelay:   1.0 * time.Second,
+	Multiplier:  1.6,
+	Jitter:      0.2,
+	MaxDelay:    120 * time.Second,
+	retryConfig: defaultRetryConfig(),
 }
 
 // FastConfig is a common configuration for fast backoff.
 var FastConfig = Config{
-	BaseDelay:  100 * time.Millisecond,
-	Multiplier: 1.6,
-	Jitter:     0.2,
-	MaxDelay:   5 * time.Second,
+	BaseDelay:   100 * time.Millisecond,
+	Multiplier:  1.6,
+	Jitter:      0.2,
+	MaxDelay:    5 * time.Second,
+	retryConfig: defaultRetryConfig(),
 }
 
 // WithPeriodicConfig configures the backoff with periodic backoff.

--- a/lib/expbackoff/retry.go
+++ b/lib/expbackoff/retry.go
@@ -4,15 +4,40 @@ import (
 	"context"
 
 	"github.com/omni-network/omni/lib/errors"
+	"github.com/omni-network/omni/lib/log"
 )
 
 const defaultRetries = 3
+
+type retryConfig struct {
+	// Count is the max number of retries to attempt.
+	Count int
+	// Check is a function that returns true if the error should be retried.
+	Check func(error) bool
+}
+
+func defaultRetryConfig() retryConfig {
+	return retryConfig{
+		Count: defaultRetries,
+		Check: func(error) bool {
+			return true
+		},
+	}
+}
 
 // WithRetryCount sets the number of retries to n.
 // Note this is only applicable for use with Retry.
 func WithRetryCount(n int) func(config *Config) {
 	return func(c *Config) {
-		c.retryCount = n
+		c.retryConfig.Count = n
+	}
+}
+
+// WithRetryCheck provides a custom error check function for retrying.
+// Note this is only applicable for use with Retry.
+func WithRetryCheck(check func(error) bool) func(config *Config) {
+	return func(c *Config) {
+		c.retryConfig.Check = check
 	}
 }
 
@@ -20,10 +45,13 @@ func WithRetryCount(n int) func(config *Config) {
 // - The function returns nil (Retry returns nil)
 // - The context is canceled (Retry returns the context error)
 // - The retry count is exhausted (Retry returns the last error).
+// - The optional check function returns false (Retry returns the function error).
 func Retry(ctx context.Context, fn func() error, opts ...func(*Config)) error {
-	var remaining int // Workaround to extract retry count from options.
+	var remaining int // Workaround to extract retry config from options.
+	var check func(error) bool
 	opts = append(opts, func(c *Config) {
-		remaining = c.retryCount
+		remaining = c.retryConfig.Count
+		check = c.retryConfig.Check
 	})
 
 	backoff := New(ctx, opts...)
@@ -33,10 +61,13 @@ func Retry(ctx context.Context, fn func() error, opts ...func(*Config)) error {
 		err := fn()
 		if err == nil {
 			return nil
+		} else if !check(err) {
+			return err
 		} else if remaining <= 0 {
 			return errors.Wrap(err, "max retries")
-		}
+		} // else log error, backoff and retry
 
+		log.Warn(ctx, "Will retry error after backoff", err, "remaining", remaining)
 		backoff()
 
 		if ctx.Err() != nil {

--- a/lib/expbackoff/retry_test.go
+++ b/lib/expbackoff/retry_test.go
@@ -57,4 +57,18 @@ func Test(t *testing.T) {
 		require.ErrorIs(t, err, context.Canceled)
 		require.Equal(t, 1, count) // No retries
 	})
+
+	t.Run("check", func(t *testing.T) {
+		const expect = 2
+		var count int
+		check := func(err error) bool {
+			return count < expect
+		}
+		err := expbackoff.Retry(ctx, func() error {
+			count++
+			return io.EOF
+		}, expbackoff.WithRetryCheck(check))
+		require.ErrorIs(t, err, io.EOF)
+		require.Equal(t, expect, count) // Not 3 retries
+	})
 }


### PR DESCRIPTION
Attempt to mitigate sporadic Permission denied SCP errors by retrying a few times when upgrading services in E2E.

issue: none