### PR TITLE
ci(e2e): bump protected web2 services

### DIFF
--- a/e2e/manifests/mainnet.toml
+++ b/e2e/manifests/mainnet.toml
@@ -5,8 +5,8 @@ multi_omni_evms = true
 prometheus   = true
 
 pinned_halo_tag = "v0.11.0"
-pinned_relayer_tag = "dffc7bf"
-pinned_monitor_tag = "dffc7bf"
+pinned_relayer_tag = "1be29e1"
+pinned_monitor_tag = "1be29e1"
 
 [node.validator01]
 [node.validator02]

--- a/e2e/manifests/omega.toml
+++ b/e2e/manifests/omega.toml
@@ -5,8 +5,8 @@ multi_omni_evms = true
 prometheus = true
 
 pinned_halo_tag = "v0.11.0"
-pinned_relayer_tag = "dffc7bf"
-pinned_monitor_tag = "dffc7bf"
+pinned_relayer_tag = "1be29e1"
+pinned_monitor_tag = "1be29e1"
 
 [node.validator01]
 [node.validator02]


### PR DESCRIPTION
Bump protected network relayer (and monitor for simplicity) to remove BUG log on cursor migration.

issue: none