### PR TITLE
ci(e2e): alias deploy as reset

### DIFF
--- a/e2e/cmd/cmd.go
+++ b/e2e/cmd/cmd.go
@@ -104,8 +104,9 @@ func newDeployCmd(def *app.Definition) *cobra.Command {
 	cfg := app.DefaultDeployConfig()
 
 	cmd := &cobra.Command{
-		Use:   "deploy",
-		Short: "Deploys the e2e network",
+		Use:     "deploy",
+		Aliases: []string{"reset"},
+		Short:   "Deploys/Resets the e2e network to start from genesis",
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			_, err := app.Deploy(cmd.Context(), *def, cfg)
 			return err


### PR DESCRIPTION
Use `reset` as an alias for `deploy` in e2e. This allows humans and github actions to refer to "resetting staging", and the use the term "deploy" for a more general process of running different docker containers.

issue: none