### PR TITLE
feat(e2e): added avs impl deployer

### DIFF
--- a/e2e/app/omniavs.go
+++ b/e2e/app/omniavs.go
@@ -1,0 +1,32 @@
+package app
+
+import (
+	"context"
+
+	"github.com/omni-network/omni/lib/contracts/avs"
+	"github.com/omni-network/omni/lib/errors"
+	"github.com/omni-network/omni/lib/log"
+)
+
+// DeployOmniAVSImpl deploys the OmniAVS implementation contract to Ethereum mainnet without upgrading the proxy
+// The proxy is managed by a manual multisig external from e2e, and will be upgraded manually.
+func DeployOmniAVSImpl(ctx context.Context, def Definition) error {
+	ethMainnet, ok := def.Testnet.EthereumChain()
+	if !ok {
+		return errors.New("no ethereum mainnet chain")
+	}
+
+	backend, err := def.Backends().Backend(ethMainnet.ChainID)
+	if err != nil {
+		return errors.Wrap(err, "backend", "chain", ethMainnet.Name)
+	}
+
+	addr, receipt, err := avs.DeployImpl(ctx, def.Testnet.Network, backend)
+	if err != nil {
+		return errors.Wrap(err, "deploy", "chain", ethMainnet.Name, "tx", maybeTxHash(receipt))
+	}
+
+	log.Info(ctx, "OmniAVS implementation deployed", "chain", ethMainnet.Name, "address", addr.Hex(), "tx", maybeTxHash(receipt))
+
+	return nil
+}

--- a/e2e/cmd/cmd.go
+++ b/e2e/cmd/cmd.go
@@ -84,6 +84,7 @@ func New() *cobra.Command {
 		newDeployGasAppCmd(&def),
 		newDeployBridgeCmd(&def),
 		newDeployFeeOracleV2Cmd(&def),
+		newDeployOmniAVSImplCmd(&def),
 		fundAccounts(&def),
 	)
 
@@ -283,6 +284,18 @@ func newDeployFeeOracleV2Cmd(def *app.Definition) *cobra.Command {
 		Short: "Deploys the FeeOracleV2 contract",
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			return app.DeployFeeOracleV2(cmd.Context(), *def)
+		},
+	}
+
+	return cmd
+}
+
+func newDeployOmniAVSImplCmd(def *app.Definition) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "deploy-omniavsimpl",
+		Short: "Deploys the Omni AVS implementation contract",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return app.DeployOmniAVSImpl(cmd.Context(), *def)
 		},
 	}
 

--- a/lib/contracts/avs/deploy.go
+++ b/lib/contracts/avs/deploy.go
@@ -1,0 +1,73 @@
+package avs
+
+import (
+	"context"
+
+	"github.com/omni-network/omni/contracts/bindings"
+	"github.com/omni-network/omni/e2e/app/eoa"
+	"github.com/omni-network/omni/lib/errors"
+	"github.com/omni-network/omni/lib/ethclient/ethbackend"
+	"github.com/omni-network/omni/lib/netconf"
+
+	"github.com/ethereum/go-ethereum/common"
+	ethtypes "github.com/ethereum/go-ethereum/core/types"
+)
+
+var (
+	delegationManager = common.HexToAddress("0x39053D51B77DC0d36036Fc1fCc8Cb819df8Ef37A")
+	avsDirectory      = common.HexToAddress("0x135DDa560e946695d6f155dACaFC6f1F25C1F5AF")
+)
+
+type implDeploymentConfig struct {
+	Deployer          common.Address
+	DelegationManager common.Address
+	AVSDirectory      common.Address
+}
+
+func isEmpty(addr common.Address) bool {
+	return addr == common.Address{}
+}
+
+func (cfg implDeploymentConfig) Validate() error {
+	if isEmpty(cfg.Deployer) {
+		return errors.New("deployer is zero")
+	}
+	if isEmpty(cfg.DelegationManager) {
+		return errors.New("delegation manager is zero")
+	}
+	if isEmpty(cfg.AVSDirectory) {
+		return errors.New("avs directory is zero")
+	}
+
+	return nil
+}
+
+// DeployImpl deploys the OmniAVS implementation contract without upgrading its proxy
+// The proxy is managed by a manual multisig external from e2e, and will be upgraded manually.
+func DeployImpl(ctx context.Context, network netconf.ID, backend *ethbackend.Backend) (common.Address, *ethtypes.Receipt, error) {
+	cfg := implDeploymentConfig{
+		Deployer:          eoa.MustAddress(network, eoa.RoleDeployer),
+		DelegationManager: delegationManager,
+		AVSDirectory:      avsDirectory,
+	}
+	if err := cfg.Validate(); err != nil {
+		return common.Address{}, nil, errors.Wrap(err, "validate cfg")
+	}
+
+	txOpts, err := backend.BindOpts(ctx, cfg.Deployer)
+	if err != nil {
+		return common.Address{}, nil, errors.Wrap(err, "bind opts")
+	}
+
+	impl, tx, _, err := bindings.DeployOmniAVS(txOpts, backend, cfg.DelegationManager, cfg.AVSDirectory)
+	if err != nil {
+		return common.Address{}, nil, errors.Wrap(err, "deploy omni avs impl")
+	}
+
+	receipt, err := backend.WaitMined(ctx, tx)
+	if err != nil {
+		return common.Address{}, nil, errors.Wrap(err, "wait mined")
+	}
+
+	return impl, receipt, nil
+}


### PR DESCRIPTION
Added a deploy routine for the new AVS implementation. Automatic proxy upgrade is not included as the AVS proxy is managed by a manual multisig.

issue: https://github.com/omni-network/ops/issues/601
