### PR TITLE
fix(halo/evmstaking2): improve delivered events metric

### DIFF
--- a/halo/app/app_config.go
+++ b/halo/app/app_config.go
@@ -57,8 +57,10 @@ const (
 	genesisTrimLag        uint64 = 1      // Allow deleting attestations in block after approval.
 	genesisCTrimLag       uint64 = 72_000 // Delete consensus attestations state after +-1 day (given a period of 1.2s).
 
-	deliverIntervalProtected = 20_000 // Roughly ~12h assumping 0.5bps
-	deliverIntervalEphemeral = 2      // Fast updates while testing
+	deliverIntervalProtected = 20_000 // Roughly ~12h assuming 0.5bps
+	// TODO(christian): remove after testing.
+	deliverIntervalStaging   = 300 // Roughly ~10m assuming 0.5bps
+	deliverIntervalEphemeral = 2   // Fast updates while testing
 )
 
 //nolint:gochecknoglobals // Cosmos-style
@@ -245,6 +247,10 @@ var (
 )
 
 func deliverInterval(network netconf.ID) int64 {
+	if network == netconf.Staging {
+		return deliverIntervalStaging
+	}
+
 	if network.IsProtected() {
 		return deliverIntervalProtected
 	}

--- a/halo/evmstaking2/keeper/keeper.go
+++ b/halo/evmstaking2/keeper/keeper.go
@@ -98,6 +98,7 @@ func (k *Keeper) EndBlock(ctx context.Context) error {
 	}
 	defer iter.Close()
 
+	delivered := false
 	for iter.Next() {
 		val, err := iter.Value()
 		if err != nil {
@@ -108,8 +109,12 @@ func (k *Keeper) EndBlock(ctx context.Context) error {
 		if err != nil {
 			return errors.Wrap(err, "delete evm event")
 		}
+		delivered = true
 	}
-	eventDeliveries.Inc()
+	if delivered {
+		eventDeliveries.Inc()
+	}
+
 	bufferedEvents.Set(0)
 
 	return nil


### PR DESCRIPTION
- changes the delivered events metric to only go up if at least one event was delivered
- adds a new interval for staging for easier testing

issue: #2525 