### PR TITLE
fix(halo/evmstaking2): fix EVM event hijacking

### DIFF
--- a/halo/app/app.go
+++ b/halo/app/app.go
@@ -108,7 +108,7 @@ func newApp(
 ) (*App, error) {
 	depCfg := depinject.Configs(
 		appConfig(ctx, network),
-		depinject.Provide(diProviders...),
+		depinject.Provide(diProviders(ctx)...),
 		depinject.Supply(
 			logger,
 			engineCl,

--- a/halo/app/app_config.go
+++ b/halo/app/app_config.go
@@ -238,11 +238,19 @@ var (
 
 	// diProviders defines a list of depinject provider functions.
 	// These are non-cosmos module constructors used in halo's app wiring.
-	diProviders = []any{
-		evmslashing.DIProvide,
-		// TODO(christian): remove later, but seems like it can stay here even if feature is enabled
-		evmstaking.DIProvide,
-		evmupgrade.DIProvide,
+	diProviders = func(ctx context.Context) []any {
+		if feature.FlagEVMStakingModule.Enabled(ctx) {
+			return []any{
+				evmslashing.DIProvide,
+				evmupgrade.DIProvide,
+			}
+		}
+
+		return []any{
+			evmslashing.DIProvide,
+			evmstaking.DIProvide,
+			evmupgrade.DIProvide,
+		}
 	}
 )
 


### PR DESCRIPTION
The current event processor seems to steal the EVM. We need to remove the injection of the processor if the valsync buffering is on.

issue: #2525 