### PR TITLE
chore(solver/app): event counter metric

### DIFF
--- a/solver/app/metrics.go
+++ b/solver/app/metrics.go
@@ -12,4 +12,11 @@ var (
 		Name:      "status_offset",
 		Help:      "Last inbox offset processed by chain and status",
 	}, []string{"chain", "status"})
+
+	processedEvents = promauto.NewCounterVec(prometheus.CounterOpts{
+		Namespace: "solver",
+		Subsystem: "processor",
+		Name:      "processed_events_total",
+		Help:      "Total number of events processed by chain and status",
+	}, []string{"chain", "status"})
 )

--- a/solver/app/processor.go
+++ b/solver/app/processor.go
@@ -65,6 +65,8 @@ func newEventProcessor(deps procDeps, chainID uint64) xchain.EventLogsCallback {
 			default:
 				return errors.New("unknown status [BUG]")
 			}
+
+			processedEvents.WithLabelValues(deps.ChainName(chainID), statusString(event.Status)).Inc()
 		}
 
 		return deps.SetCursor(ctx, chainID, height)


### PR DESCRIPTION
Add event processed counter to solver. The aim is to simply track the number of events processed by status.

issue: none