### PR TITLE
feat(monitor/xfeemngr): added gas tiers above 200 gwei

### DIFF
--- a/monitor/xfeemngr/gasprice/tiers.go
+++ b/monitor/xfeemngr/gasprice/tiers.go
@@ -15,6 +15,9 @@ var tiers = []uint64{
 	gwei(75),
 	gwei(100),
 	gwei(200),
+	gwei(300),
+	gwei(400),
+	gwei(500),
 }
 
 func Tiers() []uint64 {


### PR DESCRIPTION
In order to help resolve the noisy gas price alerts, I added more gas price tiers to the monitor. I also decreased the alert trigger threshold from 0.3 to 0.2, as we now use a model where oracle gas prices will usually be a little higher than onchain.

issue: #2678
