### PR TITLE
e2e(manifest): bump monitor in protected networks

### DIFF
--- a/e2e/manifests/mainnet.toml
+++ b/e2e/manifests/mainnet.toml
@@ -5,8 +5,8 @@ multi_omni_evms = true
 prometheus   = true
 
 pinned_halo_tag = "v0.11.0"
-pinned_relayer_tag = "1be29e1"
-pinned_monitor_tag = "1be29e1"
+pinned_relayer_tag = "3f85919"
+pinned_monitor_tag = "3f85919"
 
 [node.validator01]
 [node.validator02]

--- a/e2e/manifests/omega.toml
+++ b/e2e/manifests/omega.toml
@@ -5,8 +5,8 @@ multi_omni_evms = true
 prometheus = true
 
 pinned_halo_tag = "v0.11.0"
-pinned_relayer_tag = "1be29e1"
-pinned_monitor_tag = "1be29e1"
+pinned_relayer_tag = "3f85919"
+pinned_monitor_tag = "3f85919"
 
 [node.validator01]
 [node.validator02]


### PR DESCRIPTION
Bump relayer and monitor in protected network to latest main.

Aim is to deploy RouteScan recon on mainnet monitor.

issue: none