### PR TITLE
fix(cli/cmd): update operator init-nodes cmd

### DIFF
--- a/cli/cmd/flags.go
+++ b/cli/cmd/flags.go
@@ -33,6 +33,7 @@ func bindInitConfig(cmd *cobra.Command, cfg *InitConfig) {
 	cmd.Flags().BoolVar(&cfg.Clean, "clean", cfg.Clean, "Delete contents of home directory")
 	cmd.Flags().BoolVar(&cfg.Archive, "archive", cfg.Archive, "Enable archive mode. Note this requires more disk space")
 	cmd.Flags().BoolVar(&cfg.Debug, "debug", cfg.Debug, "Configure nodes with debug log level")
+	cmd.Flags().StringVar(&cfg.HaloTag, "halo-tag", cfg.HaloTag, "Configure halo tag to use for node")
 }
 
 func bindAVSAddress(cmd *cobra.Command, addr *string) {

--- a/cli/cmd/flags.go
+++ b/cli/cmd/flags.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"github.com/omni-network/omni/lib/feature"
 	"github.com/omni-network/omni/lib/netconf"
 
 	"github.com/spf13/cobra"
@@ -28,6 +29,7 @@ func bindRegConfig(cmd *cobra.Command, cfg *RegConfig) {
 
 func bindInitConfig(cmd *cobra.Command, cfg *InitConfig) {
 	netconf.BindFlag(cmd.Flags(), &cfg.Network)
+	feature.BindFlag(cmd.Flags(), &cfg.HaloFeatureFlags)
 	cmd.Flags().StringVar(&cfg.Moniker, "moniker", "", "Human-readable node name used in p2p networking")
 	cmd.Flags().StringVar(&cfg.Home, "home", "", "Home directory. If empty, defaults to: $HOME/.omni/<network>/")
 	cmd.Flags().BoolVar(&cfg.Clean, "clean", cfg.Clean, "Delete contents of home directory")


### PR DESCRIPTION
This PR updates the flags for the operator init-nodes cmd so that the cmd can be run directly from source without having to install the omni CLI. This PR adds a new flag **--halo-tag**, which is the halo tag to use for the new node. This is required because the current `buildinfo.GitCommit() ` func will return an err if the cmd is not run from an binary. This PR also binds the current **--feature-flags** to the init-nodes command. Now we can run the command in CI and locally as follows 

```
cd cli/cmd/omni
go run main.go operator init-nodes --network=staging \
--moniker=foo \
--home=/tmp \
--halo-tag=main \
--feature-flags=evmstaking
```

issue: none
