### PR TITLE
chore(docs): add bridge to docs

### DIFF
--- a/docs/content/core/mainnet.md
+++ b/docs/content/core/mainnet.md
@@ -20,7 +20,7 @@ Omni’s mainnet deployment supports Ethereum L1, Arbitrum One, Optimism, and Ba
 | **Resource** | **Address** |
 | --- | --- |
 | Omni EVM RPC | https://mainnet.omni.network |
-| Omni EVM Explorer | https://omniscan.network/ |
+| Omni EVM Explorer | https://omniscan.network |
 | Omni status page | https://status.omni.network |
 | $OMNI Bridge | https://bridge.omni.network/ |
 

--- a/docs/content/core/mainnet.md
+++ b/docs/content/core/mainnet.md
@@ -22,7 +22,7 @@ Omni’s mainnet deployment supports Ethereum L1, Arbitrum One, Optimism, and Ba
 | Omni EVM RPC | https://mainnet.omni.network |
 | Omni EVM Explorer | https://omniscan.network |
 | Omni status page | https://status.omni.network |
-| $OMNI Bridge | https://bridge.omni.network/ |
+| $OMNI Bridge | https://bridge.omni.network |
 
 ## Contract addresses
 

--- a/docs/content/core/mainnet.md
+++ b/docs/content/core/mainnet.md
@@ -22,6 +22,7 @@ Omni’s mainnet deployment supports Ethereum L1, Arbitrum One, Optimism, and Ba
 | Omni EVM RPC | https://mainnet.omni.network/ |
 | Omni EVM Explorer | https://omniscan.network/ |
 | Omni status page | [https://status.omni.network](https://status.omni.network/) |
+| $OMNI Bridge | https://bridge.omni.network/ |
 
 
 ## Contract addresses

--- a/docs/content/core/mainnet.md
+++ b/docs/content/core/mainnet.md
@@ -19,7 +19,7 @@ Omni’s mainnet deployment supports Ethereum L1, Arbitrum One, Optimism, and Ba
 
 | **Resource** | **Address** |
 | --- | --- |
-| Omni EVM RPC | https://mainnet.omni.network/ |
+| Omni EVM RPC | https://mainnet.omni.network |
 | Omni EVM Explorer | https://omniscan.network/ |
 | Omni status page | https://status.omni.network |
 | $OMNI Bridge | https://bridge.omni.network/ |


### PR DESCRIPTION
Add a simple link to the bridge in our docs. Could probably use a rethink though, since this is buried in the Core section.

issue: none