### PR TITLE
chore(cli): add prefix to avs commands

### DIFF
--- a/cli/cmd/avs_register.go
+++ b/cli/cmd/avs_register.go
@@ -39,11 +39,11 @@ type RegDeps struct {
 
 type regOpt func(*RegDeps)
 
-// Register registers the operator with the omni AVS contract.
+// AVSRegister registers the operator with the omni AVS contract.
 //
 // It assumes that the operator is already registered with the Eigen-Layer
 // and that the eigen-layer configuration file (and ecdsa keystore) is present on disk.
-func Register(ctx context.Context, cfg RegConfig, opts ...regOpt) error {
+func AVSRegister(ctx context.Context, cfg RegConfig, opts ...regOpt) error {
 	// Default dependencies.
 	deps := RegDeps{
 		Prompter:       eigenutils.NewPrompter(),
@@ -137,8 +137,8 @@ func Register(ctx context.Context, cfg RegConfig, opts ...regOpt) error {
 	return nil
 }
 
-// Deregister deregisters the operator from the omni AVS contract.
-func Deregister(ctx context.Context, cfg RegConfig, opts ...regOpt) error {
+// AVSDeregister deregisters the operator from the omni AVS contract.
+func AVSDeregister(ctx context.Context, cfg RegConfig, opts ...regOpt) error {
 	// Default dependencies.
 	deps := RegDeps{
 		Prompter:       eigenutils.NewPrompter(),

--- a/cli/cmd/avs_register_test.go
+++ b/cli/cmd/avs_register_test.go
@@ -512,7 +512,7 @@ func registerOperator(t *testing.T, ctx context.Context, contracts Contracts, b 
 		AVSAddr:    contracts.OmniAVSAddr.Hex(),
 	}
 
-	err = clicmd.Register(ctx, regCfg, testOpts)
+	err = clicmd.AVSRegister(ctx, regCfg, testOpts)
 	tutil.RequireNoError(t, err)
 }
 
@@ -570,7 +570,7 @@ func deregisterOperator(t *testing.T, ctx context.Context, contracts Contracts, 
 		AVSAddr:    contracts.OmniAVSAddr.Hex(),
 	}
 
-	err = clicmd.Deregister(ctx, regCfg, testOpts)
+	err = clicmd.AVSDeregister(ctx, regCfg, testOpts)
 	tutil.RequireNoError(t, err)
 }
 

--- a/cli/cmd/cmd.go
+++ b/cli/cmd/cmd.go
@@ -28,8 +28,8 @@ func newOperatorCmds() *cobra.Command {
 	}
 
 	cmd.AddCommand(
-		newRegisterCmd(),
-		newDeregisterCmd(),
+		newAVSRegisterCmd(),
+		newAVSDeregisterCmd(),
 		newInitCmd(),
 		newCreateValCmd(),
 		newCreateOperatorKeyCmd(),
@@ -41,11 +41,11 @@ func newOperatorCmds() *cobra.Command {
 	return cmd
 }
 
-func newRegisterCmd() *cobra.Command {
+func newAVSRegisterCmd() *cobra.Command {
 	var cfg RegConfig
 
 	cmd := &cobra.Command{
-		Use:   "register",
+		Use:   "avs-register",
 		Short: "Register an operator with the Omni AVS contract",
 		Long: `Register command expects a Eigen-Layer yaml config file as an argument
 to successfully register an operator address with the Omni AVS contract.
@@ -53,7 +53,7 @@ to successfully register an operator address with the Omni AVS contract.
 Note the operator must already be registered with Eigen-Layer.`,
 		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			err := Register(cmd.Context(), cfg)
+			err := AVSRegister(cmd.Context(), cfg)
 			if err != nil {
 				return errors.Wrap(err, "registration failed")
 			}
@@ -67,11 +67,11 @@ Note the operator must already be registered with Eigen-Layer.`,
 	return cmd
 }
 
-func newDeregisterCmd() *cobra.Command {
+func newAVSDeregisterCmd() *cobra.Command {
 	var cfg RegConfig
 
 	cmd := &cobra.Command{
-		Use:   "deregister",
+		Use:   "avs-deregister",
 		Short: "Deregister an operator from the Omni AVS contract",
 		Long: `Deregister command expects a EigenLayer yaml config file as an argument
 to successfully deregister an operator from the Omni AVS contract.
@@ -79,7 +79,7 @@ to successfully deregister an operator from the Omni AVS contract.
 Note the operator must already be registered on the Omni AVS contract.`,
 		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			err := Deregister(cmd.Context(), cfg)
+			err := AVSDeregister(cmd.Context(), cfg)
 			if err != nil {
 				return errors.Wrap(err, "deregistration failed")
 			}

--- a/docs/content/operate/faq.md
+++ b/docs/content/operate/faq.md
@@ -93,7 +93,8 @@ Note pure `halo` command is just `rollback`. But when running via `halovisor` on
 
 Operators can still register with Omni's Eigenlayer AVS contract following Eigenlayer's instructions [here](https://docs.eigenlayer.xyz/eigenlayer/operator-guides/operator-installation) to register operator key with their contracts and then run the following command to register within the Omni AVS contract:
 ```bash
-omni operator register --config-file ~/path/to/operator.yaml
+omni operator avs-register --config-file ~/path/to/operator.yaml
+# previously `omni operator register` (v0.11.0 or earlier)
 ```
 
 <aside>


### PR DESCRIPTION
Prefix `omni operator register / deregister` with `avs-`, as these commands only concern avs registration.

issue: none