### PR TITLE
feat(monitor/xfeemngr): always refresh full price buffer

### DIFF
--- a/monitor/xfeemngr/tokenprice/buffer.go
+++ b/monitor/xfeemngr/tokenprice/buffer.go
@@ -71,16 +71,23 @@ func (b *buffer) stream(ctx context.Context) {
 
 		guageLive(prices)
 
-		// update buffered prices, if necessary
+		// check if any prices have changed by more than the threshold
+		refresh := false
 		for token, price := range prices {
 			buffed, ok := b.price(token)
 
-			// if price is buffered, and is within threshold, skip
 			if ok && inThreshold(price, buffed, b.threshold) {
 				continue
 			}
 
-			b.setPrice(token, price)
+			refresh = true
+		}
+
+		// if any outside threshold, update all
+		if refresh {
+			for token, price := range prices {
+				b.setPrice(token, price)
+			}
 		}
 
 		b.gaugeBuffered()

--- a/monitor/xfeemngr/tokenprice/buffer_test.go
+++ b/monitor/xfeemngr/tokenprice/buffer_test.go
@@ -51,11 +51,22 @@ func TestBufferStream(t *testing.T) {
 		live, err := pricer.Price(ctx, tokens.OMNI, tokens.ETH)
 		require.NoError(t, err)
 
+		// check if any live price is outside threshold
+		shouldRefresh := false
 		for token, price := range live {
 			if inThreshold(price, buffed[token], thresh) {
-				require.InEpsilon(t, buffed[token], b.Price(token), 0.001, "should not update")
-			} else {
+				continue
+			}
+
+			shouldRefresh = true
+		}
+
+		// if any price is outside threshold, all prices should be updated
+		for token, price := range live {
+			if shouldRefresh {
 				require.InEpsilon(t, price, b.Price(token), 0.001, "should update")
+			} else {
+				require.InEpsilon(t, buffed[token], b.Price(token), 0.001, "should not update")
 			}
 		}
 	}


### PR DESCRIPTION
When a single live token price falls outside threshold,  update all buffered prices.

This should keep buffered token <> token conversion rates more in sync with live conversion rates.

issue: none