### PR TITLE
refactor(octane/evmengine): simplify event proc interface

### DIFF
--- a/halo/evmslashing/depinject.go
+++ b/halo/evmslashing/depinject.go
@@ -2,7 +2,6 @@ package evmslashing
 
 import (
 	"github.com/omni-network/omni/lib/errors"
-	"github.com/omni-network/omni/lib/ethclient"
 	evmenginetypes "github.com/omni-network/omni/octane/evmengine/types"
 
 	"cosmossdk.io/depinject"
@@ -11,7 +10,6 @@ import (
 
 type DIInputs struct {
 	depinject.In
-	EthCl          ethclient.Client
 	SlashingKeeper slashingkeeper.Keeper
 }
 
@@ -23,7 +21,6 @@ type DIOutputs struct {
 
 func DIProvide(input DIInputs) (DIOutputs, error) {
 	proc, err := New(
-		input.EthCl,
 		input.SlashingKeeper,
 	)
 	if err != nil {

--- a/halo/evmstaking/depinject.go
+++ b/halo/evmstaking/depinject.go
@@ -2,7 +2,6 @@ package evmstaking
 
 import (
 	"github.com/omni-network/omni/lib/errors"
-	"github.com/omni-network/omni/lib/ethclient"
 	evmenginetypes "github.com/omni-network/omni/octane/evmengine/types"
 
 	"cosmossdk.io/depinject"
@@ -13,7 +12,6 @@ import (
 
 type DIInputs struct {
 	depinject.In
-	EthCl         ethclient.Client
 	StakingKeeper *stakingkeeper.Keeper
 	BankKeeper    bankkeeper.Keeper
 	AccountKeeper accountkeeper.AccountKeeper
@@ -27,7 +25,6 @@ type DIOutputs struct {
 
 func DIProvide(input DIInputs) (DIOutputs, error) {
 	proc, err := New(
-		input.EthCl,
 		input.StakingKeeper,
 		input.BankKeeper,
 		input.AccountKeeper,

--- a/halo/evmstaking2/module/module.go
+++ b/halo/evmstaking2/module/module.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/omni-network/omni/halo/evmstaking2/keeper"
 	"github.com/omni-network/omni/halo/evmstaking2/types"
-	"github.com/omni-network/omni/lib/ethclient"
 	evmenginetypes "github.com/omni-network/omni/octane/evmengine/types"
 
 	"cosmossdk.io/core/appmodule"
@@ -114,7 +113,6 @@ type ModuleInputs struct {
 	depinject.In
 
 	StoreService store.KVStoreService
-	EthCl        ethclient.Client
 	AKeeper      types.AuthKeeper
 	BKeeper      types.BankKeeper
 	SKeeper      *stakingkeeper.Keeper
@@ -133,7 +131,6 @@ type ModuleOutputs struct {
 func ProvideModule(in ModuleInputs) (ModuleOutputs, error) {
 	k, err := keeper.NewKeeper(
 		in.StoreService,
-		in.EthCl,
 		in.AKeeper,
 		in.BKeeper,
 		in.SKeeper,

--- a/halo/registry/keeper/keeper.go
+++ b/halo/registry/keeper/keeper.go
@@ -8,7 +8,6 @@ import (
 	ptypes "github.com/omni-network/omni/halo/portal/types"
 	"github.com/omni-network/omni/halo/registry/types"
 	"github.com/omni-network/omni/lib/errors"
-	"github.com/omni-network/omni/lib/ethclient"
 	"github.com/omni-network/omni/lib/xchain"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -22,7 +21,6 @@ import (
 type Keeper struct {
 	emitPortal      ptypes.EmitPortal
 	networkTable    NetworkTable
-	ethCl           ethclient.Client
 	portalRegAdress common.Address
 	portalRegistry  *bindings.PortalRegistryFilterer
 	chainNamer      types.ChainNameFunc
@@ -33,7 +31,6 @@ type Keeper struct {
 func NewKeeper(
 	emitPortal ptypes.EmitPortal,
 	storeService store.KVStoreService,
-	ethCl ethclient.Client,
 	namer types.ChainNameFunc,
 ) (Keeper, error) {
 	schema := &ormv1alpha1.ModuleSchemaDescriptor{SchemaFile: []*ormv1alpha1.ModuleSchemaDescriptor_FileEntry{
@@ -51,7 +48,7 @@ func NewKeeper(
 	}
 
 	address := common.HexToAddress(predeploys.PortalRegistry)
-	protalReg, err := bindings.NewPortalRegistryFilterer(address, ethCl)
+	protalReg, err := bindings.NewPortalRegistryFilterer(address, nil) // Passing nil backend if safe since only Parse functions are used.
 	if err != nil {
 		return Keeper{}, errors.Wrap(err, "new portal registry")
 	}
@@ -59,7 +56,6 @@ func NewKeeper(
 	return Keeper{
 		emitPortal:      emitPortal,
 		networkTable:    registryStore.NetworkTable(),
-		ethCl:           ethCl,
 		portalRegAdress: address,
 		portalRegistry:  protalReg,
 		chainNamer:      namer,

--- a/halo/registry/keeper/logeventproc.go
+++ b/halo/registry/keeper/logeventproc.go
@@ -10,7 +10,6 @@ import (
 	"github.com/omni-network/omni/lib/log"
 	evmenginetypes "github.com/omni-network/omni/octane/evmengine/types"
 
-	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
@@ -29,35 +28,9 @@ func (Keeper) Name() string {
 	return types.ModuleName
 }
 
-func (k Keeper) Addresses() []common.Address {
-	return []common.Address{k.portalRegAdress}
-}
-
-// Prepare returns all omni portal registry contract EVM event logs from the provided block hash.
-func (k Keeper) Prepare(ctx context.Context, blockHash common.Hash) ([]evmenginetypes.EVMEvent, error) {
-	logs, err := k.ethCl.FilterLogs(ctx, ethereum.FilterQuery{
-		BlockHash: &blockHash,
-		Addresses: k.Addresses(),
-		Topics:    [][]common.Hash{{portalRegEvent.ID}},
-	})
-	if err != nil {
-		return nil, errors.Wrap(err, "filter logs")
-	}
-
-	resp := make([]evmenginetypes.EVMEvent, 0, len(logs))
-	for _, l := range logs {
-		topics := make([][]byte, 0, len(l.Topics))
-		for _, t := range l.Topics {
-			topics = append(topics, t.Bytes())
-		}
-		resp = append(resp, evmenginetypes.EVMEvent{
-			Address: l.Address.Bytes(),
-			Topics:  topics,
-			Data:    l.Data,
-		})
-	}
-
-	return resp, nil
+// FilterParams defines the matching EVM log events, see github.com/ethereum/go-ethereum#FilterQuery.
+func (k Keeper) FilterParams() ([]common.Address, [][]common.Hash) {
+	return []common.Address{k.portalRegAdress}, [][]common.Hash{{portalRegEvent.ID}}
 }
 
 // Deliver processes a omni portal registry events.

--- a/halo/registry/keeper/logeventproc_internal_test.go
+++ b/halo/registry/keeper/logeventproc_internal_test.go
@@ -122,7 +122,7 @@ func setupKeeper(t *testing.T) (sdk.Context, Keeper, *testEmitPortal) {
 	ctx = ctx.WithChainID(netconf.Simnet.Static().OmniConsensusChainIDStr())
 
 	emitPortal := new(testEmitPortal)
-	k, err := NewKeeper(emitPortal, storeSvc, nil, netconf.ChainNamer(netconf.Simnet))
+	k, err := NewKeeper(emitPortal, storeSvc, netconf.ChainNamer(netconf.Simnet))
 	require.NoError(t, err, "new keeper")
 
 	return ctx, k, emitPortal

--- a/halo/registry/module/module.go
+++ b/halo/registry/module/module.go
@@ -4,7 +4,6 @@ import (
 	ptypes "github.com/omni-network/omni/halo/portal/types"
 	"github.com/omni-network/omni/halo/registry/keeper"
 	"github.com/omni-network/omni/halo/registry/types"
-	"github.com/omni-network/omni/lib/ethclient"
 	evmenginetypes "github.com/omni-network/omni/octane/evmengine/types"
 
 	"cosmossdk.io/core/appmodule"
@@ -109,7 +108,6 @@ type ModuleInputs struct {
 	Cdc          codec.Codec
 	EmitPortal   ptypes.EmitPortal
 	StoreService store.KVStoreService
-	EthCl        ethclient.Client
 	ChainNamer   types.ChainNameFunc
 	Config       *Module
 }
@@ -126,7 +124,6 @@ func ProvideModule(in ModuleInputs) (ModuleOutputs, error) {
 	k, err := keeper.NewKeeper(
 		in.EmitPortal,
 		in.StoreService,
-		in.EthCl,
 		in.ChainNamer,
 	)
 	if err != nil {

--- a/octane/evmengine/keeper/keeper.go
+++ b/octane/evmengine/keeper/keeper.go
@@ -95,7 +95,8 @@ func verifyProcs(eventProcs []types.EvmEventProcessor) error {
 	names := make(map[string]bool)
 	addresses := make(map[common.Address]bool)
 	for _, proc := range eventProcs {
-		for _, address := range proc.Addresses() {
+		addrs, _ := proc.FilterParams()
+		for _, address := range addrs {
 			if addresses[address] {
 				return errors.New("duplicate event processors", "address", address)
 			}

--- a/octane/evmengine/keeper/msg_server_internal_test.go
+++ b/octane/evmengine/keeper/msg_server_internal_test.go
@@ -49,7 +49,7 @@ func Test_msgServer_ExecutionPayload(t *testing.T) {
 		address: nxtAddr,
 	}
 	frp := newRandomFeeRecipientProvider()
-	evmLogProc := mockLogProvider{deliverErr: errors.New("test error")}
+	evmLogProc := mockEventProc{deliverErr: errors.New("test error")}
 	keeper, err := NewKeeper(cdc, storeService, &mockEngine, txConfig, ap, frp, evmLogProc)
 	require.NoError(t, err)
 	keeper.SetCometAPI(cmtAPI)
@@ -88,7 +88,7 @@ func Test_msgServer_ExecutionPayload(t *testing.T) {
 	}
 
 	assertExecutionPayload := func(ctx context.Context) {
-		events, err := evmLogProc.Prepare(ctx, block.Hash())
+		events, err := keeper.evmEvents(ctx, block.Hash())
 		require.NoError(t, err)
 
 		resp, err := msgSrv.ExecutionPayload(ctx, &types.MsgExecutionPayload{

--- a/octane/evmengine/types/cpayload.go
+++ b/octane/evmengine/types/cpayload.go
@@ -27,9 +27,11 @@ type VoteExtensionProvider interface {
 // EVMEngine calls this during PreparePayload to collect all EVM-log-events to include in
 // the consensus block. It is also called during ProcessPayload to verify the proposed EVM events.
 type EvmEventProcessor interface {
+	// Name of the event processor (used for logs and metrics).
 	Name() string
-	Prepare(ctx context.Context, blockHash common.Hash) ([]EVMEvent, error)
-	Addresses() []common.Address
+	// FilterParams defines the matching EVM log events, see github.com/ethereum/go-ethereum#FilterQuery.
+	FilterParams() (addresses []common.Address, topics [][]common.Hash)
+	// Deliver is called during ProcessPayload to process events.
 	Deliver(ctx context.Context, blockHash common.Hash, log EVMEvent) error
 }
 


### PR DESCRIPTION
Simplify the `evmengine.EvmEventProcessor` interface to return filter query params, instead of doing fetch logic. This reduces lots of duplication and removes EthCl dependency from event procs

issue: #2106