### PR TITLE
refactor(octane/evmengine): simplify event processing

### DIFF
--- a/e2e/manifests/devnet2.toml
+++ b/e2e/manifests/devnet2.toml
@@ -6,7 +6,7 @@ multi_omni_evms = true
 prometheus = true
 deploy_solve = true
 
-feature_flags = ["evm-staking-module"]
+feature_flags = ["evm-staking-module","simple-evm-events"]
 
 [node.validator01]
 [node.validator02]

--- a/e2e/manifests/staging.toml
+++ b/e2e/manifests/staging.toml
@@ -4,7 +4,7 @@ multi_omni_evms = true
 prometheus = true
 deploy_solve = true
 
-feature_flags = ["evm-staking-module"]
+feature_flags = ["evm-staking-module","simple-evm-events"]
 
 [node.validator01]
 [node.validator02]

--- a/halo/app/start_test.go
+++ b/halo/app/start_test.go
@@ -165,9 +165,12 @@ func testCProvider(t *testing.T, ctx context.Context, cprov cprovider.Provider) 
 	xblock, ok, err := cprov.XBlock(ctx, 0, true)
 	tutil.RequireNoError(t, err)
 	require.True(t, ok)
-	require.Len(t, xblock.Msgs, 1)
-	require.Equal(t, xchain.ShardBroadcast0, xblock.Msgs[0].ShardID)
-	require.Equal(t, xchain.BroadcastChainID, xblock.Msgs[0].DestChainID)
+	require.Len(t, xblock.Msgs, 2)
+	for i, msg := range xblock.Msgs {
+		require.Equal(t, xchain.ShardBroadcast0, msg.ShardID)
+		require.Equal(t, xchain.BroadcastChainID, msg.DestChainID)
+		require.EqualValues(t, i, msg.LogIndex)
+	}
 
 	// Ensure getting latest xblock.
 	xblock2, ok, err := cprov.XBlock(ctx, xblock.BlockHeight, false)

--- a/lib/feature/feature.go
+++ b/lib/feature/feature.go
@@ -10,6 +10,8 @@ import (
 const (
 	// FlagEVMStakingModule enables the wip EVM Staking Module feature.
 	FlagEVMStakingModule Flag = "evm-staking-module"
+	// FlagSimpleEVMEvents enables the simplified EVM events refactor.
+	FlagSimpleEVMEvents Flag = "simple-evm-events"
 )
 
 // enabledFlags holds all globally enabled feature flags. The reason for having it is that
@@ -20,6 +22,7 @@ var enabledFlags sync.Map
 
 var allFlags = map[Flag]bool{
 	FlagEVMStakingModule: true,
+	FlagSimpleEVMEvents:  true,
 }
 
 // Flag is a feature flag.

--- a/octane/evmengine/keeper/events_test.go
+++ b/octane/evmengine/keeper/events_test.go
@@ -1,0 +1,79 @@
+package keeper_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/omni-network/omni/halo/genutil/evm/predeploys"
+	"github.com/omni-network/omni/lib/ethclient"
+	"github.com/omni-network/omni/lib/feature"
+	"github.com/omni-network/omni/lib/netconf"
+	"github.com/omni-network/omni/lib/tutil"
+	"github.com/omni-network/omni/octane/evmengine/keeper"
+	"github.com/omni-network/omni/octane/evmengine/types"
+
+	k1 "github.com/cometbft/cometbft/crypto/secp256k1"
+
+	"github.com/ethereum/go-ethereum/common"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestFetchProcEvents(t *testing.T) {
+	t.Parallel()
+
+	// Abridged addresses
+	s := common.HexToAddress(predeploys.Staking)
+	p := common.HexToAddress(predeploys.PortalRegistry)
+
+	fetch := func(ctx context.Context) []types.EVMEvent {
+		hash := tutil.RandomHash()
+		ethStake := int64(7)
+		privKey := k1.GenPrivKey()
+		ethCl, err := ethclient.NewEngineMock(
+			ethclient.WithPortalRegister(netconf.SimnetNetwork()),        // 3 events
+			ethclient.WithMockValidatorCreation(privKey.PubKey()),        // 1 event
+			ethclient.WithMockSelfDelegation(privKey.PubKey(), ethStake), // 1 event
+		)
+		require.NoError(t, err)
+
+		procs := []types.EvmEventProcessor{
+			testProc{Address: s},
+			testProc{Address: p},
+			testProc{Address: common.HexToAddress(predeploys.Slashing)},
+		}
+
+		events, err := keeper.FetchProcEvents(ctx, ethCl, hash, procs...)
+		require.NoError(t, err)
+
+		return events
+	}
+
+	ctx := context.Background()
+
+	// Legacy ordering by address > topics > data
+	events := fetch(ctx)
+	assertOrder(t, events, p, p, p, s, s)
+
+	// Simple ordering by index (see MockEngineClient for indexes)
+	ctx = feature.WithFlag(ctx, feature.FlagSimpleEVMEvents)
+	events = fetch(ctx)
+	assertOrder(t, events, s, p, p, p, s)
+}
+
+func assertOrder(t *testing.T, events []types.EVMEvent, addresses ...common.Address) {
+	t.Helper()
+	require.Len(t, events, len(addresses))
+	for i, ev := range events {
+		require.Equal(t, addresses[i], common.BytesToAddress(ev.Address))
+	}
+}
+
+type testProc struct {
+	types.EvmEventProcessor
+	Address common.Address
+}
+
+func (p testProc) FilterParams() ([]common.Address, [][]common.Hash) {
+	return []common.Address{p.Address}, nil
+}

--- a/octane/evmengine/keeper/proposal_server_internal_test.go
+++ b/octane/evmengine/keeper/proposal_server_internal_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/omni-network/omni/lib/ethclient"
 	"github.com/omni-network/omni/lib/expbackoff"
+	"github.com/omni-network/omni/lib/feature"
 	"github.com/omni-network/omni/octane/evmengine/types"
 
 	"github.com/ethereum/go-ethereum/beacon/engine"
@@ -85,6 +86,10 @@ func Test_proposalServer_ExecutionPayload(t *testing.T) {
 	}
 
 	newPayload(sdkCtx)
+	assertExecutionPayload(sdkCtx)
+
+	// Again, but with simple events
+	sdkCtx = sdkCtx.WithContext(feature.WithFlag(sdkCtx, feature.FlagSimpleEVMEvents))
 	assertExecutionPayload(sdkCtx)
 }
 

--- a/octane/evmengine/types/tx.proto
+++ b/octane/evmengine/types/tx.proto
@@ -26,7 +26,7 @@ message MsgExecutionPayload {
   option (cosmos.msg.v1.signer) = "authority";
   string            authority           = 1;
   bytes             execution_payload   = 2;
-  repeated EVMEvent prev_payload_events = 3 [(gogoproto.nullable) = false];
+  repeated EVMEvent prev_payload_events = 3 [(gogoproto.nullable) = false]; // TODO(corver): Deprecate this once simple-evm-events released.
   repeated bytes    blob_commitments    = 4; // Array of blob tx KZGCommitments, 48 bytes each.
 }
 


### PR DESCRIPTION
Simplify the evm event processing in octane. Note this is behind the new `simple-evm-events` feature flag since it is consensus breaking. Also, this skips evm events from the block before the network upgrade.

issue: #2106 