### PR TITLE
chore(halo/genuitl): remove unused and innacurate proxy admin addr

### DIFF
--- a/halo/genutil/evm/predeploys/predeploys.go
+++ b/halo/genutil/evm/predeploys/predeploys.go
@@ -8,9 +8,6 @@ import (
 )
 
 const (
-	// ProxyAdmin for all namespaces.
-	ProxyAdmin = "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
-
 	// Omni Predeploys.
 	PortalRegistry   = "0x121E240000000000000000000000000000000001"
 	OmniBridgeNative = "0x121E240000000000000000000000000000000002"


### PR DESCRIPTION
In OZ v5, proxy contracts deploy their own proxy admin.
They do so in genesis creation script.
This is no longer accurate, or needed.

issue: none