### PR TITLE
chore(cli/cmd): skip avs register test

### DIFF
--- a/cli/cmd/avs_register_test.go
+++ b/cli/cmd/avs_register_test.go
@@ -56,6 +56,10 @@ var (
 
 //nolint:paralleltest // Parallel tests not supported since we start docker containers.
 func TestRegister(t *testing.T) {
+	// Skipping flapping test until we can fix the issue.
+	// AVS registration is static and unused. Okay to skip for now.
+	t.Skip("Skipping AVS register test")
+
 	ctx, backend, contracts, eoas := setup(t)
 
 	// Register operators to omni AVS with a stake more than minimum stake


### PR DESCRIPTION
Skip flapping avs register test.

issue: none