### PR TITLE
chore(relayer): use halo gRPC cprovider

### DIFF
--- a/e2e/docker/compose.yaml.tmpl
+++ b/e2e/docker/compose.yaml.tmpl
@@ -23,7 +23,7 @@ services:
     ports:
     - {{ if $.BindAll }}26656:{{end}}26656 # CometBFT Consensus P2P
     - {{ if .ProxyPort }}{{ .ProxyPort }}:{{ end }}26657 # CometBFT Consensus RPC
-    - {{ if $.BindAll }}9999:{{end}}9090 # Cosmos gRPC API (VM port 9090 used by grafana-agent)
+    - {{ if $.BindAll }}9999:{{end}}9999 # Cosmos gRPC API (VM port 9090 used by grafana-agent)
     - {{ if $.BindAll }}1317:{{end}}1317 # Cosmos REST API
 {{- if .PrometheusProxyPort }}
     - {{ .PrometheusProxyPort }}:26660 # Prometheus
@@ -44,7 +44,7 @@ services:
     labels:
       e2e: true
     container_name: {{ .Chain.Name }}
-    platform: linux/amd64
+    {{ if $.AnvilAMD }}platform: linux/amd64{{ end }}
     image: omniops/anvilproxy:{{or $.AnvilProxyTag "main"}}
     environment:
       - ANVILPROXY_CHAIN_ID={{ .Chain.ChainID }}

--- a/e2e/docker/docker.go
+++ b/e2e/docker/docker.go
@@ -102,6 +102,7 @@ func (p *Provider) Setup() error {
 		GethVerbosity:          3, // Info
 		GethInitTags:           gethInitTags,
 		EphemeralGenesisBinary: p.testnet.Manifest.EphemeralGenesisBinary,
+		AnvilAMD:               AnvilAMD(),
 	}
 	def = SetImageTags(def, p.testnet.Manifest, p.omniTag)
 
@@ -189,6 +190,7 @@ type ComposeDef struct {
 	GethVerbosity          int            // Geth log level (1=error,2=warn,3=info(default),4=debug,5=trace)
 	GethInitTags           map[int]string // Optional geth initial tags. Defaults to latest if empty.
 	EphemeralGenesisBinary string         // Optional network upgrade to use from genesis
+	AnvilAMD               bool           // Force amd64 for anvil images
 
 	Nodes    []*e2e.Node
 	OmniEVMs []types.OmniEVM
@@ -409,4 +411,18 @@ func ReplaceUpgradeImage(dir, service string) error {
 	}
 
 	return nil
+}
+
+const AnvilAMDENV = "ANVIL_AMD"
+
+// AnvilAMD return whether to force amd64 anvil images.
+// It returns true by default, since this was always the default.
+// Some MacOS however require arm64 images, devs must set ANVIL_AMD=false to use amd64.
+func AnvilAMD() bool {
+	val, ok := os.LookupEnv(AnvilAMDENV)
+	if !ok {
+		return true
+	}
+
+	return val != "false"
 }

--- a/e2e/docker/docker_test.go
+++ b/e2e/docker/docker_test.go
@@ -24,7 +24,7 @@ import (
 //go:generate go test . -golden -clean
 
 func TestComposeTemplate(t *testing.T) {
-	t.Parallel()
+	t.Setenv(docker.AnvilAMDENV, "true") // Make tests deterministic, ignore ENV var.
 
 	tests := []struct {
 		name       string
@@ -47,7 +47,6 @@ func TestComposeTemplate(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			t.Parallel()
 			_, ipNet, err := net.ParseCIDR("10.186.73.0/24")
 			require.NoError(t, err)
 
@@ -132,7 +131,6 @@ func TestComposeTemplate(t *testing.T) {
 			tutil.RequireGoldenBytes(t, bz)
 
 			t.Run("upgrade", func(t *testing.T) {
-				t.Parallel()
 				err := docker.ReplaceUpgradeImage(dir, node0)
 				if test.upgrade == "" {
 					require.Error(t, err)

--- a/e2e/docker/testdata/TestComposeTemplate_commit.golden
+++ b/e2e/docker/testdata/TestComposeTemplate_commit.golden
@@ -20,7 +20,7 @@ services:
     ports:
     - 26656 # CometBFT Consensus P2P
     - 8584:26657 # CometBFT Consensus RPC
-    - 9090 # Cosmos gRPC API (VM port 9090 used by grafana-agent)
+    - 9999 # Cosmos gRPC API (VM port 9090 used by grafana-agent)
     - 1317 # Cosmos REST API
     - 6060 # Pprof
     volumes:

--- a/e2e/docker/testdata/TestComposeTemplate_empheral_network.golden
+++ b/e2e/docker/testdata/TestComposeTemplate_empheral_network.golden
@@ -20,7 +20,7 @@ services:
     ports:
     - 26656 # CometBFT Consensus P2P
     - 8584:26657 # CometBFT Consensus RPC
-    - 9090 # Cosmos gRPC API (VM port 9090 used by grafana-agent)
+    - 9999 # Cosmos gRPC API (VM port 9090 used by grafana-agent)
     - 1317 # Cosmos REST API
     - 6060 # Pprof
     volumes:

--- a/e2e/docker/testdata/TestComposeTemplate_empheral_network_upgrade.golden
+++ b/e2e/docker/testdata/TestComposeTemplate_empheral_network_upgrade.golden
@@ -20,7 +20,7 @@ services:
     ports:
     - 26656 # CometBFT Consensus P2P
     - 8584:26657 # CometBFT Consensus RPC
-    - 9090 # Cosmos gRPC API (VM port 9090 used by grafana-agent)
+    - 9999 # Cosmos gRPC API (VM port 9090 used by grafana-agent)
     - 1317 # Cosmos REST API
     - 6060 # Pprof
     volumes:

--- a/e2e/vmcompose/provider.go
+++ b/e2e/vmcompose/provider.go
@@ -101,6 +101,7 @@ func (p *Provider) Setup() error {
 			Solver:         services["solver"],
 			Prometheus:     p.Testnet.Prometheus,
 			GethVerbosity:  gethVerbosity,
+			AnvilAMD:       docker.AnvilAMD(),
 		}
 		def = docker.SetImageTags(def, p.Testnet.Manifest, p.omniTag)
 

--- a/e2e/vmcompose/provider_test.go
+++ b/e2e/vmcompose/provider_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/omni-network/omni/e2e/app"
+	"github.com/omni-network/omni/e2e/docker"
 	"github.com/omni-network/omni/e2e/vmcompose"
 	"github.com/omni-network/omni/lib/tutil"
 
@@ -17,7 +18,8 @@ import (
 //go:generate go test . -golden -clean
 
 func TestSetup(t *testing.T) {
-	t.Parallel()
+	t.Setenv(docker.AnvilAMDENV, "true") // Make tests deterministic, ignore ENV var.
+
 	manifestFile, dataFile := vmcompose.SetupDataFixtures(t)
 
 	def, err := app.MakeDefinition(context.Background(), app.DefinitionConfig{
@@ -39,7 +41,6 @@ func TestSetup(t *testing.T) {
 
 	for _, file := range files {
 		t.Run(filepath.Base(file), func(t *testing.T) {
-			t.Parallel()
 			bz, err := os.ReadFile(file)
 			require.NoError(t, err)
 

--- a/e2e/vmcompose/testdata/TestSetup_127-0-0-1-compose.yaml.golden
+++ b/e2e/vmcompose/testdata/TestSetup_127-0-0-1-compose.yaml.golden
@@ -16,7 +16,7 @@ services:
     ports:
     - 26656:26656 # CometBFT Consensus P2P
     - 26657:26657 # CometBFT Consensus RPC
-    - 9999:9090 # Cosmos gRPC API (VM port 9090 used by grafana-agent)
+    - 9999:9999 # Cosmos gRPC API (VM port 9090 used by grafana-agent)
     - 1317:1317 # Cosmos REST API
     - 6060 # Pprof
     volumes:

--- a/e2e/vmcompose/testdata/TestSetup_127-0-0-2-compose.yaml.golden
+++ b/e2e/vmcompose/testdata/TestSetup_127-0-0-2-compose.yaml.golden
@@ -16,7 +16,7 @@ services:
     ports:
     - 26656:26656 # CometBFT Consensus P2P
     - 26657:26657 # CometBFT Consensus RPC
-    - 9999:9090 # Cosmos gRPC API (VM port 9090 used by grafana-agent)
+    - 9999:9999 # Cosmos gRPC API (VM port 9090 used by grafana-agent)
     - 1317:1317 # Cosmos REST API
     - 6060 # Pprof
     volumes:

--- a/e2e/vmcompose/testdata/TestSetup_127-0-0-4-compose.yaml.golden
+++ b/e2e/vmcompose/testdata/TestSetup_127-0-0-4-compose.yaml.golden
@@ -16,7 +16,7 @@ services:
     ports:
     - 26656:26656 # CometBFT Consensus P2P
     - 26657:26657 # CometBFT Consensus RPC
-    - 9999:9090 # Cosmos gRPC API (VM port 9090 used by grafana-agent)
+    - 9999:9999 # Cosmos gRPC API (VM port 9090 used by grafana-agent)
     - 1317:1317 # Cosmos REST API
     - 6060 # Pprof
     volumes:

--- a/e2e/vmcompose/testdata/TestSetup_127-0-0-5-compose.yaml.golden
+++ b/e2e/vmcompose/testdata/TestSetup_127-0-0-5-compose.yaml.golden
@@ -16,7 +16,7 @@ services:
     ports:
     - 26656:26656 # CometBFT Consensus P2P
     - 26657:26657 # CometBFT Consensus RPC
-    - 9999:9090 # Cosmos gRPC API (VM port 9090 used by grafana-agent)
+    - 9999:9999 # Cosmos gRPC API (VM port 9090 used by grafana-agent)
     - 1317:1317 # Cosmos REST API
     - 6060 # Pprof
     volumes:

--- a/halo/app/start.go
+++ b/halo/app/start.go
@@ -250,8 +250,6 @@ func Start(ctx context.Context, cfg Config) (<-chan error, func(context.Context)
 
 // newCProvider returns a new cchain provider. Either GRPC if enabled since it is faster,
 // otherwise the ABCI provider.
-//
-
 func newCProvider(rpcClient *rpclocal.Local, cfg Config) (cchain.Provider, error) {
 	if cfg.SDKGRPC.Enable {
 		return cprovider.NewGRPC(cfg.SDKGRPC.Address, cfg.Network)

--- a/lib/cchain/provider/abci.go
+++ b/lib/cchain/provider/abci.go
@@ -2,6 +2,7 @@ package provider
 
 import (
 	"context"
+	"strconv"
 	"sync"
 	"time"
 
@@ -28,6 +29,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/client/grpc/cmtservice"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
+	grpctypes "github.com/cosmos/cosmos-sdk/types/grpc"
 	dtypes "github.com/cosmos/cosmos-sdk/x/distribution/types"
 	sltypes "github.com/cosmos/cosmos-sdk/x/slashing/types"
 	stypes "github.com/cosmos/cosmos-sdk/x/staking/types"
@@ -36,6 +38,7 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
 )
 
@@ -529,18 +532,41 @@ type rpcAdaptor struct {
 	abci rpcclient.ABCIClient
 }
 
-type heightKey struct{}
-
-// withCtxHeight returns a copy of the context with the `heightKey` set to the provided height.
+// withCtxHeight returns a copy of the context with the `x-cosmos-block-height` grpc metadata header
+// set to the provided height.
+//
 // This height will be supplied in ABCIQueryOptions when issuing queries in the rpcAdaptor.
-func withCtxHeight(ctx context.Context, height uint64) context.Context {
-	return context.WithValue(ctx, heightKey{}, height)
+// It will also be added to grpc queries automatically.
+func withCtxHeight(ctx context.Context, height uint64) (context.Context, error) {
+	if _, ok, err := heightFromCtx(ctx); err != nil {
+		return nil, err
+	} else if ok {
+		return nil, errors.New("height already set in context")
+	}
+
+	return metadata.AppendToOutgoingContext(ctx, grpctypes.GRPCBlockHeightHeader, strconv.FormatUint(height, 10)), nil
 }
 
-// heightFromCtx returns the `heightKey` from the supplied context, if found.
-func heightFromCtx(ctx context.Context) (uint64, bool) {
-	v, ok := ctx.Value(heightKey{}).(uint64)
-	return v, ok
+// heightFromCtx returns the `x-cosmos-block-height` grpc metadata header value from the supplied context, if found.
+func heightFromCtx(ctx context.Context) (uint64, bool, error) {
+	md, ok := metadata.FromOutgoingContext(ctx)
+	if !ok {
+		return 0, false, nil
+	}
+
+	heightHeaders := md.Get(grpctypes.GRPCBlockHeightHeader)
+	if len(heightHeaders) == 0 {
+		return 0, false, nil
+	} else if len(heightHeaders) > 1 {
+		return 0, false, errors.New("multiple height headers")
+	}
+
+	height, err := strconv.ParseUint(heightHeaders[0], 10, 64)
+	if err != nil {
+		return 0, false, errors.Wrap(err, "parse height header")
+	}
+
+	return height, true, nil
 }
 
 func (a rpcAdaptor) Invoke(ctx context.Context, method string, req, resp any, _ ...grpc.CallOption) error {
@@ -558,10 +584,10 @@ func (a rpcAdaptor) Invoke(ctx context.Context, method string, req, resp any, _ 
 		return errors.Wrap(err, "marshal approved-from request")
 	}
 
-	// If left as zero value, the latest height will be used
-	var queryHeight uint64
-	if v, ok := heightFromCtx(ctx); ok {
-		queryHeight = v
+	// Zero value for queryHeight will result the latest height
+	queryHeight, _, err := heightFromCtx(ctx)
+	if err != nil {
+		return err
 	}
 
 	queryHeightInt64, err := umath.ToInt64(queryHeight)
@@ -610,7 +636,12 @@ func getEarliestStoreHeight(ctx context.Context, cl atypes.QueryClient, chainVer
 // queryEarliestAttestation returns the earliest approved attestation for the provided chain version
 // at the provided consensus block height, or the latest block height if height is 0.
 func queryEarliestAttestation(ctx context.Context, cl atypes.QueryClient, chainVer xchain.ChainVersion, height uint64) (xchain.Attestation, bool, error) {
-	resp, err := cl.EarliestAttestation(withCtxHeight(ctx, height),
+	ctx, err := withCtxHeight(ctx, height)
+	if err != nil {
+		return xchain.Attestation{}, false, err
+	}
+
+	resp, err := cl.EarliestAttestation(ctx,
 		&atypes.EarliestAttestationRequest{
 			ChainId:   chainVer.ID,
 			ConfLevel: uint32(chainVer.ConfLevel),
@@ -632,7 +663,12 @@ func queryEarliestAttestation(ctx context.Context, cl atypes.QueryClient, chainV
 // queryLatestAttestation returns the latest approved attestation for the provided chain version
 // at the provided consensus block height, or the latest block height if height is 0.
 func queryLatestAttestation(ctx context.Context, cl atypes.QueryClient, chainVer xchain.ChainVersion, height uint64) (xchain.Attestation, bool, error) {
-	resp, err := cl.LatestAttestation(withCtxHeight(ctx, height),
+	ctx, err := withCtxHeight(ctx, height)
+	if err != nil {
+		return xchain.Attestation{}, false, err
+	}
+
+	resp, err := cl.LatestAttestation(ctx,
 		&atypes.LatestAttestationRequest{
 			ChainId:   chainVer.ID,
 			ConfLevel: uint32(chainVer.ConfLevel),
@@ -654,20 +690,25 @@ func queryLatestAttestation(ctx context.Context, cl atypes.QueryClient, chainVer
 // attsFromAtHeight returns approved attestations for the provided chain version
 // at the provided consensus block height, or the latest block height if height is 0.
 func attsFromAtHeight(ctx context.Context, cl atypes.QueryClient, chainVer xchain.ChainVersion, fromOffset, height uint64) ([]xchain.Attestation, bool, error) {
-	resp, err := cl.AttestationsFrom(withCtxHeight(ctx, height), &atypes.AttestationsFromRequest{
+	ctx, err := withCtxHeight(ctx, height)
+	if err != nil {
+		return nil, false, err
+	}
+
+	resp, err := cl.AttestationsFrom(ctx, &atypes.AttestationsFromRequest{
 		ChainId:    chainVer.ID,
 		ConfLevel:  uint32(chainVer.ConfLevel),
 		FromOffset: fromOffset,
 	})
 	if err != nil {
-		return []xchain.Attestation{}, false, errors.Wrap(err, "abci query attestations-from")
+		return nil, false, errors.Wrap(err, "abci query attestations-from")
 	} else if len(resp.Attestations) == 0 {
-		return []xchain.Attestation{}, false, nil
+		return nil, false, nil
 	}
 
 	atts, err := atypes.AttestationsFromProto(resp.Attestations)
 	if err != nil {
-		return []xchain.Attestation{}, false, errors.Wrap(err, "attestations from proto")
+		return nil, false, errors.Wrap(err, "attestations from proto")
 	}
 
 	return atts, true, nil

--- a/relayer/app/app.go
+++ b/relayer/app/app.go
@@ -6,6 +6,7 @@ import (
 	"github.com/omni-network/omni/contracts/bindings"
 	"github.com/omni-network/omni/halo/genutil/evm/predeploys"
 	"github.com/omni-network/omni/lib/buildinfo"
+	"github.com/omni-network/omni/lib/cchain"
 	cprovider "github.com/omni-network/omni/lib/cchain/provider"
 	"github.com/omni-network/omni/lib/chaos"
 	"github.com/omni-network/omni/lib/errors"
@@ -16,7 +17,6 @@ import (
 	xprovider "github.com/omni-network/omni/lib/xchain/provider"
 	"github.com/omni-network/omni/relayer/app/cursor"
 
-	"github.com/cometbft/cometbft/rpc/client"
 	"github.com/cometbft/cometbft/rpc/client/http"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -54,12 +54,11 @@ func Run(ctx context.Context, cfg Config) error {
 		return errors.Wrap(err, "failed to load private key")
 	}
 
-	tmClient, err := newClient(cfg.HaloURL)
+	cprov, err := newCProvider(ctx, cfg)
 	if err != nil {
 		return err
 	}
 
-	cprov := cprovider.NewABCI(tmClient, network.ID)
 	xprov := xprovider.New(network, rpcClientPerChain, cprov)
 
 	pricer := newTokenPricer(ctx)
@@ -124,13 +123,23 @@ func Run(ctx context.Context, cfg Config) error {
 	}
 }
 
-func newClient(tmNodeAddr string) (client.Client, error) {
-	c, err := http.New("tcp://"+tmNodeAddr, "/websocket")
+// newCProvider returns a new cchain provider. Either GRPC if enabled since it is faster,
+// otherwise the ABCI provider.
+func newCProvider(ctx context.Context, cfg Config) (cchain.Provider, error) {
+	if cfg.HaloGRPCURL != "" {
+		log.Debug(ctx, "Using grpc cprovider", "url", cfg.HaloGRPCURL)
+
+		return cprovider.NewGRPC(cfg.HaloGRPCURL, cfg.Network)
+	}
+
+	log.Debug(ctx, "Using comet cprovider", "url", cfg.HaloCometURL)
+
+	c, err := http.New("tcp://"+cfg.HaloCometURL, "/websocket")
 	if err != nil {
 		return nil, errors.Wrap(err, "new tendermint client")
 	}
 
-	return c, nil
+	return cprovider.NewABCI(c, cfg.Network), nil
 }
 
 func initializeRPCClients(chains []netconf.Chain, endpoints xchain.RPCEndpoints) (map[uint64]ethclient.Client, error) {

--- a/relayer/app/config.go
+++ b/relayer/app/config.go
@@ -18,7 +18,8 @@ import (
 type Config struct {
 	RPCEndpoints   xchain.RPCEndpoints
 	PrivateKey     string
-	HaloURL        string
+	HaloCometURL   string
+	HaloGRPCURL    string
 	Network        netconf.ID
 	MonitoringAddr string
 	DBDir          string
@@ -27,7 +28,8 @@ type Config struct {
 func DefaultConfig() Config {
 	return Config{
 		PrivateKey:     "relayer.key",
-		HaloURL:        "localhost:26657",
+		HaloCometURL:   "localhost:26657",
+		HaloGRPCURL:    "",
 		Network:        "",
 		MonitoringAddr: ":26660",
 		DBDir:          "./db",

--- a/relayer/app/config.toml.tmpl
+++ b/relayer/app/config.toml.tmpl
@@ -16,7 +16,10 @@ network = "{{ .Network }}"
 private-key = "{{ .PrivateKey }}"
 
 # The URL of the halo node to connect to.
-halo-url = "{{ .HaloURL }}"
+halo-url = "{{ .HaloCometURL }}"
+
+# The gRPC URL of the halo node to connect to.
+halo-grpc-url = "{{ .HaloGRPCURL }}"
 
 #######################################################################
 ###                             X-Chain                             ###

--- a/relayer/app/config_test.go
+++ b/relayer/app/config_test.go
@@ -19,7 +19,7 @@ func TestDefaultConfigReference(t *testing.T) {
 	tempDir := t.TempDir()
 
 	cfg := relayer.DefaultConfig()
-
+	cfg.HaloGRPCURL = "localhost:9"
 	path := filepath.Join(tempDir, "relayer.toml")
 
 	require.NoError(t, os.MkdirAll(tempDir, 0o755))

--- a/relayer/app/testdata/default_relayer.toml
+++ b/relayer/app/testdata/default_relayer.toml
@@ -18,6 +18,9 @@ private-key = "relayer.key"
 # The URL of the halo node to connect to.
 halo-url = "localhost:26657"
 
+# The gRPC URL of the halo node to connect to.
+halo-grpc-url = "localhost:9"
+
 #######################################################################
 ###                             X-Chain                             ###
 #######################################################################

--- a/relayer/cmd/flags.go
+++ b/relayer/cmd/flags.go
@@ -12,7 +12,8 @@ func bindRunFlags(flags *pflag.FlagSet, cfg *relayer.Config) {
 	netconf.BindFlag(flags, &cfg.Network)
 	xchain.BindFlags(flags, &cfg.RPCEndpoints)
 	flags.StringVar(&cfg.PrivateKey, "private-key", cfg.PrivateKey, "The path to the private key e.g path/private.key")
-	flags.StringVar(&cfg.HaloURL, "halo-url", cfg.HaloURL, "The URL of the halo node e.g localhost:26657")
+	flags.StringVar(&cfg.HaloCometURL, "halo-url", cfg.HaloCometURL, "The URL of the halo node e.g localhost:26657")
+	flags.StringVar(&cfg.HaloGRPCURL, "halo-grpc-url", cfg.HaloGRPCURL, "The gRPC URL of the halo node e.g localhost:9999")
 	flags.StringVar(&cfg.MonitoringAddr, "monitoring-addr", cfg.MonitoringAddr, "The address to bind the monitoring server")
 	flags.StringVar(&cfg.DBDir, "db-dir", cfg.DBDir, "The path to the database directory")
 }


### PR DESCRIPTION
Switch relayer to use halo gRPC CProvider for improved performance.

issue: #2252 
