### PR TITLE
feat(app/solver): v2 solve by liquidity

### DIFF
--- a/lib/cast/cast.go
+++ b/lib/cast/cast.go
@@ -74,6 +74,16 @@ func EthAddress(b []byte) (common.Address, error) {
 	return resp, nil
 }
 
+// MustEthAddress casts a byte slice to an Ethereum address.
+func MustEthAddress(b []byte) common.Address {
+	addr, err := EthAddress(b)
+	if err != nil {
+		panic(err)
+	}
+
+	return addr
+}
+
 // Array20 casts a slice to an array of length 32.
 func Array20[A any](slice []A) ([20]A, error) {
 	if len(slice) == 20 {

--- a/lib/ethclient/ethbackend/backends.go
+++ b/lib/ethclient/ethbackend/backends.go
@@ -107,6 +107,10 @@ func BackendsFromNetwork(network netconf.Network, endpoints xchain.RPCEndpoints,
 	}, nil
 }
 
+func BackendsFrom(backends map[uint64]*Backend) Backends {
+	return Backends{backends: backends}
+}
+
 // NewBackends returns a multi-backends backed by in-memory keys that supports configured all chains.
 func NewBackends(ctx context.Context, testnet types.Testnet, deployKeyFile string) (Backends, error) {
 	var err error

--- a/lib/netconf/netconf.go
+++ b/lib/netconf/netconf.go
@@ -121,15 +121,20 @@ func (n Network) EthereumChain() (Chain, bool) {
 
 // IsEthereumChain returns true if the chainID is the EthereumChainID for the given network.
 func IsEthereumChain(network ID, chainID uint64) bool {
+	return EthereumChainID(network) == chainID
+}
+
+// EthereumChainID returns the EthereumChainID for the given network.
+func EthereumChainID(network ID) uint64 {
 	switch network {
 	case Mainnet:
-		return chainID == evmchain.IDEthereum
+		return evmchain.IDEthereum
 	case Omega:
-		return chainID == evmchain.IDHolesky
+		return evmchain.IDHolesky
 	case Staging:
-		return chainID == evmchain.IDHolesky
+		return evmchain.IDHolesky
 	default:
-		return chainID == evmchain.IDMockL1
+		return evmchain.IDMockL1
 	}
 }
 

--- a/solver/app/v2/metrics.go
+++ b/solver/app/v2/metrics.go
@@ -1,6 +1,11 @@
 package appv2
 
 import (
+	"math/big"
+	"strconv"
+
+	"github.com/ethereum/go-ethereum/common"
+
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 )
@@ -19,4 +24,33 @@ var (
 		Name:      "processed_events_total",
 		Help:      "Total number of events processed by chain and status",
 	}, []string{"chain", "target", "status"})
+
+	rejectedOrders = promauto.NewCounterVec(prometheus.CounterOpts{
+		Namespace: "solver_v2",
+		Subsystem: "processor",
+		Name:      "rejected_orders_total",
+		Help:      "Total number of rejected orders by chain and reason",
+	}, []string{"src_chain", "dest_chain", "target", "reason"})
+
+	tokenBalance = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: "solver_v2",
+		Subsystem: "liquidity",
+		Name:      "token_balance",
+		Help:      "Token balance of solver",
+	}, []string{"chain", "solver_addr", "token_addr", "token_symbol", "is_native"})
 )
+
+func sampleBalance(
+	chain string,
+	token Token,
+	solver common.Address,
+	amount *big.Int,
+) {
+	tokenBalance.WithLabelValues(
+		chain,                                // chain
+		solver.Hex(),                         // solver_addr
+		token.address.Hex(),                  // token_addr
+		token.symbol,                         // token_symbol
+		strconv.FormatBool(token.isNative()), // is_native
+	).Set(float64(amount.Uint64()))
+}

--- a/solver/app/v2/processor_internal_test.go
+++ b/solver/app/v2/processor_internal_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/omni-network/omni/contracts/bindings"
 	"github.com/omni-network/omni/lib/tutil"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -104,6 +105,12 @@ func TestEventProcessor(t *testing.T) {
 					return Order{
 						ID:     id,
 						Status: test.getStatus,
+						FillInstruction: bindings.IERC7683FillInstruction{
+							DestinationSettler: [32]byte{},
+							DestinationChainId: 0,
+							OriginData:         []byte{},
+						},
+						MaxSpent: []bindings.IERC7683Output{},
 					}, true, nil
 				},
 				ShouldReject: func(ctx context.Context, _ uint64, order Order) (rejectReason, bool, error) {

--- a/solver/app/v2/reject.go
+++ b/solver/app/v2/reject.go
@@ -1,9 +1,16 @@
 package appv2
 
 import (
+	"bytes"
 	"context"
 
-	"github.com/omni-network/omni/lib/netconf"
+	"github.com/omni-network/omni/lib/cast"
+	"github.com/omni-network/omni/lib/errors"
+	"github.com/omni-network/omni/lib/ethclient/ethbackend"
+	"github.com/omni-network/omni/lib/log"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
 )
 
 //go:generate stringer -type=rejectReason -trimprefix=reject
@@ -14,12 +21,112 @@ const (
 	rejectDestCallReverts       rejectReason = 1
 	rejectInsufficientFee       rejectReason = 2
 	rejectInsufficientInventory rejectReason = 3
-	rejectInvalidTarget         rejectReason = 4
+	rejectUnsupportedToken      rejectReason = 4
+	rejectUnsupportedDestChain  rejectReason = 5
 )
 
-func newShouldRejector(_ netconf.ID) func(ctx context.Context, chainID uint64, order Order) (rejectReason, bool, error) {
-	return func(_ context.Context, _ uint64, _ Order) (rejectReason, bool, error) {
-		// TODO: check liquidity, reject
+// newShouldRejector returns as ShouldReject function for the given network.
+//
+// ShouldReject returns true and a reason if the request should be rejected.
+// It returns false if the request should be accepted.
+// Errors are unexpected and refer to internal server problems.
+func newShouldRejector(
+	backends ethbackend.Backends,
+	solverAddr common.Address,
+	targetName func(Order) string,
+	chainName func(uint64) string,
+) func(ctx context.Context, srcChainID uint64, order Order) (rejectReason, bool, error) {
+	return func(ctx context.Context, srcChainID uint64, order Order) (rejectReason, bool, error) {
+		// reject swallows the error (only logging it) and returns true and the shouldReject reason.
+		reject := func(reason rejectReason, err error) (rejectReason, bool, error) {
+			err = errors.Wrap(err, "reject",
+				"order_id", order.ID.String(),
+				"dest_chain_id", order.DestinationChainID,
+				"src_chain_id", order.SourceChainID,
+				"target", targetName(order))
+
+			rejectedOrders.WithLabelValues(
+				chainName(order.SourceChainID),
+				chainName(order.DestinationChainID),
+				targetName(order),
+				reason.String(),
+			).Inc()
+
+			log.InfoErr(ctx, "Rejecting request", err, "reason", reason)
+
+			return reason, true, nil
+		}
+
+		// returnErr returns the error, with false and rejectNone. It should be used for unexpected errors.
+		returnErr := func(err error) (rejectReason, bool, error) {
+			return rejectNone, false, err
+		}
+
+		if srcChainID != order.SourceChainID {
+			return returnErr(errors.New("source chain id mismatch [BUG]", "got", order.SourceChainID, "expected", srcChainID))
+		}
+
+		destChainID := order.DestinationChainID
+		backend, err := backends.Backend(destChainID)
+		if err != nil {
+			return reject(rejectUnsupportedDestChain, err)
+		}
+
+		// check all expenses are supported, ethereum addressed tokens
+		var expenses []Expense
+		for _, output := range order.MaxSpent {
+			chainID := output.ChainId.Uint64()
+
+			// inbox contract order resolution should ensure output.chainId matches order.DestinationChainID (derived from fillInstructions)
+			if chainID != destChainID {
+				return returnErr(errors.New("max spent chain id mismatch [BUG]", "got", chainID, "expected", destChainID))
+			}
+
+			addr, err := cast.EthAddress(output.Token[:20])
+			if err != nil {
+				return returnErr(errors.Wrap(err, "cast token address"))
+			}
+
+			if !cmpAddrs(addr, output.Token) {
+				return reject(rejectUnsupportedToken, errors.New("non-eth addressed token", "addr", hexutil.Encode(output.Token[:])))
+			}
+
+			tkn, ok := tokens.find(chainID, addr)
+			if !ok {
+				return reject(rejectUnsupportedToken, errors.New("unsupported token", "addr", addr))
+			}
+
+			expenses = append(expenses, Expense{
+				token:  tkn,
+				amount: output.Amount,
+			})
+		}
+
+		// check liquidty, reject if insufficient
+		for _, expense := range expenses {
+			bal, err := expense.token.balanceOf(ctx, backend, solverAddr)
+			if err != nil {
+				return returnErr(errors.Wrap(err, "get balance", "token", expense.token.symbol))
+			}
+
+			sampleBalance(chainName(destChainID), expense.token, solverAddr, bal)
+
+			// TODO: for native tokens, even if we have enough, we don't want to
+			// spend out whole balance. we'll need to keep some for gas
+			if bal.Cmp(expense.amount) < 0 {
+				return reject(rejectInsufficientInventory, errors.New("insufficient balance", "token", expense.token.symbol))
+			}
+		}
+
 		return rejectNone, false, nil
 	}
+}
+
+// cmpAddrs returns true if the eth address is equal to the 32-byte address.
+func cmpAddrs(addr common.Address, bz [32]byte) bool {
+	addrBz := addr.Bytes()
+	var addrBz32 [32]byte
+	copy(addrBz32[:], addrBz)
+
+	return bytes.Equal(addrBz32[:], bz[:])
 }

--- a/solver/app/v2/reject_internal_test.go
+++ b/solver/app/v2/reject_internal_test.go
@@ -1,0 +1,201 @@
+package appv2
+
+import (
+	"context"
+	"crypto/rand"
+	"math/big"
+	"testing"
+	"time"
+
+	"github.com/omni-network/omni/contracts/bindings"
+	"github.com/omni-network/omni/e2e/app/eoa"
+	"github.com/omni-network/omni/lib/cast"
+	"github.com/omni-network/omni/lib/ethclient/ethbackend"
+	"github.com/omni-network/omni/lib/ethclient/mock"
+	"github.com/omni-network/omni/lib/evmchain"
+	"github.com/omni-network/omni/lib/netconf"
+
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/common"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+)
+
+func TestCmdAddrs(t *testing.T) {
+	t.Parallel()
+
+	// zero addr
+	var bz [32]byte
+	addr, err := cast.EthAddress(bz[:20])
+	require.NoError(t, err)
+	require.True(t, cmpAddrs(addr, bz))
+
+	// within 20 bytes
+	_, err = rand.Read(bz[:20])
+	require.NoError(t, err)
+	addr, err = cast.EthAddress(bz[:20])
+	require.NoError(t, err)
+	require.True(t, cmpAddrs(addr, bz))
+
+	// not within 20 bytes
+	_, err = rand.Read(bz[:32])
+	bz[31] = 0x01 // just make sure it's not all zeros
+	require.NoError(t, err)
+	addr, err = cast.EthAddress(bz[:20])
+	require.NoError(t, err)
+	require.False(t, cmpAddrs(addr, bz))
+}
+
+//nolint:tparallel // subtests use same mock controller
+func TestShouldReject(t *testing.T) {
+	t.Parallel()
+
+	// static setup
+	ctx := context.Background()
+	srcChainID := evmchain.IDBaseSepolia
+	destChainID := evmchain.IDHolesky
+	omniERC20Addr := omniERC20(netconf.Omega).address
+	solver := eoa.MustAddress(netconf.Devnet, eoa.RoleSolver)
+	targetName := func(Order) string { return "target" }
+	chainName := func(uint64) string { return "chain" }
+
+	// mock backend, to manipulate balances
+	ctrl := gomock.NewController(t)
+	mockEthCl := mock.NewMockClient(ctrl)
+	mockBackend, err := ethbackend.NewDevBackend("mock", destChainID, time.Minute, mockEthCl)
+	require.NoError(t, err)
+	mockBackends := ethbackend.BackendsFrom(map[uint64]*ethbackend.Backend{destChainID: mockBackend})
+
+	shouldReject := newShouldRejector(mockBackends, solver, targetName, chainName)
+
+	makeOrder := func(maxSpent ...bindings.IERC7683Output) Order {
+		return Order{
+			ID:                 [32]byte{0x01},
+			SourceChainID:      srcChainID,
+			DestinationChainID: destChainID,
+			MaxSpent:           maxSpent,
+		}
+	}
+
+	mockNativeBalance := func(b *big.Int) func() {
+		return func() {
+			mockEthCl.EXPECT().BalanceAt(ctx, solver, nil).Return(b, nil)
+		}
+	}
+
+	mockERC20Balance := func(b *big.Int) func() {
+		return func() {
+			// we don't go through the trouble of matching eth msg param to IERC20(addr).balanceOf call
+			ctx := gomock.Any()
+			msg := gomock.Any()
+			mockEthCl.EXPECT().CallContract(ctx, msg, nil).Return(abiEncodeBig(t, b), nil)
+		}
+	}
+
+	nativeOutput := func(amount *big.Int) bindings.IERC7683Output {
+		return bindings.IERC7683Output{
+			Amount:  amount,
+			Token:   [32]byte{}, // native
+			ChainId: new(big.Int).SetUint64(destChainID),
+		}
+	}
+
+	erc20Output := func(amount *big.Int) bindings.IERC7683Output {
+		// we need to use omniERC20Addr, because that's the only ERC20 supported in tokens.go
+		return bindings.IERC7683Output{
+			Amount:  amount,
+			Token:   toBz32(omniERC20Addr),
+			ChainId: new(big.Int).SetUint64(destChainID),
+		}
+	}
+
+	tests := []struct {
+		name   string
+		reason rejectReason
+		reject bool
+		mock   func()
+		order  func() Order
+	}{
+		{
+			name:   "insufficient native balance",
+			reason: rejectInsufficientInventory,
+			reject: true,
+			mock:   mockNativeBalance(big.NewInt(0)),
+			order:  func() Order { return makeOrder(nativeOutput(big.NewInt(1))) },
+		},
+		{
+			name:   "sufficient native balance",
+			reason: rejectNone,
+			reject: false,
+			mock:   mockNativeBalance(big.NewInt(1)),
+			order:  func() Order { return makeOrder(nativeOutput(big.NewInt(1))) },
+		},
+		{
+			name:   "insufficient ERC20 balance",
+			reason: rejectInsufficientInventory,
+			reject: true,
+			mock:   mockERC20Balance(big.NewInt(0)),
+			order:  func() Order { return makeOrder(erc20Output(big.NewInt(1))) },
+		},
+		{
+			name:   "sufficient ERC20 balance",
+			reason: rejectNone,
+			reject: false,
+			mock:   mockERC20Balance(big.NewInt(1)),
+			order:  func() Order { return makeOrder(erc20Output(big.NewInt(1))) },
+		},
+		{
+			name:   "unsupported token",
+			reason: rejectUnsupportedToken,
+			reject: true,
+			mock:   func() {},
+			order: func() Order {
+				unknownTkn := [32]byte{0x01}
+				return makeOrder(bindings.IERC7683Output{Token: unknownTkn, ChainId: new(big.Int).SetUint64(destChainID)})
+			},
+		},
+		{
+			name:   "unsupported dest chain",
+			reason: rejectUnsupportedDestChain,
+			reject: true,
+			mock:   func() {},
+			order: func() Order {
+				badDestChainID := destChainID + 1
+				order := makeOrder(bindings.IERC7683Output{Token: [32]byte{}, ChainId: new(big.Int).SetUint64(0x01)})
+				order.DestinationChainID = badDestChainID
+
+				return order
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.mock()
+			reason, reject, err := shouldReject(ctx, srcChainID, tt.order())
+			require.NoError(t, err)
+			require.Equal(t, tt.reject, reject)
+			require.Equal(t, tt.reason, reason)
+		})
+	}
+}
+
+func abiEncodeBig(t *testing.T, n *big.Int) []byte {
+	t.Helper()
+
+	abiT, err := abi.NewType("uint256", "", nil)
+	require.NoError(t, err)
+
+	data, err := abi.Arguments{{Type: abiT}}.Pack(n)
+	require.NoError(t, err)
+
+	return data
+}
+
+func toBz32(addr common.Address) [32]byte {
+	var bz [32]byte
+	copy(bz[:], addr.Bytes())
+
+	return bz
+}

--- a/solver/app/v2/rejectreason_string.go
+++ b/solver/app/v2/rejectreason_string.go
@@ -12,12 +12,13 @@ func _() {
 	_ = x[rejectDestCallReverts-1]
 	_ = x[rejectInsufficientFee-2]
 	_ = x[rejectInsufficientInventory-3]
-	_ = x[rejectInvalidTarget-4]
+	_ = x[rejectUnsupportedToken-4]
+	_ = x[rejectUnsupportedDestChain-5]
 }
 
-const _rejectReason_name = "NoneDestCallRevertsInsufficientFeeInsufficientInventoryInvalidTarget"
+const _rejectReason_name = "NoneDestCallRevertsInsufficientFeeInsufficientInventoryUnsupportedTokenUnsupportedDestChain"
 
-var _rejectReason_index = [...]uint8{0, 4, 19, 34, 55, 68}
+var _rejectReason_index = [...]uint8{0, 4, 19, 34, 55, 71, 91}
 
 func (i rejectReason) String() string {
 	if i >= rejectReason(len(_rejectReason_index)-1) {

--- a/solver/app/v2/tokens.go
+++ b/solver/app/v2/tokens.go
@@ -1,0 +1,110 @@
+package appv2
+
+import (
+	"context"
+	"math/big"
+
+	"github.com/omni-network/omni/contracts/bindings"
+	"github.com/omni-network/omni/lib/contracts"
+	"github.com/omni-network/omni/lib/ethclient/ethbackend"
+	"github.com/omni-network/omni/lib/evmchain"
+	"github.com/omni-network/omni/lib/netconf"
+
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
+)
+
+// TODO: consider moving this to lib/tokens
+
+type Token struct {
+	symbol      string
+	name        string
+	chainID     uint64
+	address     common.Address // empty if native
+	coingeckoID string
+}
+
+type Expense struct {
+	token  Token
+	amount *big.Int
+}
+
+type Tokens []Token
+
+func (t Token) isNative() bool {
+	return t.address == common.Address{}
+}
+
+var tokens = Tokens{
+	nativeETH(evmchain.IDHolesky),
+	nativeETH(evmchain.IDArbSepolia),
+	nativeETH(evmchain.IDBaseSepolia),
+	nativeETH(evmchain.IDOpSepolia),
+	nativeETH(evmchain.IDMockL1),
+	nativeETH(evmchain.IDMockL2),
+
+	nativeOMNI(evmchain.IDOmniOmega),
+	nativeOMNI(evmchain.IDOmniStaging),
+	nativeOMNI(evmchain.IDOmniDevnet),
+
+	omniERC20(netconf.Mainnet),
+	omniERC20(netconf.Omega),
+	omniERC20(netconf.Staging),
+	omniERC20(netconf.Devnet),
+}
+
+func (ts Tokens) find(chainID uint64, addr common.Address) (Token, bool) {
+	for _, t := range ts {
+		if t.chainID == chainID && t.address == addr {
+			return t, true
+		}
+	}
+
+	return Token{}, false
+}
+
+func nativeETH(chainID uint64) Token {
+	return Token{
+		symbol:      "ETH",
+		name:        "Ether",
+		chainID:     chainID,
+		coingeckoID: "ethereum",
+	}
+}
+
+func nativeOMNI(chainID uint64) Token {
+	return Token{
+		symbol:      "OMNI",
+		name:        "Omni Network",
+		chainID:     chainID,
+		coingeckoID: "omni-network",
+	}
+}
+
+func omniERC20(network netconf.ID) Token {
+	return Token{
+		symbol:      "OMNI",
+		name:        "Omni Network",
+		chainID:     netconf.EthereumChainID(network),
+		address:     contracts.TokenAddr(network),
+		coingeckoID: "omni-network",
+	}
+}
+
+func (t Token) balanceOf(
+	ctx context.Context,
+	backend *ethbackend.Backend,
+	addr common.Address,
+) (*big.Int, error) {
+	switch {
+	case t.isNative():
+		return backend.BalanceAt(ctx, addr, nil)
+	default:
+		contract, err := bindings.NewIERC20(t.address, backend)
+		if err != nil {
+			return nil, err
+		}
+
+		return contract.BalanceOf(&bind.CallOpts{Context: ctx}, addr)
+	}
+}


### PR DESCRIPTION
Solve v2 ERC6783 orders by managing on-chain liquidity.

Liquidity only checked on ShouldReject, existing commitments not accounted for.
Restricted to hardcoded list of supported tokens.

issue: none
