### PR TITLE
ci(scripts/join): add join test for node snapshots

### DIFF
--- a/.github/workflows/ci-join-manual.yaml
+++ b/.github/workflows/ci-join-manual.yaml
@@ -1,0 +1,64 @@
+name: Join Network Tests Manual Trigger
+# Manually triggered action that tests joining network as a full node or as a node snapshot.
+
+on:
+  workflow_dispatch:
+    inputs:
+      network:
+        type: choice
+        description: Network
+        options:
+          - omega
+          - mainnet
+          - staging
+        default: "staging"
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  join:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: 'stable'
+
+      - name: "Run Join Network Test ${{github.event.inputs.network}} - Full Sync Node"
+        run: |
+          cd scripts/join
+          sudo go test . -v \
+            --integration \
+            --timeout=0 \
+            --logs_file=docker_logs_${{github.event.inputs.network}}_full_sync.txt \
+            --halo_tag="main" \
+            --network="${{github.event.inputs.network}}"
+
+      - name: "Upload Docker Logs ${{github.event.inputs.network}} - Full Sync Node"
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: docker-logs
+          path: scripts/join/docker_logs_full_sync.txt
+          retention-days: 3
+
+      - name: "Run Join Network Test ${{github.event.inputs.network}} - Node Snapshot"
+        run: |
+          cd scripts/join
+          sudo go test . -v \
+            --integration \
+            --timeout=0 \
+            --logs_file=docker_logs_${{github.event.inputs.network}}_full_sync.txt \
+            --node_snapshot \
+            --halo_tag="main" \
+            --network="${{github.event.inputs.network}}"
+
+      - name: "Upload Docker Logs ${{github.event.inputs.network}} - Node Snapshot"
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: docker-logs
+          path: "docker_logs_${{github.event.inputs.network}}_full_sync.txt"
+          retention-days: 3

--- a/.github/workflows/ci-join.yaml
+++ b/.github/workflows/ci-join.yaml
@@ -27,20 +27,39 @@ jobs:
         with:
           go-version: 'stable'
 
-      - name: Run join test
+      - name: Run Join Network Test - Full Sync Node
         run: |
           cd scripts/join
           sudo go test . -v \
             --integration \
             --timeout=0 \
-            --logs_file=docker_logs.txt \
+            --logs_file=docker_logs_full_sync.txt \
             --halo_tag="main" \
             --network="${{github.event.inputs.network || 'mainnet'}}"
 
-      - name: Upload docker logs
+      - name: Upload Docker Logs - Full Sync Node
         uses: actions/upload-artifact@v4
         if: always()
         with:
           name: docker-logs
-          path: scripts/join/docker_logs.txt
+          path: scripts/join/docker_logs_full_sync.txt
+          retention-days: 3
+
+      - name: Run Join Network Test - Snapshot Sync Node
+        run: |
+          cd scripts/join
+          sudo go test . -v \
+            --integration \
+            --timeout=0 \
+            --logs_file=docker_logs_snapshot_sync.txt \
+            --from_latest_snapshot \
+            --halo_tag="main" \
+            --network="${{github.event.inputs.network || 'mainnet'}}"
+
+      - name: Upload Docker Logs - Snapshot Sync Node
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: docker-logs
+          path: scripts/join/docker_logs_snapshot_sync.txt
           retention-days: 3

--- a/.github/workflows/ci-join.yaml
+++ b/.github/workflows/ci-join.yaml
@@ -1,16 +1,7 @@
-name: join networks nightly
-# Nightly action that tests joining network as a full node.
+name: Join Network Tests Nightly
+# Nightly action that tests joining network as a full node or as a node snapshot.
 
 on:
-  workflow_dispatch:
-    inputs:
-      network:
-        type: choice
-        description: Network
-        options:
-          - omega
-          - mainnet
-        default: "omega"
   schedule:
     - cron: "0 1 * * 1-5" # Weekdays at 1am UTC
 
@@ -27,39 +18,76 @@ jobs:
         with:
           go-version: 'stable'
 
-      - name: Run Join Network Test - Full Sync Node
+      - name: Run Join Network Test Mainnet - Full Sync Node
         run: |
           cd scripts/join
           sudo go test . -v \
             --integration \
             --timeout=0 \
-            --logs_file=docker_logs_full_sync.txt \
+            --logs_file=docker_logs_mainnet_full_sync.txt \
             --halo_tag="main" \
-            --network="${{github.event.inputs.network || 'mainnet'}}"
+            --network="mainnet"
 
-      - name: Upload Docker Logs - Full Sync Node
+      - name: Upload Docker Logs Mainnet - Full Sync Node
         uses: actions/upload-artifact@v4
         if: always()
         with:
           name: docker-logs
-          path: scripts/join/docker_logs_full_sync.txt
+          path: scripts/join/docker_logs_mainnet_full_sync.txt
           retention-days: 3
 
-      - name: Run Join Network Test - Node Snapshot
+      - name: Run Join Network Test Mainnet - Node Snapshot
         run: |
           cd scripts/join
           sudo go test . -v \
             --integration \
             --timeout=0 \
-            --logs_file=docker_logs_node_snapshot.txt \
+            --logs_file=docker_logs_mainnet_node_snapshot.txt \
             --node_snapshot \
             --halo_tag="main" \
-            --network="${{github.event.inputs.network || 'mainnet'}}"
+            --network="mainnet"
 
-      - name: Upload Docker Logs - Node Snapshot
+      - name: Upload Docker Logs Mainnet - Node Snapshot
         uses: actions/upload-artifact@v4
         if: always()
         with:
           name: docker-logs
-          path: scripts/join/docker_logs_node_snapshot.txt
+          path: scripts/join/docker_logs_mainnet_node_snapshot.txt
+          retention-days: 3
+
+      - name: Run Join Network Test Omega - Full Sync Node
+        run: |
+          cd scripts/join
+          sudo go test . -v \
+            --integration \
+            --timeout=0 \
+            --logs_file=docker_logs_omega_full_sync.txt \
+            --halo_tag="main" \
+            --network="omega"
+
+      - name: Upload Docker Logs Omega - Full Sync Node
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: docker-logs
+          path: scripts/join/docker_logs_omega_full_sync.txt
+          retention-days: 3
+
+      - name: Run Join Network Test Omega - Node Snapshot
+        run: |
+          cd scripts/join
+          sudo go test . -v \
+            --integration \
+            --timeout=0 \
+            --logs_file=docker_logs_omega_node_snapshot.txt \
+            --node_snapshot \
+            --halo_tag="main" \
+            --network="omega"
+
+      - name: Upload Docker Logs Omega - Node Snapshot
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: docker-logs
+          path: scripts/join/docker_logs_omega_node_snapshot.txt
           retention-days: 3

--- a/.github/workflows/ci-join.yaml
+++ b/.github/workflows/ci-join.yaml
@@ -45,21 +45,21 @@ jobs:
           path: scripts/join/docker_logs_full_sync.txt
           retention-days: 3
 
-      - name: Run Join Network Test - Snapshot Sync Node
+      - name: Run Join Network Test - Node Snapshot
         run: |
           cd scripts/join
           sudo go test . -v \
             --integration \
             --timeout=0 \
-            --logs_file=docker_logs_snapshot_sync.txt \
-            --from_latest_snapshot \
+            --logs_file=docker_logs_node_snapshot.txt \
+            --node_snapshot \
             --halo_tag="main" \
             --network="${{github.event.inputs.network || 'mainnet'}}"
 
-      - name: Upload Docker Logs - Snapshot Sync Node
+      - name: Upload Docker Logs - Node Snapshot
         uses: actions/upload-artifact@v4
         if: always()
         with:
           name: docker-logs
-          path: scripts/join/docker_logs_snapshot_sync.txt
+          path: scripts/join/docker_logs_node_snapshot.txt
           retention-days: 3

--- a/cli/cmd/flags.go
+++ b/cli/cmd/flags.go
@@ -35,7 +35,7 @@ func bindInitConfig(cmd *cobra.Command, cfg *InitConfig) {
 	cmd.Flags().BoolVar(&cfg.Clean, "clean", cfg.Clean, "Delete contents of home directory")
 	cmd.Flags().BoolVar(&cfg.Archive, "archive", cfg.Archive, "Enable archive mode. Note this requires more disk space")
 	cmd.Flags().BoolVar(&cfg.Debug, "debug", cfg.Debug, "Configure nodes with debug log level")
-	cmd.Flags().BoolVar(&cfg.FromLatestSnapshot, "from-latest-snapshot", cfg.FromLatestSnapshot, "Sync node from latest state snapshot available")
+	cmd.Flags().BoolVar(&cfg.NodeSnapshot, "node-snapshot", cfg.NodeSnapshot, "Download and restore latest node snapshot (geth and halo) from Omni")
 	cmd.Flags().StringVar(&cfg.HaloTag, "halo-tag", cfg.HaloTag, "Configure halo tag to use for node")
 }
 

--- a/cli/cmd/initnodes.go
+++ b/cli/cmd/initnodes.go
@@ -46,15 +46,15 @@ const (
 )
 
 type InitConfig struct {
-	Network            netconf.ID
-	Home               string
-	Moniker            string
-	Clean              bool
-	Archive            bool
-	Debug              bool
-	FromLatestSnapshot bool
-	HaloTag            string
-	HaloFeatureFlags   feature.Flags
+	Network          netconf.ID
+	Home             string
+	Moniker          string
+	Clean            bool
+	Archive          bool
+	Debug            bool
+	NodeSnapshot     bool
+	HaloTag          string
+	HaloFeatureFlags feature.Flags
 }
 
 func (c InitConfig) Verify() error {
@@ -127,7 +127,7 @@ func InitNodes(ctx context.Context, cfg InitConfig) error {
 	}
 	cfg.HaloFeatureFlags = featureFlags
 
-	if cfg.FromLatestSnapshot {
+	if cfg.NodeSnapshot {
 		if err := downloadSnapshot(ctx, cfg.Network, gethClientName); err != nil {
 			return err
 		}

--- a/scripts/join/join_test.go
+++ b/scripts/join/join_test.go
@@ -34,10 +34,11 @@ import (
 )
 
 var (
-	logsFile    = flag.String("logs_file", "join_test.log", "File to write docker logs to")
-	network     = flag.String("network", "omega", "Network to join (default: omega)")
-	integration = flag.Bool("integration", false, "Run integration tests")
-	release     = flag.String("halo_tag", "main", "Halo docker image tag, empty results in `git rev-parse HEAD`")
+	logsFile           = flag.String("logs_file", "join_test.log", "File to write docker logs to")
+	network            = flag.String("network", "omega", "Network to join (default: omega)")
+	integration        = flag.Bool("integration", false, "Run integration tests")
+	fromLatestSnapshot = flag.Bool("from_latest_snapshot", false, "Enable node sync from backup snapshot")
+	release            = flag.String("halo_tag", "main", "Halo docker image tag, empty results in `git rev-parse HEAD`")
 )
 
 // TestJoinNetwork starts a local node (using omni operator init-nodes)
@@ -65,11 +66,12 @@ func TestJoinNetwork(t *testing.T) {
 	networkID := netconf.ID(*network)
 	haloTag := haloTag(t)
 	cfg := clicmd.InitConfig{
-		Network:          networkID,
-		Home:             home,
-		Moniker:          t.Name(),
-		HaloTag:          haloTag,
-		HaloFeatureFlags: maybeGetFeatureFlags(ctx, networkID),
+		Network:            networkID,
+		Home:               home,
+		Moniker:            t.Name(),
+		FromLatestSnapshot: *fromLatestSnapshot,
+		HaloTag:            haloTag,
+		HaloFeatureFlags:   maybeGetFeatureFlags(ctx, networkID),
 	}
 
 	tutil.RequireNoError(t, ensureHaloImage(cfg.HaloTag))

--- a/scripts/join/join_test.go
+++ b/scripts/join/join_test.go
@@ -34,11 +34,11 @@ import (
 )
 
 var (
-	logsFile           = flag.String("logs_file", "join_test.log", "File to write docker logs to")
-	network            = flag.String("network", "omega", "Network to join (default: omega)")
-	integration        = flag.Bool("integration", false, "Run integration tests")
-	fromLatestSnapshot = flag.Bool("from_latest_snapshot", false, "Enable node sync from backup snapshot")
-	release            = flag.String("halo_tag", "main", "Halo docker image tag, empty results in `git rev-parse HEAD`")
+	logsFile     = flag.String("logs_file", "join_test.log", "File to write docker logs to")
+	network      = flag.String("network", "omega", "Network to join (default: omega)")
+	integration  = flag.Bool("integration", false, "Run integration tests")
+	nodeSnapshot = flag.Bool("node_snapshot", false, "Download and restore latest node snapshot (geth and halo)")
+	release      = flag.String("halo_tag", "main", "Halo docker image tag, empty results in `git rev-parse HEAD`")
 )
 
 // TestJoinNetwork starts a local node (using omni operator init-nodes)
@@ -66,12 +66,12 @@ func TestJoinNetwork(t *testing.T) {
 	networkID := netconf.ID(*network)
 	haloTag := haloTag(t)
 	cfg := clicmd.InitConfig{
-		Network:            networkID,
-		Home:               home,
-		Moniker:            t.Name(),
-		FromLatestSnapshot: *fromLatestSnapshot,
-		HaloTag:            haloTag,
-		HaloFeatureFlags:   maybeGetFeatureFlags(ctx, networkID),
+		Network:          networkID,
+		Home:             home,
+		Moniker:          t.Name(),
+		NodeSnapshot:     *nodeSnapshot,
+		HaloTag:          haloTag,
+		HaloFeatureFlags: maybeGetFeatureFlags(ctx, networkID),
 	}
 
 	tutil.RequireNoError(t, ensureHaloImage(cfg.HaloTag))


### PR DESCRIPTION
- Support testing the scenario of a node synced from a backup snapshot to join a network utilizing the new `--from-latest-snapshot` option of the `init-nodes` command.

issue:  #2803
