### PR TITLE
fix(cli/cmd): fix rel to abs snapshot download path

### DIFF
--- a/.github/workflows/ci-join-manual.yaml
+++ b/.github/workflows/ci-join-manual.yaml
@@ -21,6 +21,14 @@ jobs:
   join-tests-manual-node-snapshot:
     runs-on: ubuntu-latest
     steps:
+      - name: Maximize build space
+        uses: easimon/maximize-build-space@master
+        with:
+          remove-dotnet: 'true'
+          remove-android: 'true'
+          remove-haskell: 'true'
+          remove-codeql: 'true'
+          remove-docker-images: 'true'
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:

--- a/.github/workflows/ci-join-manual.yaml
+++ b/.github/workflows/ci-join-manual.yaml
@@ -18,7 +18,7 @@ permissions:
   pull-requests: read
 
 jobs:
-  join:
+  join-tests-manual-node-snapshot:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -26,6 +26,32 @@ jobs:
         with:
           go-version: 'stable'
 
+      - name: "Run Join Network Test ${{github.event.inputs.network}} - Node Snapshot"
+        run: |
+          cd scripts/join
+          sudo go test . -v \
+            --integration \
+            --timeout=0 \
+            --logs_file=docker_logs_${{github.event.inputs.network}}_node_snapshot.txt \
+            --node_snapshot \
+            --halo_tag="main" \
+            --network="${{github.event.inputs.network}}"
+
+      - name: "Upload Docker Logs ${{github.event.inputs.network}} - Node Snapshot"
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: docker-logs
+          path: "docker_logs_${{github.event.inputs.network}}_node_snapshot.txt"
+          retention-days: 3
+
+  join-tests-manual-full-sync:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: 'stable'
       - name: "Run Join Network Test ${{github.event.inputs.network}} - Full Sync Node"
         run: |
           cd scripts/join
@@ -41,24 +67,5 @@ jobs:
         if: always()
         with:
           name: docker-logs
-          path: scripts/join/docker_logs_full_sync.txt
-          retention-days: 3
-
-      - name: "Run Join Network Test ${{github.event.inputs.network}} - Node Snapshot"
-        run: |
-          cd scripts/join
-          sudo go test . -v \
-            --integration \
-            --timeout=0 \
-            --logs_file=docker_logs_${{github.event.inputs.network}}_full_sync.txt \
-            --node_snapshot \
-            --halo_tag="main" \
-            --network="${{github.event.inputs.network}}"
-
-      - name: "Upload Docker Logs ${{github.event.inputs.network}} - Node Snapshot"
-        uses: actions/upload-artifact@v4
-        if: always()
-        with:
-          name: docker-logs
-          path: "docker_logs_${{github.event.inputs.network}}_full_sync.txt"
+          path: "scripts/join/docker_logs_${{github.event.inputs.network}}_full_sync.txt"
           retention-days: 3

--- a/.github/workflows/ci-join.yaml
+++ b/.github/workflows/ci-join.yaml
@@ -10,7 +10,34 @@ permissions:
   pull-requests: read
 
 jobs:
-  join:
+  join-tests-mainnet-node-snapshot:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: 'stable'
+
+      - name: Run Join Network Test Mainnet - Node Snapshot
+        run: |
+          cd scripts/join
+          sudo go test . -v \
+            --integration \
+            --timeout=0 \
+            --logs_file=docker_logs_mainnet_node_snapshot.txt \
+            --node_snapshot \
+            --halo_tag="main" \
+            --network="mainnet"
+
+      - name: Upload Docker Logs Mainnet - Node Snapshot
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: docker-logs
+          path: scripts/join/docker_logs_mainnet_node_snapshot.txt
+          retention-days: 3
+
+  join-tests-mainnet-full-sync:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -36,42 +63,13 @@ jobs:
           path: scripts/join/docker_logs_mainnet_full_sync.txt
           retention-days: 3
 
-      - name: Run Join Network Test Mainnet - Node Snapshot
-        run: |
-          cd scripts/join
-          sudo go test . -v \
-            --integration \
-            --timeout=0 \
-            --logs_file=docker_logs_mainnet_node_snapshot.txt \
-            --node_snapshot \
-            --halo_tag="main" \
-            --network="mainnet"
-
-      - name: Upload Docker Logs Mainnet - Node Snapshot
-        uses: actions/upload-artifact@v4
-        if: always()
+  join-tests-omega-node-snapshot:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
         with:
-          name: docker-logs
-          path: scripts/join/docker_logs_mainnet_node_snapshot.txt
-          retention-days: 3
-
-      - name: Run Join Network Test Omega - Full Sync Node
-        run: |
-          cd scripts/join
-          sudo go test . -v \
-            --integration \
-            --timeout=0 \
-            --logs_file=docker_logs_omega_full_sync.txt \
-            --halo_tag="main" \
-            --network="omega"
-
-      - name: Upload Docker Logs Omega - Full Sync Node
-        uses: actions/upload-artifact@v4
-        if: always()
-        with:
-          name: docker-logs
-          path: scripts/join/docker_logs_omega_full_sync.txt
-          retention-days: 3
+          go-version: 'stable'
 
       - name: Run Join Network Test Omega - Node Snapshot
         run: |
@@ -90,4 +88,30 @@ jobs:
         with:
           name: docker-logs
           path: scripts/join/docker_logs_omega_node_snapshot.txt
+          retention-days: 3
+
+  join-tests-omega-full-sync:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: 'stable'
+
+      - name: Run Join Network Test Omega - Full Sync Node
+        run: |
+          cd scripts/join
+          sudo go test . -v \
+            --integration \
+            --timeout=0 \
+            --logs_file=docker_logs_omega_full_sync.txt \
+            --halo_tag="main" \
+            --network="omega"
+
+      - name: Upload Docker Logs Omega - Full Sync Node
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: docker-logs
+          path: scripts/join/docker_logs_omega_full_sync.txt
           retention-days: 3

--- a/cli/cmd/initnodes.go
+++ b/cli/cmd/initnodes.go
@@ -128,11 +128,11 @@ func InitNodes(ctx context.Context, cfg InitConfig) error {
 	cfg.HaloFeatureFlags = featureFlags
 
 	if cfg.NodeSnapshot {
-		if err := downloadSnapshot(ctx, cfg.Network, gethClientName); err != nil {
+		if err := downloadSnapshot(ctx, cfg.Network, cfg.Home, gethClientName); err != nil {
 			return err
 		}
 
-		if err := downloadSnapshot(ctx, cfg.Network, haloClientName); err != nil {
+		if err := downloadSnapshot(ctx, cfg.Network, cfg.Home, haloClientName); err != nil {
 			return err
 		}
 	}
@@ -423,11 +423,11 @@ func gethInit(ctx context.Context, cfg InitConfig, dir string) error {
 	return nil
 }
 
-func downloadSnapshot(ctx context.Context, network netconf.ID, clientName string) error {
+func downloadSnapshot(ctx context.Context, network netconf.ID, outputDir string, clientName string) error {
 	gcpCloudStorageURL := fmt.Sprintf("https://storage.googleapis.com/omni-%s-snapshots/%s_data.tar.lz4", network, clientName)
 
 	log.Info(ctx, "Downloading and restoring latest snapshot...", "url", gcpCloudStorageURL)
-	if err := downloadUntarLz4(ctx, gcpCloudStorageURL, clientName); err != nil {
+	if err := downloadUntarLz4(ctx, gcpCloudStorageURL, filepath.Join(outputDir, clientName)); err != nil {
 		return errors.Wrap(err, "download untar lz4 error", "client", clientName)
 	}
 

--- a/scripts/join/join_test.go
+++ b/scripts/join/join_test.go
@@ -76,7 +76,7 @@ func TestJoinNetwork(t *testing.T) {
 
 	tutil.RequireNoError(t, ensureHaloImage(cfg.HaloTag))
 
-	log.Info(ctx, "Exec: omni operator init-nodes", "network", networkID, "halo_tag", haloTag)
+	log.Info(ctx, "Exec: omni operator init-nodes", "network", networkID, "halo_tag", haloTag, "node_snapshot", *nodeSnapshot, "feature_flags", cfg.HaloFeatureFlags)
 	require.NoError(t, clicmd.InitNodes(log.WithNoopLogger(ctx), cfg))
 
 	t0 := time.Now()


### PR DESCRIPTION
- Fix downloading and decompressing snapshot data to an abs file path instead of a relative one.
- Fix naming of --logs_file docker logs files.
- Split running the join network test into multiple CI jobs based on the network.

issue: #2814 
