### PR TITLE
chore(e2e/solve): deploy v2 solvernet boxes

### DIFF
--- a/lib/contracts/address.go
+++ b/lib/contracts/address.go
@@ -77,28 +77,32 @@ func getStagingVersion(ctx context.Context) (string, error) {
 }
 
 type Addresses struct {
-	AVS            common.Address
-	Create3Factory common.Address
-	GasPump        common.Address
-	GasStation     common.Address
-	L1Bridge       common.Address
-	Portal         common.Address
-	Token          common.Address
-	SolveOutbox    common.Address
-	SolveInbox     common.Address
-	FeeOracleV2    common.Address
+	AVS             common.Address
+	Create3Factory  common.Address
+	GasPump         common.Address
+	GasStation      common.Address
+	L1Bridge        common.Address
+	Portal          common.Address
+	Token           common.Address
+	SolveOutbox     common.Address // TODO: remove when replaced by SolverNetInbox (below)
+	SolveInbox      common.Address // TODO: remove when replaced by SolverNetOutbox (below)
+	SolverNetInbox  common.Address
+	SolverNetOutbox common.Address
+	FeeOracleV2     common.Address
 }
 
 type Salts struct {
-	AVS         string
-	GasPump     string
-	GasStation  string
-	L1Bridge    string
-	Portal      string
-	Token       string
-	SolveOutbox string
-	SolveInbox  string
-	FeeOracleV2 string
+	AVS             string
+	GasPump         string
+	GasStation      string
+	L1Bridge        string
+	Portal          string
+	Token           string
+	SolveOutbox     string // TODO: remove when replaced by SolverNetInbox (below)
+	SolveInbox      string // TODO: remove when replaced by SolverNetOutbox (below)
+	SolverNetInbox  string
+	SolverNetOutbox string
+	FeeOracleV2     string
 }
 
 type cache[T any] struct {
@@ -134,16 +138,18 @@ func GetAddresses(ctx context.Context, network netconf.ID) (Addresses, error) {
 	}
 
 	addrs = Addresses{
-		Create3Factory: Create3Factory(network),
-		AVS:            avs(network),
-		Portal:         portal(network, ver),
-		L1Bridge:       l1Bridge(network, ver),
-		Token:          TokenAddr(network),
-		GasPump:        gasPump(network, ver),
-		GasStation:     gasStation(network, ver),
-		SolveInbox:     solveInbox(network, ver),
-		SolveOutbox:    solveOutbox(network, ver),
-		FeeOracleV2:    feeOracleV2(network, ver),
+		Create3Factory:  Create3Factory(network),
+		AVS:             avs(network),
+		Portal:          portal(network, ver),
+		L1Bridge:        l1Bridge(network, ver),
+		Token:           TokenAddr(network),
+		GasPump:         gasPump(network, ver),
+		GasStation:      gasStation(network, ver),
+		SolveInbox:      solveInbox(network, ver),
+		SolveOutbox:     solveOutbox(network, ver),
+		SolverNetInbox:  solverNetInbox(network, ver),
+		SolverNetOutbox: solverNetOutbox(network, ver),
+		FeeOracleV2:     feeOracleV2(network, ver),
 	}
 
 	addrsCache.cache[network] = addrs
@@ -167,15 +173,17 @@ func GetSalts(ctx context.Context, network netconf.ID) (Salts, error) {
 	}
 
 	salts = Salts{
-		AVS:         avsSalt(network),
-		Portal:      portalSalt(network, ver),
-		L1Bridge:    l1BridgeSalt(network, ver),
-		Token:       tokenSalt(network),
-		GasPump:     gasPumpSalt(network, ver),
-		GasStation:  gasStationSalt(network, ver),
-		SolveInbox:  solveInboxSalt(network, ver),
-		SolveOutbox: solveOutboxSalt(network, ver),
-		FeeOracleV2: feeOracleV2Salt(network, ver),
+		AVS:             avsSalt(network),
+		Portal:          portalSalt(network, ver),
+		L1Bridge:        l1BridgeSalt(network, ver),
+		Token:           tokenSalt(network),
+		GasPump:         gasPumpSalt(network, ver),
+		GasStation:      gasStationSalt(network, ver),
+		SolveInbox:      solveInboxSalt(network, ver),
+		SolveOutbox:     solveOutboxSalt(network, ver),
+		SolverNetInbox:  solverNetInboxSalt(network, ver),
+		SolverNetOutbox: solverNetOutboxSalt(network, ver),
+		FeeOracleV2:     feeOracleV2Salt(network, ver),
 	}
 
 	saltsCache.cache[network] = salts
@@ -238,6 +246,14 @@ func solveOutbox(network netconf.ID, version string) common.Address {
 	return create3.Address(Create3Factory(network), solveOutboxSalt(network, version), eoa.MustAddress(network, eoa.RoleDeployer))
 }
 
+func solverNetInbox(network netconf.ID, version string) common.Address {
+	return create3.Address(Create3Factory(network), solverNetInboxSalt(network, version), eoa.MustAddress(network, eoa.RoleDeployer))
+}
+
+func solverNetOutbox(network netconf.ID, version string) common.Address {
+	return create3.Address(Create3Factory(network), solverNetOutboxSalt(network, version), eoa.MustAddress(network, eoa.RoleDeployer))
+}
+
 func feeOracleV2(network netconf.ID, version string) common.Address {
 	return create3.Address(Create3Factory(network), feeOracleV2Salt(network, version), eoa.MustAddress(network, eoa.RoleDeployer))
 }
@@ -278,6 +294,14 @@ func solveInboxSalt(network netconf.ID, version string) string {
 
 func solveOutboxSalt(network netconf.ID, version string) string {
 	return salt(network, "solve-outbox-"+version)
+}
+
+func solverNetInboxSalt(network netconf.ID, version string) string {
+	return salt(network, "solvernet-inbox-"+version)
+}
+
+func solverNetOutboxSalt(network netconf.ID, version string) string {
+	return salt(network, "solvernet-outbox-"+version)
 }
 
 func feeOracleV2Salt(network netconf.ID, version string) string {

--- a/lib/contracts/address_test.go
+++ b/lib/contracts/address_test.go
@@ -32,16 +32,18 @@ func TestContractAddressReference(t *testing.T) {
 		require.NoError(t, err)
 
 		addrsJSON := map[string]common.Address{
-			"create3":     addrs.Create3Factory,
-			"portal":      addrs.Portal,
-			"avs":         addrs.AVS,
-			"l1bridge":    addrs.L1Bridge,
-			"token":       addrs.Token,
-			"gaspump":     addrs.GasPump,
-			"gasstation":  addrs.GasStation,
-			"solveinbox":  addrs.SolveInbox,
-			"solveoutbox": addrs.SolveOutbox,
-			"feeoraclev2": addrs.FeeOracleV2,
+			"create3":         addrs.Create3Factory,
+			"portal":          addrs.Portal,
+			"avs":             addrs.AVS,
+			"l1bridge":        addrs.L1Bridge,
+			"token":           addrs.Token,
+			"gaspump":         addrs.GasPump,
+			"gasstation":      addrs.GasStation,
+			"solveinbox":      addrs.SolveInbox,
+			"solveoutbox":     addrs.SolveOutbox,
+			"solvernetinbox":  addrs.SolverNetInbox,
+			"solvernetoutbox": addrs.SolverNetOutbox,
+			"feeoraclev2":     addrs.FeeOracleV2,
 		}
 
 		for name, addr := range addrsJSON {

--- a/lib/contracts/solvernet/inbox/deploy.go
+++ b/lib/contracts/solvernet/inbox/deploy.go
@@ -1,0 +1,193 @@
+package inbox
+
+import (
+	"context"
+
+	"github.com/omni-network/omni/contracts/bindings"
+	"github.com/omni-network/omni/e2e/app/eoa"
+	"github.com/omni-network/omni/lib/contracts"
+	"github.com/omni-network/omni/lib/create3"
+	"github.com/omni-network/omni/lib/errors"
+	"github.com/omni-network/omni/lib/ethclient/ethbackend"
+	"github.com/omni-network/omni/lib/netconf"
+
+	"github.com/ethereum/go-ethereum/common"
+	ethtypes "github.com/ethereum/go-ethereum/core/types"
+)
+
+type DeploymentConfig struct {
+	Create3Factory  common.Address
+	Create3Salt     string
+	ProxyAdminOwner common.Address
+	Owner           common.Address
+	Solver          common.Address
+	Portal          common.Address
+	Outbox          common.Address
+	Deployer        common.Address
+	ExpectedAddr    common.Address
+}
+
+func (cfg DeploymentConfig) Validate() error {
+	if (cfg.Create3Factory == common.Address{}) {
+		return errors.New("create3 factory is zero")
+	}
+	if cfg.Create3Salt == "" {
+		return errors.New("create3 salt is empty")
+	}
+	if (cfg.ProxyAdminOwner == common.Address{}) {
+		return errors.New("proxy admin is zero")
+	}
+	if contracts.IsEmptyAddress(cfg.Deployer) {
+		return errors.New("deployer is not set")
+	}
+	if contracts.IsEmptyAddress(cfg.Owner) {
+		return errors.New("owner is not set")
+	}
+	if (cfg.Outbox == common.Address{}) {
+		return errors.New("outbox is zero")
+	}
+	if (cfg.Portal == common.Address{}) {
+		return errors.New("portal is zero")
+	}
+	if (cfg.Solver == common.Address{}) {
+		return errors.New("solver is zero")
+	}
+	if (cfg.ExpectedAddr == common.Address{}) {
+		return errors.New("expected address is zero")
+	}
+
+	return nil
+}
+
+// isDeployed returns true if the SolverNetInbox contract is already deployed to its expected address.
+func isDeployed(ctx context.Context, network netconf.ID, backend *ethbackend.Backend) (bool, common.Address, error) {
+	addrs, err := contracts.GetAddresses(ctx, network)
+	if err != nil {
+		return false, common.Address{}, errors.Wrap(err, "get addresses")
+	}
+
+	addr := addrs.SolverNetInbox
+
+	code, err := backend.CodeAt(ctx, addr, nil)
+	if err != nil {
+		return false, addr, errors.Wrap(err, "code at", "address", addr)
+	}
+
+	if len(code) == 0 {
+		return false, addr, nil
+	}
+
+	return true, addr, nil
+}
+
+// DeployIfNeeded deploys a new SolverNetInbox contract if it is not already deployed.
+// If the contract is already deployed, the receipt is nil.
+func DeployIfNeeded(ctx context.Context, network netconf.ID, backend *ethbackend.Backend) (common.Address, *ethtypes.Receipt, error) {
+	deployed, addr, err := isDeployed(ctx, network, backend)
+	if err != nil {
+		return common.Address{}, nil, errors.Wrap(err, "is deployed")
+	}
+	if deployed {
+		return addr, nil, nil
+	}
+
+	return Deploy(ctx, network, backend)
+}
+
+// Deploy deploys a new SolverNetInbox contract and returns the address and receipt.
+func Deploy(ctx context.Context, network netconf.ID, backend *ethbackend.Backend) (common.Address, *ethtypes.Receipt, error) {
+	addrs, err := contracts.GetAddresses(ctx, network)
+	if err != nil {
+		return common.Address{}, nil, errors.Wrap(err, "get addresses")
+	}
+
+	salts, err := contracts.GetSalts(ctx, network)
+	if err != nil {
+		return common.Address{}, nil, errors.Wrap(err, "get salts")
+	}
+
+	cfg := DeploymentConfig{
+		Create3Factory:  addrs.Create3Factory,
+		Create3Salt:     salts.SolverNetInbox,
+		Owner:           eoa.MustAddress(network, eoa.RoleManager),
+		Deployer:        eoa.MustAddress(network, eoa.RoleDeployer),
+		ProxyAdminOwner: eoa.MustAddress(network, eoa.RoleUpgrader),
+		Solver:          eoa.MustAddress(network, eoa.RoleSolver),
+		Portal:          addrs.Portal,
+		Outbox:          addrs.SolverNetOutbox,
+		ExpectedAddr:    addrs.SolverNetInbox,
+	}
+
+	return deploy(ctx, cfg, backend)
+}
+
+func deploy(ctx context.Context, cfg DeploymentConfig, backend *ethbackend.Backend) (common.Address, *ethtypes.Receipt, error) {
+	if err := cfg.Validate(); err != nil {
+		return common.Address{}, nil, errors.Wrap(err, "validate config")
+	}
+
+	txOpts, err := backend.BindOpts(ctx, cfg.Deployer)
+	if err != nil {
+		return common.Address{}, nil, errors.Wrap(err, "bind opts")
+	}
+
+	factory, err := bindings.NewCreate3(cfg.Create3Factory, backend)
+	if err != nil {
+		return common.Address{}, nil, errors.Wrap(err, "new create3")
+	}
+
+	salt := create3.HashSalt(cfg.Create3Salt)
+
+	addr, err := factory.GetDeployed(nil, txOpts.From, salt)
+	if err != nil {
+		return common.Address{}, nil, errors.Wrap(err, "get deployed")
+	} else if (cfg.ExpectedAddr != common.Address{}) && addr != cfg.ExpectedAddr {
+		return common.Address{}, nil, errors.New("unexpected address", "expected", cfg.ExpectedAddr, "actual", addr)
+	}
+
+	impl, tx, _, err := bindings.DeploySolverNetInbox(txOpts, backend)
+	if err != nil {
+		return common.Address{}, nil, errors.Wrap(err, "deploy impl")
+	}
+
+	_, err = backend.WaitMined(ctx, tx)
+	if err != nil {
+		return common.Address{}, nil, errors.Wrap(err, "wait mined impl")
+	}
+
+	initCode, err := packInitCode(cfg, impl)
+	if err != nil {
+		return common.Address{}, nil, errors.Wrap(err, "pack init code")
+	}
+
+	tx, err = factory.DeployWithRetry(txOpts, salt, initCode) //nolint:contextcheck // Context is txOpts
+	if err != nil {
+		return common.Address{}, nil, errors.Wrap(err, "deploy proxy")
+	}
+
+	receipt, err := backend.WaitMined(ctx, tx)
+	if err != nil {
+		return common.Address{}, nil, errors.Wrap(err, "wait mined proxy")
+	}
+
+	return addr, receipt, nil
+}
+
+func packInitCode(cfg DeploymentConfig, impl common.Address) ([]byte, error) {
+	inboxAbi, err := bindings.SolverNetInboxMetaData.GetAbi()
+	if err != nil {
+		return nil, errors.Wrap(err, "get abi")
+	}
+
+	proxyAbi, err := bindings.TransparentUpgradeableProxyMetaData.GetAbi()
+	if err != nil {
+		return nil, errors.Wrap(err, "get proxy abi")
+	}
+
+	initializer, err := inboxAbi.Pack("initialize", cfg.Owner, cfg.Solver, cfg.Portal, cfg.Outbox)
+	if err != nil {
+		return nil, errors.Wrap(err, "encode initializer")
+	}
+
+	return contracts.PackInitCode(proxyAbi, bindings.TransparentUpgradeableProxyBin, impl, cfg.ProxyAdminOwner, initializer)
+}

--- a/lib/contracts/solvernet/outbox/deploy.go
+++ b/lib/contracts/solvernet/outbox/deploy.go
@@ -1,0 +1,193 @@
+package outbox
+
+import (
+	"context"
+
+	"github.com/omni-network/omni/contracts/bindings"
+	"github.com/omni-network/omni/e2e/app/eoa"
+	"github.com/omni-network/omni/lib/contracts"
+	"github.com/omni-network/omni/lib/create3"
+	"github.com/omni-network/omni/lib/errors"
+	"github.com/omni-network/omni/lib/ethclient/ethbackend"
+	"github.com/omni-network/omni/lib/netconf"
+
+	"github.com/ethereum/go-ethereum/common"
+	ethtypes "github.com/ethereum/go-ethereum/core/types"
+)
+
+type DeploymentConfig struct {
+	Create3Factory  common.Address
+	Create3Salt     string
+	ProxyAdminOwner common.Address
+	Owner           common.Address
+	Solver          common.Address
+	Portal          common.Address
+	Inbox           common.Address
+	Deployer        common.Address
+	ExpectedAddr    common.Address
+}
+
+func (cfg DeploymentConfig) Validate() error {
+	if (cfg.Create3Factory == common.Address{}) {
+		return errors.New("create3 factory is zero")
+	}
+	if cfg.Create3Salt == "" {
+		return errors.New("create3 salt is empty")
+	}
+	if (cfg.ProxyAdminOwner == common.Address{}) {
+		return errors.New("proxy admin is zero")
+	}
+	if contracts.IsEmptyAddress(cfg.Deployer) {
+		return errors.New("deployer is not set")
+	}
+	if contracts.IsEmptyAddress(cfg.Owner) {
+		return errors.New("owner is not set")
+	}
+	if (cfg.Inbox == common.Address{}) {
+		return errors.New("inbox is zero")
+	}
+	if (cfg.Portal == common.Address{}) {
+		return errors.New("portal is zero")
+	}
+	if (cfg.Solver == common.Address{}) {
+		return errors.New("solver is zero")
+	}
+	if (cfg.ExpectedAddr == common.Address{}) {
+		return errors.New("expected address is zero")
+	}
+
+	return nil
+}
+
+// isDeployed returns true if the SolverNetOutbox contract is already deployed to its expected address.
+func isDeployed(ctx context.Context, network netconf.ID, backend *ethbackend.Backend) (bool, common.Address, error) {
+	addrs, err := contracts.GetAddresses(ctx, network)
+	if err != nil {
+		return false, common.Address{}, errors.Wrap(err, "get addresses")
+	}
+
+	addr := addrs.SolverNetOutbox
+
+	code, err := backend.CodeAt(ctx, addr, nil)
+	if err != nil {
+		return false, addr, errors.Wrap(err, "code at", "address", addr)
+	}
+
+	if len(code) == 0 {
+		return false, addr, nil
+	}
+
+	return true, addr, nil
+}
+
+// DeployIfNeeded deploys a new SolverNetOutbox contract if it is not already deployed.
+// If the contract is already deployed, the receipt is nil.
+func DeployIfNeeded(ctx context.Context, network netconf.ID, backend *ethbackend.Backend) (common.Address, *ethtypes.Receipt, error) {
+	deployed, addr, err := isDeployed(ctx, network, backend)
+	if err != nil {
+		return common.Address{}, nil, errors.Wrap(err, "is deployed")
+	}
+	if deployed {
+		return addr, nil, nil
+	}
+
+	return Deploy(ctx, network, backend)
+}
+
+// Deploy deploys a new SolverNetOutbox contract and returns the address and receipt.
+func Deploy(ctx context.Context, network netconf.ID, backend *ethbackend.Backend) (common.Address, *ethtypes.Receipt, error) {
+	addrs, err := contracts.GetAddresses(ctx, network)
+	if err != nil {
+		return common.Address{}, nil, errors.Wrap(err, "get addresses")
+	}
+
+	salts, err := contracts.GetSalts(ctx, network)
+	if err != nil {
+		return common.Address{}, nil, errors.Wrap(err, "get salts")
+	}
+
+	cfg := DeploymentConfig{
+		Create3Factory:  addrs.Create3Factory,
+		Create3Salt:     salts.SolverNetOutbox,
+		Owner:           eoa.MustAddress(network, eoa.RoleManager),
+		Deployer:        eoa.MustAddress(network, eoa.RoleDeployer),
+		ProxyAdminOwner: eoa.MustAddress(network, eoa.RoleUpgrader),
+		Solver:          eoa.MustAddress(network, eoa.RoleSolver),
+		Portal:          addrs.Portal,
+		Inbox:           addrs.SolverNetInbox,
+		ExpectedAddr:    addrs.SolverNetOutbox,
+	}
+
+	return deploy(ctx, cfg, backend)
+}
+
+func deploy(ctx context.Context, cfg DeploymentConfig, backend *ethbackend.Backend) (common.Address, *ethtypes.Receipt, error) {
+	if err := cfg.Validate(); err != nil {
+		return common.Address{}, nil, errors.Wrap(err, "validate config")
+	}
+
+	txOpts, err := backend.BindOpts(ctx, cfg.Deployer)
+	if err != nil {
+		return common.Address{}, nil, errors.Wrap(err, "bind opts")
+	}
+
+	factory, err := bindings.NewCreate3(cfg.Create3Factory, backend)
+	if err != nil {
+		return common.Address{}, nil, errors.Wrap(err, "new create3")
+	}
+
+	salt := create3.HashSalt(cfg.Create3Salt)
+
+	addr, err := factory.GetDeployed(nil, txOpts.From, salt)
+	if err != nil {
+		return common.Address{}, nil, errors.Wrap(err, "get deployed")
+	} else if (cfg.ExpectedAddr != common.Address{}) && addr != cfg.ExpectedAddr {
+		return common.Address{}, nil, errors.New("unexpected address", "expected", cfg.ExpectedAddr, "actual", addr)
+	}
+
+	impl, tx, _, err := bindings.DeploySolverNetOutbox(txOpts, backend)
+	if err != nil {
+		return common.Address{}, nil, errors.Wrap(err, "deploy impl")
+	}
+
+	_, err = backend.WaitMined(ctx, tx)
+	if err != nil {
+		return common.Address{}, nil, errors.Wrap(err, "wait mined impl")
+	}
+
+	initCode, err := packInitCode(cfg, impl)
+	if err != nil {
+		return common.Address{}, nil, errors.Wrap(err, "pack init code")
+	}
+
+	tx, err = factory.DeployWithRetry(txOpts, salt, initCode) //nolint:contextcheck // Context is txOpts
+	if err != nil {
+		return common.Address{}, nil, errors.Wrap(err, "deploy proxy")
+	}
+
+	receipt, err := backend.WaitMined(ctx, tx)
+	if err != nil {
+		return common.Address{}, nil, errors.Wrap(err, "wait mined proxy")
+	}
+
+	return addr, receipt, nil
+}
+
+func packInitCode(cfg DeploymentConfig, impl common.Address) ([]byte, error) {
+	outboxAbi, err := bindings.SolverNetOutboxMetaData.GetAbi()
+	if err != nil {
+		return nil, errors.Wrap(err, "get abi")
+	}
+
+	proxyAbi, err := bindings.TransparentUpgradeableProxyMetaData.GetAbi()
+	if err != nil {
+		return nil, errors.Wrap(err, "get proxy abi")
+	}
+
+	initializer, err := outboxAbi.Pack("initialize", cfg.Owner, cfg.Solver, cfg.Portal, cfg.Inbox)
+	if err != nil {
+		return nil, errors.Wrap(err, "encode initializer")
+	}
+
+	return contracts.PackInitCode(proxyAbi, bindings.TransparentUpgradeableProxyBin, impl, cfg.ProxyAdminOwner, initializer)
+}

--- a/lib/contracts/testdata/TestContractAddressReference.golden
+++ b/lib/contracts/testdata/TestContractAddressReference.golden
@@ -9,6 +9,8 @@
   "portal": "0xc16282f0a26d042672bc4502bfe3c5fbbff4d21c",
   "solveinbox": "0x66ab85bdff90c3bc800f352a42a4417a4a287d3d",
   "solveoutbox": "0xfdf592f72a4e315714a63c92c57b36d0e74d4db6",
+  "solvernetinbox": "0x7c7759b801078ecb2c41c9caecc2db13c3079c76",
+  "solvernetoutbox": "0x29d9e8faa760841aacbe79a8632c1f42e0a858e6",
   "token": "0x73cc960fb6705e9a6a3d9eaf4de94a828cfa6d2a"
  },
  "mainnet": {
@@ -21,6 +23,8 @@
   "portal": "0x5e9a8aa213c912bf54c86bf64adb8ed6a79c04d1",
   "solveinbox": "0x1bf09c6414d1f581070eddfaf317e566543e0199",
   "solveoutbox": "0xf26f33188de6d8efe1fd791de2a95408a5113864",
+  "solvernetinbox": "0x8fcfcd0b4fa2cc2965a3c7f27995b0a43f210db8",
+  "solvernetoutbox": "0x084b603269a8fd0d0f7037e591665c025ce3549b",
   "token": "0x36e66fbbce51e4cd5bd3c62b637eb411b18949d4"
  },
  "omega": {
@@ -33,6 +37,8 @@
   "portal": "0xcb60a0451831e4865bc49f41f9c67665fc9b75c3",
   "solveinbox": "0x57f3e823041a27809ae5f6e98cfa062d18da613c",
   "solveoutbox": "0x3fdd17daa9fac84e5d2d965be38eb9136209d1a2",
+  "solvernetinbox": "0x71d48a88600a790fb1e94efdbf6c284fc08f99b8",
+  "solvernetoutbox": "0xd98068374c233e4d4081d24154489551dcd6fdf5",
   "token": "0xd036c60f46ff51dd7fbf6a819b5b171c8a076b07"
  }
 }


### PR DESCRIPTION
Deploy v2 SolverNet Inbox / Outbox contracts in e2e.

Deploy files are copy of existing `lib/contracts/solve(inbox|outboux)/deploy.so`, just changed the bindings used. 

issue: none