### PR TITLE
chore(ci): install locked foundry version in go test

### DIFF
--- a/.github/actions/setup-foundry/action.yaml
+++ b/.github/actions/setup-foundry/action.yaml
@@ -1,5 +1,12 @@
 name: Setup Foundry
 description: Install the foundry toolchain
+
+inputs:
+  docker:
+    description: "Whether or not to pull foundry docker image"
+    required: false
+    default: "false"
+
 runs:
   using: composite
   steps:
@@ -12,3 +19,8 @@ runs:
       uses: foundry-rs/foundry-toolchain@v1
       with:
         version: ${{ steps.foundry_version.outputs.version }}
+
+    - name: Install docker
+      shell: bash
+      if: ${{ inputs.docker == 'true' }}
+      run: docker pull ghcr.io/foundry-rs/foundry:${{ steps.foundry_version.outputs.version}}

--- a/.github/workflows/gotest.yaml
+++ b/.github/workflows/gotest.yaml
@@ -15,8 +15,9 @@ jobs:
         with:
           go-version: 'stable'
 
-      - name: Pull anvil # This can be slow and cause timeouts
-        run: docker pull ghcr.io/foundry-rs/foundry:latest
+      - uses: ./.github/actions/setup-foundry
+        with:
+          docker: "true"
 
       # TODO(corver): add coverage
       - name: Run all tests (with race)


### PR DESCRIPTION
Pull correct foundry docker image tag in test setup.

We were pulling latest, but tests were using the global foundry version sha in `scripts/foundry_version.txt`. 
So tests needed to pull, which caused timemouts.

issue: none
