### PR TITLE
feat(e2e): make omni token mintable on ephemeral networks

### DIFF
--- a/e2e/app/erc20faucet.go
+++ b/e2e/app/erc20faucet.go
@@ -46,7 +46,11 @@ func RunERC20Faucet(ctx context.Context, def Definition, cfg RunERC20FaucetConfi
 
 	account := common.HexToAddress(cfg.AddrToFund)
 	amt := new(big.Int).Mul(umath.NewBigInt(cfg.Amount), big.NewInt(params.Ether))
-	funder := omnitoken.InitialSupplyRecipient(networkID)
+
+	funder, err := omnitoken.InitialSupplyRecipient(networkID)
+	if err != nil {
+		return errors.Wrap(err, "initial supply recipient")
+	}
 
 	chain, ok := def.Testnet.EthereumChain()
 	if !ok {

--- a/e2e/app/tokenbridge.go
+++ b/e2e/app/tokenbridge.go
@@ -190,7 +190,10 @@ func bridgeToNative(ctx context.Context, def Definition, toBridge []BridgeTest) 
 	}
 
 	// payor is initial supply recipient, the only account with OMNI on L1 (for non-mainnet networks)
-	payor := omnitoken.InitialSupplyRecipient(networkID)
+	payor, err := omnitoken.InitialSupplyRecipient(networkID)
+	if err != nil {
+		return err
+	}
 
 	addrs, err := contracts.GetAddresses(ctx, networkID)
 	if err != nil {

--- a/lib/contracts/omnitoken/mint.go
+++ b/lib/contracts/omnitoken/mint.go
@@ -1,0 +1,48 @@
+package omnitoken
+
+import (
+	"context"
+	"math/big"
+
+	"github.com/omni-network/omni/contracts/bindings"
+	"github.com/omni-network/omni/lib/contracts"
+	"github.com/omni-network/omni/lib/errors"
+	"github.com/omni-network/omni/lib/ethclient/ethbackend"
+	"github.com/omni-network/omni/lib/netconf"
+
+	"github.com/ethereum/go-ethereum/common"
+)
+
+// Mint mints OMNI for user on ephemeral networks. The user adddress pays for the minting, and must be in given backend.
+func Mint(ctx context.Context, network netconf.ID, backend *ethbackend.Backend, user common.Address, amount *big.Int) error {
+	if !network.IsEphemeral() {
+		return errors.New("can only mint on ephemeral networks")
+	}
+
+	addrs, err := contracts.GetAddresses(ctx, network)
+	if err != nil {
+		return errors.Wrap(err, "get addrs")
+	}
+
+	txOpts, err := backend.BindOpts(ctx, user)
+	if err != nil {
+		return errors.Wrap(err, "bind opts")
+	}
+
+	contract, err := bindings.NewMockERC20(addrs.Token, backend)
+	if err != nil {
+		return errors.Wrap(err, "bind contract")
+	}
+
+	tx, err := contract.Mint(txOpts, user, amount)
+	if err != nil {
+		return errors.Wrap(err, "mint tx")
+	}
+
+	_, err = backend.WaitMined(ctx, tx)
+	if err != nil {
+		return errors.Wrap(err, "wait mined")
+	}
+
+	return nil
+}


### PR DESCRIPTION
Make OMNI mintable on devnet and staging. 

issue: none
