### PR TITLE
chore(e2e): pin monitor tag cef2aa0

### DIFF
--- a/e2e/manifests/mainnet.toml
+++ b/e2e/manifests/mainnet.toml
@@ -5,8 +5,8 @@ multi_omni_evms = true
 prometheus   = true
 
 pinned_halo_tag = "v0.11.0"
-pinned_relayer_tag = "3f85919"
-pinned_monitor_tag = "3f85919"
+pinned_relayer_tag = "cef2aa0"
+pinned_monitor_tag = "cef2aa0"
 
 [node.validator01]
 [node.validator02]

--- a/e2e/manifests/omega.toml
+++ b/e2e/manifests/omega.toml
@@ -5,8 +5,8 @@ multi_omni_evms = true
 prometheus = true
 
 pinned_halo_tag = "ead6061"
-pinned_relayer_tag = "ead6061"
-pinned_monitor_tag = "ead6061"
+pinned_relayer_tag = "cef2aa0"
+pinned_monitor_tag = "cef2aa0"
 
 [node.validator01]
 [node.validator02]


### PR DESCRIPTION
Pin monitor and relayer tag to [cef2aa0](https://github.com/omni-network/omni/commit/cef2aa06359f6743c5e4a63b4cee236339f9c747).

issue: #2275 

