### PR TITLE
chore(cli): improve init-nodes flags

### DIFF
--- a/cli/cmd/flags.go
+++ b/cli/cmd/flags.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"github.com/omni-network/omni/lib/feature"
 	"github.com/omni-network/omni/lib/netconf"
 
 	"github.com/spf13/cobra"
@@ -29,14 +28,13 @@ func bindRegConfig(cmd *cobra.Command, cfg *RegConfig) {
 
 func bindInitConfig(cmd *cobra.Command, cfg *InitConfig) {
 	netconf.BindFlag(cmd.Flags(), &cfg.Network)
-	feature.BindFlag(cmd.Flags(), &cfg.HaloFeatureFlags)
 	cmd.Flags().StringVar(&cfg.Moniker, "moniker", "", "Human-readable node name used in p2p networking")
 	cmd.Flags().StringVar(&cfg.Home, "home", "", "Home directory. If empty, defaults to: $HOME/.omni/<network>/")
 	cmd.Flags().BoolVar(&cfg.Clean, "clean", cfg.Clean, "Delete contents of home directory")
 	cmd.Flags().BoolVar(&cfg.Archive, "archive", cfg.Archive, "Enable archive mode. Note this requires more disk space")
 	cmd.Flags().BoolVar(&cfg.Debug, "debug", cfg.Debug, "Configure nodes with debug log level")
 	cmd.Flags().BoolVar(&cfg.NodeSnapshot, "node-snapshot", cfg.NodeSnapshot, "Download and restore latest node snapshot (geth and halo) from Omni")
-	cmd.Flags().StringVar(&cfg.HaloTag, "halo-tag", cfg.HaloTag, "Configure halo tag to use for node")
+	cmd.Flags().StringVar(&cfg.HaloTag, "halo-tag", cfg.HaloTag, "Docker image tag for omniops/halovisor")
 }
 
 func bindAVSAddress(cmd *cobra.Command, addr *string) {

--- a/scripts/join/join_test.go
+++ b/scripts/join/join_test.go
@@ -16,10 +16,8 @@ import (
 	"time"
 
 	clicmd "github.com/omni-network/omni/cli/cmd"
-	"github.com/omni-network/omni/e2e/manifests"
 	"github.com/omni-network/omni/lib/errors"
 	"github.com/omni-network/omni/lib/ethclient"
-	"github.com/omni-network/omni/lib/feature"
 	"github.com/omni-network/omni/lib/log"
 	"github.com/omni-network/omni/lib/netconf"
 	"github.com/omni-network/omni/lib/tutil"
@@ -64,12 +62,11 @@ func TestJoinNetwork(t *testing.T) {
 	networkID := netconf.ID(*network)
 	haloTag := haloTag(t)
 	cfg := clicmd.InitConfig{
-		Network:          networkID,
-		Home:             home,
-		Moniker:          t.Name(),
-		NodeSnapshot:     *nodeSnapshot,
-		HaloTag:          haloTag,
-		HaloFeatureFlags: maybeGetFeatureFlags(networkID),
+		Network:      networkID,
+		Home:         home,
+		Moniker:      t.Name(),
+		NodeSnapshot: *nodeSnapshot,
+		HaloTag:      haloTag,
 	}
 
 	tutil.RequireNoError(t, ensureHaloImage(cfg.HaloTag))
@@ -352,19 +349,4 @@ func getContainerStats(ctx context.Context) (stats, error) {
 	}
 
 	return resp, nil
-}
-
-func maybeGetFeatureFlags(network netconf.ID) feature.Flags {
-	if network.IsProtected() {
-		return make([]string, 0) // Protected networks never have feature flags
-	} else if network == netconf.Devnet {
-		panic("cannot join devnet")
-	}
-
-	manifest, err := manifests.Staging()
-	if err != nil {
-		panic(err)
-	}
-
-	return manifest.FeatureFlags
 }


### PR DESCRIPTION
Improve omni cli `--init-nodes` flags:
 - Remove `--feature-flags` since it wasn't actually used
 - Default `--halo-tag` to version of git commit

issue: none
