### PR TITLE
fix(github): temp remove node snapshot flow

### DIFF
--- a/.github/workflows/ci-join.yaml
+++ b/.github/workflows/ci-join.yaml
@@ -36,25 +36,6 @@ jobs:
           path: scripts/join/docker_logs_mainnet_full_sync.txt
           retention-days: 3
 
-      - name: Run Join Network Test Mainnet - Node Snapshot
-        run: |
-          cd scripts/join
-          sudo go test . -v \
-            --integration \
-            --timeout=0 \
-            --logs_file=docker_logs_mainnet_node_snapshot.txt \
-            --node_snapshot \
-            --halo_tag="main" \
-            --network="mainnet"
-
-      - name: Upload Docker Logs Mainnet - Node Snapshot
-        uses: actions/upload-artifact@v4
-        if: always()
-        with:
-          name: docker-logs
-          path: scripts/join/docker_logs_mainnet_node_snapshot.txt
-          retention-days: 3
-
       - name: Run Join Network Test Omega - Full Sync Node
         run: |
           cd scripts/join
@@ -71,23 +52,4 @@ jobs:
         with:
           name: docker-logs
           path: scripts/join/docker_logs_omega_full_sync.txt
-          retention-days: 3
-
-      - name: Run Join Network Test Omega - Node Snapshot
-        run: |
-          cd scripts/join
-          sudo go test . -v \
-            --integration \
-            --timeout=0 \
-            --logs_file=docker_logs_omega_node_snapshot.txt \
-            --node_snapshot \
-            --halo_tag="main" \
-            --network="omega"
-
-      - name: Upload Docker Logs Omega - Node Snapshot
-        uses: actions/upload-artifact@v4
-        if: always()
-        with:
-          name: docker-logs
-          path: scripts/join/docker_logs_omega_node_snapshot.txt
           retention-days: 3


### PR DESCRIPTION
- Temporarily remove node snapshot job due to them failing because of disk space issues.
- Those flows will be migrated out of this repo, but for now we just want to avoid having nightly failures for `Join Network Tests Nightly`.

issue: none
