### PR TITLE
fix(relayer): skip manual gas estimation for arb mainnet

### DIFF
--- a/relayer/app/gas.go
+++ b/relayer/app/gas.go
@@ -25,7 +25,8 @@ func newGasEstimator(network netconf.ID) gasEstimator {
 
 	// Some destination chains do not need this model and can simply rely on the proper gas estimation.
 	skipModel := map[uint64]bool{
-		evmchain.IDArbSepolia: true, // Arbitrum has non-standard gas usage, and super-fast blocks, so we skip the model.
+		evmchain.IDArbSepolia:  true, // Arbitrum has non-standard gas usage, and super-fast blocks, so we skip the model.
+		evmchain.IDArbitrumOne: true,
 	}
 
 	return func(destChain uint64, msgs []xchain.Msg) uint64 {

--- a/relayer/app/gas_internal_test.go
+++ b/relayer/app/gas_internal_test.go
@@ -52,9 +52,22 @@ func TestGasEstimator(t *testing.T) {
 			gas: properGasEstimation,
 		},
 		{
-			name:      "arb destination",
+			name:      "arb sepolia destination",
 			network:   netconf.Mainnet,
 			destChain: evmchain.IDArbSepolia,
+			msgs: []xchain.Msg{
+				{
+					MsgID: xchain.MsgID{
+						StreamID: xchain.StreamID{},
+					},
+				},
+			},
+			gas: properGasEstimation,
+		},
+		{
+			name:      "arb mainnet destination",
+			network:   netconf.Mainnet,
+			destChain: evmchain.IDArbitrumOne,
 			msgs: []xchain.Msg{
 				{
 					MsgID: xchain.MsgID{


### PR DESCRIPTION
Skip manual gas estimation for arb mainnet, like we do for arb sepolia. 

issue: none
