### PR TITLE
chore(e2e/manifests): update mainnet halo pin

### DIFF
--- a/e2e/manifests/mainnet.toml
+++ b/e2e/manifests/mainnet.toml
@@ -4,7 +4,7 @@ public_chains = ["ethereum","arbitrum_one","base","optimism"]
 multi_omni_evms = true
 prometheus   = true
 
-pinned_halo_tag = "v0.11.0"
+pinned_halo_tag = "v0.12.0"
 pinned_relayer_tag = "cef2aa0"
 pinned_monitor_tag = "cef2aa0"
 


### PR DESCRIPTION
Update mainnet halo pin to latest version v0.12.0.

issue: #2828
