### PR TITLE
test(octane/evmengine): fuzz test proposed payload

### DIFF
--- a/e2e/manifests/fuzzyhead.toml
+++ b/e2e/manifests/fuzzyhead.toml
@@ -3,6 +3,8 @@ anvil_chains = ["mock_l2", "mock_l1"]
 
 pingpong_n = 6 # Increased ping pong to span forks
 
+feature_flags = ["fuzz-octane"]
+
 [node.validator01]
 [node.validator02]
 [node.validator03]

--- a/halo/app/start.go
+++ b/halo/app/start.go
@@ -103,8 +103,11 @@ func Start(ctx context.Context, cfg Config) (<-chan error, func(context.Context)
 
 	buildinfo.Instrument(ctx)
 
-	feature.SetGlobals(cfg.FeatureFlags)
-	ctx = feature.WithFlags(ctx, cfg.FeatureFlags)
+	if cfg.Network.IsEphemeral() {
+		// Feature flags only applicable to ephemeral networks.
+		feature.SetGlobals(cfg.FeatureFlags)
+		ctx = feature.WithFlags(ctx, cfg.FeatureFlags)
+	}
 
 	tracerIDs := tracer.Identifiers{Network: cfg.Network, Service: "halo", Instance: cfg.Comet.Moniker}
 	stopTracer, err := tracer.Init(ctx, tracerIDs, cfg.Tracer)

--- a/lib/feature/feature.go
+++ b/lib/feature/feature.go
@@ -14,6 +14,8 @@ const (
 	FlagSimpleEVMEvents Flag = "simple-evm-events"
 	// FlagProtoEVMPayload enables the protobuf encoded execution payload.
 	FlagProtoEVMPayload Flag = "proto-evm-payload"
+	// FlagFuzzOctane enables fuzz testing of octane.
+	FlagFuzzOctane Flag = "fuzz-octane"
 	// FlagSolverV2 enables the new solver v2.
 	FlagSolverV2 Flag = "solver-v2"
 )
@@ -28,6 +30,7 @@ var allFlags = map[Flag]bool{
 	FlagEVMStakingModule: true,
 	FlagSimpleEVMEvents:  true,
 	FlagProtoEVMPayload:  true,
+	FlagFuzzOctane:       true,
 	FlagSolverV2:         true,
 }
 


### PR DESCRIPTION
Previous attempts at engine API error handling didn't actually work in the case that geth returns INVALID AND ERRORS. This is because the geth client, only returns responses OR errors. 

Detect application errors in NewPayloadV3 by checking for RPC error types, convert all these to INVALID status.

Also add support for fuzz testing octane evm payload proposing. This ensures that invalid payloads dont stall (slow down) the chain.

issue: #2461