### PR TITLE
docs(content): fix typos 

### DIFF
--- a/docs/content/core/intro.md
+++ b/docs/content/core/intro.md
@@ -3,6 +3,6 @@
 Omni Core consists of two components:
 
 - **Cross Chain Messaging**: A protocol for decentralized and fast cross-chain communication.
-- **Omni EVM**: A execution layer designed for global computation across chains.
+- **Omni EVM**: An execution layer designed for global computation across chains.
 
 They are both leveraged by SolverNet, but they are permissionless and can be used by any developer.

--- a/docs/content/learn/what.md
+++ b/docs/content/learn/what.md
@@ -46,7 +46,7 @@ Here's a quick breakdown of how the Omni Orderflow Engine works.
 
 2. **Solver Execution:** Solvers detect the intent, bid to execute it on the destination, and provide "just in time" liquidity to the destination rollup by depositing funds on behalf of the user.
 
-3. **Cross-Rollup Settlement:** Using Omni Core, the solvers provide proff of execution of the user's intent, allowing the escrow contract on the origin rollup to release the users deposited funds.
+3. **Cross-Rollup Settlement:** Using Omni Core, the solvers provide proof of execution of the user's intent, allowing the escrow contract on the origin rollup to release the users deposited funds.
 
 ## Why the Omni Orderflow Engine Matters
 


### PR DESCRIPTION
 In `docs/content/core/intro.md`:
- Old: "A execution layer"
- New: "An execution layer" 
Reason: Fixed article usage - "an" is used before words beginning with vowel sounds.

 In `docs/content/learn/what.md`:
- Old: "proff"
- New: "proof"
Reason: Fixed spelling error in the word "proof".

These changes improve documentation accuracy and readability by fixing typos and grammatical errors.

issue: none
