### PR TITLE
chore(e2e/agent): decrease prometheus scrape interval

### DIFF
--- a/e2e/app/agent/prometheus.yaml.tmpl
+++ b/e2e/app/agent/prometheus.yaml.tmpl
@@ -1,6 +1,6 @@
 global:
-  scrape_interval: 30s # Set the scrape interval to every 30 seconds.
-  evaluation_interval: 30s # Evaluate rules every 30 seconds.
+  scrape_interval: 1m # Set the scrape interval to 1m (default).
+  evaluation_interval: 1m # Evaluate rules every 1m (default).
 
 {{- if .RemoteURL }}
 remote_write:

--- a/e2e/app/agent/testdata/TestPromGen_manifest1_gen.golden
+++ b/e2e/app/agent/testdata/TestPromGen_manifest1_gen.golden
@@ -1,6 +1,6 @@
 global:
-  scrape_interval: 30s # Set the scrape interval to every 30 seconds.
-  evaluation_interval: 30s # Evaluate rules every 30 seconds.
+  scrape_interval: 1m # Set the scrape interval to 1m (default).
+  evaluation_interval: 1m # Evaluate rules every 1m (default).
 
 scrape_configs:
   - job_name: "halo"

--- a/e2e/app/agent/testdata/TestPromGen_manifest1_update.golden
+++ b/e2e/app/agent/testdata/TestPromGen_manifest1_update.golden
@@ -1,6 +1,6 @@
 global:
-  scrape_interval: 30s # Set the scrape interval to every 30 seconds.
-  evaluation_interval: 30s # Evaluate rules every 30 seconds.
+  scrape_interval: 1m # Set the scrape interval to 1m (default).
+  evaluation_interval: 1m # Evaluate rules every 1m (default).
 
 scrape_configs:
   - job_name: "halo"

--- a/e2e/app/agent/testdata/TestPromGen_manifest2_gen.golden
+++ b/e2e/app/agent/testdata/TestPromGen_manifest2_gen.golden
@@ -1,6 +1,6 @@
 global:
-  scrape_interval: 30s # Set the scrape interval to every 30 seconds.
-  evaluation_interval: 30s # Evaluate rules every 30 seconds.
+  scrape_interval: 1m # Set the scrape interval to 1m (default).
+  evaluation_interval: 1m # Evaluate rules every 1m (default).
 remote_write:
   - url: https://grafana.com
     basic_auth:

--- a/e2e/app/agent/testdata/TestPromGen_manifest2_update.golden
+++ b/e2e/app/agent/testdata/TestPromGen_manifest2_update.golden
@@ -1,6 +1,6 @@
 global:
-  scrape_interval: 30s # Set the scrape interval to every 30 seconds.
-  evaluation_interval: 30s # Evaluate rules every 30 seconds.
+  scrape_interval: 1m # Set the scrape interval to 1m (default).
+  evaluation_interval: 1m # Evaluate rules every 1m (default).
 remote_write:
   - url: https://grafana.com
     basic_auth:

--- a/e2e/app/agent/testdata/TestPromGen_manifest3_gen.golden
+++ b/e2e/app/agent/testdata/TestPromGen_manifest3_gen.golden
@@ -1,6 +1,6 @@
 global:
-  scrape_interval: 30s # Set the scrape interval to every 30 seconds.
-  evaluation_interval: 30s # Evaluate rules every 30 seconds.
+  scrape_interval: 1m # Set the scrape interval to 1m (default).
+  evaluation_interval: 1m # Evaluate rules every 1m (default).
 
 scrape_configs:
   - job_name: "halo"

--- a/e2e/app/agent/testdata/TestPromGen_manifest3_update.golden
+++ b/e2e/app/agent/testdata/TestPromGen_manifest3_update.golden
@@ -1,6 +1,6 @@
 global:
-  scrape_interval: 30s # Set the scrape interval to every 30 seconds.
-  evaluation_interval: 30s # Evaluate rules every 30 seconds.
+  scrape_interval: 1m # Set the scrape interval to 1m (default).
+  evaluation_interval: 1m # Evaluate rules every 1m (default).
 
 scrape_configs:
   - job_name: "halo"

--- a/e2e/app/agent/testdata/TestPromGen_manifest4_gen.golden
+++ b/e2e/app/agent/testdata/TestPromGen_manifest4_gen.golden
@@ -1,6 +1,6 @@
 global:
-  scrape_interval: 30s # Set the scrape interval to every 30 seconds.
-  evaluation_interval: 30s # Evaluate rules every 30 seconds.
+  scrape_interval: 1m # Set the scrape interval to 1m (default).
+  evaluation_interval: 1m # Evaluate rules every 1m (default).
 remote_write:
   - url: https://grafana.com
     basic_auth:

--- a/e2e/app/agent/testdata/TestPromGen_manifest4_update.golden
+++ b/e2e/app/agent/testdata/TestPromGen_manifest4_update.golden
@@ -1,6 +1,6 @@
 global:
-  scrape_interval: 30s # Set the scrape interval to every 30 seconds.
-  evaluation_interval: 30s # Evaluate rules every 30 seconds.
+  scrape_interval: 1m # Set the scrape interval to 1m (default).
+  evaluation_interval: 1m # Evaluate rules every 1m (default).
 remote_write:
   - url: https://grafana.com
     basic_auth:


### PR DESCRIPTION
Decrease prometheus scrape interval from 30s to 1m.This should reduce Grafana cloud costs by 50%.

issue: https://github.com/omni-network/ops/issues/715