### PR TITLE
ci(e2e): enable evm proto feature on staging

### DIFF
--- a/e2e/manifests/staging.toml
+++ b/e2e/manifests/staging.toml
@@ -4,7 +4,7 @@ multi_omni_evms = true
 prometheus = true
 deploy_solve = true
 
-feature_flags = ["evm-staking-module","simple-evm-events"]
+feature_flags = ["evm-staking-module","simple-evm-events","proto-evm-payload"]
 
 [node.validator01]
 [node.validator02]


### PR DESCRIPTION
Enable `evm-proto-payload` feature on staging.

issue: none