### PR TITLE
chore(cchain/provider): expose cosmos module query clients

### DIFF
--- a/lib/cchain/provider.go
+++ b/lib/cchain/provider.go
@@ -83,4 +83,7 @@ type Provider interface {
 
 	// AppliedPlan returns the applied (activated) upgrade plan by name.
 	AppliedPlan(ctx context.Context, name string) (utypes.Plan, bool, error)
+
+	// QueryClients returns the query clients for the various modules.
+	QueryClients() QueryClients
 }

--- a/lib/cchain/provider/abci.go
+++ b/lib/cchain/provider/abci.go
@@ -112,6 +112,16 @@ func newProvider(cc gogogrpc.ClientConn, network netconf.ID, opts ...func(*Provi
 		backoffFunc: backoffFunc,
 		chainNamer:  namer,
 		network:     network,
+		queryClients: cchain.QueryClients{
+			Attest:       acl,
+			Portal:       pcl,
+			Registry:     rcl,
+			ValSync:      vcl,
+			Staking:      scl,
+			Slashing:     slcl,
+			Upgrade:      ucl,
+			Distribution: dcl,
+		},
 	}
 
 	for _, opt := range opts {

--- a/lib/cchain/provider/provider.go
+++ b/lib/cchain/provider/provider.go
@@ -59,24 +59,25 @@ type valSetResponse struct {
 
 // Provider implements cchain.Provider.
 type Provider struct {
-	fetch       fetchFunc
-	allAtts     allAttsFunc
-	latest      latestFunc
-	window      windowFunc
-	valset      valsetFunc
-	val         valFunc
-	signing     signingFunc
-	vals        valsFunc
-	rewards     rewardsFunc
-	chainID     chainIDFunc
-	portalBlock portalBlockFunc
-	networkFunc networkFunc
-	genesisFunc genesisFunc
-	plannedFunc planedUpgradeFunc
-	appliedFunc appliedUpgradeFunc
-	backoffFunc func(context.Context) func()
-	chainNamer  func(xchain.ChainVersion) string
-	network     netconf.ID
+	fetch        fetchFunc
+	allAtts      allAttsFunc
+	latest       latestFunc
+	window       windowFunc
+	valset       valsetFunc
+	val          valFunc
+	signing      signingFunc
+	vals         valsFunc
+	rewards      rewardsFunc
+	chainID      chainIDFunc
+	portalBlock  portalBlockFunc
+	networkFunc  networkFunc
+	genesisFunc  genesisFunc
+	plannedFunc  planedUpgradeFunc
+	appliedFunc  appliedUpgradeFunc
+	backoffFunc  func(context.Context) func()
+	chainNamer   func(xchain.ChainVersion) string
+	network      netconf.ID
+	queryClients cchain.QueryClients
 }
 
 // NewProviderForT creates a new provider for testing.
@@ -90,6 +91,10 @@ func NewProviderForT(_ *testing.T, fetch fetchFunc, latest latestFunc, window wi
 		backoffFunc: backoffFunc,
 		chainNamer:  func(xchain.ChainVersion) string { return "" },
 	}
+}
+
+func (p Provider) QueryClients() cchain.QueryClients {
+	return p.queryClients
 }
 
 func (p Provider) CurrentPlannedPlan(ctx context.Context) (upgradetypes.Plan, bool, error) {

--- a/lib/cchain/types.go
+++ b/lib/cchain/types.go
@@ -3,6 +3,10 @@ package cchain
 import (
 	"crypto/ecdsa"
 
+	atypes "github.com/omni-network/omni/halo/attest/types"
+	ptypes "github.com/omni-network/omni/halo/portal/types"
+	rtypes "github.com/omni-network/omni/halo/registry/types"
+	vtypes "github.com/omni-network/omni/halo/valsync/types"
 	"github.com/omni-network/omni/lib/cast"
 	"github.com/omni-network/omni/lib/errors"
 	"github.com/omni-network/omni/lib/umath"
@@ -13,12 +17,26 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
 
+	utypes "cosmossdk.io/x/upgrade/types"
 	cosmosk1 "github.com/cosmos/cosmos-sdk/crypto/keys/secp256k1"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	dtypes "github.com/cosmos/cosmos-sdk/x/distribution/types"
 	sltypes "github.com/cosmos/cosmos-sdk/x/slashing/types"
 	stypes "github.com/cosmos/cosmos-sdk/x/staking/types"
 	"github.com/cosmos/gogoproto/proto"
 )
+
+// QueryClients is a collection of cosmos module gRPC query clients.
+type QueryClients struct {
+	Attest       atypes.QueryClient
+	Portal       ptypes.QueryClient
+	Registry     rtypes.QueryClient
+	ValSync      vtypes.QueryClient
+	Staking      stypes.QueryClient
+	Slashing     sltypes.QueryClient
+	Upgrade      utypes.QueryClient
+	Distribution dtypes.QueryClient
+}
 
 // PortalValidator is a consensus chain validator in a validator set emitted/submitted by/tp portals .
 type PortalValidator struct {


### PR DESCRIPTION
Expose underlying cosmos gRPC query clients in cprovider.

CProvider interface is getting very big. We don't need to wrap and customize each module function. So rather just expose all clients. If we see we want to wrap a specific method, then we can do that later once the need is clear.

issue: none