### PR TITLE
ci(e2e): convert validator01 to archive node

### DIFF
--- a/e2e/manifests/staging.toml
+++ b/e2e/manifests/staging.toml
@@ -13,9 +13,10 @@ feature_flags = ["evm-staking-module","simple-evm-events","proto-evm-payload"]
 mode = "seed"
 
 [node.fullnode01]
-mode = "archive"
+mode = "archive" # Used by relayer, so must be archive.
 
 [keys.validator01]
+mode = "archive" # Used for node snapshots, so must be archive.
 validator = "0xD6CD71dF91a6886f69761826A9C4D123178A8d9D"
 p2p_consensus = "324F0A865DB7EAFBF53A387FC74E58169EDFA6C4"
 


### PR DESCRIPTION
convert validator01 on staging's manifest to be an archive node intended for node snapshot usage

issue: #2900 