### PR TITLE
chore(e2e/solve): add mock token deployments

### DIFF
--- a/e2e/solve/deploy.go
+++ b/e2e/solve/deploy.go
@@ -28,7 +28,13 @@ func DeployContracts(ctx context.Context, network netconf.Network, backends ethb
 
 	if feature.FlagSolverV2.Enabled(ctx) {
 		log.Info(ctx, "Deploying solve v2 contracts")
-		return deployV2Boxes(ctx, network, backends)
+
+		var eg errgroup.Group
+		eg.Go(func() error { return deployV2Boxes(ctx, network, backends) })
+		eg.Go(func() error { return maybeDeployMockTokens(ctx, network, backends) })
+		if err := eg.Wait(); err != nil {
+			return errors.Wrap(err, "deploy v2")
+		}
 
 		// TODO: remove below when v2 is fully enabled
 		//

--- a/e2e/solve/mocktokens.go
+++ b/e2e/solve/mocktokens.go
@@ -1,0 +1,155 @@
+package solve
+
+import (
+	"context"
+
+	"github.com/omni-network/omni/contracts/bindings"
+	"github.com/omni-network/omni/e2e/app/eoa"
+	"github.com/omni-network/omni/lib/contracts"
+	"github.com/omni-network/omni/lib/create3"
+	"github.com/omni-network/omni/lib/errors"
+	"github.com/omni-network/omni/lib/ethclient/ethbackend"
+	"github.com/omni-network/omni/lib/evmchain"
+	"github.com/omni-network/omni/lib/log"
+	"github.com/omni-network/omni/lib/netconf"
+	"github.com/omni-network/omni/lib/tokens"
+
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
+
+	"golang.org/x/sync/errgroup"
+)
+
+type MockToken struct {
+	tokens.Token
+	ChainID   uint64
+	NetworkID netconf.ID
+}
+
+var mocks = []MockToken{
+	// staging mock wstETH
+	{Token: tokens.WSTETH, ChainID: evmchain.IDBaseSepolia, NetworkID: netconf.Staging},
+
+	// devnet mock wstETH
+	{Token: tokens.WSTETH, ChainID: evmchain.IDMockL2, NetworkID: netconf.Devnet},
+}
+
+func MockTokens() []MockToken {
+	return mocks
+}
+
+func (m MockToken) Address() common.Address {
+	return create3.Address(
+		contracts.Create3Factory(m.NetworkID),
+		m.Create3Salt(),
+		eoa.MustAddress(m.NetworkID, eoa.RoleDeployer),
+	)
+}
+
+func (m MockToken) Create3Salt() string {
+	return m.NetworkID.String() + "::mock::" + m.Symbol
+}
+
+// maybeDeployMockTokens deploys mintable ERC20 tokens on ephemeral networks, for solvernet testing.
+func maybeDeployMockTokens(ctx context.Context, network netconf.Network, backends ethbackend.Backends) error {
+	if !network.ID.IsEphemeral() {
+		return nil
+	}
+
+	var eg errgroup.Group
+
+	for _, mock := range mocks {
+		eg.Go(func() error {
+			if mock.NetworkID != network.ID {
+				return nil
+			}
+
+			chain, ok := network.Chain(mock.ChainID)
+			if !ok {
+				return errors.New("mock token chain not in network", "chain", mock.ChainID)
+			}
+
+			backend, err := backends.Backend(chain.ID)
+			if err != nil {
+				return errors.Wrap(err, "get backend", "chain", chain.Name)
+			}
+
+			return maybeDeployMockToken(ctx, network.ID, backend, mock)
+		})
+	}
+
+	if err := eg.Wait(); err != nil {
+		return errors.Wrap(err, "deploy tokens")
+	}
+
+	return nil
+}
+
+func maybeDeployMockToken(ctx context.Context, network netconf.ID, backend *ethbackend.Backend, mock MockToken) error {
+	deployer := eoa.MustAddress(network, eoa.RoleDeployer)
+
+	txOpts, err := backend.BindOpts(ctx, deployer)
+	if err != nil {
+		return errors.Wrap(err, "bind opts")
+	}
+
+	factory, err := bindings.NewCreate3(contracts.Create3Factory(network), backend)
+	if err != nil {
+		return errors.Wrap(err, "new create3")
+	}
+
+	salt := mock.Create3Salt()
+
+	addr, deployed, err := isDeployed(ctx, backend, factory, deployer, salt)
+	if err != nil {
+		return errors.Wrap(err, "is deployed")
+	}
+
+	if deployed {
+		log.Info(ctx, "MockToken already deployed", "addr", addr, "salt", salt, "name", mock.Name, "symbol", mock.Symbol)
+		return nil
+	}
+
+	abi, err := bindings.MockERC20MetaData.GetAbi()
+	if err != nil {
+		return errors.Wrap(err, "get abi")
+	}
+
+	initCode, err := contracts.PackInitCode(abi, bindings.MockERC20Bin, mock.Name, mock.Symbol)
+	if err != nil {
+		return errors.Wrap(err, "pack init code")
+	}
+
+	tx, err := factory.DeployWithRetry(txOpts, create3.HashSalt(salt), initCode) //nolint:contextcheck // Context is txOpts
+	if err != nil {
+		return errors.Wrap(err, "deploy")
+	}
+
+	_, err = backend.WaitMined(ctx, tx)
+	if err != nil {
+		return errors.Wrap(err, "wait mined")
+	}
+
+	log.Info(ctx, "MockToken deployed", "addr", addr, "salt", salt, "name", mock.Name, "symbol", mock.Symbol)
+
+	return nil
+}
+
+func isDeployed(ctx context.Context, backend *ethbackend.Backend,
+	factory *bindings.Create3, deployer common.Address, salt string) (common.Address, bool, error) {
+	addr, err := factory.GetDeployed(&bind.CallOpts{Context: ctx}, deployer, create3.HashSalt(salt))
+	if err != nil {
+		return addr, false, errors.Wrap(err, "get deployed")
+	}
+
+	code, err := backend.CodeAt(ctx, addr, nil)
+	if err != nil {
+		return addr, false, errors.Wrap(err, "code at")
+	}
+
+	if len(code) > 0 {
+		return addr, true, nil
+	}
+
+	return addr, false, nil
+}

--- a/solver/app/v2/testdata/TestTokens.golden
+++ b/solver/app/v2/testdata/TestTokens.golden
@@ -1,0 +1,138 @@
+[
+ {
+  "address": "0x0000000000000000000000000000000000000000",
+  "chainId": 17000,
+  "coingeckoId": "ethereum",
+  "isMock": false,
+  "name": "Ether",
+  "symbol": "ETH"
+ },
+ {
+  "address": "0x0000000000000000000000000000000000000000",
+  "chainId": 421614,
+  "coingeckoId": "ethereum",
+  "isMock": false,
+  "name": "Ether",
+  "symbol": "ETH"
+ },
+ {
+  "address": "0x0000000000000000000000000000000000000000",
+  "chainId": 84532,
+  "coingeckoId": "ethereum",
+  "isMock": false,
+  "name": "Ether",
+  "symbol": "ETH"
+ },
+ {
+  "address": "0x0000000000000000000000000000000000000000",
+  "chainId": 11155420,
+  "coingeckoId": "ethereum",
+  "isMock": false,
+  "name": "Ether",
+  "symbol": "ETH"
+ },
+ {
+  "address": "0x0000000000000000000000000000000000000000",
+  "chainId": 1652,
+  "coingeckoId": "ethereum",
+  "isMock": false,
+  "name": "Ether",
+  "symbol": "ETH"
+ },
+ {
+  "address": "0x0000000000000000000000000000000000000000",
+  "chainId": 1654,
+  "coingeckoId": "ethereum",
+  "isMock": false,
+  "name": "Ether",
+  "symbol": "ETH"
+ },
+ {
+  "address": "0x0000000000000000000000000000000000000000",
+  "chainId": 164,
+  "coingeckoId": "omni-network",
+  "isMock": false,
+  "name": "Omni Network",
+  "symbol": "OMNI"
+ },
+ {
+  "address": "0x0000000000000000000000000000000000000000",
+  "chainId": 1650,
+  "coingeckoId": "omni-network",
+  "isMock": false,
+  "name": "Omni Network",
+  "symbol": "OMNI"
+ },
+ {
+  "address": "0x0000000000000000000000000000000000000000",
+  "chainId": 1651,
+  "coingeckoId": "omni-network",
+  "isMock": false,
+  "name": "Omni Network",
+  "symbol": "OMNI"
+ },
+ {
+  "address": "0x36E66fbBce51e4cD5bd3C62B637Eb411b18949D4",
+  "chainId": 1,
+  "coingeckoId": "omni-network",
+  "isMock": false,
+  "name": "Omni Network",
+  "symbol": "OMNI"
+ },
+ {
+  "address": "0xD036C60f46FF51dd7Fbf6a819b5B171c8A076b07",
+  "chainId": 17000,
+  "coingeckoId": "omni-network",
+  "isMock": false,
+  "name": "Omni Network",
+  "symbol": "OMNI"
+ },
+ {
+  "address": "0xB50029Dc0DF4Db0193F25a8E41DEa207c13D09BB",
+  "chainId": 17000,
+  "coingeckoId": "omni-network",
+  "isMock": false,
+  "name": "Omni Network",
+  "symbol": "OMNI"
+ },
+ {
+  "address": "0x73cC960fb6705e9a6A3d9EAf4De94a828CFa6d2a",
+  "chainId": 1652,
+  "coingeckoId": "omni-network",
+  "isMock": false,
+  "name": "Omni Network",
+  "symbol": "OMNI"
+ },
+ {
+  "address": "0x8d09a4502Cc8Cf1547aD300E066060D043f6982D",
+  "chainId": 17000,
+  "coingeckoId": "wrapped-steth",
+  "isMock": false,
+  "name": "Wrapped Staked Ether",
+  "symbol": "wstETH"
+ },
+ {
+  "address": "0x3F1c547b21f65e10480dE3ad8E19fAAC46C95034",
+  "chainId": 17000,
+  "coingeckoId": "lido-staked-ether",
+  "isMock": false,
+  "name": "Lido Staked Ether",
+  "symbol": "stETH"
+ },
+ {
+  "address": "0x6319df7c227e34B967C1903A08a698A3cC43492B",
+  "chainId": 84532,
+  "coingeckoId": "wrapped-steth",
+  "isMock": true,
+  "name": "Wrapped Staked Ether",
+  "symbol": "wstETH"
+ },
+ {
+  "address": "0x86156a9225DCE4781005d8CDC48106e308A0F338",
+  "chainId": 1654,
+  "coingeckoId": "wrapped-steth",
+  "isMock": true,
+  "name": "Wrapped Staked Ether",
+  "symbol": "wstETH"
+ }
+]

--- a/solver/app/v2/tokens_internal_test.go
+++ b/solver/app/v2/tokens_internal_test.go
@@ -1,0 +1,33 @@
+package appv2
+
+import (
+	"testing"
+
+	"github.com/omni-network/omni/lib/tutil"
+)
+
+// TestTokens ensures solver toke list does not change without explicit golden update.
+func TestTokens(t *testing.T) {
+	t.Parallel()
+
+	golden := []map[string]any{}
+	seen := make(map[Token]bool)
+
+	for _, token := range tokens {
+		if seen[token] {
+			t.Errorf("duplicate token: %v", token)
+		}
+
+		seen[token] = true
+		golden = append(golden, map[string]any{
+			"name":        token.Name,
+			"symbol":      token.Symbol,
+			"address":     token.Address.Hex(),
+			"chainId":     token.ChainID,
+			"coingeckoId": token.CoingeckoID,
+			"isMock":      token.IsMock,
+		})
+	}
+
+	tutil.RequireGoldenJSON(t, golden)
+}


### PR DESCRIPTION
Add mock solvernet token deployments, to test solver in devnet / staging.

Relies on #2906

issue: none
