### PR TITLE
fix(scripts): fix typo in variable name

### DIFF
--- a/scripts/buf_generate.sh
+++ b/scripts/buf_generate.sh
@@ -21,7 +21,7 @@ function bufgen() {
       --path="${DIR}"
 }
 
-# Ensure we are in the root of the repo, so  ${pwd}/go.mod must exit
+# Ensure we are in the root of the repo, so ${pwd}/go.mod must exist
 if [ ! -f go.mod ]; then
   echo "Please run this script from the root of the repository"
   exit 1


### PR DESCRIPTION
### Description  

I noticed a small typo in the variable name where "exit" was used instead of "exist."
This PR corrects the spelling to ensure clarity and accuracy in the code.

issue: none