### PR TITLE
fix: fix function name in monitor.go

### DIFF
--- a/monitor/account/monitor.go
+++ b/monitor/account/monitor.go
@@ -27,7 +27,7 @@ func StartMonitoring(ctx context.Context, network netconf.Network, rpcClients ma
 	}
 }
 
-// monitorAccountsForever blocks and periodically monitors the account for the given chain.
+// monitorAccountForever blocks and periodically monitors the account for the given chain.
 func monitorAccountForever(
 	ctx context.Context,
 	network netconf.ID,


### PR DESCRIPTION
Typo in the function name. Fixed it to `monitorAccountForever` to align with the intended functionality and naming conventions.

issue: none