### PR TITLE
fix(halo/attest): fix vote extension validation issue

### DIFF
--- a/halo/attest/keeper/keeper.go
+++ b/halo/attest/keeper/keeper.go
@@ -742,7 +742,7 @@ func (k *Keeper) VerifyVoteExtension(ctx sdk.Context, req *abci.RequestVerifyVot
 	_, ok, err := k.parseAndVerifyVoteExtension(ctx, req.ValidatorAddress, req.VoteExtension, uint64(req.Height))
 	if err != nil {
 		log.Warn(ctx, "Rejecting vote extension", err, log.Hex7("validator", req.ValidatorAddress))
-		return respAccept, nil
+		return respReject, nil
 	} else if !ok {
 		log.Warn(ctx, "Rejecting vote extension containing vote behind window", nil, log.Hex7("validator", req.ValidatorAddress))
 		return respReject, nil


### PR DESCRIPTION
Fix typo that results in accepting of invalid VEs. 

Impact of bug: 
- Malicious validator can submit invalid votes which are then accepted and included in comet block.
- But, these invalid votes will be ignored in `PrepareVotes` by honest validators.
- Malicious validators that do include these in block proposals will be rejected.
- So this impact is Low as the only impact is invalid votes in consensus blocks. It cannot stall the chain or prevent block building or further vote attestations.

issue: none