### PR TITLE
feat(solver/app): require deposits match quote for expenses

### DIFF
--- a/solver/app/v2/quote.go
+++ b/solver/app/v2/quote.go
@@ -1,0 +1,93 @@
+package appv2
+
+import (
+	"math/big"
+
+	"github.com/omni-network/omni/lib/errors"
+)
+
+// getQuote returns payment in `depositTkns` required to pay for `expenses`.
+//
+// For now, this is a simple quote that requires a single expense, paid
+// for by an equal amount of an equivalent deposit token. Token equivalence is
+// determined by symbol (ex arbitrum "ETH" is equivalent to optimism "ETH").
+func getQuote(depositTkns []Token, expenses []Payment) ([]Payment, RejectOrErr) {
+	if len(depositTkns) != 1 {
+		return nil, RejectOrErr{
+			Reason: rejectInvalidDeposit,
+			Err:    errors.New("only single deposit token supported"),
+		}
+	}
+
+	if len(expenses) != 1 {
+		return nil, RejectOrErr{
+			Reason: rejectInvalidExpense,
+			Err:    errors.New("only single expense supported"),
+		}
+	}
+
+	expense := expenses[0]
+	depositTkn := depositTkns[0]
+
+	if expense.Token.Symbol != depositTkn.Symbol {
+		return nil, RejectOrErr{
+			Reason: rejectInvalidDeposit,
+			Err:    errors.New("deposit token must match expense token"),
+		}
+	}
+
+	// make sure chain class (e.g. mainnet, testnet) matches
+	// we should reject with UnsupportedDestChain before this. the solver is
+	// initialized by network, which only includes chains of the same class
+	if expense.Token.ChainClass != depositTkn.ChainClass {
+		return nil, RejectOrErr{
+			Reason: rejectInvalidDeposit,
+			Err:    errors.New("deposit and expense must be of the same chain class (e.g. mainnet, testnet)"),
+		}
+	}
+
+	return []Payment{
+		{
+			Token:  depositTkn,
+			Amount: expense.Amount,
+		},
+	}, RejectOrErr{}
+}
+
+// coversQuote checks if `deposits` match or exceed a `quote` for expenses.
+func coversQuote(deposits, quote []Payment) RejectOrErr {
+	if len(quote) != len(deposits) {
+		return RejectOrErr{}
+	}
+
+	byTkn := func(ps []Payment) map[Token]*big.Int {
+		res := make(map[Token]*big.Int)
+		for _, p := range ps {
+			res[p.Token] = p.Amount
+		}
+
+		return res
+	}
+
+	quoteByTkn := byTkn(quote)
+	depositsByTkn := byTkn(deposits)
+
+	for tkn, q := range quoteByTkn {
+		d, ok := depositsByTkn[tkn]
+		if !ok {
+			return RejectOrErr{
+				Reason: rejectInsufficientDeposit,
+				Err:    errors.New("missing deposit", "token", tkn),
+			}
+		}
+
+		if d.Cmp(q) < 0 {
+			return RejectOrErr{
+				Reason: rejectInsufficientDeposit,
+				Err:    errors.New("insufficient deposit", "token", tkn, "deposit", d, "quote", q),
+			}
+		}
+	}
+
+	return RejectOrErr{}
+}

--- a/solver/app/v2/reject.go
+++ b/solver/app/v2/reject.go
@@ -17,17 +17,40 @@ type rejectReason uint8
 const (
 	rejectNone                  rejectReason = 0
 	rejectDestCallReverts       rejectReason = 1
-	rejectInsufficientFee       rejectReason = 2
-	rejectInsufficientInventory rejectReason = 3
-	rejectUnsupportedToken      rejectReason = 4
-	rejectUnsupportedDestChain  rejectReason = 5
+	rejectInvalidDeposit        rejectReason = 2
+	rejectInvalidExpense        rejectReason = 3
+	rejectInsufficientDeposit   rejectReason = 4
+	rejectInsufficientInventory rejectReason = 5
+	rejectUnsupportedDeposit    rejectReason = 6
+	rejectUnsupportedExpense    rejectReason = 7
+	rejectUnsupportedDestChain  rejectReason = 8
 )
+
+type RejectOrErr struct {
+	Reason rejectReason
+	Err    error
+}
+
+// ShouldReject returns true if reject reason is not none.
+func (r RejectOrErr) ShouldReject() bool {
+	return r.Reason != rejectNone
+}
+
+// ShouldError returns true if there was an error without a rejection.
+func (r RejectOrErr) ShouldError() bool {
+	return r.Reason == rejectNone && r.Err != nil
+}
+
+// ShouldReturn returns true if there was a rejection or an error.
+func (r RejectOrErr) ShouldReturn() bool {
+	return r.Reason != rejectNone || r.Err != nil
+}
 
 // newShouldRejector returns as ShouldReject function for the given network.
 //
 // ShouldReject returns true and a reason if the request should be rejected.
 // It returns false if the request should be accepted.
-// Errors are unexpected and refer to internal server problems.
+// Errors are unexpected and refer to internal problems.
 func newShouldRejector(
 	backends ethbackend.Backends,
 	solverAddr common.Address,
@@ -35,9 +58,18 @@ func newShouldRejector(
 	chainName func(uint64) string,
 ) func(ctx context.Context, srcChainID uint64, order Order) (rejectReason, bool, error) {
 	return func(ctx context.Context, srcChainID uint64, order Order) (rejectReason, bool, error) {
-		// reject swallows the error (only logging it) and returns true and the shouldReject reason.
-		reject := func(reason rejectReason, err error) (rejectReason, bool, error) {
-			err = errors.Wrap(err, "reject",
+		// rejectOrErr returns either an error, or a rejectReason with shouldReject == true.
+		// For rejections, it swallows the error, only sampling / logging it.
+		rejectOrErr := func(r RejectOrErr) (rejectReason, bool, error) {
+			if !r.ShouldReturn() {
+				return rejectNone, false, errors.New("[BUG] unexpected rejectOrErr call")
+			}
+
+			if r.ShouldError() {
+				return rejectNone, false, r.Err
+			}
+
+			err := errors.Wrap(r.Err, "reject",
 				"order_id", order.ID.String(),
 				"dest_chain_id", order.DestinationChainID,
 				"src_chain_id", order.SourceChainID,
@@ -47,69 +79,175 @@ func newShouldRejector(
 				chainName(order.SourceChainID),
 				chainName(order.DestinationChainID),
 				targetName(order),
-				reason.String(),
+				r.Reason.String(),
 			).Inc()
 
-			log.InfoErr(ctx, "Rejecting request", err, "reason", reason)
+			log.InfoErr(ctx, "Rejecting request", err, "reason", r.Reason)
 
-			return reason, true, nil
+			return r.Reason, true, nil
 		}
 
-		// returnErr returns the error, with false and rejectNone. It should be used for unexpected errors.
+		reject := func(reason rejectReason, err error) (rejectReason, bool, error) {
+			return rejectOrErr(RejectOrErr{Reason: reason, Err: err})
+		}
+
 		returnErr := func(err error) (rejectReason, bool, error) {
-			return rejectNone, false, err
+			return rejectOrErr(RejectOrErr{Err: err})
 		}
 
 		if srcChainID != order.SourceChainID {
 			return returnErr(errors.New("source chain id mismatch [BUG]", "got", order.SourceChainID, "expected", srcChainID))
 		}
 
-		destChainID := order.DestinationChainID
-		backend, err := backends.Backend(destChainID)
+		backend, err := backends.Backend(order.DestinationChainID)
 		if err != nil {
 			return reject(rejectUnsupportedDestChain, err)
 		}
 
-		// check all expenses are supported, ethereum addressed tokens
-		var expenses []Expense
-		for _, output := range order.MaxSpent {
-			chainID := output.ChainId.Uint64()
-
-			// inbox contract order resolution should ensure output.chainId matches order.DestinationChainID (derived from fillInstructions)
-			if chainID != destChainID {
-				return returnErr(errors.New("max spent chain id mismatch [BUG]", "got", chainID, "expected", destChainID))
-			}
-
-			addr := toEthAddr(output.Token)
-			if !cmpAddrs(addr, output.Token) {
-				return reject(rejectUnsupportedToken, errors.New("non-eth addressed token", "addr", hexutil.Encode(output.Token[:])))
-			}
-
-			tkn, ok := tokens.find(chainID, addr)
-			if !ok {
-				return reject(rejectUnsupportedToken, errors.New("unsupported token", "addr", addr))
-			}
-
-			expenses = append(expenses, Expense{
-				token:  tkn,
-				amount: output.Amount,
-			})
+		deposits, r := parseDeposits(order)
+		if r.ShouldReturn() {
+			return rejectOrErr(r)
 		}
 
-		// check liquidty, reject if insufficient
-		for _, expense := range expenses {
-			bal, err := balanceOf(ctx, expense.token, backend, solverAddr)
-			if err != nil {
-				return returnErr(errors.Wrap(err, "get balance", "token", expense.token.Symbol))
-			}
+		expenses, r := parseExpenses(order)
+		if r.ShouldReturn() {
+			return rejectOrErr(r)
+		}
 
-			// TODO: for native tokens, even if we have enough, we don't want to
-			// spend out whole balance. we'll need to keep some for gas
-			if bal.Cmp(expense.amount) < 0 {
-				return reject(rejectInsufficientInventory, errors.New("insufficient balance", "token", expense.token.Symbol))
-			}
+		r = checkQuote(deposits, expenses)
+		if r.ShouldReturn() {
+			return rejectOrErr(r)
+		}
+
+		r = checkLiquidity(ctx, expenses, backend, solverAddr)
+		if r.ShouldReturn() {
+			return rejectOrErr(r)
 		}
 
 		return rejectNone, false, nil
 	}
+}
+
+// parseDeposits parses order.MinReceived, checks all tokens are supported, returns the list of deposits.
+func parseDeposits(order Order) ([]Payment, RejectOrErr) {
+	var deposits []Payment
+	for _, output := range order.MinReceived {
+		chainID := output.ChainId.Uint64()
+
+		// inbox contract order resolution should ensure minReceived[].output.chainId matches order.SourceChainID
+		if chainID != order.SourceChainID {
+			return nil, RejectOrErr{
+				Err: errors.New("min received chain id mismatch [BUG]", "got", chainID, "expected", order.SourceChainID),
+			}
+		}
+
+		addr := toEthAddr(output.Token)
+		if !cmpAddrs(addr, output.Token) {
+			return nil, RejectOrErr{
+				Reason: rejectUnsupportedDeposit,
+				Err:    errors.New("non-eth addressed token", "addr", hexutil.Encode(output.Token[:])),
+			}
+		}
+
+		tkn, ok := tokens.find(chainID, addr)
+		if !ok {
+			return nil, RejectOrErr{
+				Reason: rejectUnsupportedDeposit,
+				Err:    errors.New("unsupported token", "addr", addr),
+			}
+		}
+
+		deposits = append(deposits, Payment{
+			Token:  tkn,
+			Amount: output.Amount,
+		})
+	}
+
+	return deposits, RejectOrErr{}
+}
+
+// parseExpenses parses order.MaxSpent, checks all tokens are supported, returns the list of expenses.
+func parseExpenses(order Order) ([]Payment, RejectOrErr) {
+	var expenses []Payment
+	for _, output := range order.MaxSpent {
+		chainID := output.ChainId.Uint64()
+
+		// inbox contract order resolution should ensure maxSpent[].output.chainId matches order.DestinationChainID
+		if chainID != order.DestinationChainID {
+			return nil, RejectOrErr{
+				Err: errors.New("max spent chain id mismatch [BUG]", "got", chainID, "expected", order.DestinationChainID),
+			}
+		}
+
+		addr := toEthAddr(output.Token)
+		if !cmpAddrs(addr, output.Token) {
+			return nil, RejectOrErr{
+				Reason: rejectUnsupportedExpense,
+				Err:    errors.New("non-eth addressed token", "addr", hexutil.Encode(output.Token[:])),
+			}
+		}
+
+		tkn, ok := tokens.find(chainID, addr)
+		if !ok {
+			return nil, RejectOrErr{
+				Reason: rejectUnsupportedExpense,
+				Err:    errors.New("unsupported token", "addr", addr),
+			}
+		}
+
+		expenses = append(expenses, Payment{
+			Token:  tkn,
+			Amount: output.Amount,
+		})
+	}
+
+	return expenses, RejectOrErr{}
+}
+
+// checkQuote checks if deposits match or exceed quote for expenses.
+// only single expense supported with matching deposit is supported.
+func checkQuote(deposits, expenses []Payment) RejectOrErr {
+	quote, r := getQuote(tkns(deposits), expenses)
+	if r.ShouldReturn() {
+		return r
+	}
+
+	r = coversQuote(deposits, quote)
+	if r.ShouldReturn() {
+		return r
+	}
+
+	return RejectOrErr{}
+}
+
+// checkLiquidity checks that the solver has enough liquidity to pay for the expenses.
+func checkLiquidity(ctx context.Context, expenses []Payment, backend *ethbackend.Backend, solverAddr common.Address) RejectOrErr {
+	for _, expense := range expenses {
+		bal, err := balanceOf(ctx, expense.Token, backend, solverAddr)
+		if err != nil {
+			return RejectOrErr{
+				Err: errors.Wrap(err, "get balance", "token", expense.Token.Symbol),
+			}
+		}
+
+		// TODO: for native tokens, even if we have enough, we don't want to
+		// spend out whole balance. we'll need to keep some for gas
+		if bal.Cmp(expense.Amount) < 0 {
+			return RejectOrErr{
+				Reason: rejectInsufficientInventory,
+				Err:    errors.New("insufficient balance", "token", expense.Token.Symbol),
+			}
+		}
+	}
+
+	return RejectOrErr{}
+}
+
+func tkns(payments []Payment) []Token {
+	tkns := make([]Token, len(payments))
+	for i, p := range payments {
+		tkns[i] = p.Token
+	}
+
+	return tkns
 }

--- a/solver/app/v2/rejectreason_string.go
+++ b/solver/app/v2/rejectreason_string.go
@@ -10,15 +10,18 @@ func _() {
 	var x [1]struct{}
 	_ = x[rejectNone-0]
 	_ = x[rejectDestCallReverts-1]
-	_ = x[rejectInsufficientFee-2]
-	_ = x[rejectInsufficientInventory-3]
-	_ = x[rejectUnsupportedToken-4]
-	_ = x[rejectUnsupportedDestChain-5]
+	_ = x[rejectInvalidDeposit-2]
+	_ = x[rejectInvalidExpense-3]
+	_ = x[rejectInsufficientDeposit-4]
+	_ = x[rejectInsufficientInventory-5]
+	_ = x[rejectUnsupportedDeposit-6]
+	_ = x[rejectUnsupportedExpense-7]
+	_ = x[rejectUnsupportedDestChain-8]
 }
 
-const _rejectReason_name = "NoneDestCallRevertsInsufficientFeeInsufficientInventoryUnsupportedTokenUnsupportedDestChain"
+const _rejectReason_name = "NoneDestCallRevertsInvalidDepositInvalidExpenseInsufficientDepositInsufficientInventoryUnsupportedDepositUnsupportedExpenseUnsupportedDestChain"
 
-var _rejectReason_index = [...]uint8{0, 4, 19, 34, 55, 71, 91}
+var _rejectReason_index = [...]uint8{0, 4, 19, 33, 47, 66, 87, 105, 123, 143}
 
 func (i rejectReason) String() string {
 	if i >= rejectReason(len(_rejectReason_index)-1) {

--- a/solver/app/v2/testdata/TestTokens.golden
+++ b/solver/app/v2/testdata/TestTokens.golden
@@ -1,6 +1,38 @@
 [
  {
   "address": "0x0000000000000000000000000000000000000000",
+  "chainId": 1,
+  "coingeckoId": "ethereum",
+  "isMock": false,
+  "name": "Ether",
+  "symbol": "ETH"
+ },
+ {
+  "address": "0x0000000000000000000000000000000000000000",
+  "chainId": 42161,
+  "coingeckoId": "ethereum",
+  "isMock": false,
+  "name": "Ether",
+  "symbol": "ETH"
+ },
+ {
+  "address": "0x0000000000000000000000000000000000000000",
+  "chainId": 8453,
+  "coingeckoId": "ethereum",
+  "isMock": false,
+  "name": "Ether",
+  "symbol": "ETH"
+ },
+ {
+  "address": "0x0000000000000000000000000000000000000000",
+  "chainId": 10,
+  "coingeckoId": "ethereum",
+  "isMock": false,
+  "name": "Ether",
+  "symbol": "ETH"
+ },
+ {
+  "address": "0x0000000000000000000000000000000000000000",
   "chainId": 17000,
   "coingeckoId": "ethereum",
   "isMock": false,
@@ -46,6 +78,14 @@
   "isMock": false,
   "name": "Ether",
   "symbol": "ETH"
+ },
+ {
+  "address": "0x0000000000000000000000000000000000000000",
+  "chainId": 166,
+  "coingeckoId": "omni-network",
+  "isMock": false,
+  "name": "Omni Network",
+  "symbol": "OMNI"
  },
  {
   "address": "0x0000000000000000000000000000000000000000",


### PR DESCRIPTION
Require deposits match expenses 1:1.

- introduce concept of a quote. will be useful in api (e.g GET /quote)
- only support single expense / deposit, require tokens match (by symbol)

Additionally, refector reject.go to use `RejectOrErr`. Makes it easier to split `shouldReject` into utils.

issue: #2920
