### PR TITLE
chore(solver): copy holesky tokens to mock l1

### DIFF
--- a/solver/app/v2/testdata/TestTokens.golden
+++ b/solver/app/v2/testdata/TestTokens.golden
@@ -152,8 +152,24 @@
   "symbol": "wstETH"
  },
  {
+  "address": "0x8d09a4502Cc8Cf1547aD300E066060D043f6982D",
+  "chainId": 1652,
+  "coingeckoId": "wrapped-steth",
+  "isMock": false,
+  "name": "Wrapped Staked Ether",
+  "symbol": "wstETH"
+ },
+ {
   "address": "0x3F1c547b21f65e10480dE3ad8E19fAAC46C95034",
   "chainId": 17000,
+  "coingeckoId": "lido-staked-ether",
+  "isMock": false,
+  "name": "Lido Staked Ether",
+  "symbol": "stETH"
+ },
+ {
+  "address": "0x3F1c547b21f65e10480dE3ad8E19fAAC46C95034",
+  "chainId": 1652,
   "coingeckoId": "lido-staked-ether",
   "isMock": false,
   "name": "Lido Staked Ether",

--- a/solver/app/v2/tokens.go
+++ b/solver/app/v2/tokens.go
@@ -75,9 +75,11 @@ var tokens = append(Tokens{
 
 	// wtSETH
 	wstETH(evmchain.IDHolesky, common.HexToAddress("0x8d09a4502cc8cf1547ad300e066060d043f6982d")),
+	wstETH(evmchain.IDMockL1, common.HexToAddress("0x8d09a4502cc8cf1547ad300e066060d043f6982d")), // copy of holesky wstETH (for e2e fork testing)
 
 	// stETH
 	stETH(evmchain.IDHolesky, common.HexToAddress("0x3f1c547b21f65e10480de3ad8e19faac46c95034")),
+	stETH(evmchain.IDMockL1, common.HexToAddress("0x3f1c547b21f65e10480de3ad8e19faac46c95034")), // copy of holesky stETH (for e2e fork testing)
 }, mocks()...)
 
 func (ts Tokens) find(chainID uint64, addr common.Address) (Token, bool) {


### PR DESCRIPTION
Copy holesky tokens to mock L1. So we can use them in e2e fork mode.

issue: none