### PR TITLE
chore(e2e): enable v2 in devnetsolve manifest

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -82,9 +82,9 @@ devnet-deploy: ## Deploys devnet (MANIFEST=devnet1 by default)
 	@go run github.com/omni-network/omni/e2e -f e2e/manifests/$(if $(MANIFEST),$(MANIFEST),devnet1).toml deploy
 
 .PHONY: devnet-clean
-devnet-clean: ## Deletes devnet1 containers
-	@echo "Stopping the devnet in ./e2e/run/devnet1"
-	@go run github.com/omni-network/omni/e2e -f e2e/manifests/devnet1.toml clean
+devnet-clean: ## Deletes devnet containers (MANIFEST=devnet1 by default)
+	@echo "Stopping the devnet in ./e2e/run/$(if $(MANIFEST),$(MANIFEST),devnet1)"
+	@go run github.com/omni-network/omni/e2e -f e2e/manifests/$(if $(MANIFEST),$(MANIFEST),devnet1).toml clean
 
 .PHONY: e2e-ci
 e2e-ci: ## Runs all e2e CI tests

--- a/e2e/manifests/devnetsolve.toml
+++ b/e2e/manifests/devnetsolve.toml
@@ -3,6 +3,8 @@ network = "devnet"
 anvil_chains = ["mock_l1", "mock_l2"]
 deploy_solve = true
 
+feature_flags =["solver-v2"]
+
 prometheus = true
 
 [forks]


### PR DESCRIPTION
Enable v2 in devnetsolve manifest and extend manifest param to `devnet-clean`

issue: none 