### PR TITLE
chore(e2e/solve): fund solver holesky wstETH on devnet

### DIFF
--- a/e2e/solve/deploy.go
+++ b/e2e/solve/deploy.go
@@ -32,6 +32,7 @@ func DeployContracts(ctx context.Context, network netconf.Network, backends ethb
 		var eg errgroup.Group
 		eg.Go(func() error { return deployV2Boxes(ctx, network, backends) })
 		eg.Go(func() error { return maybeDeployMockTokens(ctx, network, backends) })
+		eg.Go(func() error { return maybeFundSolver(ctx, network.ID, backends) })
 		if err := eg.Wait(); err != nil {
 			return errors.Wrap(err, "deploy v2")
 		}

--- a/e2e/solve/fund.go
+++ b/e2e/solve/fund.go
@@ -1,0 +1,52 @@
+package solve
+
+import (
+	"context"
+
+	"github.com/omni-network/omni/e2e/app/eoa"
+	"github.com/omni-network/omni/lib/anvil"
+	"github.com/omni-network/omni/lib/errors"
+	"github.com/omni-network/omni/lib/ethclient/ethbackend"
+	"github.com/omni-network/omni/lib/evmchain"
+	"github.com/omni-network/omni/lib/netconf"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/params"
+
+	"cosmossdk.io/math"
+)
+
+func maybeFundSolver(ctx context.Context, network netconf.ID, backends ethbackend.Backends) error {
+	// funding solver with l1 wsETH uses anvil_setStorageAt util, which is only available on devnet
+	if network != netconf.Devnet {
+		return nil
+	}
+
+	// erc20 tokens to fund solver with on devnet. useful for solvernet development when forking public networks
+	toFund := []struct {
+		chainID uint64
+		addr    common.Address
+	}{
+		// holesky wstETH
+		{chainID: evmchain.IDMockL1, addr: common.HexToAddress("0x8d09a4502cc8cf1547ad300e066060d043f6982d")},
+	}
+
+	solver := eoa.MustAddress(netconf.Devnet, eoa.RoleSolver)
+	eth1m := math.NewInt(1_000_000).MulRaw(params.Ether).BigInt()
+
+	for _, tkn := range toFund {
+		ethCl, ok := backends.Clients()[tkn.chainID]
+		if !ok {
+			continue
+		}
+
+		// if devnet is not forking the public chain tkn is deployed on, this sets
+		// storage on an unused address, which is fine
+		err := anvil.FundERC20(ctx, ethCl, tkn.addr, eth1m, solver)
+		if err != nil {
+			return errors.Wrap(err, "fund tkn failed", "chain_id", tkn.chainID, "addr", tkn.addr)
+		}
+	}
+
+	return nil
+}


### PR DESCRIPTION
Fund solver with holeksy wstETH on devnet.

We'll do this for all devnets with MockL1. It's fine.
If we have a bunch of public tokens we want to use in fork mode, we can change it
to only fund solver if we are indeed forking that chain

issue: none
