### PR TITLE
feat(contracts/solve): drastically optimized SolverNet orderData

### DIFF
--- a/contracts/solve/src/_optimized/SolverNetExecutor.sol
+++ b/contracts/solve/src/_optimized/SolverNetExecutor.sol
@@ -1,0 +1,74 @@
+// SPDX-License-Identifier: GPL-3.0-only
+pragma solidity =0.8.24;
+
+import { SafeTransferLib } from "solady/src/utils/SafeTransferLib.sol";
+import { ISolverNetExecutor } from "./interfaces/ISolverNetExecutor.sol";
+import { AddrUtils } from "../lib/AddrUtils.sol";
+
+contract SolverNetExecutor is ISolverNetExecutor {
+    using SafeTransferLib for address;
+    using AddrUtils for bytes32;
+
+    /**
+     * @notice Address of the outbox.
+     */
+    address public immutable outbox;
+
+    /**
+     * @notice Modifier to provide access control to the outbox.
+     * @dev This was used as it is more efficient than using Ownable. Only the outbox will call these functions.
+     */
+    modifier onlyOutbox() {
+        if (msg.sender != outbox) revert NotOutbox();
+        _;
+    }
+
+    constructor(address _outbox) {
+        outbox = _outbox;
+    }
+
+    /**
+     * @notice Approves a spender (usually call target) to spend a token held by the executor.
+     * @dev Called prior to `execute` in order to ensure tokens can be spent and after to purge excess approvals.
+     */
+    function approve(address token, address spender, uint256 amount) external onlyOutbox {
+        token.safeApprove(spender, amount);
+    }
+
+    /**
+     * @notice Executes a call.
+     * @param target Address of the contract to call.
+     * @param value  Value to send with the call.
+     * @param data   Data to send with the call.
+     */
+    function execute(address target, uint256 value, bytes calldata data) external payable onlyOutbox {
+        (bool success,) = payable(target).call{ value: value }(data);
+        if (!success) revert CallFailed();
+    }
+
+    /**
+     * @notice Transfers a token to a recipient.
+     * @dev Called after `execute` in order to refund any excess or returned tokens.
+     */
+    function transfer(address token, address to, uint256 amount) external onlyOutbox {
+        token.safeTransfer(to, amount);
+    }
+
+    /**
+     * @notice Transfers native currency to a recipient.
+     * @dev Called after `execute` in order to refund any native currency sent back to the executor.
+     */
+    function transferNative(address to, uint256 amount) external onlyOutbox {
+        to.safeTransferETH(amount);
+    }
+
+    /**
+     * @dev Allows target contracts to arbitrarily return native tokens to the executor.
+     */
+    receive() external payable { }
+
+    /**
+     * @dev Allows target contracts to arbitrarily return native tokens to the executor.
+     */
+    fallback() external payable { }
+}

--- a/contracts/solve/src/_optimized/SolverNetInbox.sol
+++ b/contracts/solve/src/_optimized/SolverNetInbox.sol
@@ -1,0 +1,570 @@
+// SPDX-License-Identifier: GPL-3.0-only
+pragma solidity =0.8.24;
+
+import { OwnableRoles } from "solady/src/auth/OwnableRoles.sol";
+import { ReentrancyGuard } from "solady/src/utils/ReentrancyGuard.sol";
+import { Initializable } from "solady/src/utils/Initializable.sol";
+import { DeployedAt } from "../util/DeployedAt.sol";
+import { XAppBase } from "core/src/pkg/XAppBase.sol";
+import { IERC7683 } from "../erc7683/IERC7683.sol";
+import { ISolverNetInbox } from "./interfaces/ISolverNetInbox.sol";
+import { SafeTransferLib } from "solady/src/utils/SafeTransferLib.sol";
+import { AddrUtils } from "../lib/AddrUtils.sol";
+
+/**
+ * @title SolverNetInbox
+ * @notice Entrypoint and alt-mempool for user solve orders.
+ */
+contract SolverNetInbox is OwnableRoles, ReentrancyGuard, Initializable, DeployedAt, XAppBase, ISolverNetInbox {
+    using SafeTransferLib for address;
+    using AddrUtils for address;
+
+    /**
+     * @notice Role for solvers.
+     * @dev _ROLE_0 evaluates to '1'.
+     */
+    uint256 internal constant SOLVER = _ROLE_0;
+
+    /**
+     * @notice Typehash for the Order struct.
+     */
+    bytes32 internal constant ORDER_TYPEHASH = keccak256(
+        "Order(address owner,Call call,Values values,Deposit deposit,Expense[] expenses)Call(uint64 chainId,address target,bytes4 selector,bytes callParams)Values(uint96 nativeTip,uint96 callValue,uint32 openDeadline,uint32 fillDeadline)Deposit(address token,uint96 amount)Expense(address spender,address token,uint96 amount)"
+    );
+
+    /**
+     * @dev Counter for generating unique order IDs. Incremented each time a new order is created.
+     */
+    uint256 internal _lastId;
+
+    /**
+     * @notice Addresses of the outbox contracts.
+     */
+    mapping(uint64 chainId => address outbox) internal _outboxes;
+
+    /**
+     * @notice Map order ID to owner.
+     */
+    mapping(bytes32 id => address owner) internal _orderOwners;
+
+    /**
+     * @notice Map order ID to call parameters.
+     * @dev (chainId, target, selector, callParams)
+     */
+    mapping(bytes32 id => Call) internal _orderCalls;
+
+    /**
+     * @notice Map order ID to order values.
+     * @dev (nativeTip, callValue, openDeadline, fillDeadline)
+     */
+    mapping(bytes32 id => Values) internal _orderValues;
+
+    /**
+     * @notice Map order ID to deposit parameters.
+     * @dev (token, amount)
+     */
+    mapping(bytes32 id => Deposit) internal _orderDeposits;
+
+    /**
+     * @notice Map order ID to expense parameters.
+     * @dev (spender, token, amount)
+     */
+    mapping(bytes32 id => Expense[]) internal _orderExpenses;
+
+    /**
+     * @notice Map order ID to order parameters.
+     */
+    mapping(bytes32 id => OrderState) internal _orderState;
+
+    /**
+     * @notice Map status to latest order ID.
+     */
+    mapping(Status => bytes32 id) internal _latestOrderIdByStatus;
+
+    constructor() {
+        _disableInitializers();
+    }
+
+    /**
+     * @notice Initialize the contract's owner and solver.
+     * @dev Used instead of constructor as we want to use the transparent upgradeable proxy pattern.
+     * @param owner_  Address of the owner.
+     * @param solver_ Address of the solver.
+     * @param omni_   Address of the OmniPortal.
+     */
+    function initialize(address owner_, address solver_, address omni_) external initializer {
+        _initializeOwner(owner_);
+        _grantRoles(solver_, SOLVER);
+        _setOmniPortal(omni_);
+    }
+
+    /**
+     * @notice Set the outbox addresses for the given chain IDs.
+     * @param chainIds IDs of the chains.
+     * @param outboxes Addresses of the outboxes.
+     */
+    function setOutboxes(uint64[] calldata chainIds, address[] calldata outboxes) external onlyOwner {
+        for (uint256 i; i < chainIds.length; ++i) {
+            _outboxes[chainIds[i]] = outboxes[i];
+            emit OutboxSet(chainIds[i], outboxes[i]);
+        }
+    }
+
+    /**
+     * @notice Returns the order and its state with the given ID.
+     * @param id ID of the order.
+     */
+    function getOrder(bytes32 id)
+        external
+        view
+        returns (ResolvedCrossChainOrder memory resolved, OrderState memory state)
+    {
+        OrderData memory orderData = _getOrderData(id);
+        return (_resolve(orderData), _orderState[id]);
+    }
+
+    /**
+     * @notice Returns the next order ID.
+     */
+    function getNextId() external view returns (bytes32) {
+        return _nextId();
+    }
+
+    /**
+     * @notice Returns the latest order with the given status.
+     * @param status Order status to query.
+     */
+    function getLatestOrderIdByStatus(Status status) external view returns (bytes32) {
+        return _latestOrderIdByStatus[status];
+    }
+
+    /**
+     * @dev Validate the onchain order.
+     * @param order OnchainCrossChainOrder to validate.
+     */
+    function validate(OnchainCrossChainOrder calldata order) external view returns (bool) {
+        _validate(order);
+        return true;
+    }
+
+    /**
+     * @notice Resolve the onchain order with validation.
+     * @param order OnchainCrossChainOrder to resolve.
+     */
+    function resolve(OnchainCrossChainOrder calldata order) public view returns (ResolvedCrossChainOrder memory) {
+        OrderData memory orderData = _validate(order);
+        return _resolve(orderData);
+    }
+
+    /**
+     * @notice Open an order to execute a call on another chain, backed by deposits.
+     * @dev Token deposits are transferred from msg.sender to this inbox.
+     * @param order OnchainCrossChainOrder to open.
+     */
+    function open(OnchainCrossChainOrder calldata order) external payable nonReentrant {
+        OrderData memory orderData = _validate(order);
+        _processDeposits(orderData);
+        ResolvedCrossChainOrder memory resolved = _openOrder(orderData);
+
+        emit Open(resolved.orderId, resolved);
+    }
+
+    /**
+     * @notice Accept an open order.
+     * @dev Only a whitelisted solver can accept.
+     * @param id ID of the order.
+     */
+    function accept(bytes32 id) external onlyRoles(SOLVER) nonReentrant {
+        Values memory values = _orderValues[id];
+        OrderState memory state = _orderState[id];
+
+        if (state.latest.status != Status.Pending) revert OrderNotPending();
+        if (values.fillDeadline < block.timestamp && values.fillDeadline != 0) revert FillDeadlinePassed();
+
+        StatusUpdate memory statusUpdate = StatusUpdate({ status: Status.Accepted, timestamp: uint32(block.timestamp) });
+        _upsertOrder(id, statusUpdate, msg.sender);
+
+        emit Accepted(id, msg.sender);
+    }
+
+    /**
+     * @notice Reject an open order and refund deposits.
+     * @dev Only a whitelisted solver can reject.
+     * @param id     ID of the order.
+     * @param reason Reason code for rejection.
+     */
+    function reject(bytes32 id, uint8 reason) external onlyRoles(SOLVER) nonReentrant {
+        OrderState memory state = _orderState[id];
+
+        if (state.latest.status != Status.Pending) {
+            if (state.latest.status == Status.Accepted) {
+                if (state.acceptedBy != msg.sender) revert Unauthorized();
+            } else {
+                revert OrderNotPending();
+            }
+        }
+
+        StatusUpdate memory statusUpdate = StatusUpdate({ status: Status.Rejected, timestamp: uint32(block.timestamp) });
+        _upsertOrder(id, statusUpdate, address(0));
+        _transferDeposits(id, _orderOwners[id]);
+
+        emit Rejected(id, msg.sender, reason);
+    }
+
+    /**
+     * @notice Cancel an open and refund deposits.
+     * @dev Only order initiator can cancel.
+     * @param id ID of the order.
+     */
+    function cancel(bytes32 id) external nonReentrant {
+        OrderState memory state = _orderState[id];
+        address user = _orderOwners[id];
+
+        if (state.latest.status != Status.Pending) revert OrderNotPending();
+        if (user != msg.sender) revert Unauthorized();
+
+        StatusUpdate memory statusUpdate = StatusUpdate({ status: Status.Reverted, timestamp: uint32(block.timestamp) });
+        _upsertOrder(id, statusUpdate, address(0));
+        _transferDeposits(id, user);
+
+        emit Reverted(id);
+    }
+
+    /**
+     * @notice Fill an order.
+     * @dev Only callable by the outbox.
+     * @param id         ID of the order.
+     * @param fillHash   Hash of fill instructions origin data.
+     * @param timestamp  Timestamp of the fill.
+     * @param acceptedBy Address of the solver that filled the order if they didnt accept it first.
+     */
+    function markFilled(bytes32 id, bytes32 fillHash, uint256 timestamp, address acceptedBy)
+        external
+        xrecv
+        nonReentrant
+    {
+        Call memory call = _orderCalls[id];
+        OrderState memory state = _orderState[id];
+
+        if (state.latest.status != Status.Pending && state.latest.status != Status.Accepted) {
+            revert OrderNotPendingOrAccepted();
+        }
+        if (xmsg.sender != _outboxes[xmsg.sourceChainId]) revert Unauthorized();
+        if (xmsg.sourceChainId != call.chainId) revert WrongSourceChain();
+
+        // Ensure reported fill hash matches origin data
+        if (fillHash != _fillHash(id)) {
+            revert WrongFillHash();
+        }
+
+        StatusUpdate memory statusUpdate = StatusUpdate({ status: Status.Filled, timestamp: uint32(timestamp) });
+        _upsertOrder(id, statusUpdate, acceptedBy);
+
+        emit Filled(id, fillHash, state.acceptedBy);
+    }
+
+    /**
+     * @notice Claim a filled order.
+     * @param id ID of the order.
+     * @param to Address to send deposits to.
+     */
+    function claim(bytes32 id, address to) external nonReentrant {
+        OrderState memory state = _orderState[id];
+        if (state.latest.status != Status.Filled) revert OrderNotFilled();
+        if (state.acceptedBy != msg.sender) revert Unauthorized();
+
+        StatusUpdate memory statusUpdate = StatusUpdate({ status: Status.Claimed, timestamp: uint32(block.timestamp) });
+        _upsertOrder(id, statusUpdate, address(0));
+        _transferDeposits(id, to);
+
+        emit Claimed(id, msg.sender, to);
+    }
+
+    /**
+     * @dev Return the order data for the given ID.
+     * @param id ID of the order.
+     */
+    function _getOrderData(bytes32 id) internal view returns (OrderData memory) {
+        return OrderData({
+            owner: _orderOwners[id],
+            call: _orderCalls[id],
+            values: _orderValues[id],
+            deposit: _orderDeposits[id],
+            expenses: _orderExpenses[id]
+        });
+    }
+
+    /**
+     * @dev Parse and return order data, validate correctness.
+     * @param order OnchainCrossChainOrder to parse
+     */
+    function _validate(OnchainCrossChainOrder calldata order) internal view returns (OrderData memory) {
+        if (order.fillDeadline < block.timestamp && order.fillDeadline != 0) revert InvalidFillDeadline();
+        if (order.orderDataType != ORDER_TYPEHASH) revert InvalidOrderTypehash();
+        if (order.orderData.length == 0) revert InvalidOrderData();
+
+        OrderData memory orderData = abi.decode(order.orderData, (OrderData));
+        Call memory call = orderData.call;
+        Values memory values = orderData.values;
+        Deposit memory deposit = orderData.deposit;
+        Expense[] memory expenses = orderData.expenses;
+
+        if (orderData.owner == address(0)) orderData.owner = msg.sender;
+        if (call.chainId == 0 || call.chainId == block.chainid) revert InvalidCallChainId();
+        if (call.target == address(0)) revert InvalidCallTarget();
+        if (values.openDeadline < block.timestamp) revert InvalidOpenDeadline();
+        if (values.fillDeadline <= values.openDeadline || order.fillDeadline != values.fillDeadline) {
+            revert InvalidFillDeadline();
+        }
+        if (deposit.token == address(0) && deposit.amount != 0) revert InvalidDepositAmount();
+        if (deposit.token != address(0) && deposit.amount == 0) revert InvalidDepositAmount();
+        for (uint256 i; i < expenses.length; ++i) {
+            if (expenses[i].token == address(0)) revert InvalidExpenseToken();
+            if (expenses[i].amount == 0) revert InvalidExpenseAmount();
+        }
+
+        return orderData;
+    }
+
+    /**
+     * @dev Derive the maxSpent Output for the order.
+     * @param orderData Order data to derive from.
+     */
+    function _deriveMaxSpent(OrderData memory orderData) internal view returns (IERC7683.Output[] memory) {
+        Call memory call = orderData.call;
+        Values memory values = orderData.values;
+        Expense[] memory expenses = orderData.expenses;
+
+        IERC7683.Output[] memory maxSpent =
+            new IERC7683.Output[](values.callValue > 0 ? expenses.length + 1 : expenses.length);
+        for (uint256 i; i < expenses.length; ++i) {
+            maxSpent[i] = IERC7683.Output({
+                token: expenses[i].token.toBytes32(),
+                amount: expenses[i].amount,
+                recipient: _outboxes[call.chainId].toBytes32(),
+                chainId: call.chainId
+            });
+        }
+        if (values.callValue > 0) {
+            maxSpent[expenses.length] = IERC7683.Output({
+                token: bytes32(0),
+                amount: values.callValue,
+                recipient: _outboxes[call.chainId].toBytes32(),
+                chainId: call.chainId
+            });
+        }
+
+        return maxSpent;
+    }
+
+    /**
+     * @dev Derive the minReceived Output for the order.
+     * @param orderData Order data to derive from.
+     */
+    function _deriveMinReceived(OrderData memory orderData) internal view returns (IERC7683.Output[] memory) {
+        Values memory values = orderData.values;
+        Deposit memory deposit = orderData.deposit;
+
+        uint8 deposits;
+        bool erc20Deposit = deposit.token != address(0);
+        bool nativeDeposit = values.nativeTip > 0;
+        unchecked {
+            if (erc20Deposit) ++deposits;
+            if (nativeDeposit) ++deposits;
+        }
+
+        IERC7683.Output[] memory minReceived = new IERC7683.Output[](deposits);
+        if (erc20Deposit) {
+            minReceived[0] = IERC7683.Output({
+                token: deposit.token.toBytes32(),
+                amount: deposit.amount,
+                recipient: bytes32(0),
+                chainId: block.chainid
+            });
+        }
+        if (nativeDeposit) {
+            minReceived[deposits - 1] = IERC7683.Output({
+                token: bytes32(0),
+                amount: values.nativeTip,
+                recipient: bytes32(0),
+                chainId: block.chainid
+            });
+        }
+
+        return minReceived;
+    }
+
+    /**
+     * @dev Derive the fillInstructions for the order.
+     * @param orderData Order data to derive from.
+     */
+    function _deriveFillInstructions(OrderData memory orderData)
+        internal
+        view
+        returns (IERC7683.FillInstruction[] memory)
+    {
+        Call memory call = orderData.call;
+        Values memory values = orderData.values;
+        Expense[] memory expenses = orderData.expenses;
+
+        IERC7683.FillInstruction[] memory fillInstructions = new IERC7683.FillInstruction[](1);
+        fillInstructions[0] = IERC7683.FillInstruction({
+            destinationChainId: call.chainId,
+            destinationSettler: _outboxes[call.chainId].toBytes32(),
+            originData: abi.encode(
+                FillOriginData({
+                    srcChainId: uint64(block.chainid),
+                    destChainId: call.chainId,
+                    fillDeadline: values.fillDeadline,
+                    callValue: values.callValue,
+                    target: call.target,
+                    callData: abi.encodePacked(call.selector, call.callParams),
+                    expenses: expenses
+                })
+            )
+        });
+
+        return fillInstructions;
+    }
+
+    /**
+     * @dev Resolve the order without validation.
+     * @param orderData Order data to resolve.
+     */
+    function _resolve(OrderData memory orderData) internal view returns (ResolvedCrossChainOrder memory) {
+        Values memory values = orderData.values;
+
+        IERC7683.Output[] memory maxSpent = _deriveMaxSpent(orderData);
+        IERC7683.Output[] memory minReceived = _deriveMinReceived(orderData);
+        IERC7683.FillInstruction[] memory fillInstructions = _deriveFillInstructions(orderData);
+
+        return ResolvedCrossChainOrder({
+            user: orderData.owner,
+            originChainId: block.chainid,
+            openDeadline: values.openDeadline,
+            fillDeadline: values.fillDeadline,
+            orderId: _nextId(),
+            maxSpent: maxSpent,
+            minReceived: minReceived,
+            fillInstructions: fillInstructions
+        });
+    }
+
+    /**
+     * @notice Validate and intake ERC20 and/or native deposits.
+     * @param orderData  Order data to process.
+     */
+    function _processDeposits(OrderData memory orderData) internal {
+        Values memory values = orderData.values;
+        Deposit memory deposit = orderData.deposit;
+
+        if (msg.value != values.nativeTip) revert InvalidNativeTip();
+        if (deposit.token != address(0)) {
+            deposit.token.safeTransferFrom(msg.sender, address(this), deposit.amount);
+        }
+    }
+
+    /**
+     * @dev Opens a new order by initializing its state.
+     * @param orderData Order data to open.
+     */
+    function _openOrder(OrderData memory orderData) internal returns (ResolvedCrossChainOrder memory resolved) {
+        resolved = _resolve(orderData);
+        bytes32 id = _incrementId();
+
+        _orderOwners[id] = orderData.owner;
+        _orderCalls[id] = orderData.call;
+        _orderValues[id] = orderData.values;
+        _orderDeposits[id] = orderData.deposit;
+        for (uint256 i; i < orderData.expenses.length; ++i) {
+            _orderExpenses[id].push(orderData.expenses[i]);
+        }
+
+        StatusUpdate memory statusUpdate = StatusUpdate({ status: Status.Pending, timestamp: uint32(block.timestamp) });
+        _upsertOrder(id, statusUpdate, address(0));
+
+        return resolved;
+    }
+
+    /**
+     * @dev Transfer deposits to recipient. Used for both refunds and claims.
+     * @param id ID of the order.
+     * @param to Address to send deposits to.
+     */
+    function _transferDeposits(bytes32 id, address to) internal {
+        Values memory values = _orderValues[id];
+        Deposit memory deposit = _orderDeposits[id];
+
+        if (values.nativeTip > 0) {
+            to.safeTransferETH(values.nativeTip);
+        }
+        if (deposit.token != address(0)) {
+            deposit.token.safeTransfer(to, deposit.amount);
+        }
+    }
+
+    /**
+     * @dev Update or insert order state by id.
+     * @param id           ID of the order.
+     * @param statusUpdate Status update to upsert.
+     * @param acceptedBy   Address of the solver who accepted the order, if applicable.
+     */
+    function _upsertOrder(bytes32 id, StatusUpdate memory statusUpdate, address acceptedBy) internal {
+        OrderState memory state = _orderState[id];
+
+        // Apply most recent status update
+        state.latest = statusUpdate;
+
+        // If statusUpdate is accepted, update accepted status
+        if (statusUpdate.status == Status.Accepted) {
+            state.accepted = statusUpdate;
+            state.acceptedBy = acceptedBy;
+        }
+
+        // If statusUpdate is filled, update acceptedBy if it was filled before being accepted
+        if (statusUpdate.status == Status.Filled) {
+            if (state.accepted.timestamp > statusUpdate.timestamp) {
+                state.acceptedBy = acceptedBy;
+            }
+        }
+
+        _orderState[id] = state;
+        _latestOrderIdByStatus[statusUpdate.status] = id;
+    }
+
+    /**
+     * @dev Return the next order ID.
+     */
+    function _nextId() internal view returns (bytes32) {
+        return bytes32(_lastId + 1);
+    }
+
+    /**
+     * @dev Increment and return the next order ID.
+     */
+    function _incrementId() internal returns (bytes32) {
+        return bytes32(++_lastId);
+    }
+
+    /**
+     * @dev Returns call hash. Used to discern fulfillment.
+     * @param orderId ID of the order.
+     */
+    function _fillHash(bytes32 orderId) internal view returns (bytes32) {
+        Call memory call = _orderCalls[orderId];
+        Values memory values = _orderValues[orderId];
+        Expense[] memory expenses = _orderExpenses[orderId];
+
+        FillOriginData memory fillOriginData = FillOriginData({
+            srcChainId: uint64(block.chainid),
+            destChainId: call.chainId,
+            fillDeadline: values.fillDeadline,
+            callValue: values.callValue,
+            target: call.target,
+            callData: abi.encodePacked(call.selector, call.callParams),
+            expenses: expenses
+        });
+
+        return keccak256(abi.encode(orderId, fillOriginData));
+    }
+}

--- a/contracts/solve/src/_optimized/SolverNetOutbox.sol
+++ b/contracts/solve/src/_optimized/SolverNetOutbox.sol
@@ -31,11 +31,6 @@ contract SolverNetOutbox is OwnableRoles, ReentrancyGuard, Initializable, Deploy
     uint256 internal constant SOLVER = _ROLE_0;
 
     /**
-     * @notice Gas limit for SolveInbox.markFilled callback.
-     */
-    uint64 internal constant MARK_FILLED_GAS_LIMIT = 100_000;
-
-    /**
      * @notice Stubbed calldata for SolveInbox.markFilled. Used to estimate the gas cost.
      * @dev Type maxes used to ensure no non-zero bytes in fee estimation.
      */
@@ -231,7 +226,7 @@ contract SolverNetOutbox is OwnableRoles, ReentrancyGuard, Initializable, Deploy
             conf: ConfLevel.Finalized,
             to: _inboxes[fillData.srcChainId],
             data: abi.encodeCall(ISolverNetInbox.markFilled, (orderId, fillHash, block.timestamp, acceptedBy)),
-            gasLimit: MARK_FILLED_GAS_LIMIT
+            gasLimit: uint64(_fillGasLimit(fillData))
         });
         uint256 totalSpent = totalNativeValue + fee;
         if (msg.value < totalSpent) revert InsufficientFee();
@@ -276,6 +271,6 @@ contract SolverNetOutbox is OwnableRoles, ReentrancyGuard, Initializable, Deploy
             expensesGas += fillData.expenses.length * 5000;
         }
 
-        return metadataGas + callsGas + expensesGas + MARK_FILLED_GAS_LIMIT;
+        return metadataGas + callsGas + expensesGas + 100_000; // 100k base gas limit
     }
 }

--- a/contracts/solve/src/_optimized/SolverNetOutbox.sol
+++ b/contracts/solve/src/_optimized/SolverNetOutbox.sol
@@ -1,0 +1,226 @@
+// SPDX-License-Identifier: GPL-3.0-only
+pragma solidity =0.8.24;
+
+import { OwnableRoles } from "solady/src/auth/OwnableRoles.sol";
+import { ReentrancyGuard } from "solady/src/utils/ReentrancyGuard.sol";
+import { Initializable } from "solady/src/utils/Initializable.sol";
+import { DeployedAt } from "../util/DeployedAt.sol";
+import { XAppBase } from "core/src/pkg/XAppBase.sol";
+import { ISolverNetOutbox } from "./interfaces/ISolverNetOutbox.sol";
+import { SolverNetExecutor } from "./SolverNetExecutor.sol";
+import { SafeTransferLib } from "solady/src/utils/SafeTransferLib.sol";
+import { ConfLevel } from "core/src/libraries/ConfLevel.sol";
+import { TypeMax } from "core/src/libraries/TypeMax.sol";
+import { AddrUtils } from "../lib/AddrUtils.sol";
+import { ISolverNetInbox } from "./interfaces/ISolverNetInbox.sol";
+
+/**
+ * @title SolverNetOutbox
+ * @notice Entrypoint for fulfillments of user solve requests.
+ */
+contract SolverNetOutbox is OwnableRoles, ReentrancyGuard, Initializable, DeployedAt, XAppBase, ISolverNetOutbox {
+    using SafeTransferLib for address;
+    using AddrUtils for bytes32;
+
+    /**
+     * @notice Role for solvers.
+     * @dev _ROLE_0 evaluates to '1'.
+     */
+    uint256 internal constant SOLVER = _ROLE_0;
+
+    /**
+     * @notice Gas limit for SolveInbox.markFilled callback.
+     */
+    uint64 internal constant MARK_FILLED_GAS_LIMIT = 100_000;
+
+    /**
+     * @notice Stubbed calldata for SolveInbox.markFilled. Used to estimate the gas cost.
+     * @dev Type maxes used to ensure no non-zero bytes in fee estimation.
+     */
+    bytes internal constant MARK_FILLED_STUB_CDATA =
+        abi.encodeCall(ISolverNetInbox.markFilled, (TypeMax.Bytes32, TypeMax.Bytes32, TypeMax.Uint256, TypeMax.Address));
+
+    /**
+     * @notice Addresses of the inbox contracts.
+     */
+    mapping(uint64 chainId => address inbox) internal _inboxes;
+
+    /**
+     * @notice Executor contract handling calls.
+     * @dev An executor is used so infinite approvals from solvers cannot be abused.
+     */
+    SolverNetExecutor internal _executor;
+
+    /**
+     * @notice Maps fillHash (hash of fill instruction origin data) to true, if filled.
+     * @dev Used to prevent duplicate fulfillment.
+     */
+    mapping(bytes32 fillHash => bool filled) internal _filled;
+
+    constructor() {
+        _disableInitializers();
+    }
+
+    /**
+     * @notice Initialize the contract's owner and solver.
+     * @dev Used instead of constructor as we want to use the transparent upgradeable proxy pattern.
+     * @param owner_  Address of the owner.
+     * @param solver_ Address of the solver.
+     * @param omni_   Address of the OmniPortal.
+     */
+    function initialize(address owner_, address solver_, address omni_) external initializer {
+        _initializeOwner(owner_);
+        _grantRoles(solver_, SOLVER);
+        _setOmniPortal(omni_);
+        _executor = new SolverNetExecutor(address(this));
+    }
+
+    /**
+     * @notice Set the inbox addresses for the given chain IDs.
+     * @param chainIds IDs of the chains.
+     * @param inboxes  Addresses of the inboxes.
+     */
+    function setInboxes(uint64[] calldata chainIds, address[] calldata inboxes) external onlyOwner {
+        for (uint256 i; i < chainIds.length; ++i) {
+            _inboxes[chainIds[i]] = inboxes[i];
+            emit InboxSet(chainIds[i], inboxes[i]);
+        }
+    }
+
+    /**
+     * @notice Returns the address of the executor contract.
+     */
+    function executor() external view returns (address) {
+        return address(_executor);
+    }
+
+    /**
+     * @notice Returns the xcall fee required to mark an order filled on the source inbox.
+     * @param srcChainId Chain ID on which the order was opened.
+     * @return           Fee amount in native currency.
+     */
+    function fillFee(uint64 srcChainId) public view returns (uint256) {
+        return feeFor(srcChainId, MARK_FILLED_STUB_CDATA, MARK_FILLED_GAS_LIMIT);
+    }
+
+    /**
+     * @notice Returns true if the order has been filled.
+     * @param orderId    ID of the order the source inbox.
+     * @param originData Data emitted on the origin to parameterize the fill
+     */
+    function didFill(bytes32 orderId, bytes calldata originData) external view returns (bool) {
+        return _filled[_fillHash(orderId, originData)];
+    }
+
+    /**
+     * @notice Fills a particular order on the destination chain.
+     * @param orderId    Unique order identifier for this order.
+     * @param originData Data emitted on the origin to parameterize the fill.
+     * @param fillerData ABI encoded acceptedBy address to use if the order wasn't accepted before the fill.
+     */
+    function fill(bytes32 orderId, bytes calldata originData, bytes calldata fillerData)
+        external
+        payable
+        onlyRoles(SOLVER)
+        nonReentrant
+    {
+        FillOriginData memory fillData = abi.decode(originData, (FillOriginData));
+        address acceptedBy;
+
+        if (fillData.destChainId != block.chainid) revert WrongDestChain();
+        if (fillData.fillDeadline < block.timestamp && fillData.fillDeadline != 0) revert FillDeadlinePassed();
+        if (fillerData.length != 0 && fillerData.length != 32) revert BadFillerData();
+        if (fillerData.length == 32) acceptedBy = abi.decode(fillerData, (address));
+
+        _executeCall(fillData);
+        _markFilled(orderId, fillData, acceptedBy);
+    }
+
+    /**
+     * @notice Wrap a call with approved / enforced expenses.
+     * Approve spenders. Verify post-call balances match pre-call.
+     * @dev Expenses doesn't contain native tokens sent alongside the call.
+     */
+    modifier withExpenses(Expense[] memory expenses) {
+        // transfer from solver, approve spenders
+        for (uint256 i; i < expenses.length; ++i) {
+            Expense memory expense = expenses[i];
+            address spender = expense.spender;
+            address token = expense.token;
+            uint256 amount = expense.amount;
+
+            token.safeTransferFrom(msg.sender, address(_executor), amount);
+            // We remotely set token approvals on executor so we don't need to reprocess Call expenses there.
+            if (spender != address(0)) _executor.approve(token, spender, amount);
+        }
+
+        _;
+
+        // refund excess, revoke approvals
+        //
+        // NOTE: If anyone transfers this token to this outbox outside
+        // SolverNetOutbox.fill(...), the next solver to fill a call with
+        // that token as an expense will get the balance.
+        // This includes the call target.
+        for (uint256 i; i < expenses.length; ++i) {
+            Expense memory expense = expenses[i];
+            address token = expense.token;
+            uint256 tokenBalance = token.balanceOf(address(_executor));
+
+            if (tokenBalance > 0) {
+                address spender = expense.spender;
+                if (spender != address(0)) _executor.approve(token, spender, 0);
+                _executor.transfer(token, msg.sender, tokenBalance);
+            }
+        }
+
+        // send any potential native refund sent to executor back to solver
+        uint256 nativeBalance = address(_executor).balance;
+        if (nativeBalance > 0) _executor.transferNative(msg.sender, nativeBalance);
+    }
+
+    /**
+     * @notice Verify and execute a call. Expenses are processed and enforced.
+     * @param fillData ABI decoded fill originData.
+     */
+    function _executeCall(FillOriginData memory fillData) internal withExpenses(fillData.expenses) {
+        _executor.execute{ value: fillData.callValue }(fillData.target, fillData.callValue, fillData.callData);
+    }
+
+    /**
+     * @notice Mark an order as filled. Require sufficient native payment, refund excess.
+     * @param orderId    ID of the order.
+     * @param fillData   ABI decoded fill originData.
+     * @param acceptedBy acceptedBy address to use if the order wasn't accepted before the fill.
+     */
+    function _markFilled(bytes32 orderId, FillOriginData memory fillData, address acceptedBy) internal {
+        // mark filled on outbox (here)
+        bytes32 fillHash = _fillHash(orderId, abi.encode(fillData));
+        if (_filled[fillHash]) revert AlreadyFilled();
+        _filled[fillHash] = true;
+
+        // mark filled on inbox
+        uint256 fee = xcall({
+            destChainId: fillData.srcChainId,
+            conf: ConfLevel.Finalized,
+            to: _inboxes[fillData.srcChainId],
+            data: abi.encodeCall(ISolverNetInbox.markFilled, (orderId, fillHash, block.timestamp, acceptedBy)),
+            gasLimit: MARK_FILLED_GAS_LIMIT
+        });
+        uint256 totalSpent = fillData.callValue + fee;
+        if (msg.value < totalSpent) revert InsufficientFee();
+
+        // refund any overpayment in native currency
+        uint256 refund = msg.value - totalSpent;
+        if (refund > 0) msg.sender.safeTransferETH(refund);
+
+        emit Filled(orderId, fillHash, msg.sender);
+    }
+
+    /**
+     * @dev Returns call hash. Used to discern fulfillment.
+     */
+    function _fillHash(bytes32 srcReqId, bytes memory originData) internal pure returns (bytes32) {
+        return keccak256(abi.encode(srcReqId, originData));
+    }
+}

--- a/contracts/solve/src/_optimized/interfaces/ISolverNet.sol
+++ b/contracts/solve/src/_optimized/interfaces/ISolverNet.sol
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: GPL-3.0-only
+pragma solidity =0.8.24;
+
+interface ISolverNet {
+    struct OrderData {
+        address owner;
+        Call call;
+        Values values;
+        Deposit deposit;
+        Expense[] expenses;
+    }
+
+    struct Call {
+        uint64 chainId;
+        address target;
+        bytes4 selector;
+        bytes callParams;
+    }
+
+    struct Values {
+        uint96 nativeTip;
+        uint96 callValue;
+        uint32 openDeadline;
+        uint32 fillDeadline;
+    }
+
+    struct Deposit {
+        address token;
+        uint96 amount;
+    }
+
+    struct Expense {
+        address spender;
+        address token;
+        uint96 amount;
+    }
+
+    struct FillOriginData {
+        uint64 srcChainId;
+        uint64 destChainId;
+        uint32 fillDeadline;
+        uint96 callValue;
+        address target;
+        bytes callData;
+        Expense[] expenses;
+    }
+}

--- a/contracts/solve/src/_optimized/interfaces/ISolverNetExecutor.sol
+++ b/contracts/solve/src/_optimized/interfaces/ISolverNetExecutor.sol
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: GPL-3.0-only
+pragma solidity =0.8.24;
+
+interface ISolverNetExecutor {
+    /**
+     * @notice Error thrown when the sender is not the outbox.
+     */
+    error NotOutbox();
+
+    /**
+     * @notice Error thrown when the call fails.
+     */
+    error CallFailed();
+
+    /**
+     * @notice Address of the outbox.
+     */
+    function outbox() external view returns (address);
+
+    /**
+     * @notice Approves a spender (usually call target) to spend a token held by the executor.
+     * @dev Called prior to `execute` in order to ensure tokens can be spent and after to purge excess approvals.
+     */
+    function approve(address token, address spender, uint256 amount) external;
+
+    /**
+     * @notice Executes a call.
+     * @param target Address of the contract to call.
+     * @param value  Value to send with the call.
+     * @param data   Data to send with the call.
+     */
+    function execute(address target, uint256 value, bytes calldata data) external payable;
+
+    /**
+     * @notice Transfers a token to a recipient.
+     * @dev Called after `execute` in order to refund any excess or returned tokens.
+     */
+    function transfer(address token, address to, uint256 amount) external;
+
+    /**
+     * @notice Transfers native currency to a recipient.
+     * @dev Called after `execute` in order to refund any native currency sent back to the executor.
+     */
+    function transferNative(address to, uint256 amount) external;
+}

--- a/contracts/solve/src/_optimized/interfaces/ISolverNetInbox.sol
+++ b/contracts/solve/src/_optimized/interfaces/ISolverNetInbox.sol
@@ -86,25 +86,15 @@ interface ISolverNetInbox is IOriginSettler {
     }
 
     /**
-     * @notice Status update for an order.
-     * @param status    Order status.
-     * @param timestamp Timestamp of the status update.
-     */
-    struct StatusUpdate {
-        Status status;
-        uint32 timestamp;
-    }
-
-    /**
      * @notice State of an order.
-     * @param latest     Latest order status.
-     * @param accepted   Status of the order when it was accepted.
-     * @param acceptedBy Address of the solver that accepted the order.
+     * @param status    Latest order status.
+     * @param timestamp Timestamp of the status update.
+     * @param claimant  Address of the claimant, defined at fill.
      */
     struct OrderState {
-        StatusUpdate latest;
-        StatusUpdate accepted;
-        address acceptedBy;
+        Status status;
+        uint32 timestamp;
+        address claimant;
     }
 
     /**
@@ -165,12 +155,11 @@ interface ISolverNetInbox is IOriginSettler {
     /**
      * @notice Fill an order.
      * @dev Only callable by the outbox.
-     * @param id         ID of the order.
-     * @param fillHash   Hash of fill instructions origin data.
-     * @param timestamp  Timestamp of the fill.
-     * @param acceptedBy Address of the solver that filled the order if they didnt accept it first.
+     * @param id        ID of the order.
+     * @param fillHash  Hash of fill instructions origin data.
+     * @param claimant  Address to claim the order, provided by the filler.
      */
-    function markFilled(bytes32 id, bytes32 fillHash, uint256 timestamp, address acceptedBy) external;
+    function markFilled(bytes32 id, bytes32 fillHash, address claimant) external;
 
     /**
      * @notice Claim a filled order.

--- a/contracts/solve/src/_optimized/interfaces/ISolverNetInbox.sol
+++ b/contracts/solve/src/_optimized/interfaces/ISolverNetInbox.sol
@@ -1,0 +1,184 @@
+// SPDX-License-Identifier: GPL-3.0-only
+pragma solidity =0.8.24;
+
+import { IOriginSettler } from "../../erc7683/IOriginSettler.sol";
+import { ISolverNet } from "./ISolverNet.sol";
+
+interface ISolverNetInbox is IOriginSettler, ISolverNet {
+    // Validation errors
+    error InvalidOrderTypehash();
+    error InvalidOrderData();
+    error InvalidCallChainId();
+    error InvalidCallTarget();
+    error InvalidOpenDeadline();
+    error InvalidFillDeadline();
+    error InvalidDepositAmount();
+    error InvalidExpenseToken();
+    error InvalidExpenseAmount();
+
+    // Open order errors
+    error InvalidNativeTip();
+
+    // Order accept/reject/cancel errors
+    error OrderNotPending();
+    error FillDeadlinePassed();
+
+    // Order fill errors
+    error OrderNotPendingOrAccepted();
+    error WrongSourceChain();
+    error WrongFillHash();
+
+    // Order claim errors
+    error OrderNotFilled();
+
+    /**
+     * @notice Emitted when an outbox is set.
+     * @param chainId ID of the chain.
+     * @param outbox  Address of the outbox.
+     */
+    event OutboxSet(uint64 indexed chainId, address indexed outbox);
+
+    /**
+     * @notice Emitted when an order is accepted.
+     * @param id ID of the order.
+     * @param by Address of the solver who accepted the order.
+     */
+    event Accepted(bytes32 indexed id, address indexed by);
+
+    /**
+     * @notice Emitted when an order is rejected.
+     * @param id     ID of the order.
+     * @param by     Address of the solver who rejected the order.
+     * @param reason Reason code for rejecting the order.
+     */
+    event Rejected(bytes32 indexed id, address indexed by, uint8 indexed reason);
+
+    /**
+     * @notice Emitted when an order is cancelled.
+     * @param id ID of the order.
+     */
+    event Reverted(bytes32 indexed id);
+
+    /**
+     * @notice Emitted when an order is filled.
+     * @param id         ID of the order.
+     * @param callHash   Hash of the call executed on another chain.
+     * @param creditedTo Address of the recipient credited the funds by the solver.
+     */
+    event Filled(bytes32 indexed id, bytes32 indexed callHash, address indexed creditedTo);
+
+    /**
+     * @notice Emitted when an order is claimed.
+     * @param id ID of the order.
+     * @param by The solver address that claimed the order.
+     * @param to The recipient of claimed deposits.
+     */
+    event Claimed(bytes32 indexed id, address indexed by, address indexed to);
+
+    /**
+     * @notice Status of an order.
+     */
+    enum Status {
+        Invalid,
+        Pending,
+        Accepted,
+        Rejected,
+        Reverted,
+        Filled,
+        Claimed
+    }
+
+    /**
+     * @notice Status update for an order.
+     * @param status    Order status.
+     * @param timestamp Timestamp of the status update.
+     */
+    struct StatusUpdate {
+        Status status;
+        uint32 timestamp;
+    }
+
+    /**
+     * @notice State of an order.
+     * @param latest     Latest order status.
+     * @param accepted   Status of the order when it was accepted.
+     * @param acceptedBy Address of the solver that accepted the order.
+     */
+    struct OrderState {
+        StatusUpdate latest;
+        StatusUpdate accepted;
+        address acceptedBy;
+    }
+
+    /**
+     * @notice Set the outbox addresses for the given chain IDs.
+     * @param chainIds IDs of the chains.
+     * @param outboxes Addresses of the outboxes.
+     */
+    function setOutboxes(uint64[] calldata chainIds, address[] calldata outboxes) external;
+
+    /**
+     * @notice Returns the order and its state with the given ID.
+     * @param id ID of the order.
+     */
+    function getOrder(bytes32 id)
+        external
+        view
+        returns (ResolvedCrossChainOrder memory order, OrderState memory state);
+
+    /**
+     * @notice Returns the next order ID.
+     */
+    function getNextId() external view returns (bytes32);
+
+    /**
+     * @notice Returns the latest order with the given status.
+     * @param status Order status to query.
+     */
+    function getLatestOrderIdByStatus(Status status) external view returns (bytes32);
+
+    /**
+     * @dev Validate the onchain order.
+     * @param order OnchainCrossChainOrder to validate.
+     */
+    function validate(OnchainCrossChainOrder calldata order) external view returns (bool);
+
+    /**
+     * @notice Accept an open order.
+     * @dev Only a whitelisted solver can accept.
+     * @param id ID of the order.
+     */
+    function accept(bytes32 id) external;
+
+    /**
+     * @notice Reject an open order and refund deposits.
+     * @dev Only a whitelisted solver can reject.
+     * @param id     ID of the order.
+     * @param reason Reason code for rejection.
+     */
+    function reject(bytes32 id, uint8 reason) external;
+
+    /**
+     * @notice Cancel an open and refund deposits.
+     * @dev Only order initiator can cancel.
+     * @param id ID of the order.
+     */
+    function cancel(bytes32 id) external;
+
+    /**
+     * @notice Fill an order.
+     * @dev Only callable by the outbox.
+     * @param id         ID of the order.
+     * @param fillHash   Hash of fill instructions origin data.
+     * @param timestamp  Timestamp of the fill.
+     * @param acceptedBy Address of the solver that filled the order if they didnt accept it first.
+     */
+    function markFilled(bytes32 id, bytes32 fillHash, uint256 timestamp, address acceptedBy) external;
+
+    /**
+     * @notice Claim a filled order.
+     * @param id ID of the order.
+     * @param to Address to send deposits to.
+     */
+    function claim(bytes32 id, address to) external;
+}

--- a/contracts/solve/src/_optimized/interfaces/ISolverNetInbox.sol
+++ b/contracts/solve/src/_optimized/interfaces/ISolverNetInbox.sol
@@ -2,22 +2,19 @@
 pragma solidity =0.8.24;
 
 import { IOriginSettler } from "../../erc7683/IOriginSettler.sol";
-import { ISolverNet } from "./ISolverNet.sol";
 
-interface ISolverNetInbox is IOriginSettler, ISolverNet {
+interface ISolverNetInbox is IOriginSettler {
     // Validation errors
     error InvalidOrderTypehash();
     error InvalidOrderData();
-    error InvalidCallChainId();
-    error InvalidCallTarget();
-    error InvalidOpenDeadline();
+    error InvalidChainId();
     error InvalidFillDeadline();
-    error InvalidDepositAmount();
+    error InvalidCallTarget();
     error InvalidExpenseToken();
     error InvalidExpenseAmount();
 
     // Open order errors
-    error InvalidNativeTip();
+    error InvalidNativeDeposit();
 
     // Order accept/reject/cancel errors
     error OrderNotPending();

--- a/contracts/solve/src/_optimized/interfaces/ISolverNetOutbox.sol
+++ b/contracts/solve/src/_optimized/interfaces/ISolverNetOutbox.sol
@@ -2,9 +2,8 @@
 pragma solidity =0.8.24;
 
 import { IDestinationSettler } from "../../erc7683/IDestinationSettler.sol";
-import { ISolverNet } from "./ISolverNet.sol";
 
-interface ISolverNetOutbox is IDestinationSettler, ISolverNet {
+interface ISolverNetOutbox is IDestinationSettler {
     error BadFillerData();
     error AlreadyFilled();
     error WrongDestChain();
@@ -40,10 +39,10 @@ interface ISolverNetOutbox is IDestinationSettler, ISolverNet {
 
     /**
      * @notice Returns the xcall fee required to mark an order filled on the source inbox.
-     * @param srcChainId ID of the source chain.
+     * @param originData Data emitted on the origin to parameterize the fill.
      * @return           Fee amount in native currency.
      */
-    function fillFee(uint64 srcChainId) external view returns (uint256);
+    function fillFee(bytes calldata originData) external view returns (uint256);
 
     /**
      * @notice Returns whether a call has been filled.

--- a/contracts/solve/src/_optimized/interfaces/ISolverNetOutbox.sol
+++ b/contracts/solve/src/_optimized/interfaces/ISolverNetOutbox.sol
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: GPL-3.0-only
+pragma solidity =0.8.24;
+
+import { IDestinationSettler } from "../../erc7683/IDestinationSettler.sol";
+import { ISolverNet } from "./ISolverNet.sol";
+
+interface ISolverNetOutbox is IDestinationSettler, ISolverNet {
+    error BadFillerData();
+    error AlreadyFilled();
+    error WrongDestChain();
+    error InsufficientFee();
+    error FillDeadlinePassed();
+
+    /**
+     * @notice Emitted when an inbox is set.
+     * @param chainId ID of the chain.
+     * @param inbox   Address of the inbox.
+     */
+    event InboxSet(uint64 indexed chainId, address indexed inbox);
+
+    /**
+     * @notice Emitted when a cross-chain request is filled on the destination chain
+     * @param orderId  ID of the order on the source chain
+     * @param fillHash Hash of the fill origin data
+     * @param filledBy Address of the solver that filled the oder
+     */
+    event Filled(bytes32 indexed orderId, bytes32 indexed fillHash, address indexed filledBy);
+
+    /**
+     * @notice Set the inbox addresses for the given chain IDs.
+     * @param chainIds IDs of the chains.
+     * @param inboxes  Addresses of the inboxes.
+     */
+    function setInboxes(uint64[] calldata chainIds, address[] calldata inboxes) external;
+
+    /**
+     * @notice Returns the address of the executor contract.
+     */
+    function executor() external view returns (address);
+
+    /**
+     * @notice Returns the xcall fee required to mark an order filled on the source inbox.
+     * @param srcChainId ID of the source chain.
+     * @return           Fee amount in native currency.
+     */
+    function fillFee(uint64 srcChainId) external view returns (uint256);
+
+    /**
+     * @notice Returns whether a call has been filled.
+     * @param srcReqId   ID of the on the source inbox.
+     * @param originData Data emitted on the origin to parameterize the fill
+     * @return           Whether the call has been filled.
+     */
+    function didFill(bytes32 srcReqId, bytes calldata originData) external view returns (bool);
+}

--- a/contracts/solve/src/_optimized/lib/SolverNet.sol
+++ b/contracts/solve/src/_optimized/lib/SolverNet.sol
@@ -3,15 +3,15 @@ pragma solidity =0.8.24;
 
 library SolverNet {
     struct OrderData {
-        Metadata metadata;
+        Header header;
         Deposit deposit;
         Call[] calls;
         Expense[] expenses;
     }
 
-    struct Metadata {
+    struct Header {
         address owner;
-        uint64 chainId;
+        uint64 destChainId;
         uint32 fillDeadline;
     }
 

--- a/contracts/solve/src/_optimized/lib/SolverNet.sol
+++ b/contracts/solve/src/_optimized/lib/SolverNet.sol
@@ -1,27 +1,25 @@
 // SPDX-License-Identifier: GPL-3.0-only
 pragma solidity =0.8.24;
 
-interface ISolverNet {
+library SolverNet {
     struct OrderData {
-        address owner;
-        Call call;
-        Values values;
+        Metadata metadata;
         Deposit deposit;
+        Call[] calls;
         Expense[] expenses;
     }
 
-    struct Call {
+    struct Metadata {
+        address owner;
         uint64 chainId;
-        address target;
-        bytes4 selector;
-        bytes callParams;
+        uint32 fillDeadline;
     }
 
-    struct Values {
-        uint96 nativeTip;
-        uint96 callValue;
-        uint32 openDeadline;
-        uint32 fillDeadline;
+    struct Call {
+        address target;
+        bytes4 selector;
+        uint256 value;
+        bytes params;
     }
 
     struct Deposit {
@@ -39,9 +37,7 @@ interface ISolverNet {
         uint64 srcChainId;
         uint64 destChainId;
         uint32 fillDeadline;
-        uint96 callValue;
-        address target;
-        bytes callData;
+        Call[] calls;
         Expense[] expenses;
     }
 }


### PR DESCRIPTION
By completely refactoring the `OrderData` type and storing it instead of a `ResolvedCrossChainOrder` type, I managed to reduce costs by ~70%. The new type requires 6 slots minimally, with 2 additional slots per token approval required. This is substantially optimized from the 25+ slots required to store the entire ERC7683 resolved order.

The user and solver-facing interface remains completely unchanged. The only breaking change in this implementation is that the `OrderData` is much different. However, it is also flatter, which should make it easier for the solver to populate.

issue: #2917