### PR TITLE
chore(halo/app): use depinject for encoding config

### DIFF
--- a/e2e/app/setup.go
+++ b/e2e/app/setup.go
@@ -101,6 +101,7 @@ func Setup(ctx context.Context, def Definition, depCfg DeployConfig) error {
 	}
 
 	cosmosGenesis, err := genutil.MakeGenesis(
+		ctx,
 		def.Manifest.Network,
 		time.Now(),
 		gethGenesis.ToBlock().Hash(),

--- a/halo/app/start.go
+++ b/halo/app/start.go
@@ -42,6 +42,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/baseapp"
 	"github.com/cosmos/cosmos-sdk/client"
 	sdkflags "github.com/cosmos/cosmos-sdk/client/flags"
+	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
 	sdkserver "github.com/cosmos/cosmos-sdk/server"
 	"github.com/cosmos/cosmos-sdk/server/api"
 	"github.com/cosmos/cosmos-sdk/server/grpc"
@@ -188,7 +189,7 @@ func Start(ctx context.Context, cfg Config) (<-chan error, func(context.Context)
 		return nil, nil, err
 	}
 
-	cProvider, err := newCProvider(rpcClient, cfg)
+	cProvider, err := newCProvider(rpcClient, cfg, app.interfaceRegistry)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -253,9 +254,9 @@ func Start(ctx context.Context, cfg Config) (<-chan error, func(context.Context)
 
 // newCProvider returns a new cchain provider. Either GRPC if enabled since it is faster,
 // otherwise the ABCI provider.
-func newCProvider(rpcClient *rpclocal.Local, cfg Config) (cchain.Provider, error) {
+func newCProvider(rpcClient *rpclocal.Local, cfg Config, ir codectypes.InterfaceRegistry) (cchain.Provider, error) {
 	if cfg.SDKGRPC.Enable {
-		return cprovider.NewGRPC(cfg.SDKGRPC.Address, cfg.Network)
+		return cprovider.NewGRPC(cfg.SDKGRPC.Address, cfg.Network, ir)
 	}
 
 	return cprovider.NewABCI(rpcClient, cfg.Network), nil

--- a/halo/cmd/init.go
+++ b/halo/cmd/init.go
@@ -298,7 +298,7 @@ func InitFiles(ctx context.Context, initCfg InitConfig) error {
 			return errors.Wrap(err, "get public key")
 		}
 
-		cosmosGen, err := genutil.MakeGenesis(network, time.Now(), initCfg.ExecutionHash, initCfg.GenesisUpgrade, pubKey)
+		cosmosGen, err := genutil.MakeGenesis(ctx, network, time.Now(), initCfg.ExecutionHash, initCfg.GenesisUpgrade, pubKey)
 		if err != nil {
 			return err
 		}

--- a/halo/genutil/genutil_internal_test.go
+++ b/halo/genutil/genutil_internal_test.go
@@ -1,15 +1,17 @@
 package genutil
 
 import (
+	"context"
 	"testing"
 
+	haloapp "github.com/omni-network/omni/halo/app"
 	atypes "github.com/omni-network/omni/halo/attest/types"
+	"github.com/omni-network/omni/lib/netconf"
 	etypes "github.com/omni-network/omni/octane/evmengine/types"
 
 	"github.com/cometbft/cometbft/types"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	authtx "github.com/cosmos/cosmos-sdk/x/auth/tx"
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 	"github.com/stretchr/testify/require"
 )
@@ -34,11 +36,11 @@ func TestEncodeTXs(t *testing.T) {
 		},
 	}
 
-	cdc := getCodec()
-	txConfig := authtx.NewTxConfig(cdc, nil)
+	encConf, err := haloapp.ClientEncodingConfig(context.Background(), netconf.Simnet)
+	require.NoError(t, err)
 
-	b := txConfig.NewTxBuilder()
-	err := b.SetMsgs(msgs...)
+	b := encConf.TxConfig.NewTxBuilder()
+	err = b.SetMsgs(msgs...)
 	require.NoError(t, err)
 
 	tx := b.GetTx()

--- a/halo/genutil/genutil_test.go
+++ b/halo/genutil/genutil_test.go
@@ -1,6 +1,7 @@
 package genutil_test
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -27,7 +28,7 @@ func TestMakeGenesis(t *testing.T) {
 
 	executionBlockHash := common.BytesToHash([]byte("blockhash"))
 
-	resp, err := genutil.MakeGenesis(netconf.Simnet, timestamp, executionBlockHash, uluwatu1.UpgradeName, val1, val2)
+	resp, err := genutil.MakeGenesis(context.Background(), netconf.Simnet, timestamp, executionBlockHash, uluwatu1.UpgradeName, val1, val2)
 	tutil.RequireNoError(t, err)
 
 	tutil.RequireGoldenJSON(t, resp)

--- a/lib/cchain/provider/abci.go
+++ b/lib/cchain/provider/abci.go
@@ -27,6 +27,8 @@ import (
 	errorsmod "cosmossdk.io/errors"
 	utypes "cosmossdk.io/x/upgrade/types"
 	"github.com/cosmos/cosmos-sdk/client/grpc/cmtservice"
+	"github.com/cosmos/cosmos-sdk/codec"
+	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	grpctypes "github.com/cosmos/cosmos-sdk/types/grpc"
@@ -65,8 +67,11 @@ func NewABCI(cmtCl rpcclient.Client, network netconf.ID, opts ...func(*Provider)
 // NewGRPC returns a new provider using the provided gRPC server address.
 // This is preferred to NewABCI as it bypasses CometBFT so is much faster
 // and doesn't affect chain performance.
-func NewGRPC(target string, network netconf.ID, opts ...func(*Provider)) (Provider, error) {
-	grpcClient, err := grpc.NewClient(target, grpc.WithTransportCredentials(insecure.NewCredentials()))
+func NewGRPC(target string, network netconf.ID, ir codectypes.InterfaceRegistry, opts ...func(*Provider)) (Provider, error) {
+	grpcClient, err := grpc.NewClient(target,
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+		grpc.WithDefaultCallOptions(grpc.ForceCodec(codec.NewProtoCodec(ir).GRPCCodec())),
+	)
 	if err != nil {
 		return Provider{}, errors.Wrap(err, "new grpc client")
 	}

--- a/monitor/app/app.go
+++ b/monitor/app/app.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/omni-network/omni/contracts/bindings"
+	haloapp "github.com/omni-network/omni/halo/app"
 	"github.com/omni-network/omni/halo/genutil/evm/predeploys"
 	"github.com/omni-network/omni/lib/buildinfo"
 	"github.com/omni-network/omni/lib/cchain"
@@ -110,7 +111,12 @@ func newCProvider(ctx context.Context, cfg Config) (cchain.Provider, error) {
 	if cfg.HaloGRPCURL != "" {
 		log.Debug(ctx, "Using grpc cprovider", "url", cfg.HaloGRPCURL)
 
-		return cprovider.NewGRPC(cfg.HaloGRPCURL, cfg.Network)
+		encConf, err := haloapp.ClientEncodingConfig(ctx, cfg.Network)
+		if err != nil {
+			return nil, errors.Wrap(err, "client encoding config")
+		}
+
+		return cprovider.NewGRPC(cfg.HaloGRPCURL, cfg.Network, encConf.InterfaceRegistry)
 	}
 
 	log.Debug(ctx, "Using comet cprovider", "url", cfg.HaloCometURL)

--- a/relayer/app/app.go
+++ b/relayer/app/app.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/omni-network/omni/contracts/bindings"
+	haloapp "github.com/omni-network/omni/halo/app"
 	"github.com/omni-network/omni/halo/genutil/evm/predeploys"
 	"github.com/omni-network/omni/lib/buildinfo"
 	"github.com/omni-network/omni/lib/cchain"
@@ -129,7 +130,12 @@ func newCProvider(ctx context.Context, cfg Config) (cchain.Provider, error) {
 	if cfg.HaloGRPCURL != "" {
 		log.Debug(ctx, "Using grpc cprovider", "url", cfg.HaloGRPCURL)
 
-		return cprovider.NewGRPC(cfg.HaloGRPCURL, cfg.Network)
+		encConf, err := haloapp.ClientEncodingConfig(ctx, cfg.Network)
+		if err != nil {
+			return nil, errors.Wrap(err, "client encoding config")
+		}
+
+		return cprovider.NewGRPC(cfg.HaloGRPCURL, cfg.Network, encConf.InterfaceRegistry)
 	}
 
 	log.Debug(ctx, "Using comet cprovider", "url", cfg.HaloCometURL)


### PR DESCRIPTION
Provide a `halo_app.ClientEncodingConfig` function, similar to cosmos `MakeTestEncodingConfig` that uses depinject to load the codecs. Use this in the gRPC client so custom types can be decoded.

issue: #2963