### PR TITLE
feat(halo/app): account for validator rewards

### DIFF
--- a/halo/app/start_test.go
+++ b/halo/app/start_test.go
@@ -212,7 +212,7 @@ func testCProvider(t *testing.T, ctx context.Context, cprov cprovider.Provider) 
 	if feature.FlagEVMStakingModule.Enabled(ctx) {
 		resp, err := cprov.QueryClients().Mint.Inflation(ctx, &minttypes.QueryInflationRequest{})
 		require.NoError(t, err)
-		require.EqualValues(t, "0.110000000000000000", resp.Inflation.String())
+		require.EqualValues(t, "0.115789000000000000", resp.Inflation.String())
 	}
 }
 

--- a/halo/app/upgrades/uluwatu/upgrade.go
+++ b/halo/app/upgrades/uluwatu/upgrade.go
@@ -44,8 +44,8 @@ var (
 		SlashFractionDowntime:   math.LegacyNewDec(0),            // 0% since mainnet V1 has trusted operators.
 	}
 
-	targetInflation  = math.LegacyNewDecWithPrec(11, 2) // 11%
-	blocksPeriodSecs = 2                                // BlocksPerYear calculated based on 2 second block times
+	targetInflation  = math.LegacyNewDecWithPrec(115789, 6) // 11.5789% so that delegators earn ~11% after deducting of 5% validator rewards
+	blocksPeriodSecs = 2                                    // BlocksPerYear calculated based on 2 second block times
 	mintParams       = minttypes.Params{
 		MintDenom:           sdk.DefaultBondDenom,
 		InflationRateChange: math.LegacyNewDec(0),


### PR DESCRIPTION
Account for 5% validator rewards so that users get roughly 11% per year.

issue: #2891