### PR TITLE
fix(octane/evmengine): fix proposing invalid blobs

### DIFF
--- a/octane/evmengine/keeper/msg_server.go
+++ b/octane/evmengine/keeper/msg_server.go
@@ -35,8 +35,13 @@ func (s msgServer) ExecutionPayload(ctx context.Context, msg *types.MsgExecution
 		return nil, err
 	}
 
+	blockHashes, err := blobHashes(msg.BlobCommitments)
+	if err != nil {
+		return nil, errors.Wrap(err, "blob commitments")
+	}
+
 	err = retryForever(ctx, func(ctx context.Context) (bool, error) {
-		status, err := pushPayload(ctx, s.engineCl, payload, msg.BlobCommitments)
+		status, err := pushPayload(ctx, s.engineCl, payload, blockHashes)
 		if err != nil {
 			// We need to retry forever on networking errors, but can't easily identify them, so retry all errors.
 			log.Warn(ctx, "Processing finalized payload failed: push new payload to evm (will retry)", err)
@@ -178,18 +183,13 @@ func (s msgServer) deliverEvents(ctx context.Context, height uint64, blockHash c
 
 // pushPayload pushes the provided execution data as a possible new head to the execution client.
 // It returns the engine payload status or an error.
-func pushPayload(ctx context.Context, engineCl ethclient.EngineClient, payload engine.ExecutableData, blobCommitments [][]byte) (engine.PayloadStatusV1, error) {
+func pushPayload(ctx context.Context, engineCl ethclient.EngineClient, payload engine.ExecutableData, blobHashes []common.Hash) (engine.PayloadStatusV1, error) {
 	sdkCtx := sdk.UnwrapSDKContext(ctx)
 	appHash, err := cast.EthHash(sdkCtx.BlockHeader().AppHash)
 	if err != nil {
 		return engine.PayloadStatusV1{}, err
 	} else if appHash == (common.Hash{}) {
 		return engine.PayloadStatusV1{}, errors.New("app hash is empty")
-	}
-
-	blobHashes, err := blobHashes(blobCommitments)
-	if err != nil {
-		return engine.PayloadStatusV1{}, errors.Wrap(err, "blob hashes")
 	}
 
 	// Push it back to the execution client (mark it as possible new head).

--- a/octane/evmengine/keeper/proposal_server.go
+++ b/octane/evmengine/keeper/proposal_server.go
@@ -24,9 +24,14 @@ func (s proposalServer) ExecutionPayload(ctx context.Context, msg *types.MsgExec
 		return nil, err
 	}
 
+	blockHashes, err := blobHashes(msg.BlobCommitments)
+	if err != nil {
+		return nil, errors.Wrap(err, "blob commitments")
+	}
+
 	// Push the payload to the EVM.
 	err = retryForever(ctx, func(ctx context.Context) (bool, error) {
-		status, err := pushPayload(ctx, s.engineCl, payload, msg.BlobCommitments)
+		status, err := pushPayload(ctx, s.engineCl, payload, blockHashes)
 		if err != nil {
 			// We need to retry forever on networking errors, but can't easily identify them, so retry all errors.
 			log.Warn(ctx, "Verifying proposal failed: push new payload to evm (will retry)", err)


### PR DESCRIPTION
Fixes issue where malicious proposers can trigger `retryForever` by proposing invalid `BlobCommitments`.

issue: none