### PR TITLE
chore(sdk): fix encoded data slicing

### DIFF
--- a/sdk/src/utils/encodeOrder.ts
+++ b/sdk/src/utils/encodeOrder.ts
@@ -47,8 +47,7 @@ export function encodeOrder(order: Order): Hex {
 
     const selector = slice(callData, 0, 4)
 
-    const params =
-      callData.length > 10 ? slice(callData, 4, callData.length) : '0x'
+    const params = callData.length > 10 ? slice(callData, 4) : '0x'
 
     return {
       target: call.target,


### PR DESCRIPTION
Ignore length when slicing encoded call data, since call data is always 32 bytes and we already slice the first 4 bytes

issue: none