### PR TITLE
feat(e2e/cmd): add deploy solvernet e2e cmd

### DIFF
--- a/e2e/cmd/cmd.go
+++ b/e2e/cmd/cmd.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/omni-network/omni/e2e/app"
 	"github.com/omni-network/omni/e2e/docker"
+	"github.com/omni-network/omni/e2e/solve"
 	"github.com/omni-network/omni/e2e/types"
 	"github.com/omni-network/omni/e2e/xbridge"
 	libcmd "github.com/omni-network/omni/lib/cmd"
@@ -86,6 +87,7 @@ func New() *cobra.Command {
 		newDeployBridgeCmd(&def),
 		newDeployFeeOracleV2Cmd(&def),
 		newDeployXBridgeCmd(&def),
+		newDeploySolverNetCmd(&def),
 		fundAccounts(&def),
 	)
 
@@ -297,6 +299,18 @@ func newDeployXBridgeCmd(def *app.Definition) *cobra.Command {
 		Short: "Deploys the XBridge contracts",
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			return xbridge.Deploy(cmd.Context(), app.NetworkFromDef(*def), def.Backends())
+		},
+	}
+
+	return cmd
+}
+
+func newDeploySolverNetCmd(def *app.Definition) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "deploy-solvernet",
+		Short: "Deploys the SolverNet contracts",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return solve.Deploy(cmd.Context(), app.NetworkFromDef(*def), def.Backends())
 		},
 	}
 

--- a/e2e/solve/deploy.go
+++ b/e2e/solve/deploy.go
@@ -16,13 +16,8 @@ import (
 	"golang.org/x/sync/errgroup"
 )
 
-// Deploy deploys solve inbox / outbox contracts, and devnet app (if devnet).
+// Deploy deploys solve inbox / outbox / middleman contracts, and devnet app (if devnet).
 func Deploy(ctx context.Context, network netconf.Network, backends ethbackend.Backends) error {
-	if !network.ID.IsEphemeral() {
-		log.Warn(ctx, "Skipping solvernet deploy", nil)
-		return nil
-	}
-
 	var eg errgroup.Group
 	eg.Go(func() error { return deployBoxes(ctx, network, backends) })
 	eg.Go(func() error { return maybeDeployMockTokens(ctx, network, backends) })


### PR DESCRIPTION
Added a new `newDeploySolverNetCmd` e2e command that deploys the SolverNet contracts using `solve.Deploy`.

issue: #3007