### PR TITLE
ci(github): switch main binary to magellan

### DIFF
--- a/.github/workflows/release-official.yaml
+++ b/.github/workflows/release-official.yaml
@@ -39,7 +39,7 @@ jobs:
         with:
           file: scripts/halovisor/Dockerfile
           build-args: |
-            HALO_VERSION_1_ULUWATU=${{ github.ref_name }}
+            HALO_VERSION_2_MAGELLAN=${{ github.ref_name }}
           platforms: |
             linux/amd64
             linux/arm64

--- a/.github/workflows/release-snapshot.yaml
+++ b/.github/workflows/release-snapshot.yaml
@@ -67,7 +67,7 @@ jobs:
         with:
           file: scripts/halovisor/Dockerfile
           build-args: |
-            HALO_VERSION_1_ULUWATU=${{ steps.git_ref.outputs.short_sha }}
+            HALO_VERSION_2_MAGELLAN=${{ steps.git_ref.outputs.short_sha }}
           platforms: |
             linux/amd64
           push: true


### PR DESCRIPTION
When building `halovisor` images, use main/local commit at `magellan` not `uluwatu`.

issue: none