### PR TITLE
feat(sdk): withExecAndTransfer call constructor

### DIFF
--- a/sdk/src/constants/contracts.ts
+++ b/sdk/src/constants/contracts.ts
@@ -168,7 +168,7 @@ export const inbox = {
     },
   ],
   // TODO: this will be fetched via the solver API
-  address: '0xD8c70d0b7e93744f9d4c52fcfa407E8fc203bAcf',
+  address: '0x0de9c716676064caaa07db21407a9e029112899d',
 } as const
 
 export const outbox = {
@@ -185,5 +185,25 @@ export const outbox = {
     },
   ],
   // TODO: this will be fetched via the solver API
-  address: '0x39A896F56bd5b973d0801f59262fff6d5cd13f91',
+  address: '0x25e9397adc8fdfdc1899c45ae2c48ecc00f3d4be',
+} as const
+
+export const middleman = {
+  abi: [
+    {
+      type: 'function',
+      inputs: [
+        { name: 'token', internalType: 'address', type: 'address' },
+        { name: 'to', internalType: 'address', type: 'address' },
+        { name: 'target', internalType: 'address', type: 'address' },
+        { name: 'data', internalType: 'bytes', type: 'bytes' },
+      ],
+      name: 'executeAndTransfer',
+      outputs: [],
+      stateMutability: 'payable',
+    },
+    { type: 'error', inputs: [], name: 'CallFailed' },
+  ],
+  // TODO: this will be fetched via the solver API
+  address: '0x49ea714481bb96ce7bc17fe6efd7b5b630d1d85f',
 } as const

--- a/sdk/src/index.ts
+++ b/sdk/src/index.ts
@@ -4,6 +4,7 @@ export { typeHash } from './constants/typehash.js'
 
 ////// UTILS //////
 export { encodeOrder } from './utils/encodeOrder.js'
+export { withExecAndTransfer } from './utils/withExecAndTransfer.js'
 
 ////// HOOKS //////
 export { useOpenOrder } from './hooks/useOpenOrder.js'

--- a/sdk/src/types/order.ts
+++ b/sdk/src/types/order.ts
@@ -55,7 +55,7 @@ type Expense = {
   readonly amount: bigint
 }
 
-type Call = {
+export type Call = {
   readonly abi: Abi
   readonly target: Address
   readonly value: bigint

--- a/sdk/src/utils/withExecAndTransfer.ts
+++ b/sdk/src/utils/withExecAndTransfer.ts
@@ -1,0 +1,48 @@
+import { type Address, encodeFunctionData } from 'viem'
+import { middleman } from '../constants/contracts.js'
+import type { Call } from '../types/order.js'
+
+type WithExecAndTransferParams = {
+  readonly call: Call
+  readonly to: Address
+  readonly token: Address
+}
+
+/**
+ * @description Constructs a call to be executed via a middleware contract, that executes the input
+ * call and transfers the specified token to the recipient.
+ *
+ * @param params - Parameters for the middleware call.
+ * @returns Call
+ *
+ * @example
+ *
+ * const callWithExecAndTransfer = withExecAndTransfer({
+ *  call: {
+ *    target: '0x...',
+ *    abi,
+ *    value: BigInt(1),
+ *    functionName: '0x...',
+ *    value: BigInt(1),
+ *    args: ['0x...', BigInt(1)],
+ *  },
+ *  to: '0x...',
+ *  token: '0x...',
+ * })
+ */
+export function withExecAndTransfer(params: WithExecAndTransferParams): Call {
+  const { call, to, token } = params
+  const _callData = encodeFunctionData({
+    abi: call.abi,
+    functionName: call.functionName,
+    args: call.args,
+  })
+
+  return {
+    ...call,
+    abi: middleman.abi,
+    target: middleman.address,
+    functionName: 'executeAndTransfer',
+    args: [token, to, call.target, _callData],
+  }
+}

--- a/sdk/src/utils/withExecAndTransfer.ts
+++ b/sdk/src/utils/withExecAndTransfer.ts
@@ -4,8 +4,10 @@ import type { Call } from '../types/order.js'
 
 type WithExecAndTransferParams = {
   readonly call: Call
-  readonly to: Address
-  readonly token: Address
+  readonly transfer: {
+    readonly to: Address
+    readonly token: Address
+  }
 }
 
 /**
@@ -26,12 +28,14 @@ type WithExecAndTransferParams = {
  *    value: BigInt(1),
  *    args: ['0x...', BigInt(1)],
  *  },
- *  to: '0x...',
- *  token: '0x...',
+ *  transfer: {
+ *    to: '0x...',
+ *    token: '0x...',
+ *  }
  * })
  */
 export function withExecAndTransfer(params: WithExecAndTransferParams): Call {
-  const { call, to, token } = params
+  const { call, transfer } = params
   const _callData = encodeFunctionData({
     abi: call.abi,
     functionName: call.functionName,
@@ -43,6 +47,6 @@ export function withExecAndTransfer(params: WithExecAndTransferParams): Call {
     abi: middleman.abi,
     target: middleman.address,
     functionName: 'executeAndTransfer',
-    args: [token, to, call.target, _callData],
+    args: [transfer.token, transfer.to, call.target, _callData],
   }
 }

--- a/sdk/src/utils/withExecAndTransfer.ts
+++ b/sdk/src/utils/withExecAndTransfer.ts
@@ -37,9 +37,7 @@ type WithExecAndTransferParams = {
 export function withExecAndTransfer(params: WithExecAndTransferParams): Call {
   const { call, transfer } = params
   const _callData = encodeFunctionData({
-    abi: call.abi,
-    functionName: call.functionName,
-    args: call.args,
+    ...call,
   })
 
   return {


### PR DESCRIPTION
Introduce `ExecutionCall` to enable support for execution via middleman contract, without leaking implementation to users (mostly motivated by the fact the rp gist is incorrect right now without this). Ideally, we'd infer this rather than bloating the interface, but onBehalfOf functionality is different across protocols. 

issue: none 