### PR TITLE
ci(e2e/manifests): remove legacy feature flags from staging

### DIFF
--- a/e2e/manifests/staging.toml
+++ b/e2e/manifests/staging.toml
@@ -5,7 +5,7 @@ prometheus = true
 deploy_solve = true
 network_upgrade_height = -1 # Manual upgrades for now
 
-feature_flags = ["evm-staking-module","simple-evm-events","proto-evm-payload"]
+feature_flags = []
 
 [node.validator01]
 [node.validator02]


### PR DESCRIPTION
Remove unused legacy feature flags from staging, since it breaks manual upgrades.

issue: none