### PR TITLE
fix(e2e): remove NetworkFromDef use outside e2e deploy

### DIFF
--- a/.github/workflows/soltest.yaml
+++ b/.github/workflows/soltest.yaml
@@ -56,7 +56,7 @@ jobs:
         working-directory: contracts/solve
     steps:
       - uses: actions/checkout@v4
-      - uses: foundry-rs/foundry-toolchain@v1
+      - uses: ./.github/actions/setup-foundry
       - name: Install pnpm
         run: make install-pnpm
         working-directory: contracts

--- a/e2e/app/definition.go
+++ b/e2e/app/definition.go
@@ -470,9 +470,9 @@ func ExternalEndpoints(def Definition) xchain.RPCEndpoints {
 	return endpoints
 }
 
-// NetworkFromDef returns the network configuration from the definition.
+// networkFromDef returns the network configuration from the definition.
 // Note that this panics if not called after netman.DeployPortals.
-func NetworkFromDef(def Definition) netconf.Network {
+func networkFromDef(def Definition) netconf.Network {
 	var chains []netconf.Chain
 
 	newChain := func(chain types.EVMChain) netconf.Chain {

--- a/e2e/app/monitor.go
+++ b/e2e/app/monitor.go
@@ -18,7 +18,7 @@ import (
 )
 
 func LogMetrics(ctx context.Context, def Definition) error {
-	extNetwork := NetworkFromDef(def) // Safe to call NetworkFromDef since this after netman.DeployContracts
+	extNetwork := networkFromDef(def) // Safe to call networkFromDef since this after netman.DeployContracts
 	archiveNode, ok := def.Testnet.ArchiveNode()
 	if !ok {
 		return errors.New("monitor must use archive node, no archive node found")
@@ -43,7 +43,7 @@ func StartMonitoringReceipts(ctx context.Context, def Definition) func() error {
 		return func() error { return errors.Wrap(err, "getting client") }
 	}
 
-	network := NetworkFromDef(def) // Safe to call NetworkFromDef since this after netman.DeployContracts
+	network := networkFromDef(def) // Safe to call networkFromDef since this after netman.DeployContracts
 	cProvider := cprovider.NewABCI(client, def.Testnet.Network)
 	xProvider := xprovider.New(network, def.Backends().RPCClients(), cProvider)
 	cChainID := def.Testnet.Network.Static().OmniConsensusChainIDUint64()

--- a/e2e/app/run.go
+++ b/e2e/app/run.go
@@ -104,7 +104,7 @@ func Deploy(ctx context.Context, def Definition, cfg DeployConfig) (*pingpong.XD
 
 	if def.Manifest.DeploySolve {
 		// Deploy solver before initPortalRegistry, so solver detects boxes after netconf.Await
-		if err := solve.Deploy(ctx, NetworkFromDef(def), def.Backends()); err != nil {
+		if err := solve.Deploy(ctx, networkFromDef(def), def.Backends()); err != nil {
 			return nil, errors.Wrap(err, "deploy solve")
 		}
 	}
@@ -117,7 +117,7 @@ func Deploy(ctx context.Context, def Definition, cfg DeployConfig) (*pingpong.XD
 	eg2.Go(func() error { return DeployBridge(ctx, def) })
 	eg2.Go(func() error { return maybeSubmitNetworkUpgrades(ctx, def) })
 	eg2.Go(func() error { return FundValidatorsForTesting(ctx, def) })
-	eg2.Go(func() error { return xbridge.Deploy(ctx, NetworkFromDef(def), def.Backends()) })
+	eg2.Go(func() error { return xbridge.Deploy(ctx, networkFromDef(def), def.Backends()) })
 	if err := eg2.Wait(); err != nil {
 		return nil, errors.Wrap(err, "deploy other contracts")
 	}
@@ -131,7 +131,7 @@ func Deploy(ctx context.Context, def Definition, cfg DeployConfig) (*pingpong.XD
 		return nil, nil //nolint:nilnil // No ping pong, no XDapp to return.
 	}
 
-	pp, err := pingpong.Deploy(ctx, NetworkFromDef(def), def.Backends()) // Safe to call NetworkFromDef since this after netman.DeployContracts
+	pp, err := pingpong.Deploy(ctx, networkFromDef(def), def.Backends()) // Safe to call networkFromDef since this after netman.DeployContracts
 	if err != nil {
 		return nil, errors.Wrap(err, "deploy pingpong")
 	}
@@ -180,7 +180,7 @@ func E2ETest(ctx context.Context, def Definition, cfg E2ETestConfig) error {
 	var eg errgroup.Group
 	eg.Go(func() error { return testGasPumps(ctx, def) })
 	eg.Go(func() error { return testBridge(ctx, def) })
-	eg.Go(func() error { return xbridge.Test(ctx, NetworkFromDef(def), ExternalEndpoints(def)) })
+	eg.Go(func() error { return xbridge.Test(ctx, networkFromDef(def), ExternalEndpoints(def)) })
 	if err := eg.Wait(); err != nil {
 		return errors.Wrap(err, "test xdapps")
 	}
@@ -238,7 +238,7 @@ func E2ETest(ctx context.Context, def Definition, cfg E2ETestConfig) error {
 		}
 	}
 
-	network := NetworkFromDef(def) // Safe to call NetworkFromDef since this after netman.DeployContracts
+	network := networkFromDef(def) // Safe to call networkFromDef since this after netman.DeployContracts
 	if err := WaitAllSubmissions(ctx, network, def.Netman().Portals(), sum(msgBatches)); err != nil {
 		return err
 	}

--- a/e2e/cmd/cmd.go
+++ b/e2e/cmd/cmd.go
@@ -303,7 +303,14 @@ func newDeployXBridgeCmd(def *app.Definition) *cobra.Command {
 		Use:   "deploy-xbridge",
 		Short: "Deploys the XBridge contracts",
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			return xbridge.Deploy(cmd.Context(), app.NetworkFromDef(*def), def.Backends())
+			ctx := cmd.Context()
+
+			network, err := networkFromDef(ctx, *def)
+			if err != nil {
+				return errors.Wrap(err, "network")
+			}
+
+			return xbridge.Deploy(ctx, network, def.Backends())
 		},
 	}
 
@@ -315,7 +322,14 @@ func newDeploySolverNetCmd(def *app.Definition) *cobra.Command {
 		Use:   "deploy-solvernet",
 		Short: "Deploys the SolverNet contracts",
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			return solve.Deploy(cmd.Context(), app.NetworkFromDef(*def), def.Backends())
+			ctx := cmd.Context()
+
+			network, err := networkFromDef(ctx, *def)
+			if err != nil {
+				return errors.Wrap(err, "network")
+			}
+
+			return solve.Deploy(cmd.Context(), network, def.Backends())
 		},
 	}
 

--- a/e2e/cmd/util.go
+++ b/e2e/cmd/util.go
@@ -1,0 +1,52 @@
+package cmd
+
+import (
+	"context"
+
+	"github.com/omni-network/omni/contracts/bindings"
+	"github.com/omni-network/omni/e2e/app"
+	"github.com/omni-network/omni/halo/genutil/evm/predeploys"
+	"github.com/omni-network/omni/lib/errors"
+	"github.com/omni-network/omni/lib/ethclient"
+	"github.com/omni-network/omni/lib/netconf"
+	"github.com/omni-network/omni/lib/xchain"
+
+	"github.com/ethereum/go-ethereum/common"
+)
+
+func networkFromDef(ctx context.Context, def app.Definition) (netconf.Network, error) {
+	endpoints := app.ExternalEndpoints(def)
+	networkID := def.Testnet.Network
+
+	portalReg, err := makePortalRegistry(networkID, endpoints)
+	if err != nil {
+		return netconf.Network{}, errors.Wrap(err, "portal registry")
+	}
+
+	network, err := netconf.AwaitOnExecutionChain(ctx, networkID, portalReg, endpoints.Keys())
+	if err != nil {
+		return netconf.Network{}, errors.Wrap(err, "await onchain")
+	}
+
+	return network, nil
+}
+
+func makePortalRegistry(network netconf.ID, endpoints xchain.RPCEndpoints) (*bindings.PortalRegistry, error) {
+	meta := netconf.MetadataByID(network, network.Static().OmniExecutionChainID)
+	rpc, err := endpoints.ByNameOrID(meta.Name, meta.ChainID)
+	if err != nil {
+		return nil, err
+	}
+
+	ethCl, err := ethclient.Dial(meta.Name, rpc)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := bindings.NewPortalRegistry(common.HexToAddress(predeploys.PortalRegistry), ethCl)
+	if err != nil {
+		return nil, errors.Wrap(err, "create portal registry")
+	}
+
+	return resp, nil
+}


### PR DESCRIPTION
NetworkFromDef relies on portals deployed in e2e.
Other e2e commands outside of deploy should not use it.

issue: none