### PR TITLE
chore(lib/contracts): separate solvernet and xbridge salts from core

### DIFF
--- a/e2e/xbridge/reference_test.go
+++ b/e2e/xbridge/reference_test.go
@@ -8,6 +8,8 @@ import (
 	"github.com/omni-network/omni/lib/netconf"
 	"github.com/omni-network/omni/lib/tutil"
 
+	"github.com/ethereum/go-ethereum/common"
+
 	"github.com/stretchr/testify/require"
 )
 
@@ -18,6 +20,8 @@ func TestReference(t *testing.T) {
 
 	golden := make(map[string]map[netconf.ID]map[string]any)
 	ctx := context.Background()
+
+	seen := make(map[common.Address]bool)
 
 	for _, token := range xbridge.Tokens() {
 		golden[token.Symbol()] = make(map[netconf.ID]map[string]any)
@@ -44,6 +48,16 @@ func TestReference(t *testing.T) {
 
 			canon, err := token.Canonical(ctx, network)
 			require.NoError(t, err)
+
+			see := func(addr common.Address) {
+				require.False(t, seen[addr], "duplicate address: %s", addr.Hex())
+				seen[addr] = true
+			}
+
+			see(addr)
+			see(bridge)
+			see(lockbox)
+			see(canon.Address)
 
 			json := map[string]any{
 				"addr":    addr.Hex(),

--- a/e2e/xbridge/rlusd/xtoken.go
+++ b/e2e/xbridge/rlusd/xtoken.go
@@ -4,7 +4,6 @@ import (
 	"context"
 
 	"github.com/omni-network/omni/e2e/xbridge/types"
-	"github.com/omni-network/omni/lib/contracts"
 	"github.com/omni-network/omni/lib/errors"
 	"github.com/omni-network/omni/lib/netconf"
 
@@ -26,12 +25,7 @@ func (rlusd) Wraps() types.TokenDescriptors { return wraps }
 
 // Address returns the address of the RLUSD.e token on the given network.
 func (rlusd) Address(ctx context.Context, networkID netconf.ID) (common.Address, error) {
-	addr, err := contracts.Create3Address(ctx, networkID, saltID(xtoken))
-	if err != nil {
-		return common.Address{}, errors.Wrap(err, "salt")
-	}
-
-	return addr, nil
+	return addr(ctx, networkID, xtoken)
 }
 
 // Canonical returns the canonical RLUSD deployment by network.
@@ -43,7 +37,7 @@ func (rlusd) Canonical(ctx context.Context, networkID netconf.ID) (types.TokenDe
 
 	// if no canonical deployments in static, we deploy a stand in mock
 
-	addr, err := contracts.Create3Address(ctx, networkID, saltID(wraps))
+	addr, err := addr(ctx, networkID, wraps)
 	if err != nil {
 		return types.TokenDeployment{}, errors.Wrap(err, "salt")
 	}

--- a/e2e/xbridge/testdata/TestReference.golden
+++ b/e2e/xbridge/testdata/TestReference.golden
@@ -1,39 +1,39 @@
 {
  "RLUSD.e": {
   "devnet": {
-   "addr": "0x265300c805f5aB8D538AE63034d16b40EFc3C3c9",
-   "bridge": "0xc3394F77039f0CBB246BE350D6b644103598aFB0",
+   "addr": "0xcF15E2b44eefe8aEb1c2b43cfCAd85f013a5593F",
+   "bridge": "0x4E2d5a99028523f0Fd46EB4536A7f37456A9084b",
    "canonical": {
-    "address": "0x0354FEef21635a86671Fe424BAb0504b94aBDE1a",
+    "address": "0x9ea011e9bC127fc0afb5e481707fFee2A720094f",
     "chain_id": 1652
    },
-   "lockbox": "0x5A18D32f919ed6A36C8A60591ED817953Af42E1F",
+   "lockbox": "0x303f67F3479635b355F571e4c7f27d3aEF60aDA7",
    "wraps": {
     "name": "RLUSD",
     "symbol": "RLUSD"
    }
   },
   "mainnet": {
-   "addr": "0xa9B040356DEFe0FB5CC9Fd60a0D60EB2D519938d",
-   "bridge": "0x17130A2Ec34CEB593B014d5472f0a312eCB37803",
+   "addr": "0x07C03D1f4FBd9025EAFaE6dBE343D99Bb1ef53c7",
+   "bridge": "0x2fC7d0F025cd7958f2b08BdC38C5fAc591459EDA",
    "canonical": {
     "address": "0x8292Bb45bf1Ee4d140127049757C2E0fF06317eD",
     "chain_id": 1
    },
-   "lockbox": "0x83c95CD32fdd598EF9e2790218dE2e4DE12E2B94",
+   "lockbox": "0x9f231A2b7bA09202c5cbaC89B03622fBC9DA53ca",
    "wraps": {
     "name": "RLUSD",
     "symbol": "RLUSD"
    }
   },
   "omega": {
-   "addr": "0x73EcDdaD1F078A01495Ea55b3052157f42310B08",
-   "bridge": "0x448d3dFb0f71Cd584b9BAB7Bd6540268d93D513a",
+   "addr": "0xAB6F4E317B9D78c41FFAAF344c6E88Be1703d040",
+   "bridge": "0xd45E52d1d91f6a57DD24Bc1f684e1EAfe717AB10",
    "canonical": {
-    "address": "0xFdd827191d84080DFE17ef29Ff4108168AF8b870",
+    "address": "0x084Db6262bE13D210940D15dA1300cD1E72a5C34",
     "chain_id": 17000
    },
-   "lockbox": "0x9d333b2F24e90056cF12Fff642FEA796cfdE516f",
+   "lockbox": "0x0E498D5f2DCa6b4cB2e4653762A6D47596DebBA5",
    "wraps": {
     "name": "RLUSD",
     "symbol": "RLUSD"


### PR DESCRIPTION
Separate xbridge and solvernet salts from core.
Let's use progress them independently.

issue: none