### PR TITLE
chore(e2e/manifests): upgrade omega solver pin

### DIFF
--- a/e2e/manifests/omega.toml
+++ b/e2e/manifests/omega.toml
@@ -7,7 +7,7 @@ prometheus = true
 pinned_halo_tag = "v0.12.0"
 pinned_relayer_tag = "6d7c3ec"
 pinned_monitor_tag = "6d7c3ec"
-pinned_solver_tag = "cd3f39f"
+pinned_solver_tag = "c124876"
 
 [node.validator01]
 [node.validator02]


### PR DESCRIPTION
Upgrade omega solver pin.

Includes #3075 , avoids loop on bad unsupported test chain.

issue: none
