### PR TITLE
chore(e2e): update monitor omega git tag

### DIFF
--- a/e2e/manifests/omega.toml
+++ b/e2e/manifests/omega.toml
@@ -6,7 +6,7 @@ prometheus = true
 
 pinned_halo_tag = "v0.12.0"
 pinned_relayer_tag = "6d7c3ec"
-pinned_monitor_tag = "6d7c3ec"
+pinned_monitor_tag = "5f08ffc"
 pinned_solver_tag = "c124876"
 
 [node.validator01]


### PR DESCRIPTION
update monitor omega git tag to include the integrated RouteScan API key for increased rate limits

issue: none 