### PR TITLE
feat(upgrade/magellan): slashing params

### DIFF
--- a/e2e/test/module_test.go
+++ b/e2e/test/module_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 
 	magellan2 "github.com/omni-network/omni/halo/app/upgrades/magellan"
-	uluwatu1 "github.com/omni-network/omni/halo/app/upgrades/uluwatu"
 	"github.com/omni-network/omni/lib/cchain/provider"
 	"github.com/omni-network/omni/lib/netconf"
 	"github.com/omni-network/omni/lib/xchain"
@@ -47,6 +46,8 @@ func TestSlashing(t *testing.T) {
 
 		paramResponse, err := cprov.QueryClients().Slashing.Params(ctx, &slashingtypes.QueryParamsRequest{})
 		require.NoError(t, err)
-		require.Equal(t, uluwatu1.SlashingParams.String(), paramResponse.Params.String())
+
+		expected := magellan2.SlashingParams()
+		require.Equal(t, expected.String(), paramResponse.Params.String())
 	})
 }

--- a/halo/app/start_test.go
+++ b/halo/app/start_test.go
@@ -17,7 +17,6 @@ import (
 	haloapp "github.com/omni-network/omni/halo/app"
 	"github.com/omni-network/omni/halo/app/upgrades"
 	magellan2 "github.com/omni-network/omni/halo/app/upgrades/magellan"
-	uluwatu1 "github.com/omni-network/omni/halo/app/upgrades/uluwatu"
 	halocmd "github.com/omni-network/omni/halo/cmd"
 	halocfg "github.com/omni-network/omni/halo/config"
 	"github.com/omni-network/omni/lib/cchain"
@@ -126,7 +125,8 @@ func testModuleParams(t *testing.T, ctx context.Context, cprov cchain.Provider) 
 
 	sParamsResp, err := cprov.QueryClients().Slashing.Params(ctx, &slashingtypes.QueryParamsRequest{})
 	require.NoError(t, err)
-	require.Equal(t, uluwatu1.SlashingParams.String(), sParamsResp.Params.String())
+	expected := magellan2.SlashingParams()
+	require.Equal(t, expected.String(), sParamsResp.Params.String())
 
 	mParamsResp, err := cprov.QueryClients().Mint.Params(ctx, &minttypes.QueryParamsRequest{})
 	require.NoError(t, err)

--- a/halo/app/upgrades/magellan/upgrade_internal_test.go
+++ b/halo/app/upgrades/magellan/upgrade_internal_test.go
@@ -2,6 +2,7 @@ package magellan
 
 import (
 	"testing"
+	"time"
 
 	"github.com/ethereum/go-ethereum/params"
 
@@ -9,6 +10,17 @@ import (
 	minttypes "github.com/cosmos/cosmos-sdk/x/mint/types"
 	"github.com/stretchr/testify/require"
 )
+
+func TestSlashingParams(t *testing.T) {
+	t.Parallel()
+
+	p := SlashingParams()
+	require.True(t, p.SlashFractionDowntime.IsZero())
+	require.True(t, p.SlashFractionDoubleSign.IsZero())
+	require.Equal(t, time.Minute, p.DowntimeJailDuration)
+	require.Equal(t, "0.050000000000000000", p.MinSignedPerWindow.String())
+	require.EqualValues(t, 2000, p.SignedBlocksWindow)
+}
 
 func TestTargetInflation(t *testing.T) {
 	t.Parallel()

--- a/halo/app/upgrades/upgrades.go
+++ b/halo/app/upgrades/upgrades.go
@@ -57,6 +57,7 @@ var Upgrades = []Upgrade{
 				a.GetModuleManager(),
 				a.GetModuleConfigurator(),
 				a.GetMintKeeper(),
+				a.GetSlashingKeeper(),
 				a.GetAccountKeeper(),
 			)
 		},


### PR DESCRIPTION
Update slashing params for magellan upgrade:
 - Reduce `DowntimeJailDuration` to minimum 1min to allow fast unjailing.
 - Update `MinSignedPerWindow` to 5% which is Cosmos default.

issue: none
