### PR TITLE
chore(e2e): upgrade monitor service on mainnet

### DIFF
--- a/e2e/manifests/mainnet.toml
+++ b/e2e/manifests/mainnet.toml
@@ -6,7 +6,7 @@ prometheus   = true
 
 pinned_halo_tag = "v0.12.0"
 pinned_relayer_tag = "6d7c3ec"
-pinned_monitor_tag = "6d7c3ec"
+pinned_monitor_tag = "5f08ffc"
 
 [node.validator01]
 [node.validator02]


### PR DESCRIPTION
upgrade monitor service on mainnet to include the RouteScan provided API key for increased rate limits to their API

issue: #3053