### PR TITLE
feat(solver): use full call data in api call type

### DIFF
--- a/e2e/solve/test.go
+++ b/e2e/solve/test.go
@@ -217,7 +217,7 @@ func openOrder(ctx context.Context, backends ethbackend.Backends, order TestOrde
 	return solvernet.OpenOrder(ctx, netconf.Devnet, order.SourceChainID, backends, order.Owner, bindings.SolverNetOrderData{
 		DestChainId: order.DestChainID,
 		Expenses:    order.Expenses.NoNative(),
-		Calls:       order.Calls,
+		Calls:       order.Calls.ToBindings(),
 		Deposit:     order.Deposit,
 	}, solvernet.WithFillDeadline(order.FillDeadline))
 }

--- a/e2e/solve/testutil.go
+++ b/e2e/solve/testutil.go
@@ -34,10 +34,9 @@ func erc20Deposit(amt *big.Int, addr common.Address) solvernet.Deposit {
 
 func nativeTransferCall(amt *big.Int, to common.Address) []solvernet.Call {
 	return []solvernet.Call{{
-		Value:    amt,
-		Target:   to,
-		Selector: [4]byte{},
-		Params:   nil,
+		Value:  amt,
+		Target: to,
+		Data:   nil,
 	}}
 }
 

--- a/lib/contracts/solvernet/types_test.go
+++ b/lib/contracts/solvernet/types_test.go
@@ -1,0 +1,64 @@
+package solvernet_test
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/omni-network/omni/lib/contracts/solvernet"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCallBindings(t *testing.T) {
+	t.Parallel()
+
+	calls := solvernet.Calls{
+		{
+			Value:  ether(1),
+			Target: common.HexToAddress("0x36e66fbbce51e4cd5bd3c62b637eb411b18949d4"),
+			// selector + params
+			Data: hexutil.MustDecode("0x70a08231000000000000000000000000e3481474b23f88a8917dbcb4cbc55efcf0f68cc7"),
+		},
+		{
+			Value:  ether(1),
+			Target: common.HexToAddress("0x36e66fbbce51e4cd5bd3c62b637eb411b18949d4"),
+			// just selector
+			Data: hexutil.MustDecode("0x70a08231"),
+		},
+		{
+			Value:  ether(1),
+			Target: common.HexToAddress("0x36e66fbbce51e4cd5bd3c62b637eb411b18949d4"),
+			// no calldata
+			Data: nil,
+		},
+	}
+
+	bindings := calls.ToBindings()
+
+	require.Len(t, bindings, 3)
+
+	// full calldata
+	require.Equal(t, calls[0].Value, bindings[0].Value)
+	require.Equal(t, calls[0].Target, bindings[0].Target)
+	require.Equal(t, [4]byte(calls[0].Data[:4]), bindings[0].Selector)
+	require.Equal(t, calls[0].Data[4:], bindings[0].Params)
+
+	// just selector
+	require.Equal(t, calls[1].Value, bindings[1].Value)
+	require.Equal(t, calls[1].Target, bindings[1].Target)
+	require.Equal(t, [4]byte(calls[1].Data[:4]), bindings[1].Selector)
+	require.Equal(t, []byte(nil), bindings[1].Params)
+
+	// no calldata
+	require.Equal(t, calls[2].Value, bindings[2].Value)
+	require.Equal(t, calls[2].Target, bindings[2].Target)
+	require.Equal(t, [4]byte{}, bindings[2].Selector)
+	require.Equal(t, []byte(nil), bindings[2].Params)
+}
+
+func ether(x int64) *big.Int {
+	return new(big.Int).Mul(big.NewInt(x), big.NewInt(1e18))
+}

--- a/solver/app/check.go
+++ b/solver/app/check.go
@@ -110,7 +110,7 @@ func getFillOriginData(req CheckRequest) ([]byte, error) {
 		SrcChainId:   req.SourceChainID,
 		DestChainId:  req.DestinationChainID,
 		Expenses:     req.Expenses.Parse().NoNative(),
-		Calls:        req.Calls.Parse(),
+		Calls:        req.Calls.Parse().ToBindings(),
 	}
 
 	fillOriginDataBz, err := solvernet.PackFillOriginData(fillOriginData)

--- a/solver/app/internal_testutils.go
+++ b/solver/app/internal_testutils.go
@@ -211,8 +211,12 @@ func orderTestCases(t *testing.T, solver common.Address) []orderTestCase {
 				srcChainID: evmchain.IDHolesky,
 				dstChainID: evmchain.IDOmniOmega,
 				deposits:   []Deposit{{Amount: ether(1), Token: omegaOMNIAddr}},
-				calls:      []Call{{Value: ether(1)}},
-				expenses:   []Expense{{Amount: ether(1)}},
+				calls: []Call{{
+					Value: ether(1),
+					// actual calldata does not matter. we include it to test /check parsing
+					Data: hexutil.MustDecode("0x70a08231000000000000000000000000e3481474b23f88a8917dbcb4cbc55efcf0f68cc7"),
+				}},
+				expenses: []Expense{{Amount: ether(1)}},
 			},
 			mock: func(clients MockClients) {
 				mockNativeBalance(t, clients.Client(t, evmchain.IDOmniOmega), solver, ether(0))
@@ -228,7 +232,11 @@ func orderTestCases(t *testing.T, solver common.Address) []orderTestCase {
 				dstChainID: evmchain.IDOmniOmega,
 				// OMNI does not require fee
 				deposits: []Deposit{{Amount: ether(1), Token: omegaOMNIAddr}},
-				calls:    []Call{{Value: ether(1)}},
+				calls: []Call{{
+					Value: ether(1),
+					// actual calldata does not matter. we include it to test /check parsing
+					Data: hexutil.MustDecode("0x70a08231000000000000000000000000e3481474b23f88a8917dbcb4cbc55efcf0f68cc7"),
+				}},
 				expenses: []Expense{{Amount: ether(1)}},
 			},
 			mock: func(clients MockClients) {

--- a/solver/types/api.go
+++ b/solver/types/api.go
@@ -139,10 +139,9 @@ type JSONExpense struct {
 
 // JSONCall is a json marshal-able solvernet.Call.
 type JSONCall struct {
-	Target   common.Address `json:"target"`
-	Selector [4]byte        `json:"selector"`
-	Value    *hexutil.Big   `json:"value"`
-	Params   []byte         `json:"params"`
+	Target common.Address `json:"target"`
+	Data   *hexutil.Bytes `json:"data"`
+	Value  *hexutil.Big   `json:"value"`
 }
 
 // JSONDeposit is a json marshal-able solvernet.Deposit.
@@ -159,11 +158,12 @@ type (
 func ToJSONCalls(calls []solvernet.Call) JSONCalls {
 	var out JSONCalls
 	for _, c := range calls {
+		data := c.Data
+
 		out = append(out, JSONCall{
-			Target:   c.Target,
-			Selector: c.Selector,
-			Value:    (*hexutil.Big)(c.Value),
-			Params:   c.Params,
+			Target: c.Target,
+			Value:  (*hexutil.Big)(c.Value),
+			Data:   (*hexutil.Bytes)(&data),
 		})
 	}
 
@@ -190,14 +190,13 @@ func ToJSONDeposit(deposit solvernet.Deposit) JSONDeposit {
 	}
 }
 
-func (cs JSONCalls) Parse() []solvernet.Call {
+func (cs JSONCalls) Parse() solvernet.Calls {
 	var out []solvernet.Call
 	for _, c := range cs {
 		out = append(out, solvernet.Call{
-			Target:   c.Target,
-			Selector: c.Selector,
-			Value:    c.Value.ToInt(),
-			Params:   c.Params,
+			Target: c.Target,
+			Value:  c.Value.ToInt(),
+			Data:   *c.Data,
 		})
 	}
 


### PR DESCRIPTION
Use call data in api, hex encoded.

issue: none