### PR TITLE
chore(solver): remove mock l2 steth

### DIFF
--- a/e2e/solve/mocktokens.go
+++ b/e2e/solve/mocktokens.go
@@ -32,12 +32,6 @@ var mocks = []MockToken{
 
 	// devnet mock wstETH
 	{Token: tokens.WSTETH, ChainID: evmchain.IDMockL2, NetworkID: netconf.Devnet},
-
-	// staging mock stETH
-	{Token: tokens.STETH, ChainID: evmchain.IDBaseSepolia, NetworkID: netconf.Staging},
-
-	// devnet mock stETH
-	{Token: tokens.STETH, ChainID: evmchain.IDMockL2, NetworkID: netconf.Devnet},
 }
 
 func MockTokens() []MockToken {

--- a/solver/app/testdata/TestTokens.golden
+++ b/solver/app/testdata/TestTokens.golden
@@ -238,25 +238,5 @@
   "minSpend": "nil",
   "name": "Wrapped Staked Ether",
   "symbol": "wstETH"
- },
- {
-  "address": "0x818fdC36f383AC58C43c4388D6A6856455CF2B40",
-  "chainId": 84532,
-  "coingeckoId": "lido-staked-ether",
-  "isMock": true,
-  "maxSpend": "nil",
-  "minSpend": "nil",
-  "name": "Lido Staked Ether",
-  "symbol": "stETH"
- },
- {
-  "address": "0xaF1e06227c302960934AC5F6af3361Af9B5244d9",
-  "chainId": 1654,
-  "coingeckoId": "lido-staked-ether",
-  "isMock": true,
-  "maxSpend": "nil",
-  "minSpend": "nil",
-  "name": "Lido Staked Ether",
-  "symbol": "stETH"
  }
 ]


### PR DESCRIPTION
stETH will not exist on L2s (only wstETH).

So it's not useful to have mock L2 steth tokens.

issue: none