### PR TITLE
chore(sdk): add token addr constants

### DIFF
--- a/sdk/src/constants/tokens.ts
+++ b/sdk/src/constants/tokens.ts
@@ -1,0 +1,7 @@
+// holeskyWSTETH is the WSTETH token address on Holesky
+export const holeskyWSTETH =
+  '0x8d09a4502cc8cf1547ad300e066060d043f6982d' as const
+
+// mockBaseSepoliaWSTETH is a mintable token deployed by Omni on Base Sepolia that the solver treats as WSTETH
+export const mockBaseSepoliaWSTETH =
+  '0x6319df7c227e34B967C1903A08a698A3cC43492B' as const


### PR DESCRIPTION
Add token addresses to constants.

Will be useful for sharing mock token addrs.

issue: none
