### PR TITLE
ci(e2e/manifest): replace staging holesky with mock-l1

### DIFF
--- a/e2e/app/testdata/TestManifestServiceReference.golden
+++ b/e2e/app/testdata/TestManifestServiceReference.golden
@@ -27,6 +27,7 @@
  "staging": [
   "fullnode01",
   "fullnode01_evm",
+  "mock_l1",
   "monitor",
   "relayer",
   "seed01",

--- a/e2e/manifests/staging.toml
+++ b/e2e/manifests/staging.toml
@@ -1,5 +1,6 @@
 network = "staging"
-public_chains = ["op_sepolia","base_sepolia","arb_sepolia","holesky"]
+public_chains = ["op_sepolia","base_sepolia","arb_sepolia"]
+anvil_chains = ["mock_l1"]
 multi_omni_evms = true
 prometheus = true
 deploy_solve = true


### PR DESCRIPTION
Holesky has stalled, it is unclear when it will restart. Use mock_l1 on staging in the mean time. 

issue: none
