### PR TITLE
ci(e2e): allow val3 and val4 on mainnet

### DIFF
--- a/cli/cmd/flags.go
+++ b/cli/cmd/flags.go
@@ -86,7 +86,7 @@ func bindDelegateConfig(cmd *cobra.Command, cfg *DelegateConfig) {
 	_ = cmd.MarkFlagRequired(flagDelegationAmount)
 }
 
-func bindCreateValConfig(cmd *cobra.Command, cfg *createValConfig) {
+func bindCreateValConfig(cmd *cobra.Command, cfg *CreateValConfig) {
 	bindEOAConfig(cmd, &cfg.EOAConfig)
 
 	cmd.Flags().StringVar(&cfg.ConsensusPubKeyHex, flagConsPubKeyHex, cfg.ConsensusPubKeyHex, "Hex-encoded validator consensus public key")

--- a/cli/cmd/staking.go
+++ b/cli/cmd/staking.go
@@ -41,7 +41,7 @@ const minSelfDelegation = uint64(100)
 const minDelegation = uint64(1)
 
 func newCreateValCmd() *cobra.Command {
-	var cfg createValConfig
+	var cfg CreateValConfig
 
 	cmd := &cobra.Command{
 		Use:   "create-validator",
@@ -53,7 +53,7 @@ func newCreateValCmd() *cobra.Command {
 				return errors.Wrap(err, "verify flags")
 			}
 
-			err := createValidator(cmd.Context(), cfg)
+			err := CreateValidator(cmd.Context(), cfg)
 			if err != nil {
 				return errors.Wrap(err, "create-validator")
 			}
@@ -112,13 +112,13 @@ func (v EOAConfig) validate() error {
 	return nil
 }
 
-type createValConfig struct {
+type CreateValConfig struct {
 	EOAConfig
 	ConsensusPubKeyHex string
 	SelfDelegation     uint64
 }
 
-func (c createValConfig) consensusPublicKey() (*ecdsa.PublicKey, error) {
+func (c CreateValConfig) consensusPublicKey() (*ecdsa.PublicKey, error) {
 	if strings.HasPrefix(c.ConsensusPubKeyHex, "0x") {
 		return nil, errors.New("consensus pubkey hex should not have 0x prefix")
 	}
@@ -136,7 +136,7 @@ func (c createValConfig) consensusPublicKey() (*ecdsa.PublicKey, error) {
 	return resp, nil
 }
 
-func (c createValConfig) validate() error {
+func (c CreateValConfig) validate() error {
 	if err := c.EOAConfig.validate(); err != nil {
 		return err
 	}
@@ -156,7 +156,7 @@ func (c createValConfig) validate() error {
 	return nil
 }
 
-func createValidator(ctx context.Context, cfg createValConfig) error {
+func CreateValidator(ctx context.Context, cfg CreateValConfig) error {
 	operatorPriv, err := cfg.privateKey()
 	if err != nil {
 		return err

--- a/e2e/app/admin/allowoperator.go
+++ b/e2e/app/admin/allowoperator.go
@@ -43,6 +43,8 @@ var allowedOperators = map[netconf.ID][]common.Address{
 		common.HexToAddress("0x231a7A2872208A3e3EF75Ae6580a16308D60706b"), // Finoa
 		common.HexToAddress("0x58D2A4e3880635B7682A1BB7Ed8a43F5ac6cFD3d"), // validator01
 		common.HexToAddress("0x19a4Cb685af95A96BEd67C764b6dB137978a5B17"), // validator02
+		common.HexToAddress("0xD5f9e687c1EA2b0Da7C06bEbe80ddAb03B33C075"), // validator03
+		common.HexToAddress("0x8be1aBb26435fc1AF39Fc88DF9499f626094f9AF"), // validator04
 	},
 }
 


### PR DESCRIPTION
Adds val3 and val4 to mainnet allow list.

issue: none
