### PR TITLE
chore(lib/fireblocks): use sepolia assert instead of holesky

### DIFF
--- a/lib/fireblocks/client.go
+++ b/lib/fireblocks/client.go
@@ -81,7 +81,7 @@ func (c Client) getAssetID() string {
 	case netconf.Mainnet:
 		return assetMainnet
 	default:
-		return assetHolesky
+		return assetSepolia
 	}
 }
 

--- a/lib/fireblocks/client_test.go
+++ b/lib/fireblocks/client_test.go
@@ -6,6 +6,7 @@ import (
 	"crypto/x509"
 	"encoding/json"
 	"encoding/pem"
+	"flag"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -92,7 +93,9 @@ func parseKey(t *testing.T, data []byte) *rsa.PrivateKey {
 	return k.(*rsa.PrivateKey)
 }
 
-// Populate this or run TestSmoke via terminal
+var integration = flag.Bool("integration", false, "run integration tests")
+
+// Populate this or run TestSmoke via terminal (also enable --integration flag)
 // func init() {
 //	os.Setenv("FIREBLOCKS_APIKEY", "")
 //	os.Setenv("FIREBLOCKS_KEY_PATH", "")
@@ -100,6 +103,9 @@ func parseKey(t *testing.T, data []byte) *rsa.PrivateKey {
 
 func TestSmoke(t *testing.T) {
 	t.Parallel()
+	if !*integration {
+		t.Skip("skipping integration test")
+	}
 	ctx := context.Background()
 
 	apiKey, ok := os.LookupEnv("FIREBLOCKS_APIKEY")


### PR DESCRIPTION
Switch to using `sepolia` assets for fileblocks raw signing on staging and omega. Since holesky has paused and fireblocks are returning errors when requested to sign using that asset. Note that the asset isn't actually used, it is only required by fireblocks API for validation.

```
chain=mock_l1 nonce=0 err="sign tx: external sign: create raw sign tx: non-JSON error response" status_code=400 body="{\"message\":\"Network hard-fork issues: [https://www.tokenpost.com/news/technology/14157\](https://www.tokenpost.com/news/technology/14157/)",\"code\":1450}"
```

issue: none