### PR TITLE
feat(upgrade/magellan): update distribution params

### DIFF
--- a/halo/app/start_test.go
+++ b/halo/app/start_test.go
@@ -222,7 +222,7 @@ func testCProvider(t *testing.T, ctx context.Context, cprov cprovider.Provider) 
 
 	resp, err := cprov.QueryClients().Mint.Inflation(ctx, &minttypes.QueryInflationRequest{})
 	require.NoError(t, err)
-	require.EqualValues(t, "0.115789000000000000", resp.Inflation.String())
+	require.EqualValues(t, "0.110000000000000000", resp.Inflation.String())
 }
 
 func setupSimnet(t *testing.T) haloapp.Config {

--- a/halo/app/upgrades/magellan/upgrade.go
+++ b/halo/app/upgrades/magellan/upgrade.go
@@ -48,8 +48,8 @@ func StoreUpgrades(_ context.Context) *storetypes.StoreUpgrades {
 }
 
 var (
-	targetInflation  = math.LegacyNewDecWithPrec(115789, 6) // 11.5789% so that delegators earn ~11% after deducting of 5% validator rewards
-	blocksPeriodSecs = 2                                    // BlocksPerYear calculated based on 2 second block times
+	targetInflation  = math.LegacyNewDecWithPrec(11, 2) // Fixed 11% rewards for delegators
+	blocksPeriodSecs = 1.5                              // Avg mainnet block period is 1.5s per block
 	MintParams       = minttypes.Params{
 		MintDenom:           sdk.DefaultBondDenom,
 		InflationRateChange: math.LegacyNewDec(0),

--- a/halo/app/upgrades/magellan/upgrade_internal_test.go
+++ b/halo/app/upgrades/magellan/upgrade_internal_test.go
@@ -25,8 +25,8 @@ func TestSlashingParams(t *testing.T) {
 func TestTargetInflation(t *testing.T) {
 	t.Parallel()
 
-	require.Equal(t, "0.115789000000000000", targetInflation.String())
-	require.EqualValues(t, 15768000, MintParams.BlocksPerYear)
+	require.Equal(t, "0.110000000000000000", targetInflation.String())
+	require.EqualValues(t, 21024000, MintParams.BlocksPerYear)
 
 	totalStaked := math.NewInt(1000).MulRaw(params.Ether) // 1000 omni staked
 	bondedRatio := math.LegacyNewDec(1)                   // 100% bonded


### PR DESCRIPTION
Update `magellan` distribution params.
 - Flat 11% rewards for delegators since validators don't charge commision.
 - Block period decreased a steady 1.5s

issue: none