### PR TITLE
feat(sdk): export Quote type and expose orderId

### DIFF
--- a/sdk/package.json
+++ b/sdk/package.json
@@ -1,7 +1,7 @@
 {
   "name": "omni-network",
   "description": "Typescript interface for Omni Solvernet",
-  "version": "0.0.0-alpha.1",
+  "version": "0.0.0-alpha.2",
   "type": "module",
   "license": "MIT",
   "packageManager": "pnpm@9.1.0",

--- a/sdk/src/context/omni.tsx
+++ b/sdk/src/context/omni.tsx
@@ -79,11 +79,12 @@ async function getContracts(apiBaseUrl: string) {
 }
 
 function isContracts(json: unknown): json is OmniContracts {
+  const contracts = json as OmniContracts
   return (
-    json != null &&
-    typeof (json as any).inbox === 'string' &&
-    typeof (json as any).outbox === 'string' &&
-    typeof (json as any).middleman === 'string'
+    contracts != null &&
+    typeof contracts.inbox === 'string' &&
+    typeof contracts.outbox === 'string' &&
+    typeof contracts.middleman === 'string'
   )
 }
 

--- a/sdk/src/hooks/useOrder.ts
+++ b/sdk/src/hooks/useOrder.ts
@@ -28,6 +28,7 @@ type UseOrderParams = {
 
 type UseOrderReturnType = {
   open: () => Promise<Hex>
+  orderId?: Hex
   validation?: Validation
   txHash?: Hex
   error?: WriteContractErrorType
@@ -124,6 +125,7 @@ export function useOrder(params: UseOrderParams): UseOrderReturnType {
 
   return {
     open,
+    orderId,
     validation,
     txHash: txMutation.data,
     status,

--- a/sdk/src/hooks/useQuote.ts
+++ b/sdk/src/hooks/useQuote.ts
@@ -5,10 +5,7 @@ import { type Address, fromHex, zeroAddress } from 'viem'
 import { type FetchJSONError, fetchJSON } from '../internal/api.js'
 import { toJSON } from './util.js'
 
-// TODO add complex type to enforce one of the amounts is defined
-type Quoteable =
-  | { isNative: true; token?: never; amount?: bigint }
-  | { isNative: false; token: Address; amount?: bigint }
+import type { Quote, Quoteable } from '../types/quote.js'
 
 type UseQuoteParams = {
   srcChainId?: number
@@ -41,11 +38,6 @@ type UseQuotePending = {
 
 type UseQuoteResult = (UseQuoteSuccess | UseQuoteError | UseQuotePending) & {
   query: UseQueryResult<Quote, QuoteError>
-}
-
-type Quote = {
-  deposit: { token: Address; amount: bigint }
-  expense: { token: Address; amount: bigint }
 }
 
 // QuoteResponse is the response from the /quote endpoint, with hex encoded amounts
@@ -152,13 +144,14 @@ const useResult = (q: UseQueryResult<Quote, QuoteError>): UseQuoteResult =>
 // isQuoteRes checks if a json is a QuoteResponse
 // TODO: use zod
 function isQuoteRes(json: unknown): json is QuoteResponse {
+  const quote = json as QuoteResponse
   return (
     json != null &&
-    (json as any).deposit != null &&
-    (json as any).expense != null &&
-    typeof (json as any).deposit.token === 'string' &&
-    typeof (json as any).deposit.amount === 'string' &&
-    typeof (json as any).expense.token === 'string' &&
-    typeof (json as any).expense.amount === 'string'
+    quote.deposit != null &&
+    quote.expense != null &&
+    typeof quote.deposit.token === 'string' &&
+    typeof quote.deposit.amount === 'string' &&
+    typeof quote.expense.token === 'string' &&
+    typeof quote.expense.amount === 'string'
   )
 }

--- a/sdk/src/index.ts
+++ b/sdk/src/index.ts
@@ -6,8 +6,8 @@ export { useOrder } from './hooks/useOrder.js'
 export { useQuote } from './hooks/useQuote.js'
 
 ////// TYPES //////
-export type { Order } from './types/order.js'
-export type { OrderStatus } from './types/order.js'
+export type { Order, OrderStatus } from './types/order.js'
+export type { Quote } from './types/quote.js'
 
 ////// PROVIDER //////
 export { OmniProvider, useOmniContext } from './context/omni.js'

--- a/sdk/src/internal/api.ts
+++ b/sdk/src/internal/api.ts
@@ -25,10 +25,11 @@ export async function fetchJSON(
 
 // TODO: use zod
 function isJSONError(error: unknown): error is JSONError {
+  const err = error as JSONError
   return (
-    error != null &&
-    typeof (error as any).code === 'number' &&
-    typeof (error as any).status === 'string' &&
-    typeof (error as any).message === 'string'
+    err != null &&
+    typeof err.code === 'number' &&
+    typeof err.status === 'string' &&
+    typeof err.message === 'string'
   )
 }

--- a/sdk/src/types/quote.ts
+++ b/sdk/src/types/quote.ts
@@ -1,0 +1,11 @@
+import type { Address } from 'viem'
+
+// TODO add complex type to enforce one of the amounts is defined
+export type Quoteable =
+  | { isNative: true; token?: never; amount?: bigint }
+  | { isNative: false; token: Address; amount?: bigint }
+
+export type Quote = {
+  deposit: { token: Address; amount: bigint }
+  expense: { token: Address; amount: bigint }
+}


### PR DESCRIPTION
The `orderId` is needed to track the order on the outbox in the SolverNet app, and the `Quote` type is used internally by the app so it's convenient to have it exported by the SDK.

I also had to make some changes to the type checks so that Biome wouldn't complain about the use of `any`.

issue: none
