### PR TITLE
feat(e2e): add solvernetspec

### DIFF
--- a/e2e/app/admin/pausesolvernet.go
+++ b/e2e/app/admin/pausesolvernet.go
@@ -9,17 +9,9 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 )
 
-const (
-	pausing   = "Pausing"
-	unpausing = "Unpausing"
-)
-
 // pauseSolverNetAll pauses or unpauses all functions on the SolverNetInbox.
 func pauseSolverNetAll(ctx context.Context, s shared, c chain, addr common.Address, pause bool) error {
-	action := pausing
-	if !pause {
-		action = unpausing
-	}
+	action := getActionText(pause)
 
 	log.Info(ctx, action+" all on SolverNetInbox...", "chain", c.Name, "addr", addr)
 
@@ -40,10 +32,7 @@ func pauseSolverNetAll(ctx context.Context, s shared, c chain, addr common.Addre
 
 // pauseSolverNetOpen pauses or unpauses the open function on the SolverNetInbox.
 func pauseSolverNetOpen(ctx context.Context, s shared, c chain, addr common.Address, pause bool) error {
-	action := pausing
-	if !pause {
-		action = unpausing
-	}
+	action := getActionText(pause)
 
 	log.Info(ctx, action+" open on SolverNetInbox...", "chain", c.Name, "addr", addr)
 
@@ -64,10 +53,7 @@ func pauseSolverNetOpen(ctx context.Context, s shared, c chain, addr common.Addr
 
 // pauseSolverNetClose pauses or unpauses the close function on the SolverNetInbox.
 func pauseSolverNetClose(ctx context.Context, s shared, c chain, addr common.Address, pause bool) error {
-	action := pausing
-	if !pause {
-		action = unpausing
-	}
+	action := getActionText(pause)
 
 	log.Info(ctx, action+" close on SolverNetInbox...", "chain", c.Name, "addr", addr)
 
@@ -84,6 +70,15 @@ func pauseSolverNetClose(ctx context.Context, s shared, c chain, addr common.Add
 	log.Info(ctx, "Close function on SolverNetInbox "+getStatusText(pause)+" ✅", "chain", c.Name, "addr", addr, "out", out)
 
 	return nil
+}
+
+// getActionText returns "Pausing" or "Unpausing" based on the pause flag.
+func getActionText(pause bool) string {
+	if pause {
+		return "Pausing"
+	}
+
+	return "Unpausing"
 }
 
 // getStatusText returns "paused" or "unpaused" based on the pause flag.

--- a/e2e/app/admin/pausesolvernet.go
+++ b/e2e/app/admin/pausesolvernet.go
@@ -1,0 +1,96 @@
+package admin
+
+import (
+	"context"
+
+	"github.com/omni-network/omni/lib/errors"
+	"github.com/omni-network/omni/lib/log"
+
+	"github.com/ethereum/go-ethereum/common"
+)
+
+const (
+	pausing   = "Pausing"
+	unpausing = "Unpausing"
+)
+
+// pauseSolverNetAll pauses or unpauses all functions on the SolverNetInbox.
+func pauseSolverNetAll(ctx context.Context, s shared, c chain, addr common.Address, pause bool) error {
+	action := pausing
+	if !pause {
+		action = unpausing
+	}
+
+	log.Info(ctx, action+" all on SolverNetInbox...", "chain", c.Name, "addr", addr)
+
+	calldata, err := adminABI.Pack("pauseAll", s.manager, addr, pause)
+	if err != nil {
+		return errors.Wrap(err, "pack calldata", "chain", c.Name)
+	}
+
+	out, err := s.runForge(ctx, c.RPCEndpoint, calldata, s.manager)
+	if err != nil {
+		return errors.Wrap(err, "run forge", "out", out, "chain", c.Name)
+	}
+
+	log.Info(ctx, "All functions on SolverNetInbox "+getStatusText(pause)+" ✅", "chain", c.Name, "addr", addr, "out", out)
+
+	return nil
+}
+
+// pauseSolverNetOpen pauses or unpauses the open function on the SolverNetInbox.
+func pauseSolverNetOpen(ctx context.Context, s shared, c chain, addr common.Address, pause bool) error {
+	action := pausing
+	if !pause {
+		action = unpausing
+	}
+
+	log.Info(ctx, action+" open on SolverNetInbox...", "chain", c.Name, "addr", addr)
+
+	calldata, err := adminABI.Pack("pauseOpen", s.manager, addr, pause)
+	if err != nil {
+		return errors.Wrap(err, "pack calldata", "chain", c.Name)
+	}
+
+	out, err := s.runForge(ctx, c.RPCEndpoint, calldata, s.manager)
+	if err != nil {
+		return errors.Wrap(err, "run forge", "out", out, "chain", c.Name)
+	}
+
+	log.Info(ctx, "Open function on SolverNetInbox "+getStatusText(pause)+" ✅", "chain", c.Name, "addr", addr, "out", out)
+
+	return nil
+}
+
+// pauseSolverNetClose pauses or unpauses the close function on the SolverNetInbox.
+func pauseSolverNetClose(ctx context.Context, s shared, c chain, addr common.Address, pause bool) error {
+	action := pausing
+	if !pause {
+		action = unpausing
+	}
+
+	log.Info(ctx, action+" close on SolverNetInbox...", "chain", c.Name, "addr", addr)
+
+	calldata, err := adminABI.Pack("pauseClose", s.manager, addr, pause)
+	if err != nil {
+		return errors.Wrap(err, "pack calldata", "chain", c.Name)
+	}
+
+	out, err := s.runForge(ctx, c.RPCEndpoint, calldata, s.manager)
+	if err != nil {
+		return errors.Wrap(err, "run forge", "out", out, "chain", c.Name)
+	}
+
+	log.Info(ctx, "Close function on SolverNetInbox "+getStatusText(pause)+" ✅", "chain", c.Name, "addr", addr, "out", out)
+
+	return nil
+}
+
+// getStatusText returns "paused" or "unpaused" based on the pause flag.
+func getStatusText(pause bool) string {
+	if pause {
+		return "paused"
+	}
+
+	return "unpaused"
+}

--- a/e2e/app/admin/solvernetspec.go
+++ b/e2e/app/admin/solvernetspec.go
@@ -1,0 +1,295 @@
+package admin
+
+import (
+	"context"
+
+	"github.com/omni-network/omni/contracts/bindings"
+	"github.com/omni-network/omni/e2e/app"
+	"github.com/omni-network/omni/lib/contracts"
+	"github.com/omni-network/omni/lib/errors"
+	"github.com/omni-network/omni/lib/ethclient"
+	"github.com/omni-network/omni/lib/log"
+	"github.com/omni-network/omni/lib/netconf"
+
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
+)
+
+// solverNetSpec defines SolverNet spec per network.
+// To update SolverNet spec, update this map.
+// Then run `ensure-solvernet-spec` to apply the changes.
+var solverNetSpec = map[netconf.ID]NetworkSolverNetSpec{
+	netconf.Devnet:  {Global: DefaultSolverNetSpec()},
+	netconf.Staging: {Global: DefaultSolverNetSpec()},
+	netconf.Omega:   {Global: DefaultSolverNetSpec()},
+	netconf.Mainnet: {Global: DefaultSolverNetSpec()},
+}
+
+// SolverNetSpec is the specification for the SolverNetInbox contract.
+type SolverNetSpec struct {
+	// PauseAll indicates that open and close actions on the SolverNetInbox should be paused.
+	PauseAll bool
+
+	// PauseOpen indicates that opening new orders should be paused.
+	PauseOpen bool
+
+	// PauseClose indicates that closing orders should be paused.
+	PauseClose bool
+}
+
+// SolverNetDirectives defines updates required on a SolverNetInbox to match a spec.
+type SolverNetDirectives struct {
+	// PauseAll indicates that open and close actions on the SolverNetInbox should be paused.
+	PauseAll bool
+
+	// UnpauseAll indicates that open and close actions on the SolverNetInbox should be unpaused.
+	UnpauseAll bool
+
+	// PauseOpen indicates that opening new orders should be paused.
+	PauseOpen bool
+
+	// UnpauseOpen indicates that opening new orders should be unpaused.
+	UnpauseOpen bool
+
+	// PauseClose indicates that closing orders should be paused.
+	PauseClose bool
+
+	// UnpauseClose indicates that closing orders should be unpaused.
+	UnpauseClose bool
+}
+
+// NetworkSolverNetSpec defines the SolverNet spec for a network.
+type NetworkSolverNetSpec struct {
+	// Global is the SolverNet spec maintained on all chains.
+	Global SolverNetSpec
+
+	// ChainOverrides overrides the global spec for specific chains. Must specify full spec, not just diff.
+	ChainOverrides map[uint64]*SolverNetSpec
+}
+
+// DefaultSolverNetSpec returns a default SolverNet spec with nothing paused.
+func DefaultSolverNetSpec() SolverNetSpec {
+	return SolverNetSpec{
+		PauseAll:   false,
+		PauseOpen:  false,
+		PauseClose: false,
+	}
+}
+
+// EnsureSolverNetSpec ensures that live SolverNetInbox contracts are configured as per the local spec.
+func EnsureSolverNetSpec(ctx context.Context, def app.Definition, cfg Config, localSpecOverride *SolverNetSpec) error {
+	return setup(def, cfg).run(ctx, func(ctx context.Context, s shared, c chain) error {
+		addrs, err := contracts.GetAddresses(ctx, s.testnet.Network)
+		if err != nil {
+			return errors.Wrap(err, "get addresses", "chain", c.Name)
+		}
+
+		local, err := localSolverNetSpec(s.testnet.Network, c.ChainID)
+		if err != nil {
+			return errors.Wrap(err, "get local solvernet spec", "chain", c.Name)
+		}
+
+		if localSpecOverride != nil {
+			local = *localSpecOverride
+		}
+
+		ethCl, err := ethclient.Dial(c.Name, c.RPCEndpoint)
+		if err != nil {
+			return errors.Wrap(err, "dial eth client", "chain", c.Name)
+		}
+
+		live, err := liveSolverNetSpec(ctx, addrs.SolverNetInbox, ethCl)
+		if err != nil {
+			return errors.Wrap(err, "get live solvernet spec", "chain", c.Name)
+		}
+
+		directives, err := makeSolverNetDirectives(local, live)
+		if err != nil {
+			return errors.Wrap(err, "make directives", "chain", c.Name)
+		}
+
+		return runSolverNetDirectives(ctx, s, c, addrs.SolverNetInbox, directives)
+	})
+}
+
+// makeSolverNetDirectives returns the directives required to bring a SolverNet inbox in line with the local spec.
+func makeSolverNetDirectives(local, live SolverNetSpec) (SolverNetDirectives, error) {
+	if err := local.Verify(); err != nil {
+		return SolverNetDirectives{}, errors.Wrap(err, "verify local spec")
+	}
+
+	if err := live.Verify(); err != nil {
+		return SolverNetDirectives{}, errors.Wrap(err, "verify live spec")
+	}
+
+	// If local.PauseAll is true but live.PauseAll is false, we need to pause all
+	pauseAll := local.PauseAll && !live.PauseAll
+	// If local.PauseAll is false but live.PauseAll is true, we need to unpause all
+	unpauseAll := !local.PauseAll && live.PauseAll
+
+	// If we're not dealing with pause/unpause all, check individual pause states
+	var pauseOpen, unpauseOpen, pauseClose, unpauseClose bool
+
+	if !local.PauseAll && !live.PauseAll {
+		// If local.PauseOpen is true but live.PauseOpen is false, we need to pause open
+		pauseOpen = local.PauseOpen && !live.PauseOpen
+		// If local.PauseOpen is false but live.PauseOpen is true, we need to unpause open
+		unpauseOpen = !local.PauseOpen && live.PauseOpen
+		// If local.PauseClose is true but live.PauseClose is false, we need to pause close
+		pauseClose = local.PauseClose && !live.PauseClose
+		// If local.PauseClose is false but live.PauseClose is true, we need to unpause close
+		unpauseClose = !local.PauseClose && live.PauseClose
+	}
+
+	return SolverNetDirectives{
+		PauseAll:     pauseAll,
+		UnpauseAll:   unpauseAll,
+		PauseOpen:    pauseOpen,
+		UnpauseOpen:  unpauseOpen,
+		PauseClose:   pauseClose,
+		UnpauseClose: unpauseClose,
+	}, nil
+}
+
+// Verify checks that there are no conflicting specifications.
+func (s SolverNetSpec) Verify() error {
+	if s.PauseAll && (s.PauseOpen || s.PauseClose) {
+		return errors.New("if pause-all, no other pause flags should be specified")
+	}
+
+	return nil
+}
+
+// Verify checks that there are no conflicting directives.
+func (d SolverNetDirectives) Verify() error {
+	if d.PauseAll && d.UnpauseAll {
+		return errors.New("cannot pause and unpause all")
+	}
+
+	if d.PauseAll && (d.PauseOpen || d.PauseClose) {
+		return errors.New("if pause-all, no other pause actions should be specified")
+	}
+
+	if d.PauseOpen && d.UnpauseOpen {
+		return errors.New("cannot pause and unpause open")
+	}
+
+	if d.PauseClose && d.UnpauseClose {
+		return errors.New("cannot pause and unpause close")
+	}
+
+	return nil
+}
+
+// localSolverNetSpec returns the configured, local SolverNet spec for a chain.
+func localSolverNetSpec(network netconf.ID, chainID uint64) (SolverNetSpec, error) {
+	net, ok := solverNetSpec[network]
+	if !ok {
+		return SolverNetSpec{}, errors.New("no spec for network", "network", network)
+	}
+
+	spec := net.Global
+	if net.ChainOverrides != nil && net.ChainOverrides[chainID] != nil {
+		spec = *net.ChainOverrides[chainID]
+	}
+
+	if err := spec.Verify(); err != nil {
+		return SolverNetSpec{}, errors.Wrap(err, "verify spec", "network", network, "chain", chainID)
+	}
+
+	return spec, nil
+}
+
+// liveSolverNetSpec returns the live, on-chain SolverNet spec for a chain.
+func liveSolverNetSpec(ctx context.Context, inboxAddr common.Address, ethCl ethclient.Client) (SolverNetSpec, error) {
+	inbox, err := bindings.NewSolverNetInbox(inboxAddr, ethCl)
+	if err != nil {
+		return SolverNetSpec{}, errors.Wrap(err, "new solvernetinbox contract")
+	}
+
+	pauseState, err := inbox.PauseState(&bind.CallOpts{Context: ctx})
+	if err != nil {
+		return SolverNetSpec{}, errors.Wrap(err, "get pause state")
+	}
+
+	// Parse the pause state
+	// 0 = no pause, 1 = open paused, 2 = close paused, 3 = all paused
+	switch pauseState {
+	case 0: // NONE_PAUSED
+		return SolverNetSpec{
+			PauseAll:   false,
+			PauseOpen:  false,
+			PauseClose: false,
+		}, nil
+	case 1: // OPEN_PAUSED
+		return SolverNetSpec{
+			PauseAll:   false,
+			PauseOpen:  true,
+			PauseClose: false,
+		}, nil
+	case 2: // CLOSE_PAUSED
+		return SolverNetSpec{
+			PauseAll:   false,
+			PauseOpen:  false,
+			PauseClose: true,
+		}, nil
+	case 3: // ALL_PAUSED
+		return SolverNetSpec{
+			PauseAll:   true,
+			PauseOpen:  false,
+			PauseClose: false,
+		}, nil
+	default:
+		return SolverNetSpec{}, errors.New("unknown pause state", "state", pauseState)
+	}
+}
+
+// runSolverNetDirectives applies SolverNetDirectives on chain.
+func runSolverNetDirectives(ctx context.Context, s shared, c chain, addr common.Address, directives SolverNetDirectives) error {
+	if err := directives.Verify(); err != nil {
+		return errors.Wrap(err, "verify directives", "chain", c.Name)
+	}
+
+	if isEmpty(directives) {
+		log.Info(ctx, "No directives to apply", "chain", c.Name)
+		return nil
+	}
+
+	if directives.PauseAll {
+		if err := pauseSolverNetAll(ctx, s, c, addr, true); err != nil {
+			return errors.Wrap(err, "pause solvernet all", "chain", c.Name)
+		}
+	}
+
+	if directives.UnpauseAll {
+		if err := pauseSolverNetAll(ctx, s, c, addr, false); err != nil {
+			return errors.Wrap(err, "unpause solvernet all", "chain", c.Name)
+		}
+	}
+
+	if directives.PauseOpen {
+		if err := pauseSolverNetOpen(ctx, s, c, addr, true); err != nil {
+			return errors.Wrap(err, "pause solvernet open", "chain", c.Name)
+		}
+	}
+
+	if directives.UnpauseOpen {
+		if err := pauseSolverNetOpen(ctx, s, c, addr, false); err != nil {
+			return errors.Wrap(err, "unpause solvernet open", "chain", c.Name)
+		}
+	}
+
+	if directives.PauseClose {
+		if err := pauseSolverNetClose(ctx, s, c, addr, true); err != nil {
+			return errors.Wrap(err, "pause solvernet close", "chain", c.Name)
+		}
+	}
+
+	if directives.UnpauseClose {
+		if err := pauseSolverNetClose(ctx, s, c, addr, false); err != nil {
+			return errors.Wrap(err, "unpause solvernet close", "chain", c.Name)
+		}
+	}
+
+	return nil
+}

--- a/e2e/app/admin/solvernetspec_internal_test.go
+++ b/e2e/app/admin/solvernetspec_internal_test.go
@@ -1,0 +1,135 @@
+package admin
+
+import (
+	"testing"
+
+	"github.com/omni-network/omni/lib/netconf"
+	"github.com/omni-network/omni/lib/tutil"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestNetworkSolverNetSpec(t *testing.T) {
+	t.Parallel()
+	golden := make(map[netconf.ID]NetworkSolverNetSpec)
+
+	for _, network := range netconf.All() {
+		if network == netconf.Simnet {
+			continue
+		}
+
+		golden[network] = solverNetSpec[network]
+	}
+
+	tutil.RequireGoldenJSON(t, golden)
+}
+
+func TestMakeSolverNetDirectives(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name       string
+		local      SolverNetSpec
+		live       SolverNetSpec
+		directives SolverNetDirectives
+		isErr      bool
+	}{
+		{
+			"empties - no change",
+			SolverNetSpec{},
+			SolverNetSpec{},
+			SolverNetDirectives{},
+			false,
+		},
+		{
+			"should pause all",
+			SolverNetSpec{PauseAll: true},
+			SolverNetSpec{PauseAll: false},
+			SolverNetDirectives{PauseAll: true},
+			false,
+		},
+		{
+			"should unpause all",
+			SolverNetSpec{PauseAll: false},
+			SolverNetSpec{PauseAll: true},
+			SolverNetDirectives{UnpauseAll: true},
+			false,
+		},
+		{
+			"should pause open",
+			SolverNetSpec{PauseOpen: true},
+			SolverNetSpec{PauseOpen: false},
+			SolverNetDirectives{PauseOpen: true},
+			false,
+		},
+		{
+			"should unpause open",
+			SolverNetSpec{PauseOpen: false},
+			SolverNetSpec{PauseOpen: true},
+			SolverNetDirectives{UnpauseOpen: true},
+			false,
+		},
+		{
+			"should pause close",
+			SolverNetSpec{PauseClose: true},
+			SolverNetSpec{PauseClose: false},
+			SolverNetDirectives{PauseClose: true},
+			false,
+		},
+		{
+			"should unpause close",
+			SolverNetSpec{PauseClose: false},
+			SolverNetSpec{PauseClose: true},
+			SolverNetDirectives{UnpauseClose: true},
+			false,
+		},
+		{
+			"unpause all, pause open",
+			SolverNetSpec{PauseAll: false, PauseOpen: true},
+			SolverNetSpec{PauseAll: true},
+			SolverNetDirectives{UnpauseAll: true},
+			false,
+		},
+		{
+			"unpause specific, pause all",
+			SolverNetSpec{PauseAll: true},
+			SolverNetSpec{PauseAll: false, PauseOpen: true, PauseClose: true},
+			SolverNetDirectives{PauseAll: true},
+			false,
+		},
+		{
+			"multiple specific changes",
+			SolverNetSpec{PauseOpen: true, PauseClose: false},
+			SolverNetSpec{PauseOpen: false, PauseClose: true},
+			SolverNetDirectives{PauseOpen: true, UnpauseClose: true},
+			false,
+		},
+		{
+			"invalid spec - pause all and pause open",
+			SolverNetSpec{PauseAll: true, PauseOpen: true},
+			SolverNetSpec{},
+			SolverNetDirectives{},
+			true,
+		},
+		{
+			"invalid spec - pause all and pause close",
+			SolverNetSpec{PauseAll: true, PauseClose: true},
+			SolverNetSpec{},
+			SolverNetDirectives{},
+			true,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			dir, err := makeSolverNetDirectives(test.local, test.live)
+
+			if test.isErr {
+				require.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+			require.Equal(t, test.directives, dir)
+		})
+	}
+}

--- a/e2e/app/admin/testdata/TestNetworkSolverNetSpec.golden
+++ b/e2e/app/admin/testdata/TestNetworkSolverNetSpec.golden
@@ -1,0 +1,34 @@
+{
+ "devnet": {
+  "Global": {
+   "PauseAll": false,
+   "PauseOpen": false,
+   "PauseClose": false
+  },
+  "ChainOverrides": null
+ },
+ "mainnet": {
+  "Global": {
+   "PauseAll": false,
+   "PauseOpen": false,
+   "PauseClose": false
+  },
+  "ChainOverrides": null
+ },
+ "omega": {
+  "Global": {
+   "PauseAll": false,
+   "PauseOpen": false,
+   "PauseClose": false
+  },
+  "ChainOverrides": null
+ },
+ "staging": {
+  "Global": {
+   "PauseAll": false,
+   "PauseOpen": false,
+   "PauseClose": false
+  },
+  "ChainOverrides": null
+ }
+}

--- a/e2e/cmd/admin.go
+++ b/e2e/cmd/admin.go
@@ -21,6 +21,7 @@ func newAdminCmd(def *app.Definition) *cobra.Command {
 	cmd.AddCommand(
 		newEnsurePortalSpecCmd(def, &cfg),
 		newEnsureBridgeSpecCmd(def, &cfg),
+		newEnsureSolverNetSpecCmd(def, &cfg),
 		newUpgradePortalCmd(def, &cfg),
 		newUpgradeFeeOracleV1Cmd(def, &cfg),
 		newUpgradeGasStationCmd(def, &cfg),
@@ -81,6 +82,18 @@ func newEnsureBridgeSpecCmd(def *app.Definition, cfg *admin.Config) *cobra.Comma
 		Short: "Ensure live bridge contracts (l1 and native) match local spec, defined in e2e/app/admin/bridgespec.go",
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			return admin.EnsureBridgeSpec(cmd.Context(), *def, *cfg, nil)
+		},
+	}
+
+	return cmd
+}
+
+func newEnsureSolverNetSpecCmd(def *app.Definition, cfg *admin.Config) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "ensure-solvernet-spec",
+		Short: "Ensure live SolverNetInbox contracts match local spec, defined in e2e/app/admin/solvernetspec.go",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return admin.EnsureSolverNetSpec(cmd.Context(), *def, *cfg, nil)
 		},
 	}
 


### PR DESCRIPTION
Created `solvernetspec.go` following similar patterns found in `bridgespec.go` and `portalspec.go` to pause the `open` and `close` functions, or both. This will be used via the Contract Admin GitHub action.

issue: #3122