### PR TITLE
chore(e2e): remove mock L1 from staging manifest

### DIFF
--- a/e2e/app/testdata/TestManifestServiceReference.golden
+++ b/e2e/app/testdata/TestManifestServiceReference.golden
@@ -27,7 +27,6 @@
  "staging": [
   "fullnode01",
   "fullnode01_evm",
-  "mock_l1",
   "monitor",
   "relayer",
   "seed01",

--- a/e2e/manifests/staging.toml
+++ b/e2e/manifests/staging.toml
@@ -1,6 +1,5 @@
 network = "staging"
 public_chains = ["op_sepolia","base_sepolia","arb_sepolia"]
-anvil_chains = ["mock_l1"]
 multi_omni_evms = true
 prometheus = true
 deploy_solve = true


### PR DESCRIPTION
`mock_l1` chain is giving lots of RPC and funding errors because it does not have an externally reachable RPC. Removing it from manifest to redeploy staging without it.

issue: none