### PR TITLE
ci(e2e): deploy v0-13-0 to omega

### DIFF
--- a/e2e/manifests/omega.toml
+++ b/e2e/manifests/omega.toml
@@ -4,9 +4,9 @@ public_chains = ["holesky","op_sepolia", "base_sepolia","arb_sepolia"]
 multi_omni_evms = true
 prometheus = true
 
-pinned_halo_tag = "v0.12.0"
-pinned_relayer_tag = "6d7c3ec"
-pinned_monitor_tag = "5f08ffc"
+pinned_halo_tag = "v0.13.0"
+pinned_relayer_tag = "8622c0c"
+pinned_monitor_tag = "8622c0c"
 pinned_solver_tag = "8622c0c"
 
 [node.validator01]


### PR DESCRIPTION
Bumps omega halo nodes to v0.13.0. Also bumps relayer and monitor to a recent release.

issue: none