### PR TITLE
chore(e2e): holesky to sepolia in staging manifest

### DIFF
--- a/e2e/manifests/staging.toml
+++ b/e2e/manifests/staging.toml
@@ -1,5 +1,5 @@
 network = "staging"
-public_chains = ["op_sepolia","base_sepolia","arb_sepolia"]
+public_chains = ["sepolia","op_sepolia","base_sepolia","arb_sepolia"]
 multi_omni_evms = true
 prometheus = true
 deploy_solve = true

--- a/e2e/types/chain.go
+++ b/e2e/types/chain.go
@@ -41,6 +41,12 @@ var (
 		Shards:   allShards,
 	}
 
+	chainSepolia = EVMChain{
+		Metadata: mustMetadata(evmchain.IDSepolia),
+		IsPublic: true,
+		Shards:   allShards,
+	}
+
 	chainArbSepolia = EVMChain{
 		Metadata: mustMetadata(evmchain.IDArbSepolia),
 		IsPublic: true,
@@ -97,6 +103,8 @@ func PublicChainByName(name string) (EVMChain, error) {
 	switch name {
 	case chainHolesky.Name:
 		return chainHolesky, nil
+	case chainSepolia.Name:
+		return chainSepolia, nil
 	case chainArbSepolia.Name:
 		return chainArbSepolia, nil
 	case chainOpSepolia.Name:
@@ -121,6 +129,8 @@ func PublicRPCByName(name string) string {
 	switch name {
 	case chainHolesky.Name:
 		return "https://ethereum-holesky-rpc.publicnode.com"
+	case chainSepolia.Name:
+		return "https://ethereum-sepolia-rpc.publicnode.com"
 	case chainArbSepolia.Name:
 		return "https://sepolia-rollup.arbitrum.io/rpc"
 	case chainOpSepolia.Name:

--- a/lib/netconf/netconf.go
+++ b/lib/netconf/netconf.go
@@ -132,7 +132,7 @@ func EthereumChainID(network ID) uint64 {
 	case Omega:
 		return evmchain.IDHolesky
 	case Staging:
-		return evmchain.IDHolesky
+		return evmchain.IDSepolia
 	default:
 		return evmchain.IDMockL1
 	}

--- a/lib/xchain/connect/connect.go
+++ b/lib/xchain/connect/connect.go
@@ -110,6 +110,7 @@ func WithInfuraENV(keyVar string) option {
 		infuraNames := map[string]string{
 			"ethereum":     "mainnet",
 			"holesky":      "holesky",
+			"sepolia":      "sepolia",
 			"base":         "base-mainnet",
 			"base_sepolia": "base-sepolia",
 			"arbitrum_one": "arbitrum-mainnet",

--- a/monitor/xfeemngr/xfeemngr.go
+++ b/monitor/xfeemngr/xfeemngr.go
@@ -56,6 +56,9 @@ var chainSyncOverrides = map[uint64]time.Duration{
 
 	// overide on holesky too, to test overide on omega
 	evmchain.IDHolesky: 90 * time.Minute,
+
+	// override for sepolia, to reduce spend
+	evmchain.IDSepolia: 90 * time.Minute,
 }
 
 func Start(ctx context.Context, network netconf.Network, cfg Config, privKeyPath string) error {

--- a/solver/app/testdata/TestTokens.golden
+++ b/solver/app/testdata/TestTokens.golden
@@ -161,7 +161,7 @@
  },
  {
   "address": "0xB50029Dc0DF4Db0193F25a8E41DEa207c13D09BB",
-  "chainId": 17000,
+  "chainId": 11155111,
   "coingeckoId": "omni-network",
   "isMock": false,
   "maxSpend": "1000.0000",

--- a/solver/app/tokens.go
+++ b/solver/app/tokens.go
@@ -235,6 +235,7 @@ func chainClass(chainID uint64) (ChainClass, error) {
 		evmchain.IDOmniOmega,
 		evmchain.IDOmniStaging, // classify omni staging as testnet, because it interops with other testnets
 		evmchain.IDHolesky,
+		evmchain.IDSepolia,
 		evmchain.IDArbSepolia,
 		evmchain.IDBaseSepolia,
 		evmchain.IDOpSepolia:


### PR DESCRIPTION
Replaced holesky with sepolia in the staging manifest, and went through various regions of the codebase that needed new Sepolia references.

issue: none