### PR TITLE
chore(sdk): encoding defaults

### DIFF
--- a/sdk/src/hooks/useOrder.ts
+++ b/sdk/src/hooks/useOrder.ts
@@ -23,7 +23,7 @@ import {
 } from './useValidateOrder.js'
 
 type UseOrderParams<abis extends OptionalAbis> = Order<abis> & {
-  validate: boolean
+  validateEnabled: boolean
 }
 
 type UseOrderReturnType = {
@@ -47,7 +47,7 @@ const defaultFillDeadline = () => Math.floor(Date.now() / 1000 + 86400)
 export function useOrder<abis extends OptionalAbis>(
   params: UseOrderParams<abis>,
 ): UseOrderReturnType {
-  const { validate, ...order } = params
+  const { validateEnabled, ...order } = params
   const txMutation = useWriteContract()
   const wait = useWaitForTransactionReceipt({ hash: txMutation.data })
 
@@ -70,7 +70,7 @@ export function useOrder<abis extends OptionalAbis>(
     wait.fetchStatus,
   )
 
-  const validation = useValidateOrder({ order, enabled: validate })
+  const validation = useValidateOrder({ order, enabled: validateEnabled })
 
   const { inbox } = useOmniContext()
 

--- a/sdk/src/hooks/useValidateOrder.ts
+++ b/sdk/src/hooks/useValidateOrder.ts
@@ -96,13 +96,13 @@ export function useValidateOrder<abis extends OptionalAbis>({
     calls: _encodeCalls(),
     deposit: {
       amount: order.deposit.amount,
-      token: order.deposit.token,
+      token: order.deposit.token ?? zeroAddress,
     },
     expenses: [
       {
         amount: order.expense.amount,
-        token: order.expense.token,
-        spender: order.expense.spender,
+        token: order.expense.token ?? zeroAddress,
+        spender: order.expense.spender ?? zeroAddress,
       },
     ],
   })


### PR DESCRIPTION
Encoding defaults.

Also rename `props.validate` to `props.validateEnabled`

issue: none
