### PR TITLE
refactor(solver/app): refactor http handlers and types

### DIFF
--- a/solver/app/app.go
+++ b/solver/app/app.go
@@ -50,7 +50,7 @@ func Run(ctx context.Context, cfg Config) error {
 	// if mainnet, just run monitoring and api (/live only)
 	if cfg.Network == netconf.Mainnet {
 		log.Info(ctx, "Serving API", "address", cfg.APIAddr)
-		apiChan := serveAPI(cfg.APIAddr, map[string]http.Handler{})
+		apiChan := serveAPI(cfg.APIAddr)
 
 		select {
 		case <-ctx.Done():
@@ -119,11 +119,11 @@ func Run(ctx context.Context, cfg Config) error {
 	}
 
 	log.Info(ctx, "Serving API", "address", cfg.APIAddr)
-	apiChan := serveAPI(cfg.APIAddr, map[string]http.Handler{
-		"/api/v1/quote":     newQuoteHandler(quoter),
-		"/api/v1/check":     newCheckHandler(newChecker(backends, solverAddr, addrs.SolverNetInbox, addrs.SolverNetOutbox)),
-		"/api/v1/contracts": newContractsHandler(addrs),
-	})
+	apiChan := serveAPI(cfg.APIAddr,
+		newCheckHandler(newChecker(backends, solverAddr, addrs.SolverNetInbox, addrs.SolverNetOutbox)),
+		newContractsHandler(addrs),
+		newQuoteHandler(quoter),
+	)
 
 	if err := approveOutboxes(ctx, network, backends, solverAddr); err != nil {
 		return errors.Wrap(err, "approve outboxes")

--- a/solver/app/check_internal_test.go
+++ b/solver/app/check_internal_test.go
@@ -31,7 +31,7 @@ func TestCheck(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			backends, clients := testBackends(t)
 
-			handler := newCheckHandler(newChecker(backends, solver, inbox, outbox))
+			handler := handlerAdapter(newCheckHandler(newChecker(backends, solver, inbox, outbox)))
 
 			if tt.mock != nil {
 				tt.mock(clients)
@@ -49,7 +49,7 @@ func TestCheck(t *testing.T) {
 			require.NoError(t, err)
 
 			ctx := context.Background()
-			req, err := http.NewRequestWithContext(ctx, http.MethodPost, "api/v1/check", bytes.NewBuffer(body))
+			req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpointCheck, bytes.NewBuffer(body))
 			require.NoError(t, err)
 
 			rr := httptest.NewRecorder()

--- a/solver/app/handler.go
+++ b/solver/app/handler.go
@@ -1,0 +1,153 @@
+package app
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/omni-network/omni/lib/contracts"
+	"github.com/omni-network/omni/lib/errors"
+	"github.com/omni-network/omni/lib/log"
+	"github.com/omni-network/omni/solver/types"
+)
+
+func newAPIError(err error, statusCode int) APIError {
+	return APIError{Err: err, StatusCode: statusCode}
+}
+
+// APIError wraps an error with a non-200 HTTP status code.
+type APIError struct {
+	Err        error
+	StatusCode int
+}
+
+func (e APIError) Error() string {
+	return e.Err.Error()
+}
+
+type Handler struct {
+	// Endpoint is the http endpoint path.
+	Endpoint string
+	// ZeroReq returns a zero struct pointer of the request type used for marshaling incoming requests.
+	ZeroReq func() any
+	// HandleFunc is the function that handles the request and returns a response.
+	// The request will be a pointer (same at type returned by ZeroReq).
+	// The response must be a struct and optional error.
+	HandleFunc func(context.Context, any) (any, error)
+}
+
+// newContractsHandler returns a http handler that returns the contract address for `network`.
+func newContractsHandler(addrs contracts.Addresses) Handler {
+	return Handler{
+		Endpoint: endpointContracts,
+		ZeroReq:  func() any { return nil },
+		HandleFunc: func(context.Context, any) (any, error) {
+			return types.ContractsResponse{
+				Portal:    addrs.Portal.Hex(),
+				Inbox:     addrs.SolverNetInbox.Hex(),
+				Outbox:    addrs.SolverNetOutbox.Hex(),
+				Middleman: addrs.SolverNetMiddleman.Hex(),
+			}, nil
+		},
+	}
+}
+
+// newCheckHandler returns a handler for the /check endpoint.
+// It is responsible for http request / response handling, and delegates
+// logic to a checkFunc.
+func newCheckHandler(checkFunc checkFunc) Handler {
+	return Handler{
+		Endpoint: endpointCheck,
+		ZeroReq:  func() any { return &CheckRequest{} },
+		HandleFunc: func(ctx context.Context, request any) (any, error) {
+			req, ok := request.(*CheckRequest)
+			if !ok {
+				return nil, errors.New("invalid request type [BUG]", "type", fmt.Sprintf("%T", request))
+			}
+
+			err := checkFunc(ctx, *req)
+			if r := new(RejectionError); errors.As(err, &r) {
+				return CheckResponse{
+					Rejected:          true,
+					RejectReason:      r.Reason.String(),
+					RejectDescription: r.Err.Error(),
+				}, nil
+			} else if err != nil {
+				return CheckResponse{}, err
+			}
+
+			return CheckResponse{Accepted: true}, nil
+		},
+	}
+}
+
+// newQuoteHandler returns a handler for the /quote endpoint.
+// It is responsible to http request / response handling, and delegates
+// logic to a quoteFunc.
+func newQuoteHandler(quoteFunc quoteFunc) Handler {
+	return Handler{
+		Endpoint: endpointQuote,
+		ZeroReq:  func() any { return &QuoteRequest{} },
+		HandleFunc: func(ctx context.Context, request any) (any, error) {
+			req, ok := request.(*QuoteRequest)
+			if !ok {
+				return nil, errors.New("invalid request type [BUG]", "type", fmt.Sprintf("%T", request))
+			}
+
+			return quoteFunc(ctx, *req)
+		},
+	}
+}
+
+func handlerAdapter(h Handler) http.HandlerFunc {
+	return func(w http.ResponseWriter, rr *http.Request) {
+		defer rr.Body.Close()
+		ctx := rr.Context()
+
+		req := h.ZeroReq()
+		if req == nil { //nolint:revive // noop if-block for readability
+			// Skip request unmarshalling if ZeroReq returns nil.
+		} else if err := json.NewDecoder(rr.Body).Decode(req); err != nil {
+			writeErrResponse(ctx, w, newAPIError(err, http.StatusBadRequest))
+			return
+		}
+
+		res, err := h.HandleFunc(ctx, req)
+		if err != nil {
+			writeErrResponse(ctx, w, err)
+			return
+		}
+
+		writeJSONResponse(ctx, w, http.StatusOK, res)
+	}
+}
+
+func writeErrResponse(ctx context.Context, w http.ResponseWriter, err error) {
+	statusCode := http.StatusInternalServerError
+
+	var apiErr APIError
+	if errors.As(err, &apiErr) {
+		statusCode = apiErr.StatusCode
+	}
+
+	log.DebugErr(ctx, "Serving API error", err, "status", statusCode)
+
+	writeJSONResponse(ctx, w, statusCode, JSONErrorResponse{
+		Code:    statusCode,
+		Status:  http.StatusText(statusCode),
+		Message: removeBUG(err.Error()),
+	})
+}
+
+func writeJSONResponse(ctx context.Context, w http.ResponseWriter, status int, resp any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	if err := json.NewEncoder(w).Encode(resp); err != nil {
+		log.Error(ctx, "Failed writing api response [BUG]", err)
+	}
+}
+
+// removeBUG removes [BUG] from the error messages, so they are not included in responses to users.
+func removeBUG(s string) string { return strings.ReplaceAll(s, "[BUG]", "") }

--- a/solver/types/api.go
+++ b/solver/types/api.go
@@ -2,7 +2,6 @@ package types
 
 import (
 	"math/big"
-	"net/http"
 
 	"github.com/omni-network/omni/lib/contracts/solvernet"
 
@@ -41,21 +40,10 @@ type CheckRequest struct {
 
 // CheckResponse is the response json for the /check endpoint.
 type CheckResponse struct {
-	Accepted          bool               `json:"accepted,omitempty"`
-	Rejected          bool               `json:"rejected,omitempty"`
-	RejectReason      string             `json:"rejectReason,omitempty"`
-	RejectDescription string             `json:"rejectDescription,omitempty"`
-	Error             *JSONErrorResponse `json:"error,omitempty"`
-}
-
-var _ JSONResponse = (*CheckResponse)(nil)
-
-func (r CheckResponse) StatusCode() int {
-	if r.Error != nil {
-		return r.Error.Code
-	}
-
-	return http.StatusOK
+	Accepted          bool   `json:"accepted"`
+	Rejected          bool   `json:"rejected"`
+	RejectReason      string `json:"rejectReason"`
+	RejectDescription string `json:"rejectDescription"`
 }
 
 // QuoteRequest is the expected request body for the /api/v1/quote endpoint.
@@ -96,38 +84,16 @@ func (qu JSONQuoteUnit) Parse() QuoteUnit {
 
 // QuoteResponse is the response json for the /api/v1/quote endpoint.
 type QuoteResponse struct {
-	Deposit JSONQuoteUnit      `json:"deposit"`
-	Expense JSONQuoteUnit      `json:"expense"`
-	Error   *JSONErrorResponse `json:"error,omitempty"`
-}
-
-var _ JSONResponse = (*QuoteResponse)(nil)
-
-func (r QuoteResponse) StatusCode() int {
-	if r.Error != nil {
-		return r.Error.Code
-	}
-
-	return http.StatusOK
+	Deposit JSONQuoteUnit `json:"deposit"`
+	Expense JSONQuoteUnit `json:"expense"`
 }
 
 // ContractsResponse is the response json for the /api/vi/contracts endpoint.
 type ContractsResponse struct {
-	Portal    string             `json:"portal,omitempty"`
-	Inbox     string             `json:"inbox,omitempty"`
-	Outbox    string             `json:"outbox,omitempty"`
-	Middleman string             `json:"middleman,omitempty"`
-	Error     *JSONErrorResponse `json:"error,omitempty"`
-}
-
-var _ JSONResponse = (*ContractsResponse)(nil)
-
-func (r ContractsResponse) StatusCode() int {
-	if r.Error != nil {
-		return r.Error.Code
-	}
-
-	return http.StatusOK
+	Portal    string `json:"portal"`
+	Inbox     string `json:"inbox"`
+	Outbox    string `json:"outbox"`
+	Middleman string `json:"middleman"`
 }
 
 // JSONExpense is a json marshal-able solvernt.Expense.


### PR DESCRIPTION
Refactor solver API handlers:
 - single `handlerAdapator` that does all JSON (un)marshalling for all endpoints.
 - Decouple JSON errors from handler response types. Logic now returns struct and errors (standard go).

issue: none