### PR TITLE
ci(e2e): mainnet magellan upgrade height

### DIFF
--- a/e2e/app/admin/planupgrade.go
+++ b/e2e/app/admin/planupgrade.go
@@ -18,9 +18,13 @@ import (
 )
 
 var upgradePlans = map[netconf.ID]bindings.UpgradePlan{
-	netconf.Omega: {
+	// netconf.Omega: {
+	// Name:   magellan2.UpgradeName,
+	// Height: 8_720_000, // Mon 27 Feb 1pm UTC
+	// },
+	netconf.Mainnet: {
 		Name:   magellan2.UpgradeName,
-		Height: 8_720_000, // Mon 27 Feb 1pm UTC
+		Height: 6_964_000, // Mon 03 Mar 1pm UTC
 	},
 }
 

--- a/e2e/manifests/mainnet.toml
+++ b/e2e/manifests/mainnet.toml
@@ -4,9 +4,10 @@ public_chains = ["ethereum","arbitrum_one","base","optimism"]
 multi_omni_evms = true
 prometheus   = true
 
-pinned_halo_tag = "v0.12.0"
-pinned_relayer_tag = "6d7c3ec"
-pinned_monitor_tag = "5f08ffc"
+pinned_halo_tag = "v0.13.0"
+pinned_relayer_tag = "8622c0c"
+pinned_monitor_tag = "8622c0c"
+pinned_solver_tag = "8622c0c"
 
 [node.validator01]
 [node.validator02]


### PR DESCRIPTION
Set mainnet magellan upgrade height. 

Also bump mainnet pins.

issue: none