### PR TITLE
chore(solver): improve logs and tracing

### DIFF
--- a/solver/app/check_internal_test.go
+++ b/solver/app/check_internal_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -58,11 +59,14 @@ func TestCheck(t *testing.T) {
 
 			require.Equal(t, http.StatusOK, rr.Code)
 
-			var res types.CheckResponse
-			err = json.NewDecoder(rr.Body).Decode(&res)
+			respBody, err := io.ReadAll(rr.Body)
 			require.NoError(t, err)
 
-			t.Logf("res: %+v", res)
+			var res types.CheckResponse
+			err = json.Unmarshal(respBody, &res)
+			require.NoError(t, err)
+
+			t.Logf("resp_body: %s", respBody)
 
 			require.Equal(t, tt.res.Rejected, res.Rejected)
 			require.Equal(t, tt.res.RejectReason, res.RejectReason)

--- a/solver/app/quote_internal_test.go
+++ b/solver/app/quote_internal_test.go
@@ -27,7 +27,7 @@ func TestQuote(t *testing.T) {
 		name   string
 		req    types.QuoteRequest
 		res    types.QuoteResponse
-		expErr *JSONErrorResponse
+		expErr *types.JSONErrorResponse
 	}{
 		{
 			name: "quote deposit 1 eth expense",
@@ -104,7 +104,7 @@ func TestQuote(t *testing.T) {
 				Deposit:            zeroAddrAmt,
 				Expense:            zeroAddrAmt,
 			},
-			expErr: &JSONErrorResponse{
+			expErr: &types.JSONErrorResponse{
 				Code:    http.StatusBadRequest,
 				Status:  http.StatusText(http.StatusBadRequest),
 				Message: "deposit and expense amount cannot be both zero or both non-zero",
@@ -118,7 +118,7 @@ func TestQuote(t *testing.T) {
 				Deposit:            mockAddrAmt("1000000000000000000"),
 				Expense:            mockAddrAmt("1000000000000000000"),
 			},
-			expErr: &JSONErrorResponse{
+			expErr: &types.JSONErrorResponse{
 				Code:    http.StatusBadRequest,
 				Status:  http.StatusText(http.StatusBadRequest),
 				Message: "deposit and expense amount cannot be both zero or both non-zero",
@@ -132,7 +132,7 @@ func TestQuote(t *testing.T) {
 				Deposit:            types.AddrAmt{Token: common.HexToAddress("0x1234")},
 				Expense:            mockAddrAmt("1000000000000000000"),
 			},
-			expErr: &JSONErrorResponse{
+			expErr: &types.JSONErrorResponse{
 				Code:    http.StatusNotFound,
 				Status:  http.StatusText(http.StatusNotFound),
 				Message: "unsupported deposit token",
@@ -146,7 +146,7 @@ func TestQuote(t *testing.T) {
 				Deposit:            mockAddrAmt("1000000000000000000"),
 				Expense:            types.AddrAmt{Token: common.HexToAddress("0x1234")},
 			},
-			expErr: &JSONErrorResponse{
+			expErr: &types.JSONErrorResponse{
 				Code:    http.StatusNotFound,
 				Status:  http.StatusText(http.StatusNotFound),
 				Message: "unsupported expense token",
@@ -160,7 +160,7 @@ func TestQuote(t *testing.T) {
 				Deposit:            zeroAddrAmt,
 				Expense:            mockAddrAmt("1000000000000000000"),
 			},
-			expErr: &JSONErrorResponse{
+			expErr: &types.JSONErrorResponse{
 				Code:    http.StatusBadRequest,
 				Status:  http.StatusText(http.StatusBadRequest),
 				Message: "InvalidDeposit: deposit token must match expense token",
@@ -174,7 +174,7 @@ func TestQuote(t *testing.T) {
 				Deposit:            mockAddrAmt("1000000000000000000"),
 				Expense:            zeroAddrAmt,
 			},
-			expErr: &JSONErrorResponse{
+			expErr: &types.JSONErrorResponse{
 				Code:    http.StatusBadRequest,
 				Status:  http.StatusText(http.StatusBadRequest),
 				Message: "InvalidDeposit: deposit and expense must be of the same chain class (e.g. mainnet, testnet)",
@@ -194,9 +194,10 @@ func TestQuote(t *testing.T) {
 		rr := httptest.NewRecorder()
 		handler.ServeHTTP(rr, req)
 
+		// Response is either a QuoteResponse or a JSONErrorResponse
 		var res struct {
 			types.QuoteResponse
-			JSONErrorResponse
+			types.JSONErrorResponse
 		}
 		require.NoError(t, json.NewDecoder(rr.Body).Decode(&res))
 		if rr.Code != http.StatusOK {

--- a/solver/app/types.go
+++ b/solver/app/types.go
@@ -75,5 +75,12 @@ func validateResolved(o OrderResolved) error {
 }
 
 func (o Order) ParsedFillOriginData() (FillOriginData, error) {
-	return solvernet.ParseFillOriginData(o.FillOriginData)
+	resp, err := solvernet.ParseFillOriginData(o.FillOriginData)
+	if err != nil {
+		return FillOriginData{}, errors.Wrap(err, "parse fill origin data")
+	} else if len(resp.Calls) == 0 {
+		return FillOriginData{}, errors.New("no calls in fill origin data")
+	}
+
+	return resp, nil
 }


### PR DESCRIPTION
Improve solver logs and metrics:
 - Best effort target names `ERC20:<Symbol>` and `Native:<Symbol>`
 - Skip instrumenting `/api/v1/contracts` since it returns static data
 - Reduce call debug logs to single line (noisy)
 - Add tracing of API requests.
 
Also:
 - Remove remaining type aliases (more canonical go)

issue: #3199 