### PR TITLE
ci(e2e): enable backwards ci

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -89,7 +89,7 @@ devnet-clean: ## Deletes devnet containers (MANIFEST=devnet1 by default)
 .PHONY: e2e-ci
 e2e-ci: ## Runs all e2e CI tests
 	@go install github.com/omni-network/omni/e2e
-	@cd e2e && ./run-multiple.sh manifests/devnet1.toml manifests/devnet2.toml manifests/fuzzyhead.toml manifests/ci.toml
+	@cd e2e && ./run-multiple.sh manifests/devnet1.toml manifests/devnet2.toml manifests/fuzzyhead.toml manifests/ci.toml manifests/backwards.toml
 
 .PHONY: e2e-run
 e2e-run: ## Run specific e2e manifest (MANIFEST=single, MANIFEST=devnet1, etc). `export RUN_ARGS='--preserve'` for containers remain running after the test.

--- a/e2e/manifests/backwards.toml
+++ b/e2e/manifests/backwards.toml
@@ -3,6 +3,7 @@ network = "devnet"
 anvil_chains = ["mock_l1", "mock_l2"]
 
 multi_omni_evms = true
+ephemeral_genesis = "1_uluwatu"
 
 [node.validator01]
 [node.validator02]


### PR DESCRIPTION
Enables the `backwards.toml` now that `v0.13.0` has been released, this ensures that `main` stays backwards compatible with `v0.13.0`, the first version that supports `magellan` upgrade.

issue: none