### PR TITLE
ci(solver): enable tracing on solver

### DIFF
--- a/e2e/app/setup.go
+++ b/e2e/app/setup.go
@@ -551,7 +551,8 @@ func writeSolverConfig(ctx context.Context, def Definition, logCfg log.Config) e
 	solverCfg.LoadGenPrivKey = loadGenKeyFile
 	solverCfg.Network = def.Testnet.Network
 	solverCfg.RPCEndpoints = endpoints
-	solverCfg.FeatureFlags = def.Manifest.FeatureFlags
+	solverCfg.Tracer.Endpoint = def.Cfg.TracingEndpoint
+	solverCfg.Tracer.Headers = def.Cfg.TracingHeaders
 
 	if err := solverapp.WriteConfigTOML(solverCfg, logCfg, filepath.Join(confRoot, configFile)); err != nil {
 		return errors.Wrap(err, "write solver config")

--- a/e2e/solve/order_tracker.go
+++ b/e2e/solve/order_tracker.go
@@ -8,14 +8,15 @@ import (
 )
 
 type orderKey struct {
-	id         solvernet.OrderID
+	orderID    solvernet.OrderID
 	srcChainID uint64
 }
 
 type orderTracker struct {
-	mu     sync.Mutex
-	orders map[orderKey]TestOrder
-	status map[orderKey]solvernet.OrderStatus
+	mu      sync.Mutex
+	orders  map[orderKey]TestOrder
+	status  map[orderKey]solvernet.OrderStatus
+	tracked bool // tracked indicates when orders have been tracked. This prevents accidental misuse of the orderTracker API.
 }
 
 func newOrderTracker() *orderTracker {
@@ -25,23 +26,40 @@ func newOrderTracker() *orderTracker {
 	}
 }
 
-func (t *orderTracker) add(id solvernet.OrderID, order TestOrder) {
+func (t *orderTracker) TrackOrder(id solvernet.OrderID, order TestOrder) {
 	t.mu.Lock()
 	defer t.mu.Unlock()
-	key := orderKey{id: id, srcChainID: order.SourceChainID}
+	if t.tracked {
+		panic("all orders already tracked [BUG]")
+	}
+
+	key := orderKey{orderID: id, srcChainID: order.SourceChainID}
 	t.orders[key] = order
 }
 
-func (t *orderTracker) setStatus(id solvernet.OrderID, srcChainID uint64, status solvernet.OrderStatus) {
+func (t *orderTracker) AllTracked() {
 	t.mu.Lock()
 	defer t.mu.Unlock()
-	key := orderKey{id: id, srcChainID: srcChainID}
+	if t.tracked {
+		panic("all orders already tracked [BUG]")
+	}
+	t.tracked = true
+}
+
+func (t *orderTracker) UpdateStatus(id solvernet.OrderID, srcChainID uint64, status solvernet.OrderStatus) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	key := orderKey{orderID: id, srcChainID: srcChainID}
 	t.status[key] = status
 }
 
-func (t *orderTracker) done() (bool, error) {
+func (t *orderTracker) Done() (bool, error) {
 	t.mu.Lock()
 	defer t.mu.Unlock()
+
+	if !t.tracked {
+		return false, errors.New("not all orders tracked [BUG]")
+	}
 
 	for key, order := range t.orders {
 		status, ok := t.status[key]
@@ -51,7 +69,7 @@ func (t *orderTracker) done() (bool, error) {
 
 		if order.ShouldReject {
 			if status == solvernet.StatusFilled || status == solvernet.StatusClaimed {
-				return false, errors.New("order should have been rejected", "id", key.id, "src_chain_id", key.srcChainID, "status", status)
+				return false, errors.New("order should have been rejected", "order_id", key.orderID, "src_chain_id", key.srcChainID, "status", status)
 			}
 
 			if status != solvernet.StatusRejected {
@@ -61,7 +79,7 @@ func (t *orderTracker) done() (bool, error) {
 
 		if !order.ShouldReject {
 			if status == solvernet.StatusRejected {
-				return false, errors.New("order should have been filled", "id", key.id, "src_chain_id", key.srcChainID, "status", status)
+				return false, errors.New("order should have been filled", "order_id", key.orderID, "src_chain_id", key.srcChainID, "status", status)
 			}
 
 			if status != solvernet.StatusClaimed {

--- a/solver/app/app.go
+++ b/solver/app/app.go
@@ -18,6 +18,7 @@ import (
 	"github.com/omni-network/omni/lib/expbackoff"
 	"github.com/omni-network/omni/lib/log"
 	"github.com/omni-network/omni/lib/netconf"
+	"github.com/omni-network/omni/lib/tracer"
 	"github.com/omni-network/omni/lib/umath"
 	"github.com/omni-network/omni/lib/xchain"
 	xprovider "github.com/omni-network/omni/lib/xchain/provider"
@@ -44,6 +45,13 @@ func Run(ctx context.Context, cfg Config) error {
 	log.Info(ctx, "Starting solver service")
 
 	buildinfo.Instrument(ctx)
+
+	tracerID := tracer.Identifiers{Network: cfg.Network, Service: "solver"}
+	stopTracer, err := tracer.Init(ctx, tracerID, cfg.Tracer)
+	if err != nil {
+		return err
+	}
+	defer stopTracer(ctx) //nolint:errcheck // Tracing shutdown errors not critical
 
 	// Start monitoring first, so app is "up"
 	monitorChan := serveMonitoring(cfg.MonitoringAddr)

--- a/solver/app/config.go
+++ b/solver/app/config.go
@@ -6,9 +6,9 @@ import (
 
 	"github.com/omni-network/omni/lib/buildinfo"
 	"github.com/omni-network/omni/lib/errors"
-	"github.com/omni-network/omni/lib/feature"
 	"github.com/omni-network/omni/lib/log"
 	"github.com/omni-network/omni/lib/netconf"
+	"github.com/omni-network/omni/lib/tracer"
 	"github.com/omni-network/omni/lib/xchain"
 
 	cmtos "github.com/cometbft/cometbft/libs/os"
@@ -24,7 +24,7 @@ type Config struct {
 	SolverPrivKey  string
 	LoadGenPrivKey string
 	DBDir          string
-	FeatureFlags   feature.Flags
+	Tracer         tracer.Config
 }
 
 func DefaultConfig() Config {
@@ -33,7 +33,6 @@ func DefaultConfig() Config {
 		MonitoringAddr: ":26660",
 		APIAddr:        ":26661",
 		DBDir:          "./db",
-		FeatureFlags:   feature.Flags{}, // Zero enabled flags by default (note not nil).
 	}
 }
 

--- a/solver/app/config.toml.tmpl
+++ b/solver/app/config.toml.tmpl
@@ -8,9 +8,6 @@ version = "{{ .Version}}"
 # Omni network to participate in: mainnet, testnet, or devnet.
 network = "{{ .Network }}"
 
-{{ if .FeatureFlags }}feature-flags = {{ .FeatureFlags.FormatToml }}
-{{ end -}}
-
 #######################################################################
 ###                         Solver Options                          ###
 #######################################################################
@@ -58,3 +55,10 @@ format = "{{ .Log.Format }}"
 
 # Logging color if console format is chosen. Options are: auto, force, disable.
 color = "{{ .Log.Color }}"
+
+[tracing]
+# Open Telemetry OTLP endpoint URL. See https://pkg.go.dev/go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp.
+endpoint = "{{ .Tracer.Endpoint }}"
+
+# Open Telemetry OTLP headers. See https://grafana.com/docs/grafana-cloud/monitor-applications/application-observability/setup/quickstart/go/.
+headers = "{{ .Tracer.Headers }}"

--- a/solver/app/config_test.go
+++ b/solver/app/config_test.go
@@ -20,6 +20,7 @@ func TestDefaultConfigReference(t *testing.T) {
 
 	cfg := solver.DefaultConfig()
 	cfg.LoadGenPrivKey = "loadgen.key"
+	cfg.Tracer.Endpoint = "http://localhost:1234"
 
 	path := filepath.Join(tempDir, "solver.toml")
 

--- a/solver/app/testdata/default_solver.toml
+++ b/solver/app/testdata/default_solver.toml
@@ -51,3 +51,10 @@ format = "console"
 
 # Logging color if console format is chosen. Options are: auto, force, disable.
 color = "auto"
+
+[tracing]
+# Open Telemetry OTLP endpoint URL. See https://pkg.go.dev/go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp.
+endpoint = "http://localhost:1234"
+
+# Open Telemetry OTLP headers. See https://grafana.com/docs/grafana-cloud/monitor-applications/application-observability/setup/quickstart/go/.
+headers = ""

--- a/solver/cmd/flags.go
+++ b/solver/cmd/flags.go
@@ -1,8 +1,8 @@
 package cmd
 
 import (
-	"github.com/omni-network/omni/lib/feature"
 	"github.com/omni-network/omni/lib/netconf"
+	"github.com/omni-network/omni/lib/tracer"
 	"github.com/omni-network/omni/lib/xchain"
 	solver "github.com/omni-network/omni/solver/app"
 
@@ -12,7 +12,7 @@ import (
 func bindRunFlags(flags *pflag.FlagSet, cfg *solver.Config) {
 	netconf.BindFlag(flags, &cfg.Network)
 	xchain.BindFlags(flags, &cfg.RPCEndpoints)
-	feature.BindFlag(flags, &cfg.FeatureFlags)
+	tracer.BindFlags(flags, &cfg.Tracer)
 	flags.StringVar(&cfg.SolverPrivKey, "private-key", cfg.SolverPrivKey, "The path to the solver private key e.g path/private.key")
 	flags.StringVar(&cfg.LoadGenPrivKey, "loadgen-key", cfg.LoadGenPrivKey, "The path to the loadgen private key e.g path/loadgen.key (not applicable to protected networks)")
 	flags.StringVar(&cfg.MonitoringAddr, "monitoring-addr", cfg.MonitoringAddr, "The address to bind the monitoring server")


### PR DESCRIPTION
Configure and enable tracing on `solver`.

Also improve logging and testing a bit. Align naming to `order_id`. Ensure orders are not added to tracker after checking for done starts.

issue: #3199 