### PR TITLE
chore(lib/netconf): fix omega relayer/monitor

### DIFF
--- a/lib/netconf/provider.go
+++ b/lib/netconf/provider.go
@@ -120,6 +120,12 @@ func AwaitOnConsensusChain(ctx context.Context, netID ID, cprov cchain.Provider,
 
 // containsAll returns true if the network contains the all expected chains (by name or ID).
 func containsAll(network Network, expected []string) bool {
+	if network.ID != Devnet {
+		// Only wait for expected chains on devnet.
+		// Since portal registration already done on other networks.
+		return true
+	}
+
 	want := make(map[string]struct{}, len(expected))
 	for _, name := range expected {
 		want[name] = struct{}{}


### PR DESCRIPTION
Omega relayer/monitor is crashlooping with the error after disabling holesky.
```
Execution registry doesn't contain all eactual=map[164:omni_evm 84532:base_sepolia 421614:arb_sepolia 1000164:omni_consensus 11155420:op_sepolia] expected=[holesky omni_consensus omni_evm op_sepolia arb_sepolia base_sepolia] 
```
This disables that logic for all non-devnet networks.

issue: none
