### PR TITLE
ci(e2e): bump omega to fix holesky disable

### DIFF
--- a/e2e/manifests/omega.toml
+++ b/e2e/manifests/omega.toml
@@ -4,11 +4,11 @@ public_chains = ["holesky","op_sepolia", "base_sepolia","arb_sepolia"]
 multi_omni_evms = true
 prometheus = true
 
-# c9b8f2c disables holesky
-pinned_halo_tag = "c9b8f2c"
-pinned_relayer_tag = "c9b8f2c"
-pinned_monitor_tag = "c9b8f2c"
-pinned_solver_tag = "c9b8f2c"
+# 3e4a9f8 disables holesky
+pinned_halo_tag = "3e4a9f8"
+pinned_relayer_tag = "3e4a9f8"
+pinned_monitor_tag = "3e4a9f8"
+pinned_solver_tag = "3e4a9f8"
 
 [node.validator01]
 [node.validator02]


### PR DESCRIPTION
Bump omega images to include fix required after disabling holesky.

issue: none
