### PR TITLE
refactor(contracts/solvernet): remove slice types

### DIFF
--- a/e2e/solve/test.go
+++ b/e2e/solve/test.go
@@ -33,8 +33,8 @@ type TestOrder struct {
 	FillDeadline  time.Time
 	DestChainID   uint64
 	SourceChainID uint64
-	Expenses      solvernet.Expenses
-	Calls         solvernet.Calls
+	Expenses      []solvernet.Expense
+	Calls         []solvernet.Call
 	Deposit       solvernet.Deposit
 	ShouldReject  bool
 	RejectReason  string
@@ -395,8 +395,8 @@ func openAll(ctx context.Context, backends ethbackend.Backends, orders []TestOrd
 func openOrder(ctx context.Context, backends ethbackend.Backends, order TestOrder) ([32]byte, error) {
 	return solvernet.OpenOrder(ctx, netconf.Devnet, order.SourceChainID, backends, order.Owner, bindings.SolverNetOrderData{
 		DestChainId: order.DestChainID,
-		Expenses:    order.Expenses.NoNative(),
-		Calls:       order.Calls.ToBindings(),
+		Expenses:    solvernet.FilterNativeExpenses(order.Expenses),
+		Calls:       solvernet.CallsToBindings(order.Calls),
 		Deposit:     order.Deposit,
 	}, solvernet.WithFillDeadline(order.FillDeadline))
 }

--- a/e2e/solve/testutil.go
+++ b/e2e/solve/testutil.go
@@ -62,15 +62,15 @@ func contractCallWithInvalidCallData() []solvernet.Call {
 	}}
 }
 
-func nativeExpense(amt *big.Int) solvernet.Expenses {
+func nativeExpense(amt *big.Int) []solvernet.Expense {
 	return []solvernet.Expense{{Amount: amt}}
 }
 
-func unsupportedExpense(amt *big.Int) solvernet.Expenses {
+func unsupportedExpense(amt *big.Int) []solvernet.Expense {
 	return []solvernet.Expense{{Amount: amt, Token: invalidTokenAddress}}
 }
 
-func invalidExpense() solvernet.Expenses {
+func invalidExpense() []solvernet.Expense {
 	return nativeExpense(big.NewInt(params.Ether))
 }
 
@@ -148,7 +148,7 @@ func addrAmtFromDeposit(d solvernet.Deposit) solver.AddrAmt {
 	return solver.AddrAmt{Token: d.Token, Amount: d.Amount}
 }
 
-func callsFromBindings(calls solvernet.Calls) []solver.Call {
+func callsFromBindings(calls []solvernet.Call) []solver.Call {
 	var resp []solver.Call
 	for _, c := range calls {
 		resp = append(resp, solver.Call(c))
@@ -157,7 +157,7 @@ func callsFromBindings(calls solvernet.Calls) []solver.Call {
 	return resp
 }
 
-func expensesFromBindings(expenses solvernet.Expenses) []solver.Expense {
+func expensesFromBindings(expenses []solvernet.Expense) []solver.Expense {
 	var resp []solver.Expense
 	for _, e := range expenses {
 		resp = append(resp, solver.Expense(e))

--- a/lib/contracts/solvernet/types_test.go
+++ b/lib/contracts/solvernet/types_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/params"
 
 	"github.com/stretchr/testify/require"
 )
@@ -15,7 +16,7 @@ import (
 func TestCallBindings(t *testing.T) {
 	t.Parallel()
 
-	calls := solvernet.Calls{
+	calls := []solvernet.Call{
 		{
 			Value:  ether(1),
 			Target: common.HexToAddress("0x36e66fbbce51e4cd5bd3c62b637eb411b18949d4"),
@@ -42,7 +43,7 @@ func TestCallBindings(t *testing.T) {
 		},
 	}
 
-	bindings := calls.ToBindings()
+	bindings := solvernet.CallsToBindings(calls)
 
 	require.Len(t, bindings, 4)
 
@@ -72,5 +73,5 @@ func TestCallBindings(t *testing.T) {
 }
 
 func ether(x int64) *big.Int {
-	return new(big.Int).Mul(big.NewInt(x), big.NewInt(1e18))
+	return new(big.Int).Mul(big.NewInt(x), big.NewInt(params.Ether))
 }

--- a/monitor/flowgen/bridging/bridging.go
+++ b/monitor/flowgen/bridging/bridging.go
@@ -73,13 +73,13 @@ func orderData(
 			Token:  depositWithFee.Token.Address,
 			Amount: depositWithFee.Amount,
 		},
-		Calls: solvernet.Calls{
+		Expenses: []solvernet.Expense{},
+		Calls: []bindings.SolverNetCall{
 			{
 				Target: owner,
 				Value:  expense.Amount,
-				Data:   nil,
 			},
-		}.ToBindings(),
+		},
 	}
 
 	return orderData, nil

--- a/solver/app/check.go
+++ b/solver/app/check.go
@@ -98,8 +98,8 @@ func getFillOriginData(req types.CheckRequest) ([]byte, error) {
 		FillDeadline: req.FillDeadline,
 		SrcChainId:   req.SourceChainID,
 		DestChainId:  req.DestinationChainID,
-		Expenses:     types.ExpensesToBindings(req.Expenses).NoNative(),
-		Calls:        types.CallsToBindings(req.Calls).ToBindings(),
+		Expenses:     solvernet.FilterNativeExpenses(types.ExpensesToBindings(req.Expenses)),
+		Calls:        types.CallsToBindings(req.Calls),
 	}
 
 	fillOriginDataBz, err := solvernet.PackFillOriginData(fillOriginData)

--- a/solver/types/api.go
+++ b/solver/types/api.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"math/big"
 
+	"github.com/omni-network/omni/contracts/bindings"
 	"github.com/omni-network/omni/lib/contracts/solvernet"
 	"github.com/omni-network/omni/lib/errors"
 
@@ -186,17 +187,17 @@ func unmarshal(bz []byte, v any) error {
 	return nil
 }
 
-func CallsToBindings(calls []Call) solvernet.Calls {
-	var resp solvernet.Calls
+func CallsToBindings(calls []Call) []bindings.SolverNetCall {
+	var resp []bindings.SolverNetCall
 	for _, c := range calls {
-		resp = append(resp, solvernet.Call(c))
+		resp = append(resp, solvernet.Call(c).ToBinding())
 	}
 
 	return resp
 }
 
-func ExpensesToBindings(expenses []Expense) solvernet.Expenses {
-	var resp solvernet.Expenses
+func ExpensesToBindings(expenses []Expense) []solvernet.Expense {
+	var resp []solvernet.Expense
 	for _, e := range expenses {
 		resp = append(resp, solvernet.Expense(e))
 	}


### PR DESCRIPTION
Remove the use of slice types `solvernet.Calls` and `solvernet.Expenses`.

Reasoning:
 - Slice types isn't canonical go
 - It results in OOP style code and logic
 - Since we have multiple layers of types: `solver/types.Call` embeds `solvernet.Call` aliases `bindings.SolverNetCall`
 - It is much simpler to work since slice of those types, instead of having to create the same structure for the slice types as well.
 - less types is simpler to reason about and work with (but slightly more verbose).

issue: none