### PR TITLE
chore(e2e/app): increase go test timeout to 2m

### DIFF
--- a/e2e/app/test.go
+++ b/e2e/app/test.go
@@ -77,7 +77,7 @@ func Test(ctx context.Context, def Definition, cfg TestConfig) error {
 		strings.ToLower(EnvE2ERPCEndpoints), endpointsFile,
 	)
 
-	args := []string{"go", "test", "-timeout", "60s", "-count", "1"}
+	args := []string{"go", "test", "-timeout", "120s", "-count", "1"}
 	if cfg.Verbose {
 		args = append(args, "-v")
 	}


### PR DESCRIPTION
increase e2e go test command timeout to 2 min due to almost reaching the previous limit of 1 min

issue: none
