### PR TITLE
chore(solver): replace mock OMNI tokens

### DIFF
--- a/solver/app/testdata/TestTokens.golden
+++ b/solver/app/testdata/TestTokens.golden
@@ -240,7 +240,7 @@
   "symbol": "wstETH"
  },
  {
-  "address": "0xb8f8d179270FFe7C6C5766819DCD6a8b76f8403b",
+  "address": "0xe4075366F03C286846dECE8AAF104cF2a542294d",
   "chainId": 84532,
   "coingeckoId": "omni-network",
   "isMock": true,
@@ -250,7 +250,7 @@
   "symbol": "OMNI"
  },
  {
-  "address": "0x87590BBeEC6ec190d1af7D88d90a16585dF48fFC",
+  "address": "0x0b3AED256a51919b660fF79a280A309EecA9d688",
   "chainId": 11155420,
   "coingeckoId": "omni-network",
   "isMock": true,
@@ -260,7 +260,7 @@
   "symbol": "OMNI"
  },
  {
-  "address": "0x0DE57e38bF1FC27E6C228F15041a0e590586A3ee",
+  "address": "0xd859f9Ff3C9700fB623Dc8e76217ba2a9f8613F0",
   "chainId": 421614,
   "coingeckoId": "omni-network",
   "isMock": true,

--- a/solver/app/tokens.go
+++ b/solver/app/tokens.go
@@ -208,9 +208,9 @@ func mocks() []Token {
 
 	// Add manually deployed tokens that aren't part of the automatic mock deployment
 	tkns = append(tkns,
-		mockOMNI(evmchain.IDBaseSepolia, common.HexToAddress("0xb8f8d179270FFe7C6C5766819DCD6a8b76f8403b")),
-		mockOMNI(evmchain.IDOpSepolia, common.HexToAddress("0x87590BBeEC6ec190d1af7D88d90a16585dF48fFC")),
-		mockOMNI(evmchain.IDArbSepolia, common.HexToAddress("0x0DE57e38bF1FC27E6C228F15041a0e590586A3ee")),
+		mockOMNI(evmchain.IDBaseSepolia, common.HexToAddress("0xe4075366F03C286846dECE8AAF104cF2a542294d")),
+		mockOMNI(evmchain.IDOpSepolia, common.HexToAddress("0x0b3AED256a51919b660fF79a280A309EecA9d688")),
+		mockOMNI(evmchain.IDArbSepolia, common.HexToAddress("0xd859f9Ff3C9700fB623Dc8e76217ba2a9f8613F0")),
 	)
 
 	return tkns


### PR DESCRIPTION
The old mock OMNI tokens I deployed can no longer be verified due to updated foundry configs. Replacing them with new mocks I have verified.

issue: none