### PR TITLE
chore(e2e): update omega solver pin

### DIFF
--- a/e2e/manifests/omega.toml
+++ b/e2e/manifests/omega.toml
@@ -8,7 +8,7 @@ prometheus = true
 pinned_halo_tag = "3e4a9f8"
 pinned_relayer_tag = "3e4a9f8"
 pinned_monitor_tag = "3e4a9f8"
-pinned_solver_tag = "3e4a9f8"
+pinned_solver_tag = "fbcba5a"
 
 [node.validator01]
 [node.validator02]


### PR DESCRIPTION
Updating omega solver pinned version to get updated mock token addresses in.

issue: none