### PR TITLE
test(e2e/solve): tests covering missing branches

### DIFF
--- a/e2e/solve/test.go
+++ b/e2e/solve/test.go
@@ -60,6 +60,10 @@ func isInsufficientInventory(o TestOrder) bool {
 	return o.RejectReason == solver.RejectInsufficientInventory.String()
 }
 
+func isInvalidExpense(o TestOrder) bool {
+	return o.RejectReason == solver.RejectInvalidExpense.String()
+}
+
 func Test(ctx context.Context, network netconf.Network, endpoints xchain.RPCEndpoints) error {
 	if network.ID != netconf.Devnet {
 		return errors.New("only devnet")
@@ -205,7 +209,7 @@ func makeOrders() []TestOrder {
 			DestChainID:   evmchain.IDMockL1,
 			Expenses:      nativeExpense(requestAmt),
 			Calls:         nativeTransferCall(requestAmt, user),
-			Deposit:       unsupportedDeposit(depositAmt),
+			Deposit:       unsupportedERC20Deposit(depositAmt),
 			ShouldReject:  true,
 			RejectReason:  solver.RejectUnsupportedDeposit.String(),
 		})
@@ -311,9 +315,34 @@ func makeOrders() []TestOrder {
 		FillDeadline:  time.Now().Add(1 * time.Hour),
 		SourceChainID: evmchain.IDMockL1,
 		DestChainID:   evmchain.IDMockL2,
-		Expenses:      invalidExpense(),
+		Expenses:      invalidExpenseOutOfBounds(),
 		Calls:         nativeTransferCall(big.NewInt(1), users[0]),
 		Deposit:       erc20Deposit(big.NewInt(1), addrs.Token),
+		ShouldReject:  true,
+		RejectReason:  solver.RejectInvalidExpense.String(),
+	})
+
+	// invalid expense with multiple native expenses
+	orders = append(orders, TestOrder{
+		Owner:         users[0],
+		FillDeadline:  time.Now().Add(1 * time.Hour),
+		SourceChainID: evmchain.IDMockL1,
+		DestChainID:   evmchain.IDMockL2,
+		Expenses:      multipleNativeExpenses(validETHSpend),
+		Calls:         nativeTransferCall(validETHSpend, users[0]),
+		Deposit:       nativeDeposit(maxETHSpend),
+		ShouldReject:  true,
+		RejectReason:  solver.RejectInvalidExpense.String(),
+	})
+
+	// invalid expense with multiple ERC20 expenses
+	orders = append(orders, TestOrder{
+		Owner:         users[0],
+		FillDeadline:  time.Now().Add(1 * time.Hour),
+		SourceChainID: evmchain.IDMockL2,
+		DestChainID:   evmchain.IDMockL1,
+		Expenses:      multipleERC20Expenses(validETHSpend),
+		Deposit:       nativeDeposit(maxETHSpend),
 		ShouldReject:  true,
 		RejectReason:  solver.RejectInvalidExpense.String(),
 	})
@@ -367,7 +396,7 @@ func openAll(ctx context.Context, backends ethbackend.Backends, orders []TestOrd
 	var eg errgroup.Group
 	for _, order := range orders {
 		eg.Go(func() error {
-			if isSrcChainInvalid(order) || isDepositTokenInvalid(order) || srcAndDestChainAreSame(order) || isInsufficientInventory(order) {
+			if isInvalidExpense(order) || isSrcChainInvalid(order) || isDepositTokenInvalid(order) || srcAndDestChainAreSame(order) || isInsufficientInventory(order) {
 				return nil
 			}
 
@@ -436,7 +465,6 @@ func testCheckAPI(ctx context.Context, backends ethbackend.Backends, orders []Te
 		if err != nil {
 			return errors.Wrap(err, "do request")
 		}
-
 		if resp.StatusCode != http.StatusOK {
 			return errors.New("bad status", "status", resp.StatusCode)
 		}

--- a/e2e/solve/testutil.go
+++ b/e2e/solve/testutil.go
@@ -66,15 +66,23 @@ func nativeExpense(amt *big.Int) []solvernet.Expense {
 	return []solvernet.Expense{{Amount: amt}}
 }
 
+func multipleNativeExpenses(amt *big.Int) []solvernet.Expense {
+	return []solvernet.Expense{{Amount: amt}, {Amount: amt}}
+}
+
+func multipleERC20Expenses(amt *big.Int) []solvernet.Expense {
+	return []solvernet.Expense{{Amount: amt, Token: addrs.Token}, {Amount: amt, Token: addrs.Token}}
+}
+
 func unsupportedExpense(amt *big.Int) []solvernet.Expense {
 	return []solvernet.Expense{{Amount: amt, Token: invalidTokenAddress}}
 }
 
-func invalidExpense() []solvernet.Expense {
+func invalidExpenseOutOfBounds() []solvernet.Expense {
 	return nativeExpense(big.NewInt(params.Ether))
 }
 
-func unsupportedDeposit(amt *big.Int) solvernet.Deposit {
+func unsupportedERC20Deposit(amt *big.Int) solvernet.Deposit {
 	return solvernet.Deposit{Amount: amt, Token: invalidTokenAddress}
 }
 


### PR DESCRIPTION
Test orders for missing branches:
- Reject with `InvalidExpense` due to multiple native expenses.
- Reject with `InvalidExpense` due to multiple ERC20 expenses.

issue: #3177 
