### PR TITLE
ci(e2e): add coingecko api key to relayer and solver

### DIFF
--- a/e2e/vmcompose/provider.go
+++ b/e2e/vmcompose/provider.go
@@ -202,7 +202,6 @@ func (p *Provider) Upgrade(ctx context.Context, cfg types.ServiceConfig) error {
 	addFile("monitor", "flowgen_privatekey")
 	addFile("solver", "solver.toml")
 	addFile("solver", "privatekey")
-	addFile("solver", "loadgenkey")
 
 	// Do initial sequential ssh to each VM, ensure we can connect.
 	for vmName, instance := range p.Data.VMs {

--- a/relayer/app/app.go
+++ b/relayer/app/app.go
@@ -62,7 +62,7 @@ func Run(ctx context.Context, cfg Config) error {
 
 	xprov := xprovider.New(network, rpcClientPerChain, cprov)
 
-	pricer := newTokenPricer(ctx)
+	pricer := newTokenPricer(ctx, cfg.CoinGeckoAPIKey)
 	pnl := newPnlLogger(network.ID, pricer)
 
 	db, err := initializeDB(ctx, cfg)

--- a/relayer/app/config.go
+++ b/relayer/app/config.go
@@ -16,13 +16,14 @@ import (
 )
 
 type Config struct {
-	RPCEndpoints   xchain.RPCEndpoints
-	PrivateKey     string
-	HaloCometURL   string
-	HaloGRPCURL    string
-	Network        netconf.ID
-	MonitoringAddr string
-	DBDir          string
+	RPCEndpoints    xchain.RPCEndpoints
+	PrivateKey      string
+	HaloCometURL    string
+	HaloGRPCURL     string
+	Network         netconf.ID
+	MonitoringAddr  string
+	DBDir           string
+	CoinGeckoAPIKey string
 }
 
 func DefaultConfig() Config {

--- a/relayer/app/config.toml.tmpl
+++ b/relayer/app/config.toml.tmpl
@@ -21,6 +21,9 @@ halo-url = "{{ .HaloCometURL }}"
 # The gRPC URL of the halo node to connect to.
 halo-grpc-url = "{{ .HaloGRPCURL }}"
 
+# The CoinGecko API key to use for fetching token prices.
+coingecko-apikey = "{{ .CoinGeckoAPIKey }}"
+
 #######################################################################
 ###                             X-Chain                             ###
 #######################################################################

--- a/relayer/app/config_test.go
+++ b/relayer/app/config_test.go
@@ -20,6 +20,7 @@ func TestDefaultConfigReference(t *testing.T) {
 
 	cfg := relayer.DefaultConfig()
 	cfg.HaloGRPCURL = "localhost:9"
+	cfg.CoinGeckoAPIKey = "secret"
 	path := filepath.Join(tempDir, "relayer.toml")
 
 	require.NoError(t, os.MkdirAll(tempDir, 0o755))

--- a/relayer/app/pnl.go
+++ b/relayer/app/pnl.go
@@ -25,11 +25,10 @@ const (
 )
 
 // newTokenPricer creates a new cached pricer with priceCacheEvictInterval.
-func newTokenPricer(ctx context.Context) *tokens.CachedPricer {
-	pricer := tokens.NewCachedPricer(coingecko.New())
+func newTokenPricer(ctx context.Context, cgAPIKey string) tokens.Pricer {
+	pricer := tokens.NewCachedPricer(coingecko.New(coingecko.WithAPIKey(cgAPIKey)))
 
 	// use cached pricer avoid spamming coingecko public api
-	// TODO: use api key
 	go pricer.ClearCacheForever(ctx, priceCacheEvictInterval)
 
 	return pricer

--- a/relayer/app/testdata/default_relayer.toml
+++ b/relayer/app/testdata/default_relayer.toml
@@ -21,6 +21,9 @@ halo-url = "localhost:26657"
 # The gRPC URL of the halo node to connect to.
 halo-grpc-url = "localhost:9"
 
+# The CoinGecko API key to use for fetching token prices.
+coingecko-apikey = "secret"
+
 #######################################################################
 ###                             X-Chain                             ###
 #######################################################################

--- a/relayer/cmd/flags.go
+++ b/relayer/cmd/flags.go
@@ -16,4 +16,5 @@ func bindRunFlags(flags *pflag.FlagSet, cfg *relayer.Config) {
 	flags.StringVar(&cfg.HaloGRPCURL, "halo-grpc-url", cfg.HaloGRPCURL, "The gRPC URL of the halo node e.g localhost:9999")
 	flags.StringVar(&cfg.MonitoringAddr, "monitoring-addr", cfg.MonitoringAddr, "The address to bind the monitoring server")
 	flags.StringVar(&cfg.DBDir, "db-dir", cfg.DBDir, "The path to the database directory")
+	flags.StringVar(&cfg.CoinGeckoAPIKey, "coingecko-apikey", cfg.CoinGeckoAPIKey, "The CoinGecko API key to use for fetching token prices")
 }

--- a/solver/app/app.go
+++ b/solver/app/app.go
@@ -103,8 +103,6 @@ func Run(ctx context.Context, cfg Config) error {
 		return err
 	}
 
-	// TODO: maybeLoadgen
-
 	xprov := xprovider.New(network, backends.Clients(), nil)
 
 	db, err := newSolverDB(cfg.DBDir)

--- a/solver/app/config.go
+++ b/solver/app/config.go
@@ -17,14 +17,14 @@ import (
 )
 
 type Config struct {
-	RPCEndpoints   xchain.RPCEndpoints
-	Network        netconf.ID
-	MonitoringAddr string
-	APIAddr        string
-	SolverPrivKey  string
-	LoadGenPrivKey string
-	DBDir          string
-	Tracer         tracer.Config
+	RPCEndpoints    xchain.RPCEndpoints
+	Network         netconf.ID
+	MonitoringAddr  string
+	APIAddr         string
+	SolverPrivKey   string
+	DBDir           string
+	Tracer          tracer.Config
+	CoinGeckoAPIKey string
 }
 
 func DefaultConfig() Config {

--- a/solver/app/config.toml.tmpl
+++ b/solver/app/config.toml.tmpl
@@ -15,14 +15,15 @@ network = "{{ .Network }}"
 # Path to the ethereum private key used to for inbox and outbox request state transitions.
 private-key = "{{ .SolverPrivKey }}"
 
-# Path to the ethereum private key used to generate deposit load on ephemeral networks only.
-loadgen-key = "{{ .LoadGenPrivKey }}"
 
 # The address that the solver listens for API requests.
 api-addr = "{{ .APIAddr }}"
 
 # The address that the solver listens for metric scrape requests.
 monitoring-addr = "{{ .MonitoringAddr }}"
+
+# The CoinGecko API key to use for fetching token prices.
+coingecko-apikey = "{{ .CoinGeckoAPIKey }}"
 
 #######################################################################
 ###                             X-Chain                             ###

--- a/solver/app/config_test.go
+++ b/solver/app/config_test.go
@@ -19,8 +19,8 @@ func TestDefaultConfigReference(t *testing.T) {
 	tempDir := t.TempDir()
 
 	cfg := solver.DefaultConfig()
-	cfg.LoadGenPrivKey = "loadgen.key"
 	cfg.Tracer.Endpoint = "http://localhost:1234"
+	cfg.CoinGeckoAPIKey = "secret"
 
 	path := filepath.Join(tempDir, "solver.toml")
 

--- a/solver/app/testdata/default_solver.toml
+++ b/solver/app/testdata/default_solver.toml
@@ -15,14 +15,15 @@ network = ""
 # Path to the ethereum private key used to for inbox and outbox request state transitions.
 private-key = "solver.key"
 
-# Path to the ethereum private key used to generate deposit load on ephemeral networks only.
-loadgen-key = "loadgen.key"
 
 # The address that the solver listens for API requests.
 api-addr = ":26661"
 
 # The address that the solver listens for metric scrape requests.
 monitoring-addr = ":26660"
+
+# The CoinGecko API key to use for fetching token prices.
+coingecko-apikey = "secret"
 
 #######################################################################
 ###                             X-Chain                             ###

--- a/solver/cmd/flags.go
+++ b/solver/cmd/flags.go
@@ -14,8 +14,8 @@ func bindRunFlags(flags *pflag.FlagSet, cfg *solver.Config) {
 	xchain.BindFlags(flags, &cfg.RPCEndpoints)
 	tracer.BindFlags(flags, &cfg.Tracer)
 	flags.StringVar(&cfg.SolverPrivKey, "private-key", cfg.SolverPrivKey, "The path to the solver private key e.g path/private.key")
-	flags.StringVar(&cfg.LoadGenPrivKey, "loadgen-key", cfg.LoadGenPrivKey, "The path to the loadgen private key e.g path/loadgen.key (not applicable to protected networks)")
 	flags.StringVar(&cfg.MonitoringAddr, "monitoring-addr", cfg.MonitoringAddr, "The address to bind the monitoring server")
 	flags.StringVar(&cfg.APIAddr, "api-addr", cfg.APIAddr, "The address to bind the API server")
 	flags.StringVar(&cfg.DBDir, "db-dir", cfg.DBDir, "The path to the database directory")
+	flags.StringVar(&cfg.CoinGeckoAPIKey, "coingecko-apikey", cfg.CoinGeckoAPIKey, "The CoinGecko API key to use for fetching token prices")
 }


### PR DESCRIPTION
Add coingecko API key to relayer and solver. Solver key isn't used yet, will in next PR.

issue: none