### PR TITLE
chore(sdk): more unit tests and enable type tests

### DIFF
--- a/sdk/src/hooks/useDidFill.test-d.ts
+++ b/sdk/src/hooks/useDidFill.test-d.ts
@@ -1,12 +1,22 @@
 import { expectTypeOf, test } from 'vitest'
+import type { UseReadContractReturnType } from 'wagmi'
 import { resolvedOrder } from '../../test/shared.js'
+import type { outboxABI } from '../constants/abis.js'
 import { useDidFill } from './useDidFill.js'
+import type { useParseOpenEvent } from './useParseOpenEvent.js'
 
-test('type: useDidFill return', () => {
+test('type: useDidFill', () => {
   const result = useDidFill({
     destChainId: 1,
     resolvedOrder,
   })
-  // TODO replace return type as it doesnt assert exact type
-  expectTypeOf(result).toEqualTypeOf<ReturnType<typeof useDidFill>>()
+
+  expectTypeOf(useDidFill).parameter(0).toMatchTypeOf<{
+    destChainId: number
+    resolvedOrder?: ReturnType<typeof useParseOpenEvent>['resolvedOrder']
+  }>()
+
+  expectTypeOf(result).toEqualTypeOf<
+    UseReadContractReturnType<typeof outboxABI>
+  >()
 })

--- a/sdk/src/hooks/useGetOrder.test-d.ts
+++ b/sdk/src/hooks/useGetOrder.test-d.ts
@@ -1,0 +1,22 @@
+import type { Hex } from 'viem'
+import { expectTypeOf, test } from 'vitest'
+import type { UseReadContractReturnType } from 'wagmi'
+import { orderId } from '../../test/shared.js'
+import type { inboxABI } from '../constants/abis.js'
+import { useGetOrder } from './useGetOrder.js'
+
+test('type: useGetOrder', () => {
+  const result = useGetOrder({
+    chainId: 1,
+    orderId: orderId,
+  })
+
+  expectTypeOf(useGetOrder).parameter(0).toMatchTypeOf<{
+    chainId?: number
+    orderId?: Hex
+  }>()
+
+  expectTypeOf(result).toEqualTypeOf<
+    UseReadContractReturnType<typeof inboxABI>
+  >()
+})

--- a/sdk/src/hooks/useParseOpenEvent.test-d.ts
+++ b/sdk/src/hooks/useParseOpenEvent.test-d.ts
@@ -1,15 +1,45 @@
+import type { Log } from 'viem'
 import { expectTypeOf, test } from 'vitest'
+import type { UseWaitForTransactionReceiptReturnType } from 'wagmi'
 import type { ParseOpenEventError } from '../errors/base.js'
 import { useParseOpenEvent } from './useParseOpenEvent.js'
+
+type ResolvedOrder = {
+  user: `0x${string}`
+  originChainId: bigint
+  openDeadline: number
+  fillDeadline: number
+  orderId: `0x${string}`
+  maxSpent: readonly {
+    token: `0x${string}`
+    amount: bigint
+    recipient: `0x${string}`
+    chainId: bigint
+  }[]
+  minReceived: readonly {
+    token: `0x${string}`
+    amount: bigint
+    recipient: `0x${string}`
+    chainId: bigint
+  }[]
+  fillInstructions: readonly {
+    destinationChainId: bigint
+    destinationSettler: `0x${string}`
+    originData: `0x${string}`
+  }[]
+}
 
 test('type: useParseOpenEvent return', () => {
   const result = useParseOpenEvent({
     status: 'pending',
     logs: [],
   })
-  // TODO replace return type as it doesnt assert exact type
-  expectTypeOf(result.resolvedOrder).toEqualTypeOf<
-    ReturnType<typeof useParseOpenEvent>['resolvedOrder'] | undefined
-  >()
+
+  expectTypeOf(useParseOpenEvent).parameter(0).toMatchTypeOf<{
+    status: UseWaitForTransactionReceiptReturnType['status']
+    logs?: Log[]
+  }>()
+
+  expectTypeOf(result.resolvedOrder).toMatchTypeOf<ResolvedOrder | undefined>()
   expectTypeOf(result.error).toEqualTypeOf<ParseOpenEventError | undefined>()
 })

--- a/sdk/src/hooks/useParseOpenEvent.test.ts
+++ b/sdk/src/hooks/useParseOpenEvent.test.ts
@@ -128,7 +128,7 @@ test('behaviour: no parsing when logs is undefined', () => {
   expect(result.current.resolvedOrder).toBeUndefined()
 })
 
-test('behaviour: error when status is success and logs is []', () => {
+test('behaviour: error when status is success and logs is empty array', () => {
   const { result } = renderHook(
     () =>
       useParseOpenEvent({

--- a/sdk/vitest.config.ts
+++ b/sdk/vitest.config.ts
@@ -9,6 +9,9 @@ export default defineConfig({
           include: ['src/**/*.test.{ts,tsx}'],
           environment: 'happy-dom',
           setupFiles: ['./test/unitSetup.ts'],
+          typecheck: {
+            enabled: true,
+          },
         },
       },
       {


### PR DESCRIPTION
- useGetOrder units
- tweaks to type tests
- enable type tests in vitest unit workspace

issue: #3170