### PR TITLE
chore(sdk): units and require generic on mock

### DIFF
--- a/sdk/.gitignore
+++ b/sdk/.gitignore
@@ -13,3 +13,6 @@ coverage
 
 # asdf
 .tool-versions
+
+# vitest
+tsconfig.vitest-temp.json

--- a/sdk/src/hooks/useDidFill.test.ts
+++ b/sdk/src/hooks/useDidFill.test.ts
@@ -38,7 +38,7 @@ test('default', async () => {
   expect(useReadContract).toHaveBeenCalled()
 
   useReadContract.mockReturnValue(
-    createMockReadContractResult({
+    createMockReadContractResult<ReturnType<typeof useDidFill>>({
       data: true,
       isSuccess: true,
       status: 'success',
@@ -55,7 +55,7 @@ test('default', async () => {
 
 test('behaviour: no exception if contract read fails', () => {
   useReadContract.mockReturnValue(
-    createMockReadContractResult({
+    createMockReadContractResult<ReturnType<typeof useDidFill>>({
       isSuccess: false,
       isError: true,
       status: 'error',

--- a/sdk/src/hooks/useGetOrder.test.ts
+++ b/sdk/src/hooks/useGetOrder.test.ts
@@ -36,7 +36,7 @@ test('default', async () => {
   expect(result.current.data).toBeUndefined()
 
   useReadContract.mockReturnValue(
-    createMockReadContractResult({
+    createMockReadContractResult<ReturnType<typeof useGetOrder>>({
       data: [
         resolvedOrder,
         { status: 1, claimant: '0x123', timestamp: 1 } as const,

--- a/sdk/src/hooks/useInboxStatus.test-d.ts
+++ b/sdk/src/hooks/useInboxStatus.test-d.ts
@@ -1,0 +1,18 @@
+import type { Hex } from 'viem'
+import { expectTypeOf, test } from 'vitest'
+import { orderId } from '../../test/shared.js'
+import { useInboxStatus } from './useInboxStatus.js'
+
+test('type: useInboxStatus', () => {
+  const result = useInboxStatus({
+    chainId: 1,
+    orderId,
+  })
+
+  expectTypeOf(useInboxStatus).parameter(0).toMatchTypeOf<{
+    chainId: number
+    orderId?: Hex
+  }>()
+
+  expectTypeOf(result).toBeString()
+})

--- a/sdk/src/hooks/useInboxStatus.test.ts
+++ b/sdk/src/hooks/useInboxStatus.test.ts
@@ -1,0 +1,134 @@
+import { waitFor } from '@testing-library/react'
+import { beforeEach, expect, test, vi } from 'vitest'
+import { orderId, renderHook, resolvedOrder } from '../../test/index.js'
+import { createMockReadContractResult } from '../../test/mocks.js'
+import { useGetOrder } from './useGetOrder.js'
+import { useInboxStatus } from './useInboxStatus.js'
+
+const data = { status: 1, claimant: '0x123', timestamp: 1 } as const
+
+const { mockUseGetOrder } = vi.hoisted(() => {
+  return {
+    mockUseGetOrder: vi.fn().mockImplementation(() => {
+      return createMockReadContractResult()
+    }),
+  }
+})
+
+vi.mock('./useGetOrder.js', async () => {
+  const actual = await vi.importActual('./useGetOrder.js')
+  return {
+    ...actual,
+    useGetOrder: mockUseGetOrder,
+  }
+})
+
+beforeEach(() => {
+  mockUseGetOrder.mockReturnValue(createMockReadContractResult())
+})
+
+test('default', async () => {
+  const { result, rerender } = renderHook(
+    () => useInboxStatus({ chainId: 1 }),
+    {
+      mockContractsCall: true,
+    },
+  )
+
+  // once on mount
+  expect(useGetOrder).toHaveBeenCalledOnce()
+  expect(result.current).toBe('unknown')
+
+  mockUseGetOrder.mockReturnValue(
+    createMockReadContractResult<ReturnType<typeof useGetOrder>>({
+      data: [resolvedOrder, data],
+      isSuccess: true,
+      status: 'success',
+    }),
+  )
+
+  rerender({
+    chainId: 1,
+    orderId,
+  })
+
+  await waitFor(() => result.current === 'open')
+})
+
+test('parameters: status unknown', () => {
+  const { result } = renderHook(() => useInboxStatus({ chainId: 1 }), {
+    mockContractsCall: true,
+  })
+
+  expect(result.current).toBe('unknown')
+})
+
+test('parameters: status open', () => {
+  mockUseGetOrder.mockReturnValue(
+    createMockReadContractResult<ReturnType<typeof useGetOrder>>({
+      data: [resolvedOrder, data],
+    }),
+  )
+
+  const { result } = renderHook(() => useInboxStatus({ chainId: 1 }), {
+    mockContractsCall: true,
+  })
+
+  expect(result.current).toBe('open')
+})
+
+test('parameters: status rejected', () => {
+  mockUseGetOrder.mockReturnValue(
+    createMockReadContractResult<ReturnType<typeof useGetOrder>>({
+      data: [resolvedOrder, { ...data, status: 2 }],
+    }),
+  )
+
+  const { result } = renderHook(() => useInboxStatus({ chainId: 1 }), {
+    mockContractsCall: true,
+  })
+
+  expect(result.current).toBe('rejected')
+})
+
+test('parameters: status closed', () => {
+  mockUseGetOrder.mockReturnValue(
+    createMockReadContractResult<ReturnType<typeof useGetOrder>>({
+      data: [resolvedOrder, { ...data, status: 3 }],
+    }),
+  )
+
+  const { result } = renderHook(() => useInboxStatus({ chainId: 1 }), {
+    mockContractsCall: true,
+  })
+
+  expect(result.current).toBe('closed')
+})
+
+test('parameters: status filled', () => {
+  mockUseGetOrder.mockReturnValue(
+    createMockReadContractResult<ReturnType<typeof useGetOrder>>({
+      data: [resolvedOrder, { ...data, status: 4 }],
+    }),
+  )
+
+  const { result } = renderHook(() => useInboxStatus({ chainId: 1 }), {
+    mockContractsCall: true,
+  })
+
+  expect(result.current).toBe('filled')
+})
+
+test('parameters: status claimed', () => {
+  mockUseGetOrder.mockReturnValue(
+    createMockReadContractResult<ReturnType<typeof useGetOrder>>({
+      data: [resolvedOrder, { ...data, status: 5 }],
+    }),
+  )
+
+  const { result } = renderHook(() => useInboxStatus({ chainId: 1 }), {
+    mockContractsCall: true,
+  })
+
+  expect(result.current).toBe('filled')
+})

--- a/sdk/src/hooks/useInboxStatus.ts
+++ b/sdk/src/hooks/useInboxStatus.ts
@@ -11,6 +11,7 @@ export function useInboxStatus({
   orderId?: Hex
 }) {
   const order = useGetOrder({ chainId, orderId })
+  // TODO propagate error if getOrder fails / data not found
   const status = order?.data?.[1].status
   if (!isKnown(status)) return 'unknown'
   return strs[status]

--- a/sdk/src/hooks/useParseOpenEvent.test-d.ts
+++ b/sdk/src/hooks/useParseOpenEvent.test-d.ts
@@ -1,31 +1,31 @@
-import type { Log } from 'viem'
+import type { Hex, Log } from 'viem'
 import { expectTypeOf, test } from 'vitest'
 import type { UseWaitForTransactionReceiptReturnType } from 'wagmi'
 import type { ParseOpenEventError } from '../errors/base.js'
 import { useParseOpenEvent } from './useParseOpenEvent.js'
 
 type ResolvedOrder = {
-  user: `0x${string}`
+  user: Hex
   originChainId: bigint
   openDeadline: number
   fillDeadline: number
-  orderId: `0x${string}`
+  orderId: Hex
   maxSpent: readonly {
-    token: `0x${string}`
+    token: Hex
     amount: bigint
-    recipient: `0x${string}`
+    recipient: Hex
     chainId: bigint
   }[]
   minReceived: readonly {
-    token: `0x${string}`
+    token: Hex
     amount: bigint
-    recipient: `0x${string}`
+    recipient: Hex
     chainId: bigint
   }[]
   fillInstructions: readonly {
     destinationChainId: bigint
-    destinationSettler: `0x${string}`
-    originData: `0x${string}`
+    destinationSettler: Hex
+    originData: Hex
   }[]
 }
 

--- a/sdk/src/hooks/useQuote.test-d.ts
+++ b/sdk/src/hooks/useQuote.test-d.ts
@@ -1,0 +1,32 @@
+import type { UseQueryResult } from '@tanstack/react-query'
+import { expectTypeOf, test } from 'vitest'
+import type { FetchJSONError } from '../internal/api.js'
+import type { Quote, Quoteable } from '../types/quote.js'
+import { useQuote } from './useQuote.js'
+
+test('type: useInboxStatus', () => {
+  const result = useQuote({
+    destChainId: 2,
+    mode: 'expense',
+    deposit: { isNative: true },
+    expense: { isNative: true },
+    enabled: true,
+  })
+
+  expectTypeOf(useQuote).parameter(0).toMatchTypeOf<{
+    srcChainId?: number
+    destChainId: number
+    mode: 'expense' | 'deposit'
+    deposit: Quoteable
+    expense: Quoteable
+    enabled: boolean
+  }>()
+
+  expectTypeOf(result.isError).toBeBoolean()
+  expectTypeOf(result.isPending).toBeBoolean()
+  expectTypeOf(result.isSuccess).toBeBoolean()
+  expectTypeOf(result.query).toEqualTypeOf<
+    UseQueryResult<Quote, FetchJSONError>
+  >()
+  expectTypeOf(result.query.data).toEqualTypeOf<Quote | undefined>()
+})

--- a/sdk/src/hooks/useQuote.test.ts
+++ b/sdk/src/hooks/useQuote.test.ts
@@ -1,0 +1,161 @@
+import { waitFor } from '@testing-library/react'
+import { zeroAddress } from 'viem'
+import { expect, test, vi } from 'vitest'
+import { renderHook } from '../../test/react.js'
+import type { Quoteable } from '../types/quote.js'
+import { useQuote } from './useQuote.js'
+
+const token = '0x123'
+const deposit = { token, isNative: false } satisfies Quoteable
+const nativeExpense = { isNative: true } satisfies Quoteable
+
+const params = {
+  srcChainId: 1,
+  destChainId: 2,
+  mode: 'expense',
+  deposit: deposit,
+  expense: nativeExpense,
+  enabled: true,
+} as const
+
+const { fetchJSON } = vi.hoisted(() => {
+  return {
+    fetchJSON: vi.fn(),
+  }
+})
+
+vi.mock('../internal/api.js', async () => {
+  const actual = await vi.importActual('../internal/api.js')
+  return {
+    ...actual,
+    fetchJSON,
+  }
+})
+
+test('default', async () => {
+  const { result, rerender } = renderHook(
+    () => useQuote({ ...params, enabled: false }),
+    {
+      mockContractsCall: true,
+    },
+  )
+
+  expect(result.current.isPending).toBe(true)
+  expect(result.current.query.data).toBeUndefined()
+  expect(result.current.query.isFetched).toBeFalsy()
+
+  fetchJSON.mockResolvedValue({
+    deposit: { token, amount: '100' },
+    expense: { token: zeroAddress, amount: '99' },
+  })
+
+  rerender({ ...params, enabled: true })
+
+  await Promise.all([
+    waitFor(() => result.current.isPending === false),
+    waitFor(() => result.current.isError === false),
+    waitFor(() => result.current.isSuccess === true),
+    waitFor(() => result.current.query.data?.deposit.token === token),
+    waitFor(() => result.current.query.data?.deposit.amount === BigInt(100)),
+    waitFor(() => result.current.query.data?.expense.token === zeroAddress),
+    waitFor(() => result.current.query.data?.expense.amount === BigInt(99)),
+  ])
+})
+
+test('parameters: expense', () => {
+  const { result, rerender } = renderHook(
+    () => useQuote({ ...params, expense: { token, isNative: false } }),
+    {
+      mockContractsCall: true,
+    },
+  )
+
+  expect(result.current).toBeDefined()
+
+  // TODO token shouldn't be allowed if isNative === true
+  rerender({ ...params, expense: { token, isNative: true } })
+
+  expect(result.current).toBeDefined()
+})
+
+test('parameters: deposit', () => {
+  const { result, rerender } = renderHook(
+    () =>
+      useQuote({
+        ...params,
+        deposit: { token, isNative: false },
+      }),
+    {
+      mockContractsCall: true,
+    },
+  )
+
+  expect(result.current).toBeDefined()
+
+  // TODO token shouldn't be allowed if isNative === true
+  rerender({ ...params, expense: { token, isNative: true } })
+
+  expect(result.current).toBeDefined()
+})
+
+test('parameters: mode', () => {
+  const { result, rerender } = renderHook(
+    () =>
+      useQuote({
+        ...params,
+        mode: 'expense',
+        deposit: { isNative: true, amount: 100n },
+        // TODO expense amount shouldn't be allowed if mode === 'expense'
+        expense: { isNative: true, amount: 100n },
+      }),
+    {
+      mockContractsCall: true,
+    },
+  )
+
+  expect(result.current).toBeDefined()
+
+  rerender({
+    ...params,
+    mode: 'deposit',
+    // TODO deposit amount shouldn't be allowed if mode === 'deposit'
+    deposit: { isNative: true, amount: 100n },
+    expense: { isNative: true, amount: 100n },
+  })
+
+  expect(result.current).toBeDefined()
+})
+
+test('behaviour: quote does not fire when enabled is false', () => {
+  const { result } = renderHook(() => useQuote({ ...params, enabled: false }), {
+    mockContractsCall: true,
+  })
+
+  expect(result.current.isPending).toBe(true)
+  expect(result.current.query.data).toBeUndefined()
+  expect(result.current.query.isFetched).toBeFalsy()
+})
+
+test.each([
+  'test',
+  {},
+  { deposit: { token, amount: '100' } },
+  { expense: { token, amount: '100' } },
+  { deposit: { token }, expense: { token } },
+  { deposit: { amount: '100' }, expense: { amount: '99' } },
+])(
+  'behaviour: quote is error if response is not a quote: %s',
+  async (mockReturn) => {
+    const { result } = renderHook(
+      () => useQuote({ ...params, enabled: true }),
+      {
+        mockContractsCall: true,
+      },
+    )
+
+    fetchJSON.mockReturnValue(mockReturn)
+
+    await waitFor(() => result.current.isPending === false)
+    await waitFor(() => result.current.isError === true)
+  },
+)

--- a/sdk/src/hooks/useQuote.ts
+++ b/sdk/src/hooks/useQuote.ts
@@ -3,9 +3,8 @@ import { useMemo } from 'react'
 import { type Address, type Hex, fromHex, zeroAddress } from 'viem'
 import { useOmniContext } from '../context/omni.js'
 import { type FetchJSONError, fetchJSON } from '../internal/api.js'
-import { toJSON } from './util.js'
-
 import type { Quote, Quoteable } from '../types/quote.js'
+import { toJSON } from './util.js'
 
 type UseQuoteParams = {
   srcChainId?: number

--- a/sdk/src/hooks/useValidateOrder.test-d.ts
+++ b/sdk/src/hooks/useValidateOrder.test-d.ts
@@ -1,0 +1,45 @@
+import { expectTypeOf, test } from 'vitest'
+import { accounts } from '../../test/index.js'
+import type { OptionalAbis } from '../types/abi.js'
+import type { Order } from '../types/order.js'
+import { useValidateOrder } from './useValidateOrder.js'
+
+test('type: useInboxStatus', () => {
+  const result = useValidateOrder({
+    order: {
+      owner: accounts[0],
+      srcChainId: 1,
+      destChainId: 2,
+      calls: [
+        {
+          target: accounts[0],
+          value: 0n,
+        },
+      ],
+      deposit: {
+        amount: 0n,
+      },
+      expense: {
+        amount: 0n,
+      },
+    },
+    enabled: true,
+  })
+
+  expectTypeOf(useValidateOrder).parameter(0).toMatchTypeOf<{
+    order: Order<OptionalAbis>
+    enabled: boolean
+  }>()
+
+  expectTypeOf(result.status).toEqualTypeOf<
+    'pending' | 'rejected' | 'accepted' | 'error'
+  >()
+  expectTypeOf(result.status === 'rejected' ? result.rejectReason : undefined)
+    .toBeString
+  expectTypeOf(
+    result.status === 'rejected' ? result.rejectDescription : undefined,
+  ).toBeString
+  expectTypeOf(
+    result.status === 'error' ? result.error : undefined,
+  ).not.toBeUndefined()
+})

--- a/sdk/src/hooks/useValidateOrder.test.ts
+++ b/sdk/src/hooks/useValidateOrder.test.ts
@@ -1,0 +1,172 @@
+import { waitFor } from '@testing-library/react'
+import { erc20Abi } from 'viem'
+import { expect, test, vi } from 'vitest'
+import { accounts, renderHook } from '../../test/index.js'
+import { useValidateOrder } from './useValidateOrder.js'
+
+// TODO calls as empty array should not be allowed // throw error
+
+const order = {
+  owner: accounts[0],
+  srcChainId: 1,
+  destChainId: 2,
+  calls: [
+    {
+      abi: erc20Abi,
+      functionName: 'transfer',
+      target: '0x23e98253f372ee29910e22986fe75bb287b011fc',
+      value: BigInt(0),
+      args: [accounts[0], 0n],
+    },
+  ],
+  deposit: {
+    token: '0x123',
+    amount: 0n,
+  },
+  expense: {
+    token: '0x123',
+    amount: 0n,
+  },
+} as const
+
+const { fetchJSON } = vi.hoisted(() => {
+  return {
+    fetchJSON: vi.fn(),
+  }
+})
+
+vi.mock('../internal/api.js', async () => {
+  const actual = await vi.importActual('../internal/api.js')
+  return {
+    ...actual,
+    fetchJSON,
+  }
+})
+
+test('default: native transfer order', async () => {
+  const { result, rerender } = renderHook(
+    ({ enabled }: { enabled: boolean }) =>
+      useValidateOrder({
+        order: {
+          owner: accounts[0],
+          srcChainId: 1,
+          destChainId: 2,
+          calls: [
+            {
+              target: accounts[0],
+              value: 0n,
+            },
+          ],
+          deposit: {
+            amount: 0n,
+          },
+          expense: {
+            amount: 0n,
+          },
+        },
+        enabled,
+      }),
+    {
+      initialProps: { enabled: false },
+    },
+  )
+
+  expect(result.current.status).toBe('pending')
+
+  fetchJSON.mockResolvedValue({
+    accepted: true,
+  })
+
+  rerender({
+    enabled: true,
+  })
+  await waitFor(() => expect(result.current.status).toBe('accepted'))
+})
+
+test('default: order', async () => {
+  const { result, rerender } = renderHook(
+    ({ enabled }: { enabled: boolean }) =>
+      useValidateOrder({
+        order,
+        enabled,
+      }),
+    {
+      initialProps: { enabled: false },
+    },
+  )
+
+  expect(result.current.status).toBe('pending')
+
+  fetchJSON.mockResolvedValue({
+    accepted: true,
+  })
+
+  rerender({
+    enabled: true,
+  })
+
+  await waitFor(() => expect(result.current.status).toBe('accepted'))
+})
+
+test('behaviour: pending if query not fired', async () => {
+  const { result } = renderHook(() =>
+    useValidateOrder({ order, enabled: false }),
+  )
+
+  await waitFor(() => expect(result.current.status).toBe('pending'))
+})
+
+test('behaviour: error if response is error', async () => {
+  fetchJSON.mockResolvedValue({
+    error: {
+      code: 1,
+      message: 'an error',
+    },
+  })
+
+  const { result } = renderHook(() =>
+    useValidateOrder({ order, enabled: true }),
+  )
+
+  await waitFor(() => expect(result.current.status).toBe('error'))
+  await waitFor(() =>
+    expect(
+      result.current.status === 'error' ? result.current.error.message : null,
+    ).toBe('an error'),
+  )
+})
+
+test('behaviour: rejected if response is rejected', async () => {
+  fetchJSON.mockResolvedValue({
+    rejected: true,
+    rejectReason: 'a reason',
+    rejectDescription: 'a description',
+  })
+
+  const { result } = renderHook(() =>
+    useValidateOrder({ order, enabled: true }),
+  )
+
+  await waitFor(() => expect(result.current.status).toBe('rejected'))
+  await waitFor(() =>
+    expect(
+      result.current.status === 'rejected' ? result.current.rejectReason : null,
+    ).toBe('a reason'),
+  )
+})
+
+test.each([
+  'test',
+  {},
+  { rejected: true },
+  { rejected: true, rejectReason: 'a reason' },
+  { rejecetd: true, rejectDescription: 'a description' },
+])('behaviour: error if response is not valid: %s', async (mockReturn) => {
+  const { result } = renderHook(() =>
+    useValidateOrder({ order, enabled: true }),
+  )
+
+  fetchJSON.mockReturnValue(mockReturn)
+
+  await waitFor(() => result.current.status === 'error')
+})

--- a/sdk/test/mocks.ts
+++ b/sdk/test/mocks.ts
@@ -26,7 +26,7 @@ export function createMockReadContractResult<
   overrides?: Partial<UseReadContractReturn<TResult['data']>>,
 ): UseReadContractReturn<TResult['data']> {
   const result = {
-    data: null as TResult['data'],
+    data: undefined as TResult['data'],
     error: null,
     isError: false,
     isPending: true,

--- a/sdk/test/mocks.ts
+++ b/sdk/test/mocks.ts
@@ -1,6 +1,15 @@
 import { vi } from 'vitest'
+import type { useReadContract } from 'wagmi'
 import * as apiModule from '../src/internal/api.js'
 import { contracts } from './shared.js'
+
+type UseReadContractReturn<Data> = Omit<
+  ReturnType<typeof useReadContract>,
+  'error' | 'data'
+> & {
+  error: Error | null
+  data: Data
+}
 
 export function mockContractsQuery() {
   vi.spyOn(apiModule, 'fetchJSON').mockImplementation((url: string) => {
@@ -11,9 +20,13 @@ export function mockContractsQuery() {
   })
 }
 
-export function createMockReadContractResult(overrides = {}) {
-  return {
-    data: undefined,
+export function createMockReadContractResult<
+  TResult extends ReturnType<typeof useReadContract> = never,
+>(
+  overrides?: Partial<UseReadContractReturn<TResult['data']>>,
+): UseReadContractReturn<TResult['data']> {
+  const result = {
+    data: null as TResult['data'],
     error: null,
     isError: false,
     isPending: true,
@@ -22,7 +35,7 @@ export function createMockReadContractResult(overrides = {}) {
     isRefetchError: false,
     isSuccess: false,
     isPlaceholderData: false,
-    status: 'pending',
+    status: 'pending' as const,
     dataUpdatedAt: 0,
     errorUpdatedAt: 0,
     failureCount: 0,
@@ -36,11 +49,11 @@ export function createMockReadContractResult(overrides = {}) {
     isRefetching: false,
     isStale: false,
     refetch: vi.fn(),
-    remove: vi.fn(),
-    fetchStatus: 'idle',
+    fetchStatus: 'idle' as const,
     queryKey: [],
-    queryHash: '',
     promise: Promise.resolve(),
     ...overrides,
-  } as const
+  }
+
+  return result
 }

--- a/sdk/test/shared.ts
+++ b/sdk/test/shared.ts
@@ -1,4 +1,4 @@
-import { parseEther, toBytes, toHex } from 'viem'
+import { type Hex, parseEther, toBytes, toHex } from 'viem'
 import { arbitrum, base, optimism } from 'viem/chains'
 import { http, createConfig, mock } from 'wagmi'
 import { mainnet } from 'wagmi/chains'
@@ -29,6 +29,19 @@ export const web3Config = createConfig({
 ////////////////////////////////////////
 //// TEST DATA
 ////////////////////////////////////////
+type Transfer = {
+  token: Hex
+  amount: bigint
+  recipient: Hex
+  chainId: bigint
+}
+
+type FillInstruction = {
+  destinationChainId: bigint
+  destinationSettler: Hex
+  originData: Hex
+}
+
 export const oneEth = parseEther('1')
 export const contracts = {
   inbox: '0x123',
@@ -51,7 +64,7 @@ export const resolvedOrder = {
       recipient: bytes32Addr,
       chainId: 1n,
     },
-  ],
+  ] as readonly Transfer[],
   minReceived: [
     {
       token: bytes32Addr,
@@ -59,12 +72,12 @@ export const resolvedOrder = {
       recipient: bytes32Addr,
       chainId: 1n,
     },
-  ],
+  ] as readonly Transfer[],
   fillInstructions: [
     {
       destinationChainId: 1n,
       destinationSettler: bytes32Addr,
       originData,
     },
-  ],
-}
+  ] as readonly FillInstruction[],
+} as const

--- a/sdk/test/shared.ts
+++ b/sdk/test/shared.ts
@@ -3,6 +3,9 @@ import { arbitrum, base, optimism } from 'viem/chains'
 import { http, createConfig, mock } from 'wagmi'
 import { mainnet } from 'wagmi/chains'
 
+////////////////////////////////////////
+//// TEST DATA
+////////////////////////////////////////
 export const MOCK_L1_ID = 1652
 export const MOCK_L2_ID = 1654
 export const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000'
@@ -26,9 +29,6 @@ export const web3Config = createConfig({
   },
 })
 
-////////////////////////////////////////
-//// TEST DATA
-////////////////////////////////////////
 type Transfer = {
   token: Hex
   amount: bigint


### PR DESCRIPTION
- useInboxStatus units
- require generic on `createMockReadContractResult` to restrict input type of data to match expected

issue: #3170 