### PR TITLE
fix(monitor): use wall time for rewards estimation

### DIFF
--- a/lib/cchain/provider.go
+++ b/lib/cchain/provider.go
@@ -9,6 +9,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 
 	utypes "cosmossdk.io/x/upgrade/types"
+	"github.com/cosmos/cosmos-sdk/client/grpc/node"
 )
 
 // ProviderCallback is the callback function signature that will be called with each approved attestation per
@@ -84,8 +85,8 @@ type Provider interface {
 	// AppliedPlan returns the applied (activated) upgrade plan by name.
 	AppliedPlan(ctx context.Context, name string) (utypes.Plan, bool, error)
 
-	// BlockHeight returns the current consensus block height.
-	BlockHeight(ctx context.Context) (uint64, error)
+	// NodeStatus returns the consensus node status.
+	NodeStatus(ctx context.Context) (*node.StatusResponse, error)
 
 	// QueryClients returns the query clients for the various modules.
 	QueryClients() QueryClients

--- a/lib/cchain/provider/provider.go
+++ b/lib/cchain/provider/provider.go
@@ -106,14 +106,14 @@ func (p Provider) AppliedPlan(ctx context.Context, name string) (upgradetypes.Pl
 	return p.appliedFunc(ctx, name)
 }
 
-// BlockHeight returns the current consensus block height.
-func (p Provider) BlockHeight(ctx context.Context) (uint64, error) {
+// NodeStatus returns the current consensus node status.
+func (p Provider) NodeStatus(ctx context.Context) (*node.StatusResponse, error) {
 	status, err := p.QueryClients().Node.Status(ctx, &node.StatusRequest{})
 	if err != nil {
-		return 0, errors.Wrap(err, "node status query")
+		return &node.StatusResponse{}, errors.Wrap(err, "node status query")
 	}
 
-	return status.Height, nil
+	return status, nil
 }
 
 func (p Provider) AttestationsFrom(

--- a/lib/cchain/queryutil/rewards.go
+++ b/lib/cchain/queryutil/rewards.go
@@ -5,7 +5,6 @@ import (
 	"time"
 
 	"github.com/omni-network/omni/lib/cchain"
-	"github.com/omni-network/omni/lib/cchain/provider"
 	"github.com/omni-network/omni/lib/errors"
 	"github.com/omni-network/omni/lib/forkjoin"
 
@@ -15,7 +14,7 @@ import (
 	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
 )
 
-var blocksPerYear = math.LegacyNewDec(365 * 24 * 60 * 60 / 2) // Matches upgrades/magellan::blocksPerYear
+var yearDuration = math.LegacyNewDec(365 * 24 * time.Hour.Milliseconds())
 
 // AvgInflationRate returns the average inflation for all delegations over the given number of blocks
 // or true if all delegations changed (couldn't calculate inflation).
@@ -58,7 +57,7 @@ func AvgInflationRate(ctx context.Context, cprov cchain.Provider, waitBlocks uin
 // DelegatorInflationRates returns the inflation rate per delegation for the given delegator over the given number of blocks,
 // or true if the delegation changed (couldn't calculate inflation).
 func DelegatorInflationRates(ctx context.Context, cprov cchain.Provider, delegator sdk.AccAddress, waitBlocks uint64) ([]math.LegacyDec, bool, error) {
-	rewards0, height0, err := getDelegationRewards(ctx, cprov, delegator)
+	rewards0, height0, timestamp0, err := getDelegationRewards(ctx, cprov, delegator)
 	if err != nil {
 		return nil, false, err
 	}
@@ -67,14 +66,14 @@ func DelegatorInflationRates(ctx context.Context, cprov cchain.Provider, delegat
 		return nil, false, err
 	}
 
-	rewards1, height1, err := getDelegationRewards(ctx, cprov, delegator)
+	rewards1, _, timestamp1, err := getDelegationRewards(ctx, cprov, delegator)
 	if err != nil {
 		return nil, false, err
 	} else if len(rewards0) != len(rewards1) {
 		return nil, true, errors.New("delegations mismatch") // Staking actions occurred
 	}
 
-	blockDelta := math.LegacyNewDec(int64(height1) - int64(height0)) //nolint:gosec // No risk of overflow
+	timeDelta := math.LegacyNewDec(timestamp1.Sub(*timestamp0).Milliseconds())
 
 	var resp []math.LegacyDec
 	for i := range len(rewards0) {
@@ -86,7 +85,7 @@ func DelegatorInflationRates(ctx context.Context, cprov cchain.Provider, delegat
 		}
 
 		rewardDelta := rew1.Rewards.Sub(rew0.Rewards)
-		rewardsPerYear := rewardDelta.Mul(blocksPerYear).Quo(blockDelta)
+		rewardsPerYear := rewardDelta.Mul(yearDuration).Quo(timeDelta)
 		stake := rew0.Delegation.Balance.Amount.ToLegacyDec()
 		rewardsAPY := rewardsPerYear.Quo(stake)
 
@@ -131,16 +130,17 @@ func allDelegators(ctx context.Context, cprov cchain.Provider) ([]sdk.AccAddress
 
 func waitUntil(ctx context.Context, cprov cchain.Provider, target uint64) error {
 	for {
-		height, err := cprov.BlockHeight(ctx)
+		status, err := cprov.NodeStatus(ctx)
 		if err != nil {
 			return errors.Wrap(err, "get block")
 		}
+		height := status.Height
 
 		if height >= target {
 			return nil
 		}
 
-		time.Sleep(time.Second)
+		time.Sleep(2 * time.Second)
 	}
 }
 
@@ -151,23 +151,21 @@ type delegationReward struct {
 }
 
 // getDelegationRewards returns the current rewards-per-delegation (and height) for the given delegator.
-func getDelegationRewards(ctx context.Context, cprov cchain.Provider, delegator sdk.AccAddress) ([]delegationReward, uint64, error) {
-	height, err := cprov.BlockHeight(ctx)
+func getDelegationRewards(ctx context.Context, cprov cchain.Provider, delegator sdk.AccAddress) ([]delegationReward, uint64, *time.Time, error) {
+	status, err := cprov.NodeStatus(ctx)
 	if err != nil {
-		return nil, 0, errors.Wrap(err, "get block")
+		return nil, 0, &time.Time{}, errors.Wrap(err, "node status")
 	}
-	ctx, err = provider.WithCtxHeight(ctx, height)
-	if err != nil {
-		return nil, 0, errors.Wrap(err, "set height")
-	}
+	timestamp := status.Timestamp
+	height := status.Height
 
 	resp, err := cprov.QueryClients().Staking.DelegatorDelegations(ctx, &stakingtypes.QueryDelegatorDelegationsRequest{
 		DelegatorAddr: delegator.String(),
 	})
 	if err != nil {
-		return nil, 0, errors.Wrap(err, "query delegator delegations")
+		return nil, 0, timestamp, errors.Wrap(err, "query delegator delegations")
 	} else if len(resp.DelegationResponses) == 0 {
-		return nil, 0, errors.New("no delegations")
+		return nil, 0, timestamp, errors.New("no delegations")
 	}
 
 	var delegationRewards []delegationReward
@@ -177,7 +175,7 @@ func getDelegationRewards(ctx context.Context, cprov cchain.Provider, delegator 
 			ValidatorAddress: del.Delegation.ValidatorAddress,
 		})
 		if err != nil {
-			return nil, 0, errors.Wrap(err, "query delegation rewards")
+			return nil, 0, timestamp, errors.Wrap(err, "query delegation rewards")
 		} else if len(rewardResp.Rewards) != 1 {
 			continue // This is expected if delegation was processed in same block.
 		}
@@ -188,5 +186,5 @@ func getDelegationRewards(ctx context.Context, cprov cchain.Provider, delegator 
 		})
 	}
 
-	return delegationRewards, height, nil
+	return delegationRewards, height, timestamp, nil
 }

--- a/monitor/app/rewards.go
+++ b/monitor/app/rewards.go
@@ -11,7 +11,7 @@ import (
 )
 
 func monitorInflationForever(ctx context.Context, cprov cchain.Provider) {
-	ticker := time.NewTicker(time.Minute)
+	ticker := time.NewTicker(time.Hour)
 	defer ticker.Stop()
 
 	for {
@@ -28,7 +28,9 @@ func monitorInflationForever(ctx context.Context, cprov cchain.Provider) {
 				continue
 			}
 
-			inflation, _, err := queryutil.AvgInflationRate(ctx, cprov, 3)
+			// Collect data during multiple blocks.
+			blocks := uint64(30)
+			inflation, _, err := queryutil.AvgInflationRate(ctx, cprov, blocks)
 			if err != nil {
 				log.Warn(ctx, "Failed to get inflation rate (will retry)", err)
 				continue


### PR DESCRIPTION
Use wall time for the estimation of effective inflation.

issue: #3279