### PR TITLE
chore(geth): downgrade geth server to v1-14-13

### DIFF
--- a/cli/cmd/compose.yaml.tpl
+++ b/cli/cmd/compose.yaml.tpl
@@ -24,6 +24,8 @@ services:
       - --verbosity={{.GethVerbosity}}                 # Log level (1=error,2=warn,3=info,4=debug)
       {{ if .GethArchive }}- --gcmode=archive{{ end }}
       # Flags not available via config.toml
+      #- --nat=extip:<my-external-ip> # External IP for P2P via NAT
+      #- --metrics                    # Enable prometheus metrics
       #- --pprof                      # Enable prometheus metrics
       #- --pprof.addr=0.0.0.0         # Enable prometheus metrics
     healthcheck:

--- a/cli/cmd/initnodes.go
+++ b/cli/cmd/initnodes.go
@@ -282,7 +282,7 @@ func writeComposeFile(ctx context.Context, cfg InitConfig, upgrade string) error
 		GenesisBinary string
 	}{
 		HaloTag:       cfg.HaloTag,
-		GethTag:       geth.Version,
+		GethTag:       geth.ServerVersion,
 		GethVerbosity: verbosity,
 		GethArchive:   cfg.Archive,
 		GenesisBinary: upgrade,
@@ -295,7 +295,7 @@ func writeComposeFile(ctx context.Context, cfg InitConfig, upgrade string) error
 		return errors.Wrap(err, "writing compose file")
 	}
 
-	log.Info(ctx, "Generated docker compose file", "path", filepath.Join(cfg.Home, "compose.yaml"), "geth_version", geth.Version, "halo_version", cfg.HaloTag)
+	log.Info(ctx, "Generated docker compose file", "path", filepath.Join(cfg.Home, "compose.yaml"), "geth_version", geth.ServerVersion, "halo_version", cfg.HaloTag)
 
 	return nil
 }
@@ -375,7 +375,7 @@ func gethInit(ctx context.Context, cfg InitConfig, dir string) error {
 
 	// Run geth init via docker
 	{
-		image := "ethereum/client-go:" + geth.Version
+		image := "ethereum/client-go:" + geth.ServerVersion
 
 		stateScheme := "path"
 		if cfg.NodeSnapshot || cfg.Archive {

--- a/e2e/app/geth/config.go
+++ b/e2e/app/geth/config.go
@@ -5,6 +5,7 @@ import (
 	"math/big"
 	"os"
 	"path/filepath"
+	"regexp"
 	"time"
 
 	"github.com/omni-network/omni/e2e/types"
@@ -71,6 +72,14 @@ func WriteConfigTOML(conf Config, path string) error {
 	bz, err := tomlSettings.Marshal(MakeGethConfig(conf))
 	if err != nil {
 		return errors.Wrap(err, "marshal toml")
+	}
+
+	// Remove some config introduced in v1.15 (golang dependency)  but not supported by v1.14 (server)
+	for _, pattern := range []string{
+		"NAT = \".*\"\n",
+	} {
+		re := regexp.MustCompile(pattern)
+		bz = re.ReplaceAll(bz, nil)
 	}
 
 	if err := os.WriteFile(path, bz, 0o644); err != nil {

--- a/e2e/app/geth/config_internal_test.go
+++ b/e2e/app/geth/config_internal_test.go
@@ -85,7 +85,7 @@ func TestWriteConfigTOML(t *testing.T) {
 			// Geth does some custom config parsing/sanitizing/updating of the config, so we ensure our config doesn't
 			// get silently updated by geth.
 			// See https://github.com/ethereum/go-ethereum/blob/master/cmd/utils/flags.go#L1640
-			result := gethDumpConfigToml(t, MakeGethConfig(data))
+			result := gethDumpConfigToml(t, data)
 			require.Equal(t, string(bz), string(result))
 		})
 	}
@@ -106,25 +106,23 @@ func TestGethVersion(t *testing.T) {
 	err = json.Unmarshal(out, &resp)
 	require.NoError(t, err)
 
-	require.Equal(t, Version, resp.Module.Version, "A different geth has been released, update `geth.Version`")
+	require.Equal(t, ClientVersion, resp.Module.Version, "A different geth dependency is installed, update `geth.Version`")
 }
 
 // gethDumpConfigToml executes `geth dumpconfig` using the provided base config and
 // returns the resulting toml config file content.
-func gethDumpConfigToml(t *testing.T, baseCfg FullConfig) []byte {
+func gethDumpConfigToml(t *testing.T, baseCfg Config) []byte {
 	t.Helper()
 
-	bz, err := tomlSettings.Marshal(baseCfg)
-	require.NoError(t, err)
-
 	baseFile := filepath.Join(t.TempDir(), "base.toml")
-	err = os.WriteFile(baseFile, bz, 0o644)
+	err := WriteConfigTOML(baseCfg, baseFile)
 	require.NoError(t, err)
 
 	var stdout, stderr bytes.Buffer
 	cmd := exec.Command("docker", "run",
+		"--rm",
 		fmt.Sprintf("--volume=%s:/tmp/config.toml", baseFile),
-		fmt.Sprintf("ethereum/client-go:%s", Version),
+		fmt.Sprintf("ethereum/client-go:%s", ServerVersion),
 		"dumpconfig",
 		"--config=/tmp/config.toml")
 	cmd.Stdout = &stdout

--- a/e2e/app/geth/testdata/TestWriteConfigTOML_archive.golden
+++ b/e2e/app/geth/testdata/TestWriteConfigTOML_archive.golden
@@ -86,7 +86,6 @@ StaticNodes = []
 TrustedNodes = ["enode://3a514176466fa815ed481ffad09110a2d344f6c9b78c1d14afc351c3a51be33d8072e77939dc03ba44790779b7a1025baf3003f6732430e20cd9b76d953391b3@127.0.0.1:1", "enode://3a514176466fa815ed481ffad09110a2d344f6c9b78c1d14afc351c3a51be33d8072e77939dc03ba44790779b7a1025baf3003f6732430e20cd9b76d953391b3@127.0.0.2:2"]
 ListenAddr = "0.0.0.0:30303"
 DiscAddr = ""
-NAT = "any"
 EnableMsgEvents = false
 
 [Node.HTTPTimeouts]

--- a/e2e/app/geth/testdata/TestWriteConfigTOML_full.golden
+++ b/e2e/app/geth/testdata/TestWriteConfigTOML_full.golden
@@ -86,7 +86,6 @@ StaticNodes = []
 TrustedNodes = ["enode://3a514176466fa815ed481ffad09110a2d344f6c9b78c1d14afc351c3a51be33d8072e77939dc03ba44790779b7a1025baf3003f6732430e20cd9b76d953391b3@127.0.0.1:1", "enode://3a514176466fa815ed481ffad09110a2d344f6c9b78c1d14afc351c3a51be33d8072e77939dc03ba44790779b7a1025baf3003f6732430e20cd9b76d953391b3@127.0.0.2:2"]
 ListenAddr = "0.0.0.0:30303"
 DiscAddr = ""
-NAT = "extip:1.2.3.4"
 EnableMsgEvents = false
 
 [Node.HTTPTimeouts]

--- a/e2e/app/geth/testdata/default_config.toml
+++ b/e2e/app/geth/testdata/default_config.toml
@@ -84,7 +84,6 @@ StaticNodes = []
 TrustedNodes = []
 ListenAddr = "0.0.0.0:30303"
 DiscAddr = ""
-NAT = "any"
 EnableMsgEvents = false
 
 [Node.HTTPTimeouts]

--- a/e2e/app/geth/types.go
+++ b/e2e/app/geth/types.go
@@ -14,16 +14,19 @@ import (
 	"github.com/naoina/toml"
 )
 
-// Version defines the geth version deployed to all networks.
-const Version = "v1.15.5"
+// ServerVersion defines the geth version deployed to all networks.
+const ServerVersion = "v1.14.13"
 
-// SupportedVersions are the supported older geth versions.
+// ClientVersion defines the geth version used mostly for ethclient.
+const ClientVersion = "v1.15.5"
+
+// SupportedVersions are the supported older geth server versions.
 // These are tested in backwards.toml.
 var SupportedVersions = []string{
-	"v1.14.13",
 	"v1.14.12",
 	"v1.14.11",
 	"v1.14.8",
+	"v1.14.7",
 }
 
 // Config is the configurable options for the standard omni geth config.

--- a/e2e/app/geth/types_test.go
+++ b/e2e/app/geth/types_test.go
@@ -11,5 +11,5 @@ import (
 func TestVersions(t *testing.T) {
 	t.Parallel()
 	require.Len(t, geth.SupportedVersions, 4) // Only support (max) 4 versions
-	require.NotContains(t, geth.SupportedVersions, geth.Version)
+	require.NotContains(t, geth.SupportedVersions, geth.ServerVersion)
 }

--- a/e2e/docker/compose.yaml.tmpl
+++ b/e2e/docker/compose.yaml.tmpl
@@ -77,8 +77,10 @@ services:
     command:
       - --config=/geth/config.toml
       # Flags not available via config.toml
+      - --nat=extip:{{ .AdvertisedIP }}
       - --pprof
       - --pprof.addr=0.0.0.0
+      - --metrics
       - --graphql
       - --verbosity={{$.GethVerbosity}} # Log level (1=error,2=warn,3=info,4=debug)
       {{ if .IsArchive }}- --gcmode=archive{{ end }}

--- a/e2e/docker/docker.go
+++ b/e2e/docker/docker.go
@@ -215,14 +215,14 @@ func (c ComposeDef) UpgradeGeth(index int) bool {
 
 // UpgradeGethTag returns the geth docker image tag to upgrade to.
 func (ComposeDef) UpgradeGethTag() string {
-	return geth.Version
+	return geth.ServerVersion
 }
 
 // InitialGethTag return the geth docker image tag to initially deploy.
 func (c ComposeDef) InitialGethTag(index int) string {
 	tag, ok := c.GethInitTags[index]
 	if !ok {
-		return geth.Version
+		return geth.ServerVersion
 	}
 
 	return tag

--- a/e2e/docker/testdata/TestComposeTemplate_commit.golden
+++ b/e2e/docker/testdata/TestComposeTemplate_commit.golden
@@ -81,13 +81,15 @@ services:
     labels:
       e2e: true
     container_name: omni_evm_0
-    image: ethereum/client-go:v1.15.5
+    image: ethereum/client-go:v1.14.13
     restart: unless-stopped
     command:
       - --config=/geth/config.toml
       # Flags not available via config.toml
+      - --nat=extip:10.186.73.0
       - --pprof
       - --pprof.addr=0.0.0.0
+      - --metrics
       - --graphql
       - --verbosity=3 # Log level (1=error,2=warn,3=info,4=debug)
       

--- a/e2e/docker/testdata/TestComposeTemplate_empheral_network.golden
+++ b/e2e/docker/testdata/TestComposeTemplate_empheral_network.golden
@@ -81,13 +81,15 @@ services:
     labels:
       e2e: true
     container_name: omni_evm_0
-    image: ethereum/client-go:v1.14.13 # Upgrade omni_evm_0:ethereum/client-go:v1.15.5
+    image: ethereum/client-go:v1.14.12 # Upgrade omni_evm_0:ethereum/client-go:v1.14.13
     restart: unless-stopped
     command:
       - --config=/geth/config.toml
       # Flags not available via config.toml
+      - --nat=extip:10.186.73.0
       - --pprof
       - --pprof.addr=0.0.0.0
+      - --metrics
       - --graphql
       - --verbosity=3 # Log level (1=error,2=warn,3=info,4=debug)
       

--- a/e2e/docker/testdata/TestComposeTemplate_empheral_network_upgrade.golden
+++ b/e2e/docker/testdata/TestComposeTemplate_empheral_network_upgrade.golden
@@ -81,13 +81,15 @@ services:
     labels:
       e2e: true
     container_name: omni_evm_0
-    image: ethereum/client-go:v1.15.5
+    image: ethereum/client-go:v1.14.13
     restart: unless-stopped
     command:
       - --config=/geth/config.toml
       # Flags not available via config.toml
+      - --nat=extip:10.186.73.0
       - --pprof
       - --pprof.addr=0.0.0.0
+      - --metrics
       - --graphql
       - --verbosity=3 # Log level (1=error,2=warn,3=info,4=debug)
       

--- a/e2e/vmcompose/testdata/TestSetup_127-0-0-1-compose.yaml.golden
+++ b/e2e/vmcompose/testdata/TestSetup_127-0-0-1-compose.yaml.golden
@@ -34,13 +34,15 @@ services:
     labels:
       e2e: true
     container_name: validator01_evm
-    image: ethereum/client-go:v1.15.5
+    image: ethereum/client-go:v1.14.13
     restart: unless-stopped
     command:
       - --config=/geth/config.toml
       # Flags not available via config.toml
+      - --nat=extip:127.0.0.1
       - --pprof
       - --pprof.addr=0.0.0.0
+      - --metrics
       - --graphql
       - --verbosity=3 # Log level (1=error,2=warn,3=info,4=debug)
       

--- a/e2e/vmcompose/testdata/TestSetup_127-0-0-2-compose.yaml.golden
+++ b/e2e/vmcompose/testdata/TestSetup_127-0-0-2-compose.yaml.golden
@@ -34,13 +34,15 @@ services:
     labels:
       e2e: true
     container_name: validator02_evm
-    image: ethereum/client-go:v1.15.5
+    image: ethereum/client-go:v1.14.13
     restart: unless-stopped
     command:
       - --config=/geth/config.toml
       # Flags not available via config.toml
+      - --nat=extip:127.0.0.2
       - --pprof
       - --pprof.addr=0.0.0.0
+      - --metrics
       - --graphql
       - --verbosity=3 # Log level (1=error,2=warn,3=info,4=debug)
       

--- a/e2e/vmcompose/testdata/TestSetup_127-0-0-4-compose.yaml.golden
+++ b/e2e/vmcompose/testdata/TestSetup_127-0-0-4-compose.yaml.golden
@@ -34,13 +34,15 @@ services:
     labels:
       e2e: true
     container_name: seed01_evm
-    image: ethereum/client-go:v1.15.5
+    image: ethereum/client-go:v1.14.13
     restart: unless-stopped
     command:
       - --config=/geth/config.toml
       # Flags not available via config.toml
+      - --nat=extip:127.0.0.4
       - --pprof
       - --pprof.addr=0.0.0.0
+      - --metrics
       - --graphql
       - --verbosity=3 # Log level (1=error,2=warn,3=info,4=debug)
       

--- a/e2e/vmcompose/testdata/TestSetup_127-0-0-5-compose.yaml.golden
+++ b/e2e/vmcompose/testdata/TestSetup_127-0-0-5-compose.yaml.golden
@@ -34,13 +34,15 @@ services:
     labels:
       e2e: true
     container_name: fullnode01_evm
-    image: ethereum/client-go:v1.15.5
+    image: ethereum/client-go:v1.14.13
     restart: unless-stopped
     command:
       - --config=/geth/config.toml
       # Flags not available via config.toml
+      - --nat=extip:127.0.0.5
       - --pprof
       - --pprof.addr=0.0.0.0
+      - --metrics
       - --graphql
       - --verbosity=3 # Log level (1=error,2=warn,3=info,4=debug)
       

--- a/solver/app/handlers_internal_test.go
+++ b/solver/app/handlers_internal_test.go
@@ -1,0 +1,66 @@
+package app
+
+import (
+	"bytes"
+	"context"
+	"math/big"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/omni-network/omni/lib/errors"
+	"github.com/omni-network/omni/solver/types"
+
+	"github.com/ethereum/go-ethereum/common"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+//nolint:bodyclose,noctx // Not critical for tests
+func TestCheckHandlerRequests(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		Name    string
+		Input   string
+		Request types.CheckRequest
+	}{
+		{
+			Name:    "empty",
+			Input:   `{}`,
+			Request: types.CheckRequest{},
+		}, {
+			Name:  "missing deposit amount",
+			Input: `{"deposit":{"token":"0x0123456789012345678901234567890123456789"}}`,
+			Request: types.CheckRequest{
+				Deposit: types.AddrAmt{
+					Token:  common.HexToAddress("0x0123456789012345678901234567890123456789"),
+					Amount: big.NewInt(0),
+				},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.Name, func(t *testing.T) {
+			t.Parallel()
+			handler := newCheckHandler(func(_ context.Context, req types.CheckRequest) error {
+				if !assert.Equal(t, test.Request, req) {
+					return errors.New("unexpected request")
+				}
+
+				return nil
+			})
+
+			srv := httptest.NewServer(handlerAdapter(handler))
+
+			req, err := http.NewRequest(http.MethodPost, srv.URL, bytes.NewBufferString(test.Input))
+			require.NoError(t, err)
+
+			resp, err := http.DefaultClient.Do(req)
+			require.NoError(t, err)
+			require.Equal(t, http.StatusOK, resp.StatusCode)
+		})
+	}
+}


### PR DESCRIPTION
Downgrade geth server to previous v1.14.13 since v1.15.5 isn't compatible with existing omega and mainnet genesis stored in chain DB.

issue: none