### PR TITLE
feat(solver): delay solving by one block on l1

### DIFF
--- a/lib/xchain/provider.go
+++ b/lib/xchain/provider.go
@@ -32,6 +32,7 @@ type EventLogsReq struct {
 	ConfLevel     ConfLevel      // Confirmation level to ensure
 	FilterAddress common.Address // Filter logs by optional address
 	FilterTopics  []common.Hash  // Filters zero or more topics (in the first position only).
+	Delay         uint64         // Delay in heights applied to event processing to address possible reorgs.
 }
 
 func (r EventLogsReq) ChainVersion() ChainVersion {

--- a/solver/app/app.go
+++ b/solver/app/app.go
@@ -375,12 +375,20 @@ func streamEventsForever(
 			continue
 		}
 
+		var delay uint64
+		// For L1 we delay the processing of events by two heights to minimize the risks
+		// of the intent trasaction getting excluded during a reorg.
+		if chainID == evmchain.IDEthereum {
+			delay = 2
+		}
+
 		req := xchain.EventLogsReq{
 			ChainID:       chainID,
 			Height:        from, // Note the previous height is re-processed (idempotency FTW)
 			ConfLevel:     confLevel,
 			FilterAddress: inboxAddr,
 			FilterTopics:  solvernet.AllEventTopics(),
+			Delay:         delay,
 		}
 		err = xprov.StreamEventLogs(ctx, req, newEventProcessor(deps, chainID))
 		if ctx.Err() != nil {


### PR DESCRIPTION
To address potential reorgs excluding the intent tx, we delay solving by one block.

issue: none