### PR TITLE
chore(lib/xchain): add support for head-min-1 conf level

### DIFF
--- a/lib/xchain/conflevel_string.go
+++ b/lib/xchain/conflevel_string.go
@@ -11,24 +11,25 @@ func _() {
 	_ = x[ConfUnknown-0]
 	_ = x[ConfLatest-1]
 	_ = x[ConfFinalized-4]
-	_ = x[confSentinel-5]
+	_ = x[ConfMin1-5]
+	_ = x[confSentinel-6]
 }
 
 const (
 	_ConfLevel_name_0 = "unknownlatest"
-	_ConfLevel_name_1 = "finalsentinel must always be last"
+	_ConfLevel_name_1 = "finalmin1sentinel must always be last"
 )
 
 var (
 	_ConfLevel_index_0 = [...]uint8{0, 7, 13}
-	_ConfLevel_index_1 = [...]uint8{0, 5, 33}
+	_ConfLevel_index_1 = [...]uint8{0, 5, 9, 37}
 )
 
 func (i ConfLevel) String() string {
 	switch {
 	case i <= 1:
 		return _ConfLevel_name_0[_ConfLevel_index_0[i]:_ConfLevel_index_0[i+1]]
-	case 4 <= i && i <= 5:
+	case 4 <= i && i <= 6:
 		i -= 4
 		return _ConfLevel_name_1[_ConfLevel_index_1[i]:_ConfLevel_index_1[i+1]]
 	default:

--- a/lib/xchain/types.go
+++ b/lib/xchain/types.go
@@ -51,8 +51,13 @@ func (c ConfLevel) IsFinalized() bool {
 }
 
 // Label returns a short label for the confirmation level.
-// IT is the uppercase first letter of the confirmation level.
+// It is the number-only for `minX` or,
+// it is the uppercase first letter of the confirmation level.
 func (c ConfLevel) Label() string {
+	if strings.Contains(c.String(), "min") {
+		return strings.TrimPrefix(c.String(), "min")
+	}
+
 	return strings.ToUpper(c.String()[:1])
 }
 
@@ -63,12 +68,13 @@ const (
 	_             ConfLevel = 2 // reserved
 	_             ConfLevel = 3 // reserved
 	ConfFinalized ConfLevel = 4 // final
-	confSentinel  ConfLevel = 5 // sentinel must always be last
+	ConfMin1      ConfLevel = 5 // min1
+	confSentinel  ConfLevel = 6 // sentinel must always be last
 )
 
 // FuzzyConfLevels returns a list of all fuzzy confirmation levels.
 func FuzzyConfLevels() []ConfLevel {
-	return []ConfLevel{ConfLatest}
+	return []ConfLevel{ConfLatest, ConfMin1}
 }
 
 type ShardID uint64


### PR DESCRIPTION
Add support for `xchain.ConfMin1` which lags behind head by 1 block.

issue: none
