### PR TITLE
fix(halo): assert msg authority fields

### DIFF
--- a/halo/attest/keeper/msg_server.go
+++ b/halo/attest/keeper/msg_server.go
@@ -10,6 +10,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 )
 
 type msgServer struct {
@@ -23,6 +24,10 @@ func (s msgServer) AddVotes(ctx context.Context, msg *types.MsgAddVotes,
 	sdkCtx := sdk.UnwrapSDKContext(ctx)
 	if sdkCtx.ExecMode() != sdk.ExecModeFinalize {
 		return nil, errors.New("only allowed in finalize mode")
+	}
+
+	if msg.Authority != authtypes.NewModuleAddress(types.ModuleName).String() {
+		return nil, errors.New("invalid authority")
 	}
 
 	for _, aggVote := range msg.Votes {

--- a/halo/attest/keeper/proposal_server.go
+++ b/halo/attest/keeper/proposal_server.go
@@ -8,6 +8,7 @@ import (
 	"github.com/omni-network/omni/lib/netconf"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 )
 
 type proposalServer struct {
@@ -22,6 +23,10 @@ func (s proposalServer) AddVotes(ctx context.Context, msg *types.MsgAddVotes,
 	consensusID, err := netconf.ConsensusChainIDStr2Uint64(sdkCtx.ChainID())
 	if err != nil {
 		return nil, errors.Wrap(err, "parse chain id")
+	}
+
+	if msg.Authority != authtypes.NewModuleAddress(types.ModuleName).String() {
+		return nil, errors.New("invalid authority")
 	}
 
 	// Verify proposed msg

--- a/octane/evmengine/keeper/keeper.go
+++ b/octane/evmengine/keeper/keeper.go
@@ -21,6 +21,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/codec"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 	grpc1 "github.com/cosmos/gogoproto/grpc"
 )
 
@@ -145,6 +146,10 @@ func (k *Keeper) RegisterProposalService(server grpc1.Server) {
 // parseAndVerifyProposedPayload parses and verifies and returns the proposed payload
 // if comparing it against the latest execution block succeeds.
 func (k *Keeper) parseAndVerifyProposedPayload(ctx context.Context, msg *types.MsgExecutionPayload) (engine.ExecutableData, error) {
+	if msg.Authority != authtypes.NewModuleAddress(types.ModuleName).String() {
+		return engine.ExecutableData{}, errors.New("invalid authority")
+	}
+
 	// Block of magellan network upgrade height is built by uluwatu logic,
 	// support both that and new magellan proto payloads.
 	// Note this should strictly only be allowed for that first block, but is tricky to enforce.


### PR DESCRIPTION
Assert msg authority fields.

issue: #3328 
