### PR TITLE
chore(sdk): add useOmniContracts hook

### DIFF
--- a/sdk/README.md
+++ b/sdk/README.md
@@ -97,7 +97,7 @@ function App() {
 
 ```
 
-Finally, open the order, and checks it's status:
+Finally, check the order is ready to be opened, open the order, and checks it's status:
 
 ```tsx
 import { useOrder, useQuote } from '@omni-network/react'
@@ -115,11 +115,12 @@ function App() {
     isOpen,
     isTxPending,
     isValidated,
+    isReady,
   } = order
 
   return (
     <div>
-        <button onClick={open}>Bridge</button>
+        <button disabled={!isReady} onClick={open}>Bridge</button>
         <p>Order status: {status}</p>
     </div>
   )
@@ -132,7 +133,8 @@ Order status lets you track the order's progress.
 
 ```tsx
 export type OrderStatus =
-  | 'idle'
+  | 'initializing'
+  | 'ready'
   | 'opening'
   | 'open'
   | 'closed'

--- a/sdk/src/context/omni.tsx
+++ b/sdk/src/context/omni.tsx
@@ -1,23 +1,25 @@
-import { useQuery } from '@tanstack/react-query'
 import { createContext, useContext, useMemo } from 'react'
-import type { Address } from 'viem'
-import { fetchJSON } from '../internal/api.js'
 import { throwingProxy } from '../internal/util.js'
 
 type Environment = 'devnet' | 'testnet'
+
+function apiUrl(env: Environment): string {
+  switch (env) {
+    case 'devnet':
+      return 'http://localhost:26661/api/v1'
+    case 'testnet':
+      return 'https://solver.omega.omni.network/api/v1'
+    default:
+      throw new Error(`Invalid environment supplied: ${env}`)
+  }
+}
 
 type OmniProviderProps = {
   env: Environment
   __apiBaseUrl?: string
 }
 
-type OmniContracts = {
-  inbox: Address
-  outbox: Address
-  middleman: Address
-}
-
-type OmniContextValue = OmniContracts & {
+type OmniContextValue = {
   apiBaseUrl: string
   env: Environment
 }
@@ -33,40 +35,9 @@ export function OmniProvider({
 }: React.PropsWithChildren<OmniProviderProps>) {
   const apiBaseUrl = apiOverride ?? apiUrl(env)
 
-  const contracts = useQuery({
-    queryKey: ['contracts', env],
-    queryFn: () => getContracts(apiBaseUrl),
-  })
-
   const value = useMemo(() => {
-    // if api url overrided, provide no defaults, must fetch from api
-    const defaults = apiOverride
-      ? ({
-          inbox: '0x',
-          outbox: '0x',
-          middleman: '0x',
-        } as const)
-      : defaultContracts(env)
-
-    // Currently we override defaults with API response when available
-    //
-    // Reasoning: defaults will almost always match api response. so for most
-    // cases, explicit api loading state would be unnecessarily cumbersome.
-    // Additionally, api response will generally be available before
-    // an address is used.
-    //
-    // This does mean that if the api is unreachable, we will use defaults.
-    // If we are changing addresses in prod, this is a problem.
-    //
-    // TODO: track ready / error states in context, and log warnings
-    // when opening orders, or block order operations entirely.
-    return {
-      ...defaults,
-      ...contracts.data,
-      apiBaseUrl,
-      env,
-    }
-  }, [contracts.data, env, apiBaseUrl, apiOverride])
+    return { apiBaseUrl, env }
+  }, [env, apiBaseUrl])
 
   return <OmniContext.Provider value={value}>{children}</OmniContext.Provider>
 }
@@ -79,50 +50,4 @@ export function useOmniContext() {
   }
 
   return context
-}
-
-async function getContracts(apiBaseUrl: string) {
-  const json = await fetchJSON(`${apiBaseUrl}/contracts`)
-
-  if (!isContracts(json)) throw new Error('Unexpected /contracts response')
-
-  return json
-}
-
-function isContracts(json: unknown): json is OmniContracts {
-  const contracts = json as OmniContracts
-  return (
-    contracts != null &&
-    typeof contracts.inbox === 'string' &&
-    typeof contracts.outbox === 'string' &&
-    typeof contracts.middleman === 'string'
-  )
-}
-
-function apiUrl(env: Environment): string {
-  switch (env) {
-    case 'devnet':
-      return 'http://localhost:26661/api/v1'
-    case 'testnet':
-      return 'https://solver.omega.omni.network/api/v1'
-    default:
-      throw new Error(`Invalid environment supplied: ${env}`)
-  }
-}
-
-function defaultContracts(env: Environment): OmniContracts {
-  switch (env) {
-    case 'devnet':
-      return {
-        inbox: '0x7c7759b801078ecb2c41c9caecc2db13c3079c76',
-        outbox: '0x29d9e8faa760841aacbe79a8632c1f42e0a858e6',
-        middleman: '0x1b99e432d5f9e8110102b8d3dce2d0b462a37942',
-      }
-    case 'testnet':
-      return {
-        inbox: '0x80b6ed465241a17080dc4a68be42e80fea1214dd',
-        outbox: '0x020b76746606c6ddb4708b6996cad9adb821604e',
-        middleman: '0x191e0a0aab2b21e946a0ff0ecbd36218b90801c9',
-      }
-  }
 }

--- a/sdk/src/errors/base.ts
+++ b/sdk/src/errors/base.ts
@@ -32,3 +32,7 @@ export class ValidateOrderError extends BaseError {
 export class ParseOpenEventError extends BaseError {
   override name = 'ParseOpenEventError' as const
 }
+
+export class LoadContractsError extends BaseError {
+  override name = 'LoadContractsError' as const
+}

--- a/sdk/src/hooks/useDidFill.ts
+++ b/sdk/src/hooks/useDidFill.ts
@@ -1,6 +1,6 @@
 import { useReadContract } from 'wagmi'
 import { outboxABI } from '../constants/abis.js'
-import { useOmniContext } from '../context/omni.js'
+import { useOmniContracts } from './useOmniContracts.js'
 import type { useParseOpenEvent } from './useParseOpenEvent.js'
 
 type UseDidFillParams = {
@@ -10,10 +10,10 @@ type UseDidFillParams = {
 
 export function useDidFill(params: UseDidFillParams) {
   const { resolvedOrder, destChainId } = params
-  const { outbox } = useOmniContext()
+  const { data: contracts } = useOmniContracts()
   const filled = useReadContract({
     chainId: destChainId,
-    address: outbox,
+    address: contracts?.outbox,
     abi: outboxABI,
     functionName: 'didFill',
     args: resolvedOrder?.fillInstructions[0].originData
@@ -21,7 +21,9 @@ export function useDidFill(params: UseDidFillParams) {
       : undefined,
     query: {
       enabled:
-        !!resolvedOrder && !!resolvedOrder.fillInstructions[0].originData,
+        !!contracts &&
+        !!resolvedOrder &&
+        !!resolvedOrder.fillInstructions[0].originData,
       refetchInterval: 1000,
     },
   })

--- a/sdk/src/hooks/useGetOrder.ts
+++ b/sdk/src/hooks/useGetOrder.ts
@@ -1,7 +1,7 @@
 import type { Hex } from 'viem'
 import { useReadContract } from 'wagmi'
 import { inboxABI } from '../constants/abis.js'
-import { useOmniContext } from '../context/omni.js'
+import { useOmniContracts } from './useOmniContracts.js'
 
 export function useGetOrder({
   chainId,
@@ -10,15 +10,15 @@ export function useGetOrder({
   chainId?: number
   orderId?: Hex
 }) {
-  const { inbox } = useOmniContext()
+  const { data: contracts } = useOmniContracts()
   return useReadContract({
-    address: inbox,
+    address: contracts?.inbox,
     abi: inboxABI,
     functionName: 'getOrder',
     chainId,
     args: orderId ? [orderId] : undefined,
     query: {
-      enabled: !!orderId && !!chainId,
+      enabled: !!contracts && !!orderId && !!chainId,
       refetchInterval: 1000,
     },
   })

--- a/sdk/src/hooks/useOmniContracts.ts
+++ b/sdk/src/hooks/useOmniContracts.ts
@@ -1,38 +1,12 @@
 import { type UseQueryResult, useQuery } from '@tanstack/react-query'
-import type { Address } from 'viem'
+
 import { useOmniContext } from '../context/omni.js'
-import { fetchJSON } from '../internal/api.js'
-
-export type OmniContracts = {
-  inbox: Address
-  outbox: Address
-  middleman: Address
-}
-
-async function getContracts(apiBaseUrl: string) {
-  const json = await fetchJSON(`${apiBaseUrl}/contracts`)
-
-  if (!isContracts(json)) throw new Error('Unexpected /contracts response')
-
-  return json
-}
-
-function isContracts(json: unknown): json is OmniContracts {
-  const contracts = json as OmniContracts
-  return (
-    contracts != null &&
-    typeof contracts.inbox === 'string' &&
-    typeof contracts.outbox === 'string' &&
-    typeof contracts.middleman === 'string'
-  )
-}
+import type { OmniContracts } from '../types/contracts.js'
+import { getOmniContractsQueryOptions } from '../utils/getContracts.js'
 
 export type UseOmniContractsResult = UseQueryResult<OmniContracts>
 
 export function useOmniContracts(): UseOmniContractsResult {
-  const { apiBaseUrl, env } = useOmniContext()
-  return useQuery({
-    queryKey: ['contracts', env],
-    queryFn: () => getContracts(apiBaseUrl),
-  })
+  const config = useOmniContext()
+  return useQuery(getOmniContractsQueryOptions(config))
 }

--- a/sdk/src/hooks/useOmniContracts.ts
+++ b/sdk/src/hooks/useOmniContracts.ts
@@ -1,0 +1,38 @@
+import { type UseQueryResult, useQuery } from '@tanstack/react-query'
+import type { Address } from 'viem'
+import { useOmniContext } from '../context/omni.js'
+import { fetchJSON } from '../internal/api.js'
+
+export type OmniContracts = {
+  inbox: Address
+  outbox: Address
+  middleman: Address
+}
+
+async function getContracts(apiBaseUrl: string) {
+  const json = await fetchJSON(`${apiBaseUrl}/contracts`)
+
+  if (!isContracts(json)) throw new Error('Unexpected /contracts response')
+
+  return json
+}
+
+function isContracts(json: unknown): json is OmniContracts {
+  const contracts = json as OmniContracts
+  return (
+    contracts != null &&
+    typeof contracts.inbox === 'string' &&
+    typeof contracts.outbox === 'string' &&
+    typeof contracts.middleman === 'string'
+  )
+}
+
+export type UseOmniContractsResult = UseQueryResult<OmniContracts>
+
+export function useOmniContracts(): UseOmniContractsResult {
+  const { apiBaseUrl, env } = useOmniContext()
+  return useQuery({
+    queryKey: ['contracts', env],
+    queryFn: () => getContracts(apiBaseUrl),
+  })
+}

--- a/sdk/src/index.test.ts
+++ b/sdk/src/index.test.ts
@@ -5,6 +5,7 @@ import * as lib from './index.js'
 it('exports the expected APIs', () => {
   expect(Object.keys(lib)).toEqual([
     'withExecAndTransfer',
+    'useOmniContracts',
     'useOrder',
     'useQuote',
     'useValidateOrder',

--- a/sdk/src/index.ts
+++ b/sdk/src/index.ts
@@ -2,6 +2,7 @@
 export { withExecAndTransfer } from './utils/withExecAndTransfer.js'
 
 ////// HOOKS //////
+export { useOmniContracts } from './hooks/useOmniContracts.js'
 export { useOrder } from './hooks/useOrder.js'
 export { useQuote } from './hooks/useQuote.js'
 export { useValidateOrder } from './hooks/useValidateOrder.js'

--- a/sdk/src/types/config.ts
+++ b/sdk/src/types/config.ts
@@ -1,0 +1,6 @@
+export type Environment = 'devnet' | 'testnet'
+
+export type OmniConfig = {
+  apiBaseUrl: string
+  env: Environment
+}

--- a/sdk/src/types/contracts.ts
+++ b/sdk/src/types/contracts.ts
@@ -1,0 +1,7 @@
+import type { Address } from 'viem'
+
+export type OmniContracts = {
+  inbox: Address
+  outbox: Address
+  middleman: Address
+}

--- a/sdk/src/types/order.ts
+++ b/sdk/src/types/order.ts
@@ -8,7 +8,8 @@ import type {
 import type { AbiWriteMutability, OptionalAbi, OptionalAbis } from './abi.js'
 
 export type OrderStatus =
-  | 'idle'
+  | 'initializing'
+  | 'ready'
   | 'opening'
   | 'open'
   | 'closed'

--- a/sdk/src/utils/getContracts.ts
+++ b/sdk/src/utils/getContracts.ts
@@ -1,0 +1,31 @@
+import type { FetchQueryOptions } from '@tanstack/react-query'
+import { fetchJSON } from '../internal/api.js'
+import type { OmniConfig } from '../types/config.js'
+import type { OmniContracts } from '../types/contracts.js'
+
+function isContracts(json: unknown): json is OmniContracts {
+  const contracts = json as OmniContracts
+  return (
+    contracts != null &&
+    typeof contracts.inbox === 'string' &&
+    typeof contracts.outbox === 'string' &&
+    typeof contracts.middleman === 'string'
+  )
+}
+
+export async function getContracts(apiBaseUrl: string): Promise<OmniContracts> {
+  const json = await fetchJSON(`${apiBaseUrl}/contracts`)
+
+  if (!isContracts(json)) throw new Error('Unexpected /contracts response')
+
+  return json
+}
+
+export function getOmniContractsQueryOptions(
+  config: OmniConfig,
+): FetchQueryOptions<OmniContracts> {
+  return {
+    queryKey: ['contracts', config.env],
+    queryFn: () => getContracts(config.apiBaseUrl),
+  }
+}

--- a/sdk/src/utils/withExecAndTransfer.ts
+++ b/sdk/src/utils/withExecAndTransfer.ts
@@ -1,10 +1,10 @@
 import type { Abi, Address } from 'viem'
 import { encodeFunctionData } from 'viem'
 import { middlemanABI } from '../constants/abis.js'
-import { useOmniContext } from '../context/omni.js'
 import type { Call } from '../types/order.js'
 
 type WithExecAndTransferParams = {
+  readonly middlemanAddress: Address
   readonly call: Call<Abi>
   readonly transfer: {
     readonly to: Address
@@ -39,14 +39,13 @@ type WithExecAndTransferParams = {
 export function withExecAndTransfer(
   params: WithExecAndTransferParams,
 ): Call<typeof middlemanABI> {
-  const { middleman } = useOmniContext()
   const { call, transfer } = params
   const _callData = encodeFunctionData({ ...call })
 
   return {
     ...call,
     abi: middlemanABI,
-    target: middleman,
+    target: params.middlemanAddress,
     functionName: 'executeAndTransfer',
     args: [transfer.token, transfer.to, call.target, _callData],
   }


### PR DESCRIPTION
Extracts the contract addresses from the Omni context to ensure they are always loaded from the API.
This affects other hooks and APIs that need to handle loading the contracts addresses.

issue: https://github.com/omni-network/omni/issues/3332
