### PR TITLE
chore: fix some function names in comment

### DIFF
--- a/cli/cmd/avs_register_test.go
+++ b/cli/cmd/avs_register_test.go
@@ -185,7 +185,7 @@ func deployAVS(t *testing.T, ctx context.Context, backend *ethbackend.Backend) c
 	return addr
 }
 
-// packInitializer encodes the initializer parameters for the AVS contract.
+// packInitialzer encodes the initializer parameters for the AVS contract.
 func packInitialzer(t *testing.T, cfg deployConfig) []byte {
 	t.Helper()
 

--- a/e2e/app/admin/common.go
+++ b/e2e/app/admin/common.go
@@ -202,7 +202,7 @@ func (s shared) runForge(ctx context.Context, rpc string, input []byte, senders 
 	}
 }
 
-// runForge runs an Admin forge script against an rpc, returning the ouptut.
+// runForgeOnce runs an Admin forge script against an rpc, returning the ouptut.
 // if the senders are known anvil accounts, it will sign with private keys directly.
 // otherwise, it will use the unlocked flag.
 func runForgeOnce(ctx context.Context, rpc string, input []byte, broadcast, resume bool, senders ...common.Address,

--- a/e2e/docker/docker.go
+++ b/e2e/docker/docker.go
@@ -228,7 +228,7 @@ func (c ComposeDef) InitialGethTag(index int) string {
 	return tag
 }
 
-// hnitialGethTag return the geth docker image tag to initially deploy.
+// haloGenesisBinary return the geth docker image tag to initially deploy.
 func (c ComposeDef) haloGenesisBinary(node string) string {
 	for _, n := range c.Nodes {
 		if n.Name != node {


### PR DESCRIPTION
fix some function names in comment

issue: none

<!--
  PR title and body follows conventional commit; https://www.conventionalcommits.org/en/v1.0.0
  Title template: `type(app/pkg): concise description`
  See allowed types: https://github.com/conventional-changelog/commitlint/tree/master/%40commitlint/config-conventional#type-enum
  Description must be concise: lower case, no punctuation, no more than 50 characters.
  Scope must be concise: only a one or two folders; e.g. 'halo/cmd' or 'github' or '*'
-->
