### PR TITLE
chore(monitor): add solver xdapp metrics

### DIFF
--- a/monitor/xmonitor/indexer/indexer_internal_test.go
+++ b/monitor/xmonitor/indexer/indexer_internal_test.go
@@ -27,7 +27,7 @@ func TestIndexer(t *testing.T) {
 
 	streamNamer := func(s xchain.StreamID) string { return fmt.Sprint(s) }
 
-	indexer, err := newIndexer(db, mockXProvider{}, streamNamer)
+	indexer, err := newIndexer(db, mockXProvider{}, streamNamer, nil)
 	require.NoError(t, err)
 	var samples []sample
 	indexer.sampleFunc = func(s sample) {


### PR DESCRIPTION
Adds `solver` xdapp (outbox address) to monitor indexer. This ensures we can monitor/instrument/alerts on fill reverts and all other xmsg related metrics.

issue: #3199 