### PR TITLE
feat(solver): restrict call targets

### DIFF
--- a/lib/contracts/solvernet/bindings.go
+++ b/lib/contracts/solvernet/bindings.go
@@ -1,6 +1,8 @@
 package solvernet
 
 import (
+	"math/big"
+
 	"github.com/omni-network/omni/contracts/bindings"
 	"github.com/omni-network/omni/lib/errors"
 
@@ -206,6 +208,22 @@ func PackOrderData(data bindings.SolverNetOrderData) ([]byte, error) {
 }
 
 func PackFillOriginData(data bindings.SolverNetFillOriginData) ([]byte, error) {
+	// replaces nil call values with zero (inputs.Pack panics if value is nil)
+	zeroNils := func(calls []bindings.SolverNetCall) []bindings.SolverNetCall {
+		var out []bindings.SolverNetCall
+
+		for i, c := range calls {
+			out = append(out, c)
+			if out[i].Value == nil {
+				out[i].Value = big.NewInt(0)
+			}
+		}
+
+		return out
+	}
+
+	data.Calls = zeroNils(data.Calls)
+
 	packed, err := inputsFillOriginData.Pack(data)
 	if err != nil {
 		return nil, errors.Wrap(err, "pack fill data")

--- a/lib/contracts/solvernet/bindings.go
+++ b/lib/contracts/solvernet/bindings.go
@@ -208,21 +208,19 @@ func PackOrderData(data bindings.SolverNetOrderData) ([]byte, error) {
 }
 
 func PackFillOriginData(data bindings.SolverNetFillOriginData) ([]byte, error) {
-	// replaces nil call values with zero (inputs.Pack panics if value is nil)
-	zeroNils := func(calls []bindings.SolverNetCall) []bindings.SolverNetCall {
-		var out []bindings.SolverNetCall
-
-		for i, c := range calls {
-			out = append(out, c)
-			if out[i].Value == nil {
-				out[i].Value = big.NewInt(0)
-			}
+	// Replaces nil call values with zero (inputs.Pack panics if value is nil)
+	for i := range data.Calls {
+		if data.Calls[i].Value == nil {
+			data.Calls[i].Value = big.NewInt(0)
 		}
-
-		return out
 	}
 
-	data.Calls = zeroNils(data.Calls)
+	// Same for expenses
+	for i := range data.Expenses {
+		if data.Expenses[i].Amount == nil {
+			data.Expenses[i].Amount = big.NewInt(0)
+		}
+	}
 
 	packed, err := inputsFillOriginData.Pack(data)
 	if err != nil {

--- a/solver/app/app.go
+++ b/solver/app/app.go
@@ -137,7 +137,7 @@ func Run(ctx context.Context, cfg Config) error {
 
 	log.Info(ctx, "Serving API", "address", cfg.APIAddr)
 	apiChan := serveAPI(cfg.APIAddr,
-		newCheckHandler(newChecker(backends, solverAddr, addrs.SolverNetOutbox)),
+		newCheckHandler(newChecker(backends, callAllower, solverAddr, addrs.SolverNetOutbox)),
 		newContractsHandler(addrs),
 		newQuoteHandler(quoter),
 	)
@@ -324,7 +324,6 @@ func startEventStreams(
 
 		return f(height)
 	}
-
 
 	callAllower := newCallAllower(network.ID, addrs.SolverNetMiddleman)
 

--- a/solver/app/app.go
+++ b/solver/app/app.go
@@ -133,6 +133,8 @@ func Run(ctx context.Context, cfg Config) error {
 		return errors.Wrap(err, "start event streams")
 	}
 
+	callAllower := newCallAllower(network.ID, addrs.SolverNetMiddleman)
+
 	log.Info(ctx, "Serving API", "address", cfg.APIAddr)
 	apiChan := serveAPI(cfg.APIAddr,
 		newCheckHandler(newChecker(backends, solverAddr, addrs.SolverNetOutbox)),
@@ -323,6 +325,9 @@ func startEventStreams(
 		return f(height)
 	}
 
+
+	callAllower := newCallAllower(network.ID, addrs.SolverNetMiddleman)
+
 	for _, chainID := range inboxChains {
 		// Ensure chain version processors don't process same height concurrently.
 		callbackWrapper := newHeightMutexer()
@@ -334,7 +339,7 @@ func startEventStreams(
 			deps := procDeps{
 				ParseID:        newIDParser(inboxContracts),
 				GetOrder:       newOrderGetter(inboxContracts),
-				ShouldReject:   newShouldRejector(backends, solverAddr, addrs.SolverNetOutbox),
+				ShouldReject:   newShouldRejector(backends, callAllower, solverAddr, addrs.SolverNetOutbox),
 				DidFill:        newDidFiller(outboxContracts),
 				Reject:         newRejector(inboxContracts, backends, solverAddr),
 				Fill:           newFiller(outboxContracts, backends, solverAddr, addrs.SolverNetOutbox, pricer),

--- a/solver/app/check.go
+++ b/solver/app/check.go
@@ -33,10 +33,6 @@ func newChecker(backends ethbackend.Backends, isAllowedCall callAllowFunc, solve
 			return newRejection(types.RejectUnsupportedDestChain, errors.New("unsupported destination chain", "chain_id", req.DestinationChainID))
 		}
 
-		if err := checkCalls(req.DestinationChainID, req.Calls, isAllowedCall); err != nil {
-			return err
-		}
-
 		deposit, err := parseTokenAmt(req.SourceChainID, req.Deposit)
 		if err != nil {
 			return err
@@ -58,6 +54,10 @@ func newChecker(backends ethbackend.Backends, isAllowedCall callAllowFunc, solve
 		}
 
 		if err := checkLiquidity(ctx, expenses, dstBackend, solverAddr); err != nil {
+			return err
+		}
+
+		if err := checkCalls(req.DestinationChainID, req.Calls, isAllowedCall); err != nil {
 			return err
 		}
 

--- a/solver/app/check_internal_test.go
+++ b/solver/app/check_internal_test.go
@@ -14,6 +14,8 @@ import (
 	"github.com/omni-network/omni/lib/netconf"
 	"github.com/omni-network/omni/solver/types"
 
+	"github.com/ethereum/go-ethereum/common"
+
 	"github.com/stretchr/testify/require"
 )
 
@@ -32,7 +34,8 @@ func TestCheck(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			backends, clients := testBackends(t)
 
-			handler := handlerAdapter(newCheckHandler(newChecker(backends, solver, outbox)))
+			callAllower := func(_ uint64, _ common.Address, _ []byte) bool { return !tt.disallowCall }
+			handler := handlerAdapter(newCheckHandler(newChecker(backends, callAllower, solver, outbox)))
 
 			if tt.mock != nil {
 				tt.mock(clients)

--- a/solver/app/internal_testutils.go
+++ b/solver/app/internal_testutils.go
@@ -43,7 +43,7 @@ type testOrder struct {
 // orderTestCase is a test case for both shouldReject and quote handlers.
 type orderTestCase struct {
 	name         string
-	reason       rejectReason
+	reason       types.RejectReason
 	reject       bool
 	fillReverts  bool
 	disallowCall bool
@@ -54,7 +54,7 @@ type orderTestCase struct {
 // rejectTestCase is a test case for shouldReject(...)
 type rejectTestCase struct {
 	name         string
-	reason       rejectReason
+	reason       types.RejectReason
 	reject       bool
 	fillReverts  bool
 	disallowCall bool
@@ -466,16 +466,19 @@ func orderTestCases(t *testing.T, solver common.Address) []orderTestCase {
 		},
 		{
 			name:         "disallowed call",
-			reason:       rejectCallNotAllowed,
+			reason:       types.RejectCallNotAllowed,
 			reject:       true,
 			disallowCall: true,
 			// rest does not matter
 			order: testOrder{
 				srcChainID: evmchain.IDHolesky,
-				dstChainID: evmchain.IDOmniOmega,
-				deposits:   []types.AddrAmt{{Amount: big.NewInt(1)}},
-				calls:      []types.Call{{Value: big.NewInt(1)}},
-				expenses:   []types.Expense{{Amount: big.NewInt(1)}},
+				dstChainID: evmchain.IDBaseSepolia,
+				deposits:   []types.AddrAmt{{Amount: ether(2)}},
+				calls:      []types.Call{{Value: ether(1)}},
+				expenses:   []types.Expense{{Amount: ether(1)}},
+			},
+			mock: func(clients MockClients) {
+				mockNativeBalance(t, clients.Client(t, evmchain.IDBaseSepolia), solver, ether(2))
 			},
 		},
 	}

--- a/solver/app/reject.go
+++ b/solver/app/reject.go
@@ -315,7 +315,7 @@ func checkOrderCalls(order Order, isAllowed callAllowFunc) error {
 func checkCalls(destChainID uint64, calls []types.Call, isAllowed callAllowFunc) error {
 	for _, call := range calls {
 		if !isAllowed(destChainID, call.Target, call.Data) {
-			return newRejection(rejectCallNotAllowed, errors.New("call not allowed", "target", call.Target.Hex(), "data", hexutil.Encode(call.Data)))
+			return newRejection(types.RejectCallNotAllowed, errors.New("call not allowed", "target", call.Target.Hex(), "data", hexutil.Encode(call.Data)))
 		}
 	}
 

--- a/solver/app/reject.go
+++ b/solver/app/reject.go
@@ -45,6 +45,7 @@ func newRejection(reason types.RejectReason, err error) *RejectionError {
 // should be made before calling ShouldReject.
 func newShouldRejector(
 	backends ethbackend.Backends,
+	isAllowedCall callAllowFunc,
 	solverAddr, outboxAddr common.Address,
 ) func(ctx context.Context, order Order) (types.RejectReason, bool, error) {
 	return func(ctx context.Context, order Order) (types.RejectReason, bool, error) {
@@ -53,6 +54,10 @@ func newShouldRejector(
 			backend, err := backends.Backend(order.DestinationChainID)
 			if err != nil {
 				return newRejection(types.RejectUnsupportedDestChain, err)
+			}
+
+			if err := checkOrderCalls(order, isAllowedCall); err != nil {
+				return err
 			}
 
 			deposits, err := parseMinReceived(order)
@@ -281,6 +286,36 @@ func checkLiquidity(ctx context.Context, expenses []TokenAmt, backend *ethbacken
 		// spend out whole balance. we'll need to keep some for gas
 		if bal.Cmp(expense.Amount) < 0 {
 			return newRejection(types.RejectInsufficientInventory, errors.New("insufficient balance", "token", expense.Token.Symbol))
+		}
+	}
+
+	return nil
+}
+
+// checkOrderCalls checks if all calls in an order are allowed.
+func checkOrderCalls(order Order, isAllowed callAllowFunc) error {
+	fill, err := order.ParsedFillOriginData()
+	if err != nil {
+		return errors.Wrap(err, "parse fill origin data")
+	}
+
+	var calls []types.Call
+	for _, call := range fill.Calls {
+		calls = append(calls, types.Call{
+			Target: call.Target,
+			Value:  call.Value,
+			Data:   append(call.Selector[:], call.Params...),
+		})
+	}
+
+	return checkCalls(order.DestinationChainID, calls, isAllowed)
+}
+
+// checkCalls checks if all calls to destChainID are allowed.
+func checkCalls(destChainID uint64, calls []types.Call, isAllowed callAllowFunc) error {
+	for _, call := range calls {
+		if !isAllowed(destChainID, call.Target, call.Data) {
+			return newRejection(rejectCallNotAllowed, errors.New("call not allowed", "target", call.Target.Hex(), "data", hexutil.Encode(call.Data)))
 		}
 	}
 

--- a/solver/app/reject_internal_test.go
+++ b/solver/app/reject_internal_test.go
@@ -9,6 +9,8 @@ import (
 	"github.com/omni-network/omni/lib/contracts"
 	"github.com/omni-network/omni/lib/netconf"
 
+	"github.com/ethereum/go-ethereum/common"
+
 	"github.com/stretchr/testify/require"
 )
 
@@ -49,7 +51,8 @@ func TestShouldReject(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			backends, clients := testBackends(t)
 
-			shouldReject := newShouldRejector(backends, solver, outbox)
+			callAllower := func(_ uint64, _ common.Address, _ []byte) bool { return !tt.disallowCall }
+			shouldReject := newShouldRejector(backends, callAllower, solver, outbox)
 
 			if tt.mock != nil {
 				tt.mock(clients)

--- a/solver/app/targets.go
+++ b/solver/app/targets.go
@@ -1,0 +1,134 @@
+package app
+
+import (
+	"bytes"
+
+	"github.com/omni-network/omni/contracts/bindings"
+	"github.com/omni-network/omni/e2e/app/eoa"
+	"github.com/omni-network/omni/halo/genutil/evm/predeploys"
+	"github.com/omni-network/omni/lib/errors"
+	"github.com/omni-network/omni/lib/evmchain"
+	"github.com/omni-network/omni/lib/netconf"
+
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+)
+
+var (
+	middlemanABI          = mustGetABI(bindings.SolverNetMiddlemanMetaData)
+	execAndTransferMethod = mustMethod(middlemanABI, "executeAndTransfer")
+)
+
+type callAllowFunc func(chainID uint64, target common.Address, calldata []byte) bool
+
+var (
+	// targetsRestricted maps each network to whether targets should be restricted to the allowed set.
+	targetsRestricted = map[netconf.ID]bool{
+		netconf.Staging: true,
+		netconf.Omega:   true,
+		netconf.Mainnet: true,
+	}
+
+	// allowedTargets maps chain id to a set of allowed target addresses.
+	allowedTargets = map[uint64]map[common.Address]bool{
+		evmchain.IDSepolia: {
+			common.HexToAddress("0x77F170Dcd0439c0057055a6D7e5A1Eb9c48cCD2a"): true, // wstETH vault 1
+			common.HexToAddress("0x1BAe55e4774372F6181DaAaB4Ca197A8D9CC06Dd"): true, // wstETH vault 2
+			common.HexToAddress("0x6415D3B5fc615D4a00C71f4044dEc24C141EBFf8"): true, // wstETH vault 3
+		},
+		evmchain.IDHolesky: {
+			common.HexToAddress("0xd88dDf98fE4d161a66FB836bee4Ca469eb0E4a75"): true, // wstETH vault 1
+			common.HexToAddress("0xa4c81649c79f8378a4409178E758B839F1d57a54"): true, // wstETH vault 2
+		},
+		evmchain.IDOmniStaging: {
+			common.HexToAddress(predeploys.Staking): true,
+		},
+		evmchain.IDOmniOmega: {
+			common.HexToAddress(predeploys.Staking): true,
+		},
+		evmchain.IDOmniMainnet: {
+			common.HexToAddress(predeploys.Staking): true,
+		},
+	}
+)
+
+func newCallAllower(network netconf.ID, middlemanAddr common.Address) callAllowFunc {
+	return func(chainID uint64, target common.Address, calldata []byte) bool {
+		if !targetsRestricted[network] {
+			return true
+		}
+
+		// flowgen can bridge to itself
+		if target == eoa.MustAddress(network, eoa.RoleFlowgen) {
+			return true
+		}
+
+		if target == middlemanAddr {
+			proxiedTarget, _, err := parseMiddlemanCall(calldata)
+			if err != nil {
+				return false
+			}
+
+			target = proxiedTarget
+		}
+
+		if _, ok := allowedTargets[chainID]; !ok {
+			return false
+		}
+
+		if allowed, ok := allowedTargets[chainID][target]; !ok || !allowed {
+			return false
+		}
+
+		return true
+	}
+}
+
+// parseMiddlemanCall parses a call to the middleman contract, and returns proxied target and call data.
+func parseMiddlemanCall(data []byte) (common.Address, []byte, error) {
+	methodID := data[:4]
+
+	// executeAndTransfer is only supported method
+	method := execAndTransferMethod
+	if !bytes.Equal(methodID, method.ID) {
+		return common.Address{}, nil, errors.New("unknown method", "method", hexutil.Encode(methodID))
+	}
+
+	// decode call arguments
+	unpacked, err := method.Inputs.Unpack(data[4:])
+	if err != nil {
+		return common.Address{}, nil, errors.Wrap(err, "unpack call args")
+	}
+
+	wrap := struct {
+		Token  common.Address
+		To     common.Address
+		Target common.Address
+		Data   []byte
+	}{}
+	if err := method.Inputs.Copy(&wrap, unpacked); err != nil {
+		return common.Address{}, nil, errors.Wrap(err, "copy call args")
+	}
+
+	return wrap.Target, wrap.Data, nil
+}
+
+func mustGetABI(metadata *bind.MetaData) *abi.ABI {
+	abi, err := metadata.GetAbi()
+	if err != nil {
+		panic(err)
+	}
+
+	return abi
+}
+
+func mustMethod(abi *abi.ABI, name string) abi.Method {
+	method, ok := abi.Methods[name]
+	if !ok {
+		panic("method not found")
+	}
+
+	return method
+}

--- a/solver/app/targets_internal_test.go
+++ b/solver/app/targets_internal_test.go
@@ -1,0 +1,168 @@
+package app
+
+import (
+	"testing"
+
+	"github.com/omni-network/omni/e2e/app/eoa"
+	"github.com/omni-network/omni/halo/genutil/evm/predeploys"
+	"github.com/omni-network/omni/lib/evmchain"
+	"github.com/omni-network/omni/lib/netconf"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCallAllower(t *testing.T) {
+	t.Parallel()
+
+	// actual address does not matter
+	middlemanAddr := common.HexToAddress("0x1234567890123456789012345678901234567890")
+
+	tests := []struct {
+		name     string
+		network  netconf.ID
+		chainID  uint64
+		target   common.Address
+		calldata []byte
+		allowed  bool
+	}{
+		{
+			name:     "staging flowgen",
+			network:  netconf.Staging,
+			chainID:  evmchain.IDSepolia,
+			target:   eoa.MustAddress(netconf.Staging, eoa.RoleFlowgen),
+			calldata: nil,
+			allowed:  true,
+		},
+		{
+			name:     "omega flowgen",
+			network:  netconf.Omega,
+			chainID:  evmchain.IDSepolia,
+			target:   eoa.MustAddress(netconf.Omega, eoa.RoleFlowgen),
+			calldata: nil,
+			allowed:  true,
+		},
+		{
+			name:     "mainnet flowgen",
+			network:  netconf.Mainnet,
+			chainID:  evmchain.IDSepolia,
+			target:   eoa.MustAddress(netconf.Mainnet, eoa.RoleFlowgen),
+			calldata: nil,
+			allowed:  true,
+		},
+		{
+			name:     "sepolia symbiotic",
+			network:  netconf.Staging,
+			chainID:  evmchain.IDSepolia,
+			target:   common.HexToAddress("0x77F170Dcd0439c0057055a6D7e5A1Eb9c48cCD2a"), // wstETH vault 1
+			calldata: []byte{0x01, 0x02, 0x03},                                          // doesn't matter,
+			allowed:  true,
+		},
+		{
+			name:     "holesky symbiotic",
+			network:  netconf.Omega,
+			chainID:  evmchain.IDHolesky,
+			target:   common.HexToAddress("0xd88dDf98fE4d161a66FB836bee4Ca469eb0E4a75"), // wstETH vault 1
+			calldata: []byte{0x01, 0x02, 0x03},                                          // doesn't matter,
+			allowed:  true,
+		},
+		{
+			name:     "staging staking",
+			network:  netconf.Staging,
+			chainID:  evmchain.IDOmniStaging,
+			target:   common.HexToAddress(predeploys.Staking),
+			calldata: []byte{0x01, 0x02, 0x03}, // doesn't matter,
+			allowed:  true,
+		},
+		{
+			name:     "omega staking",
+			network:  netconf.Omega,
+			chainID:  evmchain.IDOmniOmega,
+			target:   common.HexToAddress(predeploys.Staking),
+			calldata: []byte{0x01, 0x02, 0x03}, // doesn't matter,
+			allowed:  true,
+		},
+		{
+			name:     "mainnet staking",
+			network:  netconf.Mainnet,
+			chainID:  evmchain.IDOmniMainnet,
+			target:   common.HexToAddress(predeploys.Staking),
+			calldata: []byte{0x01, 0x02, 0x03}, // doesn't matter,
+			allowed:  true,
+		},
+		{
+			name:    "middleman allowed call",
+			network: netconf.Omega,
+			chainID: evmchain.IDSepolia,
+			target:  middlemanAddr,
+			// executeAndTransfer call to allowed target (sepolia symbiotic wstETH vault)
+			calldata: hexutil.MustDecode("0xfebe2c2c000000000000000000000000b82381a3fbd3fafa77b3a7be693342618240067b000000000000000000000000e3481474b23f88a8917dbcb4cbc55efcf0f68cc70000000000000000000000006415d3b5fc615d4a00c71f4044dec24c141ebff80000000000000000000000000000000000000000000000000000000000000080000000000000000000000000000000000000000000000000000000000000004447e7ef24000000000000000000000000e3481474b23f88a8917dbcb4cbc55efcf0f68cc70000000000000000000000000000000000000000000000008ac7230489e8000000000000000000000000000000000000000000000000000000000000"),
+			allowed:  true,
+		},
+		{
+			name:    "middleman disallowed call",
+			network: netconf.Omega,
+			chainID: evmchain.IDSepolia,
+			target:  middlemanAddr,
+			// executeAndTransfer call to disallowed target
+			calldata: hexutil.MustDecode("0xfebe2c2c000000000000000000000000b82381a3fbd3fafa77b3a7be693342618240067b0000000000000000000000006415d3b5fc615d4a00c71f4044dec24c141ebff8000000000000000000000000e3481474b23f88a8917dbcb4cbc55efcf0f68cc70000000000000000000000000000000000000000000000000000000000000080000000000000000000000000000000000000000000000000000000000000004447e7ef240000000000000000000000006415d3b5fc615d4a00c71f4044dec24c141ebff80000000000000000000000000000000000000000000000008ac7230489e8000000000000000000000000000000000000000000000000000000000000"),
+			allowed:  false,
+		},
+		{
+			name:    "middleman invalid params",
+			network: netconf.Omega,
+			chainID: evmchain.IDSepolia,
+			target:  middlemanAddr,
+			// executeAndTransfer, invalid params (only selector)
+			calldata: hexutil.MustDecode("0xfebe2c2c"),
+			allowed:  false,
+		},
+		{
+			name:    "middleman invalid calldata",
+			network: netconf.Omega,
+			chainID: evmchain.IDSepolia,
+			target:  middlemanAddr,
+			// invalid calldata (not executeAndTransfer)
+			calldata: hexutil.MustDecode("0x12345678"),
+			allowed:  false,
+		},
+		{
+			name:     "devnet, calls not restricted",
+			network:  netconf.Devnet,
+			chainID:  evmchain.IDSepolia,
+			target:   common.HexToAddress("0xe3481474b23f88a8917DbcB4cBC55Efcf0f68CC7"), // doesn't matter
+			calldata: []byte{0x01, 0x02, 0x03},                                          // doesn't matter,
+			allowed:  true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			allow := newCallAllower(tt.network, middlemanAddr)
+			allowed := allow(tt.chainID, tt.target, tt.calldata)
+
+			require.Equal(t, tt.allowed, allowed)
+		})
+	}
+}
+
+func TestParseMiddlemanCall(t *testing.T) {
+	t.Parallel()
+
+	// executeAndTransfer call to allowed target (0x6415D3B5fc615D4a00C71f4044dEc24C141EBFf8 - sepolia symbiotic wstETH vault)
+	calldata := hexutil.MustDecode("0xfebe2c2c000000000000000000000000b82381a3fbd3fafa77b3a7be693342618240067b000000000000000000000000e3481474b23f88a8917dbcb4cbc55efcf0f68cc70000000000000000000000006415d3b5fc615d4a00c71f4044dec24c141ebff80000000000000000000000000000000000000000000000000000000000000080000000000000000000000000000000000000000000000000000000000000004447e7ef24000000000000000000000000e3481474b23f88a8917dbcb4cbc55efcf0f68cc70000000000000000000000000000000000000000000000008ac7230489e8000000000000000000000000000000000000000000000000000000000000")
+	target, proxiedData, err := parseMiddlemanCall(calldata)
+	require.NoError(t, err)
+	require.Equal(t, common.HexToAddress("0x6415D3B5fc615D4a00C71f4044dEc24C141EBFf8"), target)
+	require.Equal(t, "0x47e7ef24000000000000000000000000e3481474b23f88a8917dbcb4cbc55efcf0f68cc70000000000000000000000000000000000000000000000008ac7230489e80000", hexutil.Encode(proxiedData))
+
+	// executeAndTransfer call to disallowed target (0xe3481474b23f88a8917DbcB4cBC55Efcf0f68CC7)
+	calldata = hexutil.MustDecode("0xfebe2c2c000000000000000000000000b82381a3fbd3fafa77b3a7be693342618240067b0000000000000000000000006415d3b5fc615d4a00c71f4044dec24c141ebff8000000000000000000000000e3481474b23f88a8917dbcb4cbc55efcf0f68cc70000000000000000000000000000000000000000000000000000000000000080000000000000000000000000000000000000000000000000000000000000004447e7ef240000000000000000000000006415d3b5fc615d4a00c71f4044dec24c141ebff80000000000000000000000000000000000000000000000008ac7230489e8000000000000000000000000000000000000000000000000000000000000")
+	target, proxiedData, err = parseMiddlemanCall(calldata)
+	require.NoError(t, err)
+	require.Equal(t, common.HexToAddress("0xe3481474b23f88a8917DbcB4cBC55Efcf0f68CC7"), target)
+	require.Equal(t, "0x47e7ef240000000000000000000000006415d3b5fc615d4a00c71f4044dec24c141ebff80000000000000000000000000000000000000000000000008ac7230489e80000", hexutil.Encode(proxiedData))
+}

--- a/solver/targets/targets.go
+++ b/solver/targets/targets.go
@@ -1,0 +1,60 @@
+// Package defines list of targets supported by Omni's v1 solver. Targets are
+// restricted to reduce attack surface area, and keep order flow predictable.
+// Targets restriction will be removed / lessened in future versions.
+package targets
+
+import (
+	"github.com/omni-network/omni/halo/genutil/evm/predeploys"
+	"github.com/omni-network/omni/lib/evmchain"
+	"github.com/omni-network/omni/lib/netconf"
+
+	"github.com/ethereum/go-ethereum/common"
+)
+
+var (
+	SymbioticSepoliaWSTETHVault1 = common.HexToAddress("0x77F170Dcd0439c0057055a6D7e5A1Eb9c48cCD2a")
+	SymbioticSepoliaWSTETHVault2 = common.HexToAddress("0x1BAe55e4774372F6181DaAaB4Ca197A8D9CC06Dd")
+	SymbioticSepoliaWSTETHVault3 = common.HexToAddress("0x6415D3B5fc615D4a00C71f4044dEc24C141EBFf8")
+	SymbioticHoleskyWSTETHVault1 = common.HexToAddress("0xd88dDf98fE4d161a66FB836bee4Ca469eb0E4a75")
+	SymbioticHoleskyWSTETHVault2 = common.HexToAddress("0xa4c81649c79f8378a4409178E758B839F1d57a54")
+	OmniStaking                  = common.HexToAddress(predeploys.Staking)
+
+	// targetsRestricted maps each network to whether targets should be restricted to the allowed set.
+	targetsRestricted = map[netconf.ID]bool{
+		netconf.Staging: true,
+		netconf.Omega:   true,
+		netconf.Mainnet: true,
+	}
+
+	// allowedTargets maps chain id to a set of allowed target addresses.
+	allowedTargets = map[uint64]map[common.Address]bool{
+		evmchain.IDSepolia: {
+			SymbioticSepoliaWSTETHVault1: true,
+			SymbioticSepoliaWSTETHVault2: true,
+			SymbioticSepoliaWSTETHVault3: true,
+		},
+		evmchain.IDHolesky: {
+			SymbioticHoleskyWSTETHVault1: true,
+			SymbioticHoleskyWSTETHVault2: true,
+		},
+		evmchain.IDOmniStaging: {
+			OmniStaking: true,
+		},
+		evmchain.IDOmniOmega: {
+			OmniStaking: true,
+		},
+		evmchain.IDOmniMainnet: {
+			OmniStaking: true,
+		},
+	}
+)
+
+// IsRestricted returns true if the given network restricts targets.
+func IsRestricted(network netconf.ID) bool {
+	return targetsRestricted[network]
+}
+
+// IsAllowedTarget returns true if the target address is allowed on the given chain.
+func IsAllowedTarget(chainID uint64, target common.Address) bool {
+	return allowedTargets[chainID][target]
+}

--- a/solver/types/reject.go
+++ b/solver/types/reject.go
@@ -17,4 +17,5 @@ const (
 	RejectSameChain             RejectReason = 10
 	RejectExpenseOverMax        RejectReason = 11
 	RejectExpenseUnderMin       RejectReason = 12
+	RejectCallNotAllowed        RejectReason = 13
 )

--- a/solver/types/rejectreason_string.go
+++ b/solver/types/rejectreason_string.go
@@ -21,11 +21,12 @@ func _() {
 	_ = x[RejectSameChain-10]
 	_ = x[RejectExpenseOverMax-11]
 	_ = x[RejectExpenseUnderMin-12]
+	_ = x[RejectCallNotAllowed-13]
 }
 
-const _RejectReason_name = "NoneDestCallRevertsInvalidDepositInvalidExpenseInsufficientDepositInsufficientInventoryUnsupportedDepositUnsupportedExpenseUnsupportedDestChainUnsupportedSrcChainSameChainExpenseOverMaxExpenseUnderMin"
+const _RejectReason_name = "NoneDestCallRevertsInvalidDepositInvalidExpenseInsufficientDepositInsufficientInventoryUnsupportedDepositUnsupportedExpenseUnsupportedDestChainUnsupportedSrcChainSameChainExpenseOverMaxExpenseUnderMinCallNotAllowed"
 
-var _RejectReason_index = [...]uint8{0, 4, 19, 33, 47, 66, 87, 105, 123, 143, 162, 171, 185, 200}
+var _RejectReason_index = [...]uint8{0, 4, 19, 33, 47, 66, 87, 105, 123, 143, 162, 171, 185, 200, 214}
 
 func (i RejectReason) String() string {
 	if i >= RejectReason(len(_RejectReason_index)-1) {


### PR DESCRIPTION
Restrict call targets

Allow
- symbiotic wsteth vaults on sepolia
- staking contract on omni evm
- flowgen bridging
- calls through middleman to allowed targets

Middleman is part of the "product" for devs, so we need to support it. 

issue: #3349
