### PR TITLE
ci(e2e/anvil): infer upstream image platform

### DIFF
--- a/e2e/anvilproxy/Dockerfile
+++ b/e2e/anvilproxy/Dockerfile
@@ -1,5 +1,5 @@
 ARG FOUNDRY_VERSION
-FROM --platform=linux/amd64 ghcr.io/foundry-rs/foundry:${FOUNDRY_VERSION}
+FROM ghcr.io/foundry-rs/foundry:${FOUNDRY_VERSION}
 
 # Need wget for localhost perturbations
 # apk for apline (https://github.com/foundry-rs/foundry/blob/master/Dockerfile)


### PR DESCRIPTION
When building `anvilproxy`, don't hardcode upstream forge docker image platform. Rather infer from environment. 

On latest docker and MacOS, this resulted in the forge binary being amd64, while the anvil proxy image was arm64, so it crashed.

issue: none