### PR TITLE
ci(e2e): enable holesky on omega monitor

### DIFF
--- a/e2e/manifests/omega.toml
+++ b/e2e/manifests/omega.toml
@@ -4,10 +4,10 @@ public_chains = ["holesky","op_sepolia", "base_sepolia","arb_sepolia"]
 multi_omni_evms = true
 prometheus = true
 
-# 3e4a9f8 disables holesky
+# 1849471 enables holesky
 pinned_halo_tag = "3e4a9f8"
 pinned_relayer_tag = "3e4a9f8"
-pinned_monitor_tag = "3e4a9f8"
+pinned_monitor_tag = "1849471"
 
 # 2664dee enables holesky in solver
 pinned_solver_tag = "2664dee"


### PR DESCRIPTION
Bump omega monitor (only), enabling holesky, to see how finalization and chain heads look like.

issue: none