### PR TITLE
refactor(solver/app): explicit pending data

### DIFF
--- a/lib/contracts/solvernet/types.go
+++ b/lib/contracts/solvernet/types.go
@@ -1,6 +1,7 @@
 package solvernet
 
 import (
+	"encoding/hex"
 	"math/big"
 
 	"github.com/omni-network/omni/contracts/bindings"
@@ -16,8 +17,13 @@ type (
 	FillOriginData = bindings.SolverNetFillOriginData
 )
 
-// String returns the Uint64 representation of the order ID as a string.
+// String returns the short hex (7 chars) representation of the order ID.
 func (id OrderID) String() string {
+	return hex.EncodeToString(id[:])[:7]
+}
+
+// Hex returns the full 0xHEX representation of the order ID.
+func (id OrderID) Hex() string {
 	return hexutil.Encode(id[:])
 }
 

--- a/lib/xchain/connect/connect.go
+++ b/lib/xchain/connect/connect.go
@@ -64,6 +64,26 @@ func (c Connector) Portal(ctx context.Context, chainID uint64) (*bindings.OmniPo
 	return contract, nil
 }
 
+// SolverNetInbox returns a SolverNetInbox contract.
+func (c Connector) SolverNetInbox(ctx context.Context, chainID uint64) (*bindings.SolverNetInbox, error) {
+	backend, err := c.Backends.Backend(chainID)
+	if err != nil {
+		return nil, err
+	}
+
+	addrs, err := contracts.GetAddresses(ctx, c.Network.ID)
+	if err != nil {
+		return nil, err
+	}
+
+	contract, err := bindings.NewSolverNetInbox(addrs.SolverNetInbox, backend)
+	if err != nil {
+		return nil, err
+	}
+
+	return contract, nil
+}
+
 type options struct {
 	Endpoints xchain.RPCEndpoints
 	PrivKeys  []*ecdsa.PrivateKey

--- a/lib/xchain/provider/streamlogs.go
+++ b/lib/xchain/provider/streamlogs.go
@@ -40,7 +40,7 @@ func (p *Provider) StreamEventLogs(ctx context.Context, req xchain.EventLogsReq,
 	}
 
 	chainVersionName := p.network.ChainVersionName(req.ChainVersion())
-	ctx = log.WithCtx(ctx, "chain", chainVersionName)
+	ctx = log.WithCtx(ctx, "chain_version", chainVersionName)
 
 	deps := stream.Deps[events]{
 		FetchWorkers: workers,

--- a/monitor/flowgen/bridging/bridging.go
+++ b/monitor/flowgen/bridging/bridging.go
@@ -31,11 +31,16 @@ func NewJob(
 		return types.Job{}, errors.Wrap(err, "new job")
 	}
 
+	cadence := 30 * time.Minute
+	if network == netconf.Devnet {
+		cadence = time.Second * 10
+	}
+
 	namer := netconf.ChainNamer(network)
 
 	return types.Job{
 		Name:    fmt.Sprintf("Bridging (%v->%v)", namer(srcChain), namer(dstChain)),
-		Cadence: 30 * time.Minute,
+		Cadence: cadence,
 		Network: network,
 
 		SrcChain: srcChain,

--- a/solver/app/internal_testutils.go
+++ b/solver/app/internal_testutils.go
@@ -148,13 +148,19 @@ func toRejectTestCase(t *testing.T, tt orderTestCase, outbox common.Address) rej
 		disallowCall: tt.disallowCall,
 		mock:         tt.mock,
 		order: Order{
-			ID:                 [32]byte{0x01},
-			SourceChainID:      tt.order.srcChainID,
-			DestinationChainID: tt.order.dstChainID,
-			DestinationSettler: outbox,
-			MaxSpent:           maxSpent,
-			MinReceived:        minReceived,
-			FillOriginData:     fillOriginData,
+			ID:            [32]byte{0x01},
+			SourceChainID: tt.order.srcChainID,
+			Status:        solvernet.StatusPending,
+			pendingData: PendingData{
+				DestinationChainID: tt.order.dstChainID,
+				DestinationSettler: outbox,
+				MaxSpent:           maxSpent,
+				MinReceived:        minReceived,
+				FillOriginData:     fillOriginData,
+			},
+			filledData: FilledData{
+				MinReceived: minReceived,
+			},
 		},
 	}
 }
@@ -204,8 +210,7 @@ func checkTestCases(t *testing.T, solver common.Address) []checkTestCase {
 func rejectTestCases(t *testing.T, solver, outbox common.Address) []rejectTestCase {
 	t.Helper()
 
-	tests := []rejectTestCase{}
-
+	var tests []rejectTestCase
 	for _, tt := range orderTestCases(t, solver) {
 		tests = append(tests, toRejectTestCase(t, tt, outbox))
 	}

--- a/solver/app/metrics.go
+++ b/solver/app/metrics.go
@@ -10,22 +10,22 @@ var (
 		Namespace: "solver",
 		Subsystem: "processor",
 		Name:      "status_offset",
-		Help:      "Last inbox offset processed by chain and status",
-	}, []string{"chain", "target", "status"})
+		Help:      "Last inbox offset processed by chain version and status",
+	}, []string{"chain_version", "status"})
 
 	processedEvents = promauto.NewCounterVec(prometheus.CounterOpts{
 		Namespace: "solver",
 		Subsystem: "processor",
 		Name:      "processed_events_total",
 		Help:      "Total number of events processed by chain and status",
-	}, []string{"chain", "target", "status"})
+	}, []string{"chain_version", "status"})
 
 	rejectedOrders = promauto.NewCounterVec(prometheus.CounterOpts{
 		Namespace: "solver",
 		Subsystem: "processor",
 		Name:      "rejected_orders_total",
 		Help:      "Total number of rejected orders by chain and reason",
-	}, []string{"src_chain", "dest_chain", "target", "reason"})
+	}, []string{"chain", "reason"})
 
 	orderAge = promauto.NewHistogramVec(prometheus.HistogramOpts{
 		Namespace: "solver",
@@ -33,7 +33,7 @@ var (
 		Name:      "order_age_seconds",
 		Help:      "Order age (from creation) in seconds by chain and status",
 		Buckets:   prometheus.ExponentialBucketsRange(1, 60, 5),
-	}, []string{"chain", "target", "status"})
+	}, []string{"chain", "status"})
 
 	apiLatency = promauto.NewHistogramVec(prometheus.HistogramOpts{
 		Namespace: "solver",

--- a/solver/app/pnl.go
+++ b/solver/app/pnl.go
@@ -13,7 +13,12 @@ import (
 
 // pnlExpenses logs the solver expense PnL for the order.
 func pnlExpenses(ctx context.Context, pricer tokenslib.Pricer, order Order, outboxAddr common.Address, dstChainName string) error {
-	maxSpent, err := parseMaxSpent(order, outboxAddr)
+	pendingData, err := order.PendingData()
+	if err != nil {
+		return errors.Wrap(err, "get pending data [BUG]")
+	}
+
+	maxSpent, err := parseMaxSpent(pendingData, outboxAddr)
 	if err != nil {
 		return errors.Wrap(err, "parse max spent [BUG]") // This should never fail here.
 	}

--- a/solver/app/processor_internal_test.go
+++ b/solver/app/processor_internal_test.go
@@ -88,12 +88,14 @@ func TestEventProcessor(t *testing.T) {
 					return Order{
 						ID:     id,
 						Status: test.getStatus,
-						FillInstruction: bindings.IERC7683FillInstruction{
-							DestinationSettler: [32]byte{},
-							DestinationChainId: 0,
-							OriginData:         []byte{},
+						pendingData: PendingData{
+							FillInstruction: bindings.IERC7683FillInstruction{
+								DestinationSettler: [32]byte{},
+								DestinationChainId: 0,
+								OriginData:         []byte{},
+							},
+							MaxSpent: []bindings.IERC7683Output{},
 						},
-						MaxSpent: []bindings.IERC7683Output{},
 					}, true, nil
 				},
 				DidFill: func(ctx context.Context, order Order) (bool, error) {
@@ -131,7 +133,7 @@ func TestEventProcessor(t *testing.T) {
 					return nil
 				},
 				ChainName:      func(uint64) string { return "" },
-				TargetName:     func(Order) string { return "" },
+				TargetName:     func(PendingData) string { return "" },
 				BlockTimestamp: func(uint64, uint64) time.Time { return time.Time{} },
 			}
 

--- a/solver/app/reject_internal_test.go
+++ b/solver/app/reject_internal_test.go
@@ -57,7 +57,7 @@ func TestShouldReject(t *testing.T) {
 			if tt.mock != nil {
 				tt.mock(clients)
 
-				destClient := clients.Client(t, tt.order.DestinationChainID)
+				destClient := clients.Client(t, tt.order.pendingData.DestinationChainID)
 				mockFill(t, destClient, outbox, tt.fillReverts)
 				mockFillFee(t, destClient, outbox)
 


### PR DESCRIPTION
Split `solver/app.Order`into multiple types, since not all fields are always available. `PendingData` is only available in `pending` state, similarly for `FilledData`.

Had to refactor monitoring since the data isn't always available.

issue: #3199 