### PR TITLE
chore(ci): skip SDK tests in environments without solver

### DIFF
--- a/e2e/test/sdk_test.go
+++ b/e2e/test/sdk_test.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/omni-network/omni/e2e/types"
 	"github.com/omni-network/omni/lib/netconf"
 	"github.com/omni-network/omni/lib/xchain"
 
@@ -16,7 +17,10 @@ import (
 
 func TestSDK(t *testing.T) {
 	t.Parallel()
-	testNetwork(t, func(ctx context.Context, t *testing.T, network netconf.Network, endpoints xchain.RPCEndpoints) {
+	skipFunc := func(manifest types.Manifest) bool {
+		return !manifest.DeploySolve
+	}
+	maybeTestNetwork(t, skipFunc, func(ctx context.Context, t *testing.T, network netconf.Network, endpoints xchain.RPCEndpoints) {
 		t.Helper()
 
 		cwd, err := os.Getwd()

--- a/sdk/integration-tests/flows.test.tsx
+++ b/sdk/integration-tests/flows.test.tsx
@@ -22,7 +22,7 @@ import {
   testConnector,
 } from './test-utils.js'
 
-test.skip('successfully processes order from quote to filled', async () => {
+test('successfully processes order from quote to filled', async () => {
   const wagmiConfig = createWagmiConfig()
   const renderHook = createRenderHook({ wagmiConfig })
 

--- a/sdk/integration-tests/flows.test.tsx
+++ b/sdk/integration-tests/flows.test.tsx
@@ -22,7 +22,7 @@ import {
   testConnector,
 } from './test-utils.js'
 
-test('successfully processes order from quote to filled', async () => {
+test.skip('successfully processes order from quote to filled', async () => {
   const wagmiConfig = createWagmiConfig()
   const renderHook = createRenderHook({ wagmiConfig })
 


### PR DESCRIPTION
Skip tests if SolverNet is not available

issue: none
