### PR TITLE
chore(e2e): update monitor pin on omega

### DIFF
--- a/e2e/manifests/omega.toml
+++ b/e2e/manifests/omega.toml
@@ -7,7 +7,8 @@ prometheus = true
 # 1849471 enables holesky
 pinned_halo_tag = "1849471"
 pinned_relayer_tag = "1849471"
-pinned_monitor_tag = "1849471"
+# fixes staking metrics
+pinned_monitor_tag = "d945a97"
 pinned_solver_tag = "98ce013"
 
 [node.validator01]


### PR DESCRIPTION
Update monitor pin on omega to pick up staking metric fixes.

issue: none