### PR TITLE
refactor(solver/app): refactor pnl

### DIFF
--- a/solver/app/metrics.go
+++ b/solver/app/metrics.go
@@ -10,15 +10,15 @@ var (
 		Namespace: "solver",
 		Subsystem: "processor",
 		Name:      "status_offset",
-		Help:      "Last inbox offset processed by chain version and status",
-	}, []string{"chain_version", "status"})
+		Help:      "Last inbox offset processed by processor and status",
+	}, []string{"proc", "status"})
 
 	processedEvents = promauto.NewCounterVec(prometheus.CounterOpts{
 		Namespace: "solver",
 		Subsystem: "processor",
 		Name:      "processed_events_total",
-		Help:      "Total number of events processed by chain and status",
-	}, []string{"chain_version", "status"})
+		Help:      "Total number of events processed by processor and status",
+	}, []string{"proc", "status"})
 
 	rejectedOrders = promauto.NewCounterVec(prometheus.CounterOpts{
 		Namespace: "solver",

--- a/solver/app/pnl.go
+++ b/solver/app/pnl.go
@@ -11,58 +11,75 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 )
 
-// pnlExpenses logs the solver expense PnL for the order.
-func pnlExpenses(ctx context.Context, pricer tokenslib.Pricer, order Order, outboxAddr common.Address, dstChainName string) error {
-	pendingData, err := order.PendingData()
-	if err != nil {
-		return errors.Wrap(err, "get pending data [BUG]")
-	}
+type pnlFunc func(ctx context.Context, order Order) error
+type targetFunc func(PendingData) string
 
-	maxSpent, err := parseMaxSpent(pendingData, outboxAddr)
-	if err != nil {
-		return errors.Wrap(err, "parse max spent [BUG]") // This should never fail here.
-	}
-
-	for _, tknAmt := range maxSpent {
-		p := pnl.LogP{
-			Type:        pnl.Expense,
-			AmountGwei:  toGweiF64(tknAmt.Amount),
-			Currency:    pnl.Currency(tknAmt.Token.Symbol),
-			Category:    "solver",
-			Subcategory: "spend",
-			Chain:       dstChainName,
-			ID:          order.ID.String(),
-		}
-		pnl.Log(ctx, p)
-		usdPnL(ctx, pricer, tknAmt.Token.Token, p)
-	}
-
-	return nil
-}
-
-// pnlIncome logs the solver income PnL for the order.
-func pnlIncome(ctx context.Context, pricer tokenslib.Pricer, order Order, srcChainName string) error {
-	minReceived, err := parseMinReceived(order)
-	if err != nil {
-		return errors.Wrap(err, "parse min received [BUG]") // This should never fail here.
-	}
-
-	for _, tknAmt := range minReceived {
-		p := pnl.LogP{
-			Type:        pnl.Income,
-			AmountGwei:  toGweiF64(tknAmt.Amount),
-			Currency:    pnl.Currency(tknAmt.Token.Symbol),
-			Category:    "solver",
-			Subcategory: "receive",
-			Chain:       srcChainName,
-			ID:          order.ID.String(),
+// newPnlFunc returns a pnlFunc that logs the PnL for an order.
+// This is done immediately after successful fill.
+//
+// Technically, income should only be logged after successful claim, but
+// target is used as subcategory and this is only available in pending data.
+//
+// So technically, the claim can fail and the PnL income will still be logged.
+func newPnlFunc(
+	pricer tokenslib.Pricer,
+	targetName targetFunc,
+	namer func(uint64) string,
+	outbox common.Address,
+) pnlFunc {
+	return func(ctx context.Context, order Order) error {
+		pendingData, err := order.PendingData()
+		if err != nil {
+			return errors.Wrap(err, "get pending data [BUG]")
 		}
 
-		pnl.Log(ctx, p)
-		usdPnL(ctx, pricer, tknAmt.Token.Token, p)
-	}
+		target := targetName(pendingData)
+		srcChainName := namer(order.SourceChainID)
+		dstChainName := namer(pendingData.DestinationChainID)
 
-	return nil
+		maxSpent, err := parseMaxSpent(pendingData, outbox)
+		if err != nil {
+			return errors.Wrap(err, "parse max spent [BUG]") // This should never fail here.
+		}
+
+		minReceived, err := parseMinReceived(order)
+		if err != nil {
+			return errors.Wrap(err, "parse min received [BUG]") // This should never fail here.
+		}
+
+		const pnlCategory = "solver"
+
+		for _, tknAmt := range maxSpent {
+			p := pnl.LogP{
+				Type:        pnl.Expense,
+				AmountGwei:  toGweiF64(tknAmt.Amount),
+				Currency:    pnl.Currency(tknAmt.Token.Symbol),
+				Category:    pnlCategory,
+				Subcategory: target,
+				Chain:       dstChainName,
+				ID:          order.ID.String(),
+			}
+			pnl.Log(ctx, p)
+			usdPnL(ctx, pricer, tknAmt.Token.Token, p)
+		}
+
+		for _, tknAmt := range minReceived {
+			p := pnl.LogP{
+				Type:        pnl.Income,
+				AmountGwei:  toGweiF64(tknAmt.Amount),
+				Currency:    pnl.Currency(tknAmt.Token.Symbol),
+				Category:    pnlCategory,
+				Subcategory: target,
+				Chain:       srcChainName,
+				ID:          order.ID.String(),
+			}
+
+			pnl.Log(ctx, p)
+			usdPnL(ctx, pricer, tknAmt.Token.Token, p)
+		}
+
+		return nil
+	}
 }
 
 // usdPnL logs the USD equivalent PnL.

--- a/solver/app/targets.go
+++ b/solver/app/targets.go
@@ -42,7 +42,9 @@ func newCallAllower(network netconf.ID, middlemanAddr common.Address) callAllowF
 			target = proxiedTarget
 		}
 
-		return targets.IsAllowedTarget(chainID, target)
+		_, ok := targets.Get(chainID, target)
+
+		return ok
 	}
 }
 

--- a/solver/targets/targets.go
+++ b/solver/targets/targets.go
@@ -1,4 +1,4 @@
-// Package defines list of targets supported by Omni's v1 solver. Targets are
+// Package targets defines list of targets supported by Omni's v1 solver. Targets are
 // restricted to reduce attack surface area, and keep order flow predictable.
 // Targets restriction will be removed / lessened in future versions.
 package targets
@@ -11,13 +11,17 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 )
 
+type Target struct {
+	Name      string
+	Addresses func(chainID uint64) map[common.Address]bool
+}
+
 var (
 	SymbioticSepoliaWSTETHVault1 = common.HexToAddress("0x77F170Dcd0439c0057055a6D7e5A1Eb9c48cCD2a")
 	SymbioticSepoliaWSTETHVault2 = common.HexToAddress("0x1BAe55e4774372F6181DaAaB4Ca197A8D9CC06Dd")
 	SymbioticSepoliaWSTETHVault3 = common.HexToAddress("0x6415D3B5fc615D4a00C71f4044dEc24C141EBFf8")
 	SymbioticHoleskyWSTETHVault1 = common.HexToAddress("0xd88dDf98fE4d161a66FB836bee4Ca469eb0E4a75")
 	SymbioticHoleskyWSTETHVault2 = common.HexToAddress("0xa4c81649c79f8378a4409178E758B839F1d57a54")
-	OmniStaking                  = common.HexToAddress(predeploys.Staking)
 
 	// targetsRestricted maps each network to whether targets should be restricted to the allowed set.
 	targetsRestricted = map[netconf.ID]bool{
@@ -26,35 +30,50 @@ var (
 		netconf.Mainnet: true,
 	}
 
-	// allowedTargets maps chain id to a set of allowed target addresses.
-	allowedTargets = map[uint64]map[common.Address]bool{
-		evmchain.IDSepolia: {
-			SymbioticSepoliaWSTETHVault1: true,
-			SymbioticSepoliaWSTETHVault2: true,
-			SymbioticSepoliaWSTETHVault3: true,
+	targets = []Target{
+		{
+			Name: "Symbiotic",
+			Addresses: networkChainAddrs(map[uint64]map[common.Address]bool{
+				evmchain.IDSepolia: {
+					SymbioticSepoliaWSTETHVault1: true,
+					SymbioticSepoliaWSTETHVault2: true,
+					SymbioticSepoliaWSTETHVault3: true,
+				},
+				evmchain.IDHolesky: {
+					SymbioticHoleskyWSTETHVault1: true,
+					SymbioticHoleskyWSTETHVault2: true,
+				},
+			}),
 		},
-		evmchain.IDHolesky: {
-			SymbioticHoleskyWSTETHVault1: true,
-			SymbioticHoleskyWSTETHVault2: true,
-		},
-		evmchain.IDOmniStaging: {
-			OmniStaking: true,
-		},
-		evmchain.IDOmniOmega: {
-			OmniStaking: true,
-		},
-		evmchain.IDOmniMainnet: {
-			OmniStaking: true,
+		{
+			Name: "OmniStaking",
+			Addresses: func(uint64) map[common.Address]bool {
+				return map[common.Address]bool{
+					common.HexToAddress(predeploys.Staking): true,
+				}
+			},
 		},
 	}
 )
+
+func networkChainAddrs(m map[uint64]map[common.Address]bool) func(uint64) map[common.Address]bool {
+	return func(chainID uint64) map[common.Address]bool {
+		return m[chainID]
+	}
+}
 
 // IsRestricted returns true if the given network restricts targets.
 func IsRestricted(network netconf.ID) bool {
 	return targetsRestricted[network]
 }
 
-// IsAllowedTarget returns true if the target address is allowed on the given chain.
-func IsAllowedTarget(chainID uint64, target common.Address) bool {
-	return allowedTargets[chainID][target]
+// Get returns the allowed target for the given chain and address.
+func Get(chainID uint64, target common.Address) (Target, bool) {
+	for _, t := range targets {
+		if _, ok := t.Addresses(chainID)[target]; ok {
+			return t, true
+		}
+	}
+
+	return Target{}, false
 }


### PR DESCRIPTION
Refactor solver PNL to include `target` as subcategory. 

This required moving `Income` to filled (from claimed), since target only available in pending data.

Also refactor target package to provide names.

issue: #3199 
