### PR TITLE
refactor(solver/app): refactor age cache

### DIFF
--- a/solver/app/age.go
+++ b/solver/app/age.go
@@ -1,0 +1,133 @@
+package app
+
+import (
+	"context"
+	"log/slog"
+	"sync"
+	"time"
+
+	"github.com/omni-network/omni/lib/contracts/solvernet"
+	"github.com/omni-network/omni/lib/ethclient/ethbackend"
+	"github.com/omni-network/omni/lib/log"
+	"github.com/omni-network/omni/lib/umath"
+)
+
+const (
+	maxAgeCache = 10000 // Max orders to track in age cache
+
+	// statusDestFilled is an un-official status when an order was filled on the destination chain.
+	// This contrasts with the official "filled" status which is emitted on the source chain after xmsg received.
+	statusDestFilled = "dest_filled"
+)
+
+type instrDestFilledFunc func(ctx context.Context, dstChainID uint64, dstHeight uint64, order Order)
+
+func newAgeCache(backends ethbackend.Backends) *ageCache {
+	return &ageCache{
+		createdAts: make(map[solvernet.OrderID]time.Time),
+		backends:   backends,
+	}
+}
+
+// ageCache enables best-effort tracking of order ages.
+// Since on-chain state doesn't contain "created_height", a cache is used.
+type ageCache struct {
+	mu         sync.Mutex
+	backends   ethbackend.Backends
+	createdAts map[solvernet.OrderID]time.Time
+}
+
+func (a *ageCache) blockMeta(ctx context.Context, chainID uint64, height uint64) (string, time.Time, error) {
+	backend, err := a.backends.Backend(chainID)
+	if err != nil {
+		return "", time.Time{}, err
+	}
+
+	header, err := backend.HeaderByNumber(ctx, umath.NewBigInt(height))
+	if err != nil {
+		return "", time.Time{}, err
+	}
+	timeI64, err := umath.ToInt64(header.Time)
+	if err != nil {
+		return "", time.Time{}, err
+	}
+
+	name, _ := backend.Chain()
+
+	return name, time.Unix(timeI64, 0), nil
+}
+
+// InstrumentAge instruments the age of an order event.
+func (a *ageCache) InstrumentAge(ctx context.Context, srcChainID uint64, srcHeight uint64, order Order) slog.Attr {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	age, err := a.instrumentUnsafe(ctx, srcChainID, srcHeight, order.ID, order.Status.String())
+	if err != nil {
+		log.Warn(ctx, "Failed instrumenting order event (will retry)", err)
+	}
+
+	if a.maybePurge() {
+		log.Warn(ctx, "Purged overflowing age cache", nil)
+	}
+
+	if age == 0 {
+		return slog.Attr{}
+	}
+
+	return slog.Duration("age", age)
+}
+
+// InstrumentDestFilled instruments the age of an order filled on the destination chain.
+func (a *ageCache) InstrumentDestFilled(ctx context.Context, dstChainID uint64, dstHeight uint64, order Order) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	_, err := a.instrumentUnsafe(ctx, dstChainID, dstHeight, order.ID, statusDestFilled)
+	if err != nil {
+		log.Warn(ctx, "Failed instrumenting order filled (will retry)", err)
+	}
+}
+
+func (a *ageCache) instrumentUnsafe(ctx context.Context, chainID uint64, height uint64, orderID OrderID, status string) (time.Duration, error) {
+	chainName, timestamp, err := a.blockMeta(ctx, chainID, height)
+	if err != nil {
+		return 0, err
+	}
+
+	if status == solvernet.StatusPending.String() {
+		// Order is created in the block that emits pending status
+		a.createdAts[orderID] = timestamp
+
+		return 0, nil
+	}
+
+	createdAt, ok := a.createdAts[orderID]
+	if !ok {
+		// Pending event not seen or purged, best-effort ignore
+		return 0, nil
+	}
+
+	age := timestamp.Sub(createdAt)
+	orderAge.WithLabelValues(chainName, status).Observe(age.Seconds())
+
+	// Remove from cache once final status is reached
+	if status == solvernet.StatusRejected.String() ||
+		status == solvernet.StatusClaimed.String() {
+		delete(a.createdAts, orderID)
+	}
+
+	return age, nil
+}
+
+// maybePurge returns true if the cache was purged.
+// This is required to prevent memory leaks.
+func (a *ageCache) maybePurge() bool {
+	if len(a.createdAts) < maxAgeCache {
+		return false
+	}
+
+	a.createdAts = make(map[solvernet.OrderID]time.Time)
+
+	return true
+}

--- a/solver/app/metrics.go
+++ b/solver/app/metrics.go
@@ -32,7 +32,7 @@ var (
 		Subsystem: "processor",
 		Name:      "order_age_seconds",
 		Help:      "Order age (from creation) in seconds by chain and status",
-		Buckets:   prometheus.ExponentialBucketsRange(1, 60, 5),
+		Buckets:   prometheus.ExponentialBucketsRange(1, 60*60, 8),
 	}, []string{"chain", "status"})
 
 	apiLatency = promauto.NewHistogramVec(prometheus.HistogramOpts{

--- a/solver/app/processor.go
+++ b/solver/app/processor.go
@@ -2,7 +2,6 @@ package app
 
 import (
 	"context"
-	"time"
 
 	"github.com/omni-network/omni/lib/contracts/solvernet"
 	"github.com/omni-network/omni/lib/errors"
@@ -13,17 +12,9 @@ import (
 	"github.com/ethereum/go-ethereum/core/types"
 )
 
-const (
-	statusDestFilled = "dest_filled" // Unofficial state after destination fill
-
-	maxAgeCache = 10000 // Max orders to track in age cache
-)
-
 // newEventProcessor returns a callback provided to xchain.Provider::StreamEventLogs processing
 // all inbox contract events and driving order lifecycle.
 func newEventProcessor(deps procDeps, chainID uint64) xchain.EventLogsCallback {
-	ageCache := newAgeCache()
-
 	return func(ctx context.Context, height uint64, elogs []types.Log) error {
 		for _, elog := range elogs {
 			event, ok := solvernet.EventByTopic(elog.Topics[0])
@@ -43,23 +34,22 @@ func newEventProcessor(deps procDeps, chainID uint64) xchain.EventLogsCallback {
 				return errors.New("order not found [BUG]")
 			}
 
-			timestamp := deps.BlockTimestamp(chainID, elog.BlockNumber)
-			age := ageCache.InstrumentAge(order.ID, order.Status.String(), timestamp)
 			statusOffset.WithLabelValues(deps.ProcessorName, event.Status.String()).Set(float64(order.Offset))
 
 			ctx := log.WithCtx(ctx,
 				"order_id", order.ID.String(),
 				"offset", order.Offset,
 				"status", order.Status,
-				"age", age,
 			)
 
-			log.Debug(ctx, "Processing order event")
-
 			if event.Status != order.Status {
-				log.Debug(ctx, "Ignoring old event (status already changed)", "event_status", event.Status.String())
+				log.Debug(ctx, "Ignoring old order event (status already changed)", "event_status", event.Status.String())
 				continue
 			}
+
+			age := deps.InstrumentAge(ctx, chainID, height, order)
+
+			log.Debug(ctx, "Processing order event", age)
 
 			alreadyFilled := func() bool {
 				// ignore err. maybeReject will handle unsupported dest chain
@@ -97,8 +87,6 @@ func newEventProcessor(deps procDeps, chainID uint64) xchain.EventLogsCallback {
 					return nil
 				}
 
-				// Track all orders for now, since we reject explicitly.
-				ageCache.Add(order.ID, timestamp)
 				debugPendingData(ctx, deps, order)
 
 				if didReject, err := maybeReject(); err != nil {
@@ -111,16 +99,13 @@ func newEventProcessor(deps procDeps, chainID uint64) xchain.EventLogsCallback {
 				if err := deps.Fill(ctx, order); err != nil {
 					return errors.Wrap(err, "fill order")
 				}
-				ageCache.InstrumentAge(order.ID, statusDestFilled, time.Now())
 			case solvernet.StatusFilled:
 				log.Info(ctx, "Claiming order")
 				if err := deps.Claim(ctx, order); err != nil {
 					return errors.Wrap(err, "claim order")
 				}
-				ageCache.Remove(order.ID) // Delete from cache on final state
 			case solvernet.StatusRejected, solvernet.StatusClosed, solvernet.StatusClaimed:
 				// Noop for now
-				ageCache.Remove(order.ID) // Delete from cache on final state
 			default:
 				return errors.New("unknown status [BUG]")
 			}
@@ -128,61 +113,8 @@ func newEventProcessor(deps procDeps, chainID uint64) xchain.EventLogsCallback {
 			processedEvents.WithLabelValues(deps.ProcessorName, event.Status.String()).Inc()
 		}
 
-		if ageCache.MaybePurge() {
-			log.Warn(ctx, "Purged overflowing age cache [BUG]", nil)
-		}
-
 		return deps.SetCursor(ctx, chainID, height)
 	}
-}
-
-func newAgeCache() *ageCache {
-	return &ageCache{
-		createdAts: make(map[solvernet.OrderID]time.Time),
-	}
-}
-
-// ageCache enables best-effort tracking of order ages.
-// Since on-chain state doesn't contain "created_height", a cache is used.
-type ageCache struct {
-	createdAts map[solvernet.OrderID]time.Time
-}
-
-// InstrumentAge records the age of an order, returning the age.
-func (a *ageCache) InstrumentAge(order OrderID, status string, timestamp time.Time) time.Duration {
-	if timestamp.IsZero() {
-		return 0 // Best effort ignore for now
-	}
-	t0, ok := a.createdAts[order]
-	if !ok {
-		return 0 // Best effort ignore for now
-	}
-	age := timestamp.Sub(t0)
-	orderAge.WithLabelValues("", status).Observe(age.Seconds())
-
-	return age
-}
-
-// Remove removes an order from the cache.
-func (a *ageCache) Remove(order OrderID) {
-	delete(a.createdAts, order)
-}
-
-// Add adds a new order to the cache.
-func (a *ageCache) Add(order OrderID, timestamp time.Time) {
-	a.createdAts[order] = timestamp
-}
-
-// MaybePurge returns true if the cache was purged.
-// This is required to prevent memory leaks.
-func (a *ageCache) MaybePurge() bool {
-	if len(a.createdAts) < maxAgeCache {
-		return false
-	}
-
-	a.createdAts = make(map[solvernet.OrderID]time.Time)
-
-	return true
 }
 
 func debugPendingData(ctx context.Context, deps procDeps, order Order) {

--- a/solver/app/processor_internal_test.go
+++ b/solver/app/processor_internal_test.go
@@ -2,8 +2,8 @@ package app
 
 import (
 	"context"
+	"log/slog"
 	"testing"
-	"time"
 
 	"github.com/omni-network/omni/contracts/bindings"
 	"github.com/omni-network/omni/lib/contracts/solvernet"
@@ -132,9 +132,9 @@ func TestEventProcessor(t *testing.T) {
 
 					return nil
 				},
-				ChainName:      func(uint64) string { return "" },
-				TargetName:     func(PendingData) string { return "" },
-				BlockTimestamp: func(uint64, uint64) time.Time { return time.Time{} },
+				ChainName:     func(uint64) string { return "" },
+				TargetName:    func(PendingData) string { return "" },
+				InstrumentAge: func(context.Context, uint64, uint64, Order) slog.Attr { return slog.Attr{} },
 			}
 
 			processor := newEventProcessor(deps, chainID)


### PR DESCRIPTION
Refactor age cache:
- Use a central cache (since orderID unique across chains, and multiple processors may process the same order)
- Avoid adding `ago=0s` to most orders, only add is actually found.
- Use `dest_filled` block timestamp for accurate age

issue: #3199 