### PR TITLE
chore(e2e): update mainnet solver pin

### DIFF
--- a/e2e/manifests/mainnet.toml
+++ b/e2e/manifests/mainnet.toml
@@ -7,7 +7,7 @@ prometheus   = true
 pinned_halo_tag = "v0.13.0"
 pinned_relayer_tag = "8622c0c"
 pinned_monitor_tag = "8622c0c"
-pinned_solver_tag = "8622c0c"
+pinned_solver_tag = "98ce013"
 
 [node.validator01]
 [node.validator02]


### PR DESCRIPTION
Update solver pin to latest stable omega.

issue: none