### PR TITLE
chore(sdk): add integration tests for native orders

### DIFF
--- a/sdk/integration-tests/flows.test.tsx
+++ b/sdk/integration-tests/flows.test.tsx
@@ -1,9 +1,11 @@
 import { act, render, waitFor } from '@testing-library/react'
 import { createRef } from 'react'
-import { expect, test } from 'vitest'
+import type { PrivateKeyAccount } from 'viem/accounts'
+import { describe, expect, should, test } from 'vitest'
 import { useConnect } from 'wagmi'
 
 import {
+  type Order,
   type Quote,
   useOrder,
   useQuote,
@@ -11,16 +13,107 @@ import {
 } from '../src/index.js'
 
 import {
+  ACCOUNTS_RECORD,
   ContextProvider,
   ETHER,
   MOCK_L1_ID,
   MOCK_L2_ID,
   ZERO_ADDRESS,
   accounts,
+  createClientFactory,
   createRenderHook,
+  createTestConnector,
   createWagmiConfig,
   testConnector,
 } from './test-utils.js'
+
+type AnyOrder = Order<Array<unknown>>
+
+describe('solver test orders', () => {
+  type TestOrder = {
+    label: string
+    account: PrivateKeyAccount
+    order: AnyOrder
+    shouldReject: boolean
+    rejectReason: string
+  }
+
+  const testAccounts = Object.values(ACCOUNTS_RECORD)
+
+  const nativeOrders: Array<TestOrder> = testAccounts.map((account, i) => {
+    const isOverMax = i < 3
+    const isUnderMin = i > 6
+
+    const [label, amount, shouldReject, rejectReason] = isOverMax
+      ? [
+          'Native order failing with expense over max amount',
+          2n * ETHER,
+          true,
+          'ExpenseOverMax',
+        ]
+      : isUnderMin
+        ? [
+            'Native order failing with expense under min amount',
+            1n,
+            true,
+            'ExpenseUnderMin',
+          ]
+        : ['Native order succeeding', ETHER, false, '']
+
+    const order: AnyOrder = {
+      owner: account.address,
+      srcChainId: MOCK_L1_ID,
+      destChainId: MOCK_L2_ID,
+      expense: { token: ZERO_ADDRESS, amount },
+      calls: [{ target: account.address, value: amount }],
+      deposit: { token: ZERO_ADDRESS, amount: amount + ETHER },
+    }
+
+    return { label, account, order, shouldReject, rejectReason }
+  })
+
+  test.each(nativeOrders)(
+    '$label with account $account.address',
+    async ({ account, order, shouldReject, rejectReason }) => {
+      const createClient = createClientFactory(account)
+      const testConnector = createTestConnector(createClient)
+
+      const connectRef = createRef()
+      const orderRef = createRef()
+
+      // useOrder() can only be used with a connected account, so we need to render it conditionally
+      function TestOrder() {
+        orderRef.current = useOrder({ ...order, validateEnabled: true })
+        return null
+      }
+
+      // Wrap TestOrder to only render if connected
+      function TestConnectAndOrder() {
+        const connectReturn = useConnect()
+        connectRef.current = connectReturn
+        return connectReturn.data ? <TestOrder /> : null
+      }
+
+      render(<TestConnectAndOrder />, { wrapper: ContextProvider })
+      act(() => {
+        connectRef.current?.connect({ connector: testConnector })
+      })
+
+      await waitFor(() => expect(orderRef.current?.isReady).toBe(true))
+
+      if (shouldReject) {
+        expect(orderRef.current?.validation?.status).toBe('rejected')
+        expect(orderRef.current?.validation?.rejectReason).toBe(rejectReason)
+      } else {
+        expect(orderRef.current?.validation?.status).toBe('accepted')
+        act(() => {
+          orderRef.current?.open()
+        })
+        await waitFor(() => expect(orderRef.current?.txHash).toBeDefined())
+      }
+    },
+  )
+})
 
 test('successfully processes order from quote to filled', async () => {
   const wagmiConfig = createWagmiConfig()

--- a/sdk/integration-tests/test-utils.tsx
+++ b/sdk/integration-tests/test-utils.tsx
@@ -1,8 +1,8 @@
 import { readFileSync } from 'node:fs'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { type RenderHookResult, renderHook } from '@testing-library/react'
-import { http, type Chain, createWalletClient } from 'viem'
-import { privateKeyToAccount } from 'viem/accounts'
+import { http, type Address, type Chain, createWalletClient } from 'viem'
+import { type PrivateKeyAccount, privateKeyToAccount } from 'viem/accounts'
 import {
   type Config,
   type CreateConnectorFn,
@@ -28,6 +28,7 @@ if (endpointsFilePath != null && endpointsFilePath.trim() !== '') {
 }
 
 export const ETHER = 1_000_000_000_000_000_000n // 18 decimals
+export const OMNI_DEVNET_ID = 1651
 export const MOCK_L1_ID = 1652
 export const MOCK_L2_ID = 1654
 export const ZERO_ADDRESS =
@@ -60,29 +61,66 @@ const MOCK_CHAINS: Record<number, Chain> = {
   [MOCK_L2_ID]: MOCK_L2_CHAIN,
 }
 
-export const accounts = ['0xE0cF003AC27FaeC91f107E3834968A601842e9c6'] as const
+export const ACCOUNTS_RECORD = {
+  '0xE0cF003AC27FaeC91f107E3834968A601842e9c6': privateKeyToAccount(
+    '0xbb119deceaff95378015e684292e91a37ef2ae1522f300a2cfdcb5b004bbf00d',
+  ),
+  '0x3C298a8fAb961CC155F48557872D37D39015c5bc': privateKeyToAccount(
+    '0xed3dccb053880be5b681f6f0256fc18410f99bd69fedfc80f6b37e7930d1c526',
+  ),
+  '0xD1862026335f1cfD7c5DB13e58bA4C97247A7998': privateKeyToAccount(
+    '0xe0cff2136e89d72576e1e8a3af640af8509fa07191429766d89814923b9ddbc2',
+  ),
+  '0xC38Ef10ecC4aD9c24554cACd67cA4896B4fb2F9C': privateKeyToAccount(
+    '0x7b63e2b097b37620054a0c3ba9e2c0253751b26f62f866dcbde64508071c0048',
+  ),
+  '0x8696e3d6cAD982C32F86320a6f0E1AB8aB3Db3b9': privateKeyToAccount(
+    '0x2b6c35e1914655810e6471aea16358c335995985eb5d1a8e2a49ee5dca6779c1',
+  ),
+  '0xB5775c7e3796822dA059B73218E8a9033dA9bC67': privateKeyToAccount(
+    '0x49f5dabfb06f9febf27b3b07dc68f5c3a022edf8ac56631e92ba8879d7d7f44e',
+  ),
+  '0x9637Bc245647B4cdD85e3bB092c672e2ddD28539': privateKeyToAccount(
+    '0x07fe974baf69d3d4d93438698155adffae10e24ab14eaa468e69a17c2a1295d3',
+  ),
+  '0x23a4523A3EE6220fB2CdDc5Ab94A2780D6493230': privateKeyToAccount(
+    '0x8b8638c2c593903c63f096200dad748af3e36ca4dbcfd11f57cfa83e98cfdbc8',
+  ),
+  '0xACb32F1b31F818511139a67b79010fA011960764': privateKeyToAccount(
+    '0xdf6cd4fcdba1068873acef34a91f41c9af581dafd52fbc2908add6fb213f5e02',
+  ),
+  '0x3c56a0cDB54D07A91791b698d8B390aB53208E92': privateKeyToAccount(
+    '0xefebe60ea08dbc53c3e59612380501d4cbe7309548d84692ec978e06e3c61137',
+  ),
+} as const satisfies Record<Address, PrivateKeyAccount>
+
+export const accounts = Object.keys(ACCOUNTS_RECORD) as [Address, ...Address[]]
 
 const mockConnector = mock({ accounts })
 
-const account = privateKeyToAccount(
-  '0xbb119deceaff95378015e684292e91a37ef2ae1522f300a2cfdcb5b004bbf00d',
-)
-
-function createClient({ chain }: { chain: Chain }) {
-  return createWalletClient({ account, chain, transport: http() })
-}
-
-export const testConnector: CreateConnectorFn = (config) => {
-  const connector = mockConnector(config)
-  connector.getClient = async ({ chainId } = {}) => {
-    const chain = chainId ? MOCK_CHAINS[chainId] : MOCK_L1_CHAIN
-    if (chain == null) {
-      throw new Error(`Unsupported chain: ${chainId}`)
-    }
-    return createClient({ chain })
+export function createClientFactory(account: PrivateKeyAccount) {
+  return function createClient({ chain }: { chain: Chain }) {
+    return createWalletClient({ account, chain, transport: http() })
   }
-  return connector
 }
+
+export function createTestConnector(createClient): CreateConnectorFn {
+  return function testConnector(config) {
+    const connector = mockConnector(config)
+    connector.getClient = async ({ chainId } = {}) => {
+      const chain = chainId ? MOCK_CHAINS[chainId] : MOCK_L1_CHAIN
+      if (chain == null) {
+        throw new Error(`Unsupported chain: ${chainId}`)
+      }
+      return createClient({ chain })
+    }
+    return connector
+  }
+}
+
+const createClient = createClientFactory(ACCOUNTS_RECORD[accounts[0]])
+
+export const testConnector = createTestConnector(createClient)
 
 export function createWagmiConfig() {
   return createConfig({


### PR DESCRIPTION
Copying logic from `e2e/solve/test.go`

issue: none