### PR TITLE
feat(solver): allow different spend bounds by chain class

### DIFF
--- a/solver/app/testdata/TestTokens.golden
+++ b/solver/app/testdata/TestTokens.golden
@@ -104,7 +104,7 @@
   "chainId": 166,
   "coingeckoId": "omni-network",
   "isMock": false,
-  "maxSpend": "1000.0000",
+  "maxSpend": "120000.0000",
   "minSpend": "0.1000",
   "name": "Omni Network",
   "symbol": "OMNI"
@@ -144,7 +144,7 @@
   "chainId": 1,
   "coingeckoId": "omni-network",
   "isMock": false,
-  "maxSpend": "1000.0000",
+  "maxSpend": "120000.0000",
   "minSpend": "0.1000",
   "name": "Omni Network",
   "symbol": "OMNI"

--- a/solver/app/tokens.go
+++ b/solver/app/tokens.go
@@ -56,14 +56,56 @@ func (t Token) IsOMNI() bool {
 	return t.Token == tokenslib.OMNI
 }
 
+type SpendBounds struct {
+	MinSpend *big.Int // minimum spend amount
+	MaxSpend *big.Int // maximum spend amount
+}
+
 var (
-	// TODO: increase max spend on mainnet, keep low for staging / omega.
-	maxETHSpend    = bi.Ether(1)     // 1 ETH
-	minETHSpend    = bi.Ether(0.001) // 0.001 ETH
-	maxWSTETHSpend = bi.Ether(1)     // 1 wstETH
-	minWSTETHSpend = bi.Ether(0.001) // 0.001 wstETH
-	maxOMNISpend   = bi.Ether(1_000) // 1000 OMNI
-	minOMNISpend   = bi.Ether(0.1)   // 0.1 OMNI
+	spendBounds = map[tokenslib.Token]map[ChainClass]SpendBounds{
+		tokenslib.ETH: {
+			ClassMainnet: {
+				MinSpend: bi.Ether(0.001), // 0.001 ETH
+				MaxSpend: bi.Ether(1),     // 1 ETH
+			},
+			ClassTestnet: {
+				MinSpend: bi.Ether(0.001), // 0.001 ETH
+				MaxSpend: bi.Ether(1),     // 1 ETH
+			},
+			ClassDevent: {
+				MinSpend: bi.Ether(0.001), // 0.001 ETH
+				MaxSpend: bi.Ether(1),     // 1 ETH
+			},
+		},
+		tokenslib.OMNI: {
+			ClassMainnet: {
+				MinSpend: bi.Ether(0.1),     // 0.1 OMNI
+				MaxSpend: bi.Ether(120_000), // 120k OMNI
+			},
+			ClassTestnet: {
+				MinSpend: bi.Ether(0.1),   // 0.1 OMNI
+				MaxSpend: bi.Ether(1_000), // 1k OMNI
+			},
+			ClassDevent: {
+				MinSpend: bi.Ether(0.1),   // 0.1 OMNI
+				MaxSpend: bi.Ether(1_000), // 1k OMNI
+			},
+		},
+		tokenslib.WSTETH: {
+			ClassMainnet: {
+				MinSpend: bi.Ether(0.001), // 0.001 wstETH
+				MaxSpend: bi.Ether(4),     // 4 wstETH
+			},
+			ClassTestnet: {
+				MinSpend: bi.Ether(0.001), // 0.001 wstETH
+				MaxSpend: bi.Ether(1),     // 1 wstETH
+			},
+			ClassDevent: {
+				MinSpend: bi.Ether(0.001), // 0.001 wstETH
+				MaxSpend: bi.Ether(1),     // 1 wstETH
+			},
+		},
+	}
 )
 
 var tokens = append(Tokens{
@@ -135,49 +177,60 @@ func (ts Tokens) ForChain(chainID uint64) Tokens {
 }
 
 func nativeETH(chainID uint64) Token {
+	chainClass := mustChainClass(chainID)
+	bounds := mustSpendBounds(tokenslib.ETH, chainClass)
+
 	return Token{
 		Token:      tokenslib.ETH,
 		ChainID:    chainID,
 		ChainClass: mustChainClass(chainID),
-		MaxSpend:   maxETHSpend,
-		MinSpend:   minETHSpend,
+		MaxSpend:   bounds.MaxSpend,
+		MinSpend:   bounds.MinSpend,
 		Address:    NativeAddr,
 	}
 }
 
 func nativeOMNI(chainID uint64) Token {
+	chainClass := mustChainClass(chainID)
+	bounds := mustSpendBounds(tokenslib.OMNI, chainClass)
+
 	return Token{
 		Token:      tokenslib.OMNI,
 		ChainID:    chainID,
 		ChainClass: mustChainClass(chainID),
-		MaxSpend:   maxOMNISpend,
-		MinSpend:   minOMNISpend,
+		MaxSpend:   bounds.MaxSpend,
+		MinSpend:   bounds.MinSpend,
 		Address:    NativeAddr,
 	}
 }
 
 func omniERC20(network netconf.ID) Token {
 	chainID := netconf.EthereumChainID(network)
+	chainClass := mustChainClass(chainID)
+	bounds := mustSpendBounds(tokenslib.OMNI, chainClass)
 
 	return Token{
 		Token:      tokenslib.OMNI,
 		ChainID:    chainID,
 		ChainClass: mustChainClass(chainID),
 		Address:    contracts.TokenAddr(network),
-		MaxSpend:   maxOMNISpend,
-		MinSpend:   minOMNISpend,
+		MaxSpend:   bounds.MaxSpend,
+		MinSpend:   bounds.MinSpend,
 	}
 }
 
 // mockOMNI returns a manually deployed OMNI token on a given chain for testing purposes.
 func mockOMNI(chainID uint64, addr common.Address) Token {
+	chainClass := mustChainClass(chainID)
+	bounds := mustSpendBounds(tokenslib.OMNI, chainClass)
+
 	return Token{
 		Token:      tokenslib.OMNI,
 		ChainID:    chainID,
 		ChainClass: mustChainClass(chainID),
 		Address:    addr,
-		MaxSpend:   maxOMNISpend,
-		MinSpend:   minOMNISpend,
+		MaxSpend:   bounds.MaxSpend,
+		MinSpend:   bounds.MinSpend,
 		IsMock:     true,
 	}
 }
@@ -192,13 +245,16 @@ func stETH(chainID uint64, addr common.Address) Token {
 }
 
 func wstETH(chainID uint64, addr common.Address) Token {
+	chainClass := mustChainClass(chainID)
+	bounds := mustSpendBounds(tokenslib.WSTETH, chainClass)
+
 	return Token{
 		Token:      tokenslib.WSTETH,
 		ChainID:    chainID,
 		ChainClass: mustChainClass(chainID),
 		Address:    addr,
-		MaxSpend:   maxWSTETHSpend,
-		MinSpend:   minWSTETHSpend,
+		MaxSpend:   bounds.MaxSpend,
+		MinSpend:   bounds.MinSpend,
 	}
 }
 
@@ -252,6 +308,15 @@ func mustChainClass(chainID uint64) ChainClass {
 	}
 
 	return class
+}
+
+func mustSpendBounds(tkn tokenslib.Token, chainClass ChainClass) SpendBounds {
+	bounds, ok := spendBounds[tkn][chainClass]
+	if !ok {
+		panic(errors.New("spend bounds not found", "token", tkn, "chain_class", chainClass))
+	}
+
+	return bounds
 }
 
 func chainClass(chainID uint64) (ChainClass, error) {

--- a/solver/app/tokens_internal_test.go
+++ b/solver/app/tokens_internal_test.go
@@ -24,19 +24,21 @@ func TestTokens(t *testing.T) {
 			t.Errorf("duplicate token: %v", token)
 		}
 
+		chainClass := mustChainClass(token.ChainID)
+
 		if token.Symbol == tokenslib.ETH.Symbol && !token.IsMock {
-			require.Equal(t, token.MaxSpend, maxETHSpend)
-			require.Equal(t, token.MinSpend, minETHSpend)
+			require.Equal(t, token.MaxSpend, spendBounds[tokenslib.ETH][chainClass].MaxSpend)
+			require.Equal(t, token.MinSpend, spendBounds[tokenslib.ETH][chainClass].MinSpend)
 		}
 
 		if token.Symbol == tokenslib.WSTETH.Symbol && !token.IsMock {
-			require.Equal(t, token.MaxSpend, maxWSTETHSpend)
-			require.Equal(t, token.MinSpend, minWSTETHSpend)
+			require.Equal(t, token.MaxSpend, spendBounds[tokenslib.WSTETH][chainClass].MaxSpend)
+			require.Equal(t, token.MinSpend, spendBounds[tokenslib.WSTETH][chainClass].MinSpend)
 		}
 
 		if token.Symbol == tokenslib.OMNI.Symbol && !token.IsMock {
-			require.Equal(t, token.MaxSpend, maxOMNISpend)
-			require.Equal(t, token.MinSpend, minOMNISpend)
+			require.Equal(t, token.MaxSpend, spendBounds[tokenslib.OMNI][chainClass].MaxSpend)
+			require.Equal(t, token.MinSpend, spendBounds[tokenslib.OMNI][chainClass].MinSpend)
 		}
 
 		seen[token] = true
@@ -55,12 +57,20 @@ func TestTokens(t *testing.T) {
 	tutil.RequireGoldenJSON(t, golden)
 
 	// check max / min
-	require.Equal(t, "1.0000", etherStr(maxETHSpend))
-	require.Equal(t, "0.0010", etherStr(minETHSpend))
-	require.Equal(t, "1.0000", etherStr(maxWSTETHSpend))
-	require.Equal(t, "0.0010", etherStr(minWSTETHSpend))
-	require.Equal(t, "1000.0000", etherStr(maxOMNISpend))
-	require.Equal(t, "0.1000", etherStr(minOMNISpend))
+	require.Equal(t, "1.0000", etherStr(spendBounds[tokenslib.ETH]["mainnet"].MaxSpend))
+	require.Equal(t, "0.0010", etherStr(spendBounds[tokenslib.ETH]["mainnet"].MinSpend))
+	require.Equal(t, "1.0000", etherStr(spendBounds[tokenslib.ETH]["testnet"].MaxSpend))
+	require.Equal(t, "0.0010", etherStr(spendBounds[tokenslib.ETH]["testnet"].MinSpend))
+
+	require.Equal(t, "4.0000", etherStr(spendBounds[tokenslib.WSTETH]["mainnet"].MaxSpend))
+	require.Equal(t, "0.0010", etherStr(spendBounds[tokenslib.WSTETH]["mainnet"].MinSpend))
+	require.Equal(t, "1.0000", etherStr(spendBounds[tokenslib.WSTETH]["testnet"].MaxSpend))
+	require.Equal(t, "0.0010", etherStr(spendBounds[tokenslib.WSTETH]["testnet"].MinSpend))
+
+	require.Equal(t, "120000.0000", etherStr(spendBounds[tokenslib.OMNI]["mainnet"].MaxSpend))
+	require.Equal(t, "0.1000", etherStr(spendBounds[tokenslib.OMNI]["mainnet"].MinSpend))
+	require.Equal(t, "1000.0000", etherStr(spendBounds[tokenslib.OMNI]["testnet"].MaxSpend))
+	require.Equal(t, "0.1000", etherStr(spendBounds[tokenslib.OMNI]["testnet"].MinSpend))
 }
 
 func etherStr(amount *big.Int) string {


### PR DESCRIPTION
Allow different spend bounds by chain class.
Increase spend bounds for mainnet.

issue: none
