### PR TITLE
fix(solver/app): round up when quoting deposit

### DIFF
--- a/lib/bi/big.go
+++ b/lib/bi/big.go
@@ -84,7 +84,27 @@ func Div(a *big.Int, bs ...*big.Int) *big.Int {
 func DivRaw[I constraints.Integer](a *big.Int, bs ...I) *big.Int {
 	resp := Clone(a)
 	for _, b := range bs {
-		resp.Div(resp, N(b))
+		resp = Div(resp, N(b))
+	}
+
+	return resp
+}
+
+// Mod returns a % b0 [% b1 % b2 ...].
+func Mod(a *big.Int, bs ...*big.Int) *big.Int {
+	resp := Clone(a)
+	for _, b := range bs {
+		resp.Mod(resp, b)
+	}
+
+	return resp
+}
+
+// ModRaw returns a % b0 [% b1 % b2 ...].
+func ModRaw[I constraints.Integer](a *big.Int, bs ...I) *big.Int {
+	resp := Clone(a)
+	for _, b := range bs {
+		resp.Mod(resp, N(b))
 	}
 
 	return resp

--- a/solver/app/quote.go
+++ b/solver/app/quote.go
@@ -139,19 +139,20 @@ func feeBipsFor(tkn Token) int64 {
 
 // depositFor returns the deposit required to cover `expense` with a fee in bips.
 func depositFor(expense *big.Int, bips int64) *big.Int {
-	// deposit = expense + (expense * bips / 10_000)
+	// deposit = expense + ceil(expense * bips / 10_000)
 
-	fee := bi.DivRaw(
-		bi.MulRaw(expense, bips),
-		10_000,
-	)
+	feeDividend := bi.Mul(expense, bi.N(bips))
+	feeDividend = bi.Add(feeDividend, bi.N(9_999)) // Add 9_999 to dividend to round up.
+	feeDivisor := bi.N(10_000)
+
+	fee := bi.Div(feeDividend, feeDivisor)
 
 	return bi.Add(expense, fee)
 }
 
 // expenseFor returns the expense allowed for `deposit` with a fee in bips.
 func expenseFor(deposit *big.Int, bips int64) *big.Int {
-	// expense = 10_000 * d / (10_000 + bips)
+	// expense = floor(d * 10_000 / (10_000 + bips))
 
 	return bi.DivRaw(
 		bi.MulRaw(deposit, 10_000),


### PR DESCRIPTION
When quoting deposits, round up (instead of down). This ensures that:
```
deposit := y
fee := z

expense = quoteExpense(deposit, fee)
deposit2 := quoteDeposit(expense, fee)
deposit2 == deposit
```

issue: none
