### PR TITLE
chore(solver): return 408 on request cancel

### DIFF
--- a/solver/app/handler.go
+++ b/solver/app/handler.go
@@ -131,6 +131,10 @@ func handlerAdapter(h Handler) http.Handler {
 
 func writeErrResponse(ctx context.Context, w http.ResponseWriter, err error) {
 	statusCode := http.StatusInternalServerError
+	if ctx.Err() != nil {
+		// If request context is canceled, return a 408 instead of 500.
+		statusCode = http.StatusRequestTimeout
+	}
 
 	var apiErr APIError
 	if errors.As(err, &apiErr) {


### PR DESCRIPTION
When the request context is cancelled, return a 408 instead of 500, since it isn't "internal server error", but rather "request cancelled (or timeout)" for user side. So 4XX instead of 5XX.

issue: none