### PR TITLE
chore(e2e): update omega solver pin

### DIFF
--- a/e2e/manifests/omega.toml
+++ b/e2e/manifests/omega.toml
@@ -8,7 +8,7 @@ prometheus = true
 pinned_halo_tag = "1849471"
 pinned_relayer_tag = "1849471"
 pinned_monitor_tag = "eb23f09"
-pinned_solver_tag = "7cdfd5e"
+pinned_solver_tag = "5a77b00"
 
 [node.validator01]
 [node.validator02]


### PR DESCRIPTION
Updating omega solver pin.

Runs conf2 on ethereum chains.

issue: none
