### PR TITLE
chore(e2e): update mainnet solver pin

### DIFF
--- a/e2e/manifests/mainnet.toml
+++ b/e2e/manifests/mainnet.toml
@@ -7,7 +7,7 @@ prometheus   = true
 pinned_halo_tag = "v0.13.0"
 pinned_relayer_tag = "8622c0c"
 pinned_monitor_tag = "eb23f09"
-pinned_solver_tag = "7cdfd5e"
+pinned_solver_tag = "5a77b00"
 
 [node.validator01]
 [node.validator02]


### PR DESCRIPTION
Updating mainnet solver pin.

Runs conf2 event proc for l1 chains.

issue: none
