### PR TITLE
chore(solver/app): explicit proc lag metric

### DIFF
--- a/e2e/solve/test.go
+++ b/e2e/solve/test.go
@@ -117,7 +117,7 @@ func Test(ctx context.Context, network netconf.Network, endpoints xchain.RPCEndp
 			}
 
 			// Stream all inbox event logs and update order status in tracker
-			proc := func(ctx context.Context, _ uint64, logs []types.Log) error {
+			proc := func(ctx context.Context, _ *types.Header, logs []types.Log) error {
 				for _, l := range logs {
 					orderID, status, err := solvernet.ParseEvent(l)
 					if err != nil {

--- a/lib/xchain/provider.go
+++ b/lib/xchain/provider.go
@@ -41,7 +41,7 @@ func (r EventLogsReq) ChainVersion() ChainVersion {
 	}
 }
 
-type EventLogsCallback func(ctx context.Context, height uint64, events []types.Log) error
+type EventLogsCallback func(ctx context.Context, header *types.Header, events []types.Log) error
 
 // Provider abstracts fetching cross chain data from any supported chain.
 // This is basically a cross-chain data client for all supported chains.

--- a/lib/xchain/provider/metrics.go
+++ b/lib/xchain/provider/metrics.go
@@ -24,7 +24,7 @@ var (
 		Namespace: "lib",
 		Subsystem: "xprovider",
 		Name:      "stream_height",
-		Help:      "Latest streamed height per source chain version and stream type. Alert if not growing.",
+		Help:      "Latest successfully streamed height per source chain version and stream type. Alert if not growing.",
 	}, []string{"chain_version", "type"})
 
 	callbackLatency = promauto.NewHistogramVec(prometheus.HistogramOpts{

--- a/solver/app/app.go
+++ b/solver/app/app.go
@@ -346,7 +346,8 @@ func startEventStreams(
 func newHeightMutexer() func(callback xchain.EventLogsCallback) xchain.EventLogsCallback {
 	var mutexes sync.Map
 	return func(callback xchain.EventLogsCallback) xchain.EventLogsCallback {
-		return func(ctx context.Context, height uint64, events []types.Log) error {
+		return func(ctx context.Context, header *types.Header, events []types.Log) error {
+			height := header.Number.Uint64()
 			anyMutex, _ := mutexes.LoadOrStore(height, new(sync.Mutex))
 			mutex := anyMutex.(*sync.Mutex) //nolint:revive,forcetypeassert // Known type
 			mutex.Lock()
@@ -355,7 +356,7 @@ func newHeightMutexer() func(callback xchain.EventLogsCallback) xchain.EventLogs
 				mutexes.Delete(height)
 			}()
 
-			return callback(ctx, height, events)
+			return callback(ctx, header, events)
 		}
 	}
 }

--- a/solver/app/metrics.go
+++ b/solver/app/metrics.go
@@ -20,6 +20,13 @@ var (
 		Help:      "Total number of events processed by processor and status",
 	}, []string{"proc", "status"})
 
+	processorLag = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: "solver",
+		Subsystem: "processor",
+		Name:      "lag_seconds",
+		Help:      "The elapsed seconds since latest processed block timestamp per processor",
+	}, []string{"proc"})
+
 	rejectedOrders = promauto.NewCounterVec(prometheus.CounterOpts{
 		Namespace: "solver",
 		Subsystem: "processor",

--- a/solver/app/processor_internal_test.go
+++ b/solver/app/processor_internal_test.go
@@ -3,6 +3,7 @@ package app
 import (
 	"context"
 	"log/slog"
+	"math/big"
 	"testing"
 
 	"github.com/omni-network/omni/contracts/bindings"
@@ -139,7 +140,8 @@ func TestEventProcessor(t *testing.T) {
 
 			processor := newEventProcessor(deps, chainID)
 
-			err := processor(context.Background(), height, []types.Log{{Topics: []common.Hash{test.event, orderID}}})
+			header := &types.Header{Number: big.NewInt(height)}
+			err := processor(context.Background(), header, []types.Log{{Topics: []common.Hash{test.event, orderID}}})
 			require.NoError(t, err)
 			require.Equal(t, test.expect, actual)
 		})


### PR DESCRIPTION
Add explicit processor lag metric. Since `ConfMin2` "head" isn't tracked, so we can't implicitly calculate lag by comparing processor height to head height.

Refactor EventStreamer to pass in `header` instead of just `height`.

issue: none