### PR TITLE
fix(lib/xchain): conf minX using explicit parents

### DIFF
--- a/lib/ethclient/ethclient_gen.go
+++ b/lib/ethclient/ethclient_gen.go
@@ -35,99 +35,100 @@ type Client interface {
 	ProgressIfSyncing(ctx context.Context) (*ethereum.SyncProgress, bool, error)
 	CallContext(ctx context.Context, result interface{}, method string, args ...interface{}) error
 	Address() string
+	Name() string
 	Close()
 }
 
-func (w Wrapper) BlockByHash(ctx context.Context, hash common.Hash) (*types.Block, error) {
+func (w wrapper) BlockByHash(ctx context.Context, hash common.Hash) (*types.Block, error) {
 	const endpoint = "block_by_hash"
-	defer latency(w.chain, endpoint)()
+	defer latency(w.name, endpoint)()
 
 	ctx, span := tracer.Start(ctx, spanName(endpoint))
 	defer span.End()
 
 	res0, err := w.cl.BlockByHash(ctx, hash)
 	if err != nil {
-		incError(w.chain, endpoint)
+		incError(w.name, endpoint)
 		err = errors.Wrap(err, "json-rpc", "endpoint", endpoint)
 	}
 
 	return res0, err
 }
 
-func (w Wrapper) BlockByNumber(ctx context.Context, number *big.Int) (*types.Block, error) {
+func (w wrapper) BlockByNumber(ctx context.Context, number *big.Int) (*types.Block, error) {
 	const endpoint = "block_by_number"
-	defer latency(w.chain, endpoint)()
+	defer latency(w.name, endpoint)()
 
 	ctx, span := tracer.Start(ctx, spanName(endpoint))
 	defer span.End()
 
 	res0, err := w.cl.BlockByNumber(ctx, number)
 	if err != nil {
-		incError(w.chain, endpoint)
+		incError(w.name, endpoint)
 		err = errors.Wrap(err, "json-rpc", "endpoint", endpoint)
 	}
 
 	return res0, err
 }
 
-func (w Wrapper) HeaderByHash(ctx context.Context, hash common.Hash) (*types.Header, error) {
+func (w wrapper) HeaderByHash(ctx context.Context, hash common.Hash) (*types.Header, error) {
 	const endpoint = "header_by_hash"
-	defer latency(w.chain, endpoint)()
+	defer latency(w.name, endpoint)()
 
 	ctx, span := tracer.Start(ctx, spanName(endpoint))
 	defer span.End()
 
 	res0, err := w.cl.HeaderByHash(ctx, hash)
 	if err != nil {
-		incError(w.chain, endpoint)
+		incError(w.name, endpoint)
 		err = errors.Wrap(err, "json-rpc", "endpoint", endpoint)
 	}
 
 	return res0, err
 }
 
-func (w Wrapper) HeaderByNumber(ctx context.Context, number *big.Int) (*types.Header, error) {
+func (w wrapper) HeaderByNumber(ctx context.Context, number *big.Int) (*types.Header, error) {
 	const endpoint = "header_by_number"
-	defer latency(w.chain, endpoint)()
+	defer latency(w.name, endpoint)()
 
 	ctx, span := tracer.Start(ctx, spanName(endpoint))
 	defer span.End()
 
 	res0, err := w.cl.HeaderByNumber(ctx, number)
 	if err != nil {
-		incError(w.chain, endpoint)
+		incError(w.name, endpoint)
 		err = errors.Wrap(err, "json-rpc", "endpoint", endpoint)
 	}
 
 	return res0, err
 }
 
-func (w Wrapper) TransactionCount(ctx context.Context, blockHash common.Hash) (uint, error) {
+func (w wrapper) TransactionCount(ctx context.Context, blockHash common.Hash) (uint, error) {
 	const endpoint = "transaction_count"
-	defer latency(w.chain, endpoint)()
+	defer latency(w.name, endpoint)()
 
 	ctx, span := tracer.Start(ctx, spanName(endpoint))
 	defer span.End()
 
 	res0, err := w.cl.TransactionCount(ctx, blockHash)
 	if err != nil {
-		incError(w.chain, endpoint)
+		incError(w.name, endpoint)
 		err = errors.Wrap(err, "json-rpc", "endpoint", endpoint)
 	}
 
 	return res0, err
 }
 
-func (w Wrapper) TransactionInBlock(ctx context.Context, blockHash common.Hash, index uint) (*types.Transaction, error) {
+func (w wrapper) TransactionInBlock(ctx context.Context, blockHash common.Hash, index uint) (*types.Transaction, error) {
 	const endpoint = "transaction_in_block"
-	defer latency(w.chain, endpoint)()
+	defer latency(w.name, endpoint)()
 
 	ctx, span := tracer.Start(ctx, spanName(endpoint))
 	defer span.End()
 
 	res0, err := w.cl.TransactionInBlock(ctx, blockHash, index)
 	if err != nil {
-		incError(w.chain, endpoint)
+		incError(w.name, endpoint)
 		err = errors.Wrap(err, "json-rpc", "endpoint", endpoint)
 	}
 
@@ -137,16 +138,16 @@ func (w Wrapper) TransactionInBlock(ctx context.Context, blockHash common.Hash, 
 // This method subscribes to notifications about changes of the head block of
 // the canonical chain.
 
-func (w Wrapper) SubscribeNewHead(ctx context.Context, ch chan<- *types.Header) (ethereum.Subscription, error) {
+func (w wrapper) SubscribeNewHead(ctx context.Context, ch chan<- *types.Header) (ethereum.Subscription, error) {
 	const endpoint = "subscribe_new_head"
-	defer latency(w.chain, endpoint)()
+	defer latency(w.name, endpoint)()
 
 	ctx, span := tracer.Start(ctx, spanName(endpoint))
 	defer span.End()
 
 	res0, err := w.cl.SubscribeNewHead(ctx, ch)
 	if err != nil {
-		incError(w.chain, endpoint)
+		incError(w.name, endpoint)
 		err = errors.Wrap(err, "json-rpc", "endpoint", endpoint)
 	}
 
@@ -158,16 +159,16 @@ func (w Wrapper) SubscribeNewHead(ctx context.Context, ch chan<- *types.Header) 
 // mined yet. Note that the transaction may not be part of the canonical chain even if
 // it's not pending.
 
-func (w Wrapper) TransactionByHash(ctx context.Context, txHash common.Hash) (*types.Transaction, bool, error) {
+func (w wrapper) TransactionByHash(ctx context.Context, txHash common.Hash) (*types.Transaction, bool, error) {
 	const endpoint = "transaction_by_hash"
-	defer latency(w.chain, endpoint)()
+	defer latency(w.name, endpoint)()
 
 	ctx, span := tracer.Start(ctx, spanName(endpoint))
 	defer span.End()
 
 	res0, res1, err := w.cl.TransactionByHash(ctx, txHash)
 	if err != nil {
-		incError(w.chain, endpoint)
+		incError(w.name, endpoint)
 		err = errors.Wrap(err, "json-rpc", "endpoint", endpoint)
 	}
 
@@ -178,304 +179,304 @@ func (w Wrapper) TransactionByHash(ctx context.Context, txHash common.Hash) (*ty
 // transaction may not be included in the current canonical chain even if a receipt
 // exists.
 
-func (w Wrapper) TransactionReceipt(ctx context.Context, txHash common.Hash) (*types.Receipt, error) {
+func (w wrapper) TransactionReceipt(ctx context.Context, txHash common.Hash) (*types.Receipt, error) {
 	const endpoint = "transaction_receipt"
-	defer latency(w.chain, endpoint)()
+	defer latency(w.name, endpoint)()
 
 	ctx, span := tracer.Start(ctx, spanName(endpoint))
 	defer span.End()
 
 	res0, err := w.cl.TransactionReceipt(ctx, txHash)
 	if err != nil {
-		incError(w.chain, endpoint)
+		incError(w.name, endpoint)
 		err = errors.Wrap(err, "json-rpc", "endpoint", endpoint)
 	}
 
 	return res0, err
 }
 
-func (w Wrapper) BalanceAt(ctx context.Context, account common.Address, blockNumber *big.Int) (*big.Int, error) {
+func (w wrapper) BalanceAt(ctx context.Context, account common.Address, blockNumber *big.Int) (*big.Int, error) {
 	const endpoint = "balance_at"
-	defer latency(w.chain, endpoint)()
+	defer latency(w.name, endpoint)()
 
 	ctx, span := tracer.Start(ctx, spanName(endpoint))
 	defer span.End()
 
 	res0, err := w.cl.BalanceAt(ctx, account, blockNumber)
 	if err != nil {
-		incError(w.chain, endpoint)
+		incError(w.name, endpoint)
 		err = errors.Wrap(err, "json-rpc", "endpoint", endpoint)
 	}
 
 	return res0, err
 }
 
-func (w Wrapper) StorageAt(ctx context.Context, account common.Address, key common.Hash, blockNumber *big.Int) ([]byte, error) {
+func (w wrapper) StorageAt(ctx context.Context, account common.Address, key common.Hash, blockNumber *big.Int) ([]byte, error) {
 	const endpoint = "storage_at"
-	defer latency(w.chain, endpoint)()
+	defer latency(w.name, endpoint)()
 
 	ctx, span := tracer.Start(ctx, spanName(endpoint))
 	defer span.End()
 
 	res0, err := w.cl.StorageAt(ctx, account, key, blockNumber)
 	if err != nil {
-		incError(w.chain, endpoint)
+		incError(w.name, endpoint)
 		err = errors.Wrap(err, "json-rpc", "endpoint", endpoint)
 	}
 
 	return res0, err
 }
 
-func (w Wrapper) CodeAt(ctx context.Context, account common.Address, blockNumber *big.Int) ([]byte, error) {
+func (w wrapper) CodeAt(ctx context.Context, account common.Address, blockNumber *big.Int) ([]byte, error) {
 	const endpoint = "code_at"
-	defer latency(w.chain, endpoint)()
+	defer latency(w.name, endpoint)()
 
 	ctx, span := tracer.Start(ctx, spanName(endpoint))
 	defer span.End()
 
 	res0, err := w.cl.CodeAt(ctx, account, blockNumber)
 	if err != nil {
-		incError(w.chain, endpoint)
+		incError(w.name, endpoint)
 		err = errors.Wrap(err, "json-rpc", "endpoint", endpoint)
 	}
 
 	return res0, err
 }
 
-func (w Wrapper) NonceAt(ctx context.Context, account common.Address, blockNumber *big.Int) (uint64, error) {
+func (w wrapper) NonceAt(ctx context.Context, account common.Address, blockNumber *big.Int) (uint64, error) {
 	const endpoint = "nonce_at"
-	defer latency(w.chain, endpoint)()
+	defer latency(w.name, endpoint)()
 
 	ctx, span := tracer.Start(ctx, spanName(endpoint))
 	defer span.End()
 
 	res0, err := w.cl.NonceAt(ctx, account, blockNumber)
 	if err != nil {
-		incError(w.chain, endpoint)
+		incError(w.name, endpoint)
 		err = errors.Wrap(err, "json-rpc", "endpoint", endpoint)
 	}
 
 	return res0, err
 }
 
-func (w Wrapper) CallContract(ctx context.Context, call ethereum.CallMsg, blockNumber *big.Int) ([]byte, error) {
+func (w wrapper) CallContract(ctx context.Context, call ethereum.CallMsg, blockNumber *big.Int) ([]byte, error) {
 	const endpoint = "call_contract"
-	defer latency(w.chain, endpoint)()
+	defer latency(w.name, endpoint)()
 
 	ctx, span := tracer.Start(ctx, spanName(endpoint))
 	defer span.End()
 
 	res0, err := w.cl.CallContract(ctx, call, blockNumber)
 	if err != nil {
-		incError(w.chain, endpoint)
+		incError(w.name, endpoint)
 		err = errors.Wrap(err, "json-rpc", "endpoint", endpoint)
 	}
 
 	return res0, err
 }
 
-func (w Wrapper) FilterLogs(ctx context.Context, q ethereum.FilterQuery) ([]types.Log, error) {
+func (w wrapper) FilterLogs(ctx context.Context, q ethereum.FilterQuery) ([]types.Log, error) {
 	const endpoint = "filter_logs"
-	defer latency(w.chain, endpoint)()
+	defer latency(w.name, endpoint)()
 
 	ctx, span := tracer.Start(ctx, spanName(endpoint))
 	defer span.End()
 
 	res0, err := w.cl.FilterLogs(ctx, q)
 	if err != nil {
-		incError(w.chain, endpoint)
+		incError(w.name, endpoint)
 		err = errors.Wrap(err, "json-rpc", "endpoint", endpoint)
 	}
 
 	return res0, err
 }
 
-func (w Wrapper) SubscribeFilterLogs(ctx context.Context, q ethereum.FilterQuery, ch chan<- types.Log) (ethereum.Subscription, error) {
+func (w wrapper) SubscribeFilterLogs(ctx context.Context, q ethereum.FilterQuery, ch chan<- types.Log) (ethereum.Subscription, error) {
 	const endpoint = "subscribe_filter_logs"
-	defer latency(w.chain, endpoint)()
+	defer latency(w.name, endpoint)()
 
 	ctx, span := tracer.Start(ctx, spanName(endpoint))
 	defer span.End()
 
 	res0, err := w.cl.SubscribeFilterLogs(ctx, q, ch)
 	if err != nil {
-		incError(w.chain, endpoint)
+		incError(w.name, endpoint)
 		err = errors.Wrap(err, "json-rpc", "endpoint", endpoint)
 	}
 
 	return res0, err
 }
 
-func (w Wrapper) SendTransaction(ctx context.Context, tx *types.Transaction) error {
+func (w wrapper) SendTransaction(ctx context.Context, tx *types.Transaction) error {
 	const endpoint = "send_transaction"
-	defer latency(w.chain, endpoint)()
+	defer latency(w.name, endpoint)()
 
 	ctx, span := tracer.Start(ctx, spanName(endpoint))
 	defer span.End()
 
 	err := w.cl.SendTransaction(ctx, tx)
 	if err != nil {
-		incError(w.chain, endpoint)
+		incError(w.name, endpoint)
 		err = errors.Wrap(err, "json-rpc", "endpoint", endpoint)
 	}
 
 	return err
 }
 
-func (w Wrapper) SuggestGasPrice(ctx context.Context) (*big.Int, error) {
+func (w wrapper) SuggestGasPrice(ctx context.Context) (*big.Int, error) {
 	const endpoint = "suggest_gas_price"
-	defer latency(w.chain, endpoint)()
+	defer latency(w.name, endpoint)()
 
 	ctx, span := tracer.Start(ctx, spanName(endpoint))
 	defer span.End()
 
 	res0, err := w.cl.SuggestGasPrice(ctx)
 	if err != nil {
-		incError(w.chain, endpoint)
+		incError(w.name, endpoint)
 		err = errors.Wrap(err, "json-rpc", "endpoint", endpoint)
 	}
 
 	return res0, err
 }
 
-func (w Wrapper) SuggestGasTipCap(ctx context.Context) (*big.Int, error) {
+func (w wrapper) SuggestGasTipCap(ctx context.Context) (*big.Int, error) {
 	const endpoint = "suggest_gas_tip_cap"
-	defer latency(w.chain, endpoint)()
+	defer latency(w.name, endpoint)()
 
 	ctx, span := tracer.Start(ctx, spanName(endpoint))
 	defer span.End()
 
 	res0, err := w.cl.SuggestGasTipCap(ctx)
 	if err != nil {
-		incError(w.chain, endpoint)
+		incError(w.name, endpoint)
 		err = errors.Wrap(err, "json-rpc", "endpoint", endpoint)
 	}
 
 	return res0, err
 }
 
-func (w Wrapper) PendingBalanceAt(ctx context.Context, account common.Address) (*big.Int, error) {
+func (w wrapper) PendingBalanceAt(ctx context.Context, account common.Address) (*big.Int, error) {
 	const endpoint = "pending_balance_at"
-	defer latency(w.chain, endpoint)()
+	defer latency(w.name, endpoint)()
 
 	ctx, span := tracer.Start(ctx, spanName(endpoint))
 	defer span.End()
 
 	res0, err := w.cl.PendingBalanceAt(ctx, account)
 	if err != nil {
-		incError(w.chain, endpoint)
+		incError(w.name, endpoint)
 		err = errors.Wrap(err, "json-rpc", "endpoint", endpoint)
 	}
 
 	return res0, err
 }
 
-func (w Wrapper) PendingStorageAt(ctx context.Context, account common.Address, key common.Hash) ([]byte, error) {
+func (w wrapper) PendingStorageAt(ctx context.Context, account common.Address, key common.Hash) ([]byte, error) {
 	const endpoint = "pending_storage_at"
-	defer latency(w.chain, endpoint)()
+	defer latency(w.name, endpoint)()
 
 	ctx, span := tracer.Start(ctx, spanName(endpoint))
 	defer span.End()
 
 	res0, err := w.cl.PendingStorageAt(ctx, account, key)
 	if err != nil {
-		incError(w.chain, endpoint)
+		incError(w.name, endpoint)
 		err = errors.Wrap(err, "json-rpc", "endpoint", endpoint)
 	}
 
 	return res0, err
 }
 
-func (w Wrapper) PendingCodeAt(ctx context.Context, account common.Address) ([]byte, error) {
+func (w wrapper) PendingCodeAt(ctx context.Context, account common.Address) ([]byte, error) {
 	const endpoint = "pending_code_at"
-	defer latency(w.chain, endpoint)()
+	defer latency(w.name, endpoint)()
 
 	ctx, span := tracer.Start(ctx, spanName(endpoint))
 	defer span.End()
 
 	res0, err := w.cl.PendingCodeAt(ctx, account)
 	if err != nil {
-		incError(w.chain, endpoint)
+		incError(w.name, endpoint)
 		err = errors.Wrap(err, "json-rpc", "endpoint", endpoint)
 	}
 
 	return res0, err
 }
 
-func (w Wrapper) PendingNonceAt(ctx context.Context, account common.Address) (uint64, error) {
+func (w wrapper) PendingNonceAt(ctx context.Context, account common.Address) (uint64, error) {
 	const endpoint = "pending_nonce_at"
-	defer latency(w.chain, endpoint)()
+	defer latency(w.name, endpoint)()
 
 	ctx, span := tracer.Start(ctx, spanName(endpoint))
 	defer span.End()
 
 	res0, err := w.cl.PendingNonceAt(ctx, account)
 	if err != nil {
-		incError(w.chain, endpoint)
+		incError(w.name, endpoint)
 		err = errors.Wrap(err, "json-rpc", "endpoint", endpoint)
 	}
 
 	return res0, err
 }
 
-func (w Wrapper) PendingTransactionCount(ctx context.Context) (uint, error) {
+func (w wrapper) PendingTransactionCount(ctx context.Context) (uint, error) {
 	const endpoint = "pending_transaction_count"
-	defer latency(w.chain, endpoint)()
+	defer latency(w.name, endpoint)()
 
 	ctx, span := tracer.Start(ctx, spanName(endpoint))
 	defer span.End()
 
 	res0, err := w.cl.PendingTransactionCount(ctx)
 	if err != nil {
-		incError(w.chain, endpoint)
+		incError(w.name, endpoint)
 		err = errors.Wrap(err, "json-rpc", "endpoint", endpoint)
 	}
 
 	return res0, err
 }
 
-func (w Wrapper) EstimateGas(ctx context.Context, call ethereum.CallMsg) (uint64, error) {
+func (w wrapper) EstimateGas(ctx context.Context, call ethereum.CallMsg) (uint64, error) {
 	const endpoint = "estimate_gas"
-	defer latency(w.chain, endpoint)()
+	defer latency(w.name, endpoint)()
 
 	ctx, span := tracer.Start(ctx, spanName(endpoint))
 	defer span.End()
 
 	res0, err := w.cl.EstimateGas(ctx, call)
 	if err != nil {
-		incError(w.chain, endpoint)
+		incError(w.name, endpoint)
 		err = errors.Wrap(err, "json-rpc", "endpoint", endpoint)
 	}
 
 	return res0, err
 }
 
-func (w Wrapper) BlockNumber(ctx context.Context) (uint64, error) {
+func (w wrapper) BlockNumber(ctx context.Context) (uint64, error) {
 	const endpoint = "block_number"
-	defer latency(w.chain, endpoint)()
+	defer latency(w.name, endpoint)()
 
 	ctx, span := tracer.Start(ctx, spanName(endpoint))
 	defer span.End()
 
 	res0, err := w.cl.BlockNumber(ctx)
 	if err != nil {
-		incError(w.chain, endpoint)
+		incError(w.name, endpoint)
 		err = errors.Wrap(err, "json-rpc", "endpoint", endpoint)
 	}
 
 	return res0, err
 }
 
-func (w Wrapper) ChainID(ctx context.Context) (*big.Int, error) {
+func (w wrapper) ChainID(ctx context.Context) (*big.Int, error) {
 	const endpoint = "chain_id"
-	defer latency(w.chain, endpoint)()
+	defer latency(w.name, endpoint)()
 
 	ctx, span := tracer.Start(ctx, spanName(endpoint))
 	defer span.End()
 
 	res0, err := w.cl.ChainID(ctx)
 	if err != nil {
-		incError(w.chain, endpoint)
+		incError(w.name, endpoint)
 		err = errors.Wrap(err, "json-rpc", "endpoint", endpoint)
 	}
 

--- a/lib/ethclient/genwrap/genwrap.go
+++ b/lib/ethclient/genwrap/genwrap.go
@@ -53,21 +53,22 @@ type Client interface {
 	ProgressIfSyncing(ctx context.Context) (*ethereum.SyncProgress, bool, error)
 	CallContext(ctx context.Context, result interface{}, method string, args ...interface{}) error
 	Address() string
+	Name() string
 	Close()
 }
 
 {{range .Methods}}
 	{{.Doc}}
-	func (w Wrapper) {{.Name}}({{.Params}}) ({{.ResultTypes}}) {
+	func (w wrapper) {{.Name}}({{.Params}}) ({{.ResultTypes}}) {
 		const endpoint = "{{.Label}}"
-		{{if .Latency}}defer latency(w.chain, endpoint)() {{end}}
+		{{if .Latency}}defer latency(w.name, endpoint)() {{end}}
 
 		ctx, span := tracer.Start(ctx, spanName(endpoint))
 		defer span.End()
 
 		{{.ResultNames}} := w.cl.{{.Name}}({{.ParamNames}})
 		if err != nil {
-			incError(w.chain, endpoint)
+			incError(w.name, endpoint)
 			err = errors.Wrap(err, "json-rpc", "endpoint", endpoint)
 		}
 

--- a/lib/ethclient/headercache.go
+++ b/lib/ethclient/headercache.go
@@ -1,0 +1,99 @@
+package ethclient
+
+import (
+	"context"
+	"math/big"
+	"sync"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+)
+
+const defaultCacheLimit = 1000
+
+func newHeaderCache(ethCl Client) *headerCache {
+	return &headerCache{
+		Client:  ethCl,
+		limit:   defaultCacheLimit,
+		headers: make(map[common.Hash]*types.Header),
+	}
+}
+
+// headerCache extends/wraps a Client with a read-through FIFO cache for headers.
+//
+// It only caches headers by hash, not type or height.
+type headerCache struct {
+	Client
+	limit int
+
+	mu      sync.RWMutex
+	fifo    []common.Hash
+	headers map[common.Hash]*types.Header
+}
+
+func (c *headerCache) HeaderByNumber(ctx context.Context, num *big.Int) (*types.Header, error) {
+	header, err := c.Client.HeaderByNumber(ctx, num)
+	if err != nil {
+		return nil, err
+	}
+
+	c.add(header)
+
+	return header, nil
+}
+
+func (c *headerCache) HeaderByType(ctx context.Context, typ HeadType) (*types.Header, error) {
+	header, err := c.Client.HeaderByType(ctx, typ)
+	if err != nil {
+		return nil, err
+	}
+
+	c.add(header)
+
+	return header, nil
+}
+
+func (c *headerCache) HeaderByHash(ctx context.Context, hash common.Hash) (*types.Header, error) {
+	if header, ok := c.get(hash); ok {
+		return header, nil
+	}
+
+	header, err := c.Client.HeaderByHash(ctx, hash)
+	if err != nil {
+		return nil, err
+	}
+
+	c.add(header)
+
+	return header, nil
+}
+
+func (c *headerCache) add(h *types.Header) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	hash := h.Hash()
+	c.fifo = append(c.fifo, hash)
+	c.headers[hash] = h
+
+	c.maybePruneUnsafe()
+}
+
+func (c *headerCache) get(hash common.Hash) (*types.Header, bool) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	header, ok := c.headers[hash]
+
+	return header, ok
+}
+
+// maybePrune removes the oldest header if over the limit.
+// It is unsafe since it assumes the lock is held.
+func (c *headerCache) maybePruneUnsafe() {
+	for len(c.fifo) > c.limit {
+		hash := c.fifo[0]
+		delete(c.headers, hash)
+		c.fifo = c.fifo[1:]
+	}
+}

--- a/lib/ethclient/headercahce_internal_test.go
+++ b/lib/ethclient/headercahce_internal_test.go
@@ -1,0 +1,128 @@
+package ethclient
+
+import (
+	"context"
+	"math/big"
+	"testing"
+
+	"github.com/omni-network/omni/lib/bi"
+	"github.com/omni-network/omni/lib/errors"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestHeaderCache(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	h1 := &types.Header{Number: bi.N(1)}
+	h2 := &types.Header{Number: bi.N(2), ParentHash: h1.Hash()}
+	h3 := &types.Header{Number: bi.N(3), ParentHash: h2.Hash()}
+
+	testCl := &testClient{headers: []*types.Header{h1, h2, h3}}
+	cache := newHeaderCache(testCl)
+	cache.limit = 2
+
+	// Fetch h1 by hash, ensure queried
+	h, err := cache.HeaderByHash(ctx, h1.Hash())
+	require.NoError(t, err)
+	require.Equal(t, h1, h)
+	require.Equal(t, 1, testCl.headerByHash)
+
+	// Fetch h1 by hash again, ensure cached
+	h, err = cache.HeaderByHash(ctx, h1.Hash())
+	require.NoError(t, err)
+	require.Equal(t, h1, h)
+	require.Equal(t, 1, testCl.headerByHash)
+
+	// Fetch h1 by number, ensure queried
+	h, err = cache.HeaderByNumber(ctx, h1.Number)
+	require.NoError(t, err)
+	require.Equal(t, h1, h)
+	require.Equal(t, 1, testCl.headerByNumber)
+
+	// Fetch h2 by number, ensure queried
+	h, err = cache.HeaderByNumber(ctx, h2.Number)
+	require.NoError(t, err)
+	require.Equal(t, h2, h)
+	require.Equal(t, 2, testCl.headerByNumber)
+
+	// Fetch h2 by hash, ensure cached
+	h, err = cache.HeaderByHash(ctx, h2.Hash())
+	require.NoError(t, err)
+	require.Equal(t, h2, h)
+	require.Equal(t, 1, testCl.headerByHash)
+
+	// Fetch h3 by type, ensure queried
+	h, err = cache.HeaderByType(ctx, HeadLatest)
+	require.NoError(t, err)
+	require.Equal(t, h3, h)
+	require.Equal(t, 1, testCl.headerByType)
+
+	// Fetch h3 by type again, ensure queried
+	h, err = cache.HeaderByType(ctx, HeadLatest)
+	require.NoError(t, err)
+	require.Equal(t, h3, h)
+	require.Equal(t, 2, testCl.headerByType)
+
+	// Fetch h3 by number, ensure queried
+	h, err = cache.HeaderByNumber(ctx, h3.Number)
+	require.NoError(t, err)
+	require.Equal(t, h3, h)
+	require.Equal(t, 3, testCl.headerByNumber)
+
+	// Fetch h3 by hash, ensure cached
+	h, err = cache.HeaderByHash(ctx, h3.Hash())
+	require.NoError(t, err)
+	require.Equal(t, h3, h)
+	require.Equal(t, 2, testCl.headerByHash)
+
+	// Ensure h1 pruned, so queried when fetched by hash
+	h, err = cache.HeaderByHash(ctx, h1.Hash())
+	require.NoError(t, err)
+	require.Equal(t, h1, h)
+	require.Equal(t, 3, testCl.headerByHash)
+}
+
+type testClient struct {
+	Client
+	headerByHash   int
+	headerByType   int
+	headerByNumber int
+	headers        []*types.Header
+}
+
+func (c *testClient) HeaderByType(_ context.Context, typ HeadType) (*types.Header, error) {
+	if typ != HeadLatest {
+		return nil, errors.New("invalid head type")
+	}
+
+	c.headerByType++
+
+	return c.headers[len(c.headers)-1], nil
+}
+
+func (c *testClient) HeaderByNumber(_ context.Context, num *big.Int) (*types.Header, error) {
+	c.headerByNumber++
+	for _, h := range c.headers {
+		if bi.EQ(h.Number, num) {
+			return h, nil
+		}
+	}
+
+	return nil, errors.New("invalid number")
+}
+
+func (c *testClient) HeaderByHash(_ context.Context, hash common.Hash) (*types.Header, error) {
+	c.headerByHash++
+	for _, h := range c.headers {
+		if h.Hash() == hash {
+			return h, nil
+		}
+	}
+
+	return nil, errors.New("invalid hash")
+}

--- a/lib/ethclient/mock/mock_interfaces.go
+++ b/lib/ethclient/mock/mock_interfaces.go
@@ -285,6 +285,20 @@ func (mr *MockClientMockRecorder) HeaderByType(ctx, typ any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HeaderByType", reflect.TypeOf((*MockClient)(nil).HeaderByType), ctx, typ)
 }
 
+// Name mocks base method.
+func (m *MockClient) Name() string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Name")
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// Name indicates an expected call of Name.
+func (mr *MockClientMockRecorder) Name() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Name", reflect.TypeOf((*MockClient)(nil).Name))
+}
+
 // NonceAt mocks base method.
 func (m *MockClient) NonceAt(ctx context.Context, account common.Address, blockNumber *big.Int) (uint64, error) {
 	m.ctrl.T.Helper()

--- a/lib/xchain/provider/provider.go
+++ b/lib/xchain/provider/provider.go
@@ -216,7 +216,7 @@ func (p *Provider) stream(
 	return stream.Stream(ctx, deps, fromHeight, cb)
 }
 
-// getEVMChain provides the configuration of the given chainID.
+// getEVMChain returns the configuration, eth client and header cache of the given EVM chainID.
 func (p *Provider) getEVMChain(chainID uint64) (netconf.Chain, ethclient.Client, error) {
 	if chainID == p.cChainID {
 		return netconf.Chain{}, nil, errors.New("consensus chain not supported")

--- a/lib/xchain/types.go
+++ b/lib/xchain/types.go
@@ -61,6 +61,13 @@ func (c ConfLevel) Label() string {
 	return strings.ToUpper(c.String()[:1])
 }
 
+// MinX returns X for ConfMinX conf levels, otherwise zero.
+func (c ConfLevel) MinX() uint64 {
+	delay, _ := strconv.ParseUint(c.Label(), 10, 64)
+
+	return delay
+}
+
 // ConfLevel values MUST never change as they are persisted on-chain.
 const (
 	ConfUnknown   ConfLevel = 0 // unknown

--- a/lib/xchain/types_internal_test.go
+++ b/lib/xchain/types_internal_test.go
@@ -9,11 +9,19 @@ import (
 func TestConfLevelFuzzy(t *testing.T) {
 	t.Parallel()
 	var fuzzies []ConfLevel
+	var minXs []ConfLevel
 	for conf := ConfUnknown; conf < confSentinel; conf++ {
-		if conf.Valid() && conf.IsFuzzy() {
+		if !conf.Valid() {
+			continue
+		}
+		if conf.IsFuzzy() {
 			fuzzies = append(fuzzies, conf)
+		}
+		if conf.MinX() > 0 {
+			minXs = append(minXs, conf)
 		}
 	}
 
 	require.EqualValues(t, fuzzies, FuzzyConfLevels())
+	require.EqualValues(t, []ConfLevel{ConfMin1, ConfMin2}, minXs)
 }


### PR DESCRIPTION
When fetching `xchain.ConfMinX` headers, don't use `latest block heigh - X` since this can return old forks, especially from RPC providers which load balance requests over multiple nodes. 

Instead, walk back up the chain from latest using parentHash.

Add a headerCache to ethclient to mitigate increased queries.

issue: none