### PR TITLE
chore(solver/app): improve PnL

### DIFF
--- a/lib/pnl/log.go
+++ b/lib/pnl/log.go
@@ -41,6 +41,7 @@ func Log(ctx context.Context, ps ...LogP) {
 			"PnL",
 			"type", p.Type,
 			"amt_gwei", fstr(p.AmountGwei),
+			"delta_gwei", deltaFstr(p.AmountGwei, p.Type),
 			"currency", p.Currency,
 			"category", p.Category,
 			"subcategory", p.Subcategory,
@@ -54,6 +55,15 @@ func Log(ctx context.Context, ps ...LogP) {
 // fstr returns a string repr of a float.
 func fstr(f float64) string {
 	return fmt.Sprintf("%.2f", f)
+}
+
+// deltaFstr returns a string repr of a float with an optional negative sign for expenses.
+func deltaFstr(f float64, t Type) string {
+	if t == Expense {
+		return "-" + fstr(f)
+	}
+
+	return fstr(f)
 }
 
 // mdstr returns a key-ordered string representation of metadata.

--- a/lib/xchain/provider/metrics.go
+++ b/lib/xchain/provider/metrics.go
@@ -32,6 +32,6 @@ var (
 		Subsystem: "xprovider",
 		Name:      "callback_latency_seconds",
 		Help:      "Callback latency in seconds per source chain version and type. Alert if growing.",
-		Buckets:   []float64{.001, .002, .005, .01, .025, .05, .1, .25, .5, 1, 2.5},
+		Buckets:   []float64{.001, .002, .005, .01, .025, .05, .1, .25, .5, 1, 2.5, 5, 10, 25, 50, 100},
 	}, []string{"chain_version", "type"})
 )

--- a/solver/app/app.go
+++ b/solver/app/app.go
@@ -306,7 +306,7 @@ func startEventStreams(
 	go monitorAgeCacheForever(ctx, ageCache, network.ChainName)
 
 	filledPnL := newFilledPnlFunc(pricer, targetName, network.ChainName, addrs.SolverNetOutbox, ageCache.InstrumentDestFilled)
-	orderGasPnL := newOrderGasPnLFunc(pricer, network.ChainName)
+	updatePnL := newUpdatePnLFunc(pricer, network.ChainName)
 
 	for _, chainID := range inboxChains {
 		// Ensure chain version processors don't process same height concurrently.
@@ -321,9 +321,9 @@ func startEventStreams(
 				GetOrder:      newOrderGetter(inboxContracts),
 				ShouldReject:  newShouldRejector(backends, callAllower, solverAddr, addrs.SolverNetOutbox),
 				DidFill:       newDidFiller(outboxContracts),
-				Reject:        newRejector(inboxContracts, backends, solverAddr, orderGasPnL),
+				Reject:        newRejector(inboxContracts, backends, solverAddr, updatePnL),
 				Fill:          newFiller(outboxContracts, backends, solverAddr, addrs.SolverNetOutbox, filledPnL),
-				Claim:         newClaimer(network.ID, inboxContracts, backends, solverAddr, orderGasPnL),
+				Claim:         newClaimer(network.ID, inboxContracts, backends, solverAddr, updatePnL),
 				SetCursor:     cursorSetter,
 				ChainName:     network.ChainName,
 				ProcessorName: network.ChainVersionName(chainVer),

--- a/solver/app/pnl.go
+++ b/solver/app/pnl.go
@@ -16,7 +16,8 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 )
 
-type orderPnLFunc func(ctx context.Context, order Order, rec *ethclient.Receipt) error
+type filledPnLFunc func(ctx context.Context, order Order, rec *ethclient.Receipt) error
+type updatePnLFunc func(ctx context.Context, order Order, rec *ethclient.Receipt, update string) error
 type simpleGasPnLFunc func(ctx context.Context, chainID uint64, rec *ethclient.Receipt, subCat string) error
 
 type targetFunc func(PendingData) string
@@ -33,7 +34,7 @@ func newFilledPnlFunc(
 	namer func(uint64) string,
 	outbox common.Address,
 	destFilledAge destFilledAge,
-) orderPnLFunc {
+) filledPnLFunc {
 	return func(ctx context.Context, order Order, rec *ethclient.Receipt) error {
 		pendingData, err := order.PendingData()
 		if err != nil {
@@ -96,11 +97,11 @@ func newFilledPnlFunc(
 	}
 }
 
-// newOrderGasPnLFunc returns a orderPnLFunc that logs the gas expense PnL for updating order status, except for filled orders.
-func newOrderGasPnLFunc(pricer tokenslib.Pricer, namer func(uint64) string) orderPnLFunc {
-	return func(ctx context.Context, order Order, rec *ethclient.Receipt) error {
+// newUpdatePnLFunc returns a updatePnLFunc that logs the gas expense PnL for updating order status, except for filled orders.
+func newUpdatePnLFunc(pricer tokenslib.Pricer, namer func(uint64) string) updatePnLFunc {
+	return func(ctx context.Context, order Order, rec *ethclient.Receipt, update string) error {
 		srcChainName := namer(order.SourceChainID)
-		return gasPnL(ctx, pricer, order.SourceChainID, srcChainName, rec, order.Status.String(), order.ID.String())
+		return gasPnL(ctx, pricer, order.SourceChainID, srcChainName, rec, update, order.ID.String())
 	}
 }
 

--- a/solver/app/procdeps.go
+++ b/solver/app/procdeps.go
@@ -44,7 +44,7 @@ func newClaimer(
 	inboxContracts map[uint64]*bindings.SolverNetInbox,
 	backends ethbackend.Backends,
 	solverAddr common.Address,
-	pnl orderPnLFunc,
+	pnl updatePnLFunc,
 ) func(ctx context.Context, order Order) error {
 	return func(ctx context.Context, order Order) error {
 		inbox, ok := inboxContracts[order.SourceChainID]
@@ -80,7 +80,7 @@ func newClaimer(
 			return errors.Wrap(err, "wait mined")
 		}
 
-		return pnl(ctx, order, rec)
+		return pnl(ctx, order, rec, "Inbox:Claim")
 	}
 }
 
@@ -88,7 +88,7 @@ func newFiller(
 	outboxContracts map[uint64]*bindings.SolverNetOutbox,
 	backends ethbackend.Backends,
 	solverAddr, outboxAddr common.Address,
-	pnl orderPnLFunc,
+	pnl filledPnLFunc,
 ) func(ctx context.Context, order Order) error {
 	return func(ctx context.Context, order Order) error {
 		pendingData, err := order.PendingData()
@@ -191,7 +191,7 @@ func newRejector(
 	inboxContracts map[uint64]*bindings.SolverNetInbox,
 	backends ethbackend.Backends,
 	solverAddr common.Address,
-	pnl orderPnLFunc,
+	pnl updatePnLFunc,
 ) func(ctx context.Context, order Order, reason stypes.RejectReason) error {
 	return func(ctx context.Context, order Order, reason stypes.RejectReason) error {
 		inbox, ok := inboxContracts[order.SourceChainID]
@@ -225,7 +225,7 @@ func newRejector(
 			return errors.Wrap(err, "wait mined")
 		}
 
-		return pnl(ctx, order, rec)
+		return pnl(ctx, order, rec, "Inbox:Reject")
 	}
 }
 


### PR DESCRIPTION
Improve PnL:
- Add `delta_gwei` field to all PnL logs, so profile can be calculated by simply summing all delta values.
- Rename gas+status PNL `filled` subcatefory to `Inbox:Claim`, and similarly `pending` to `Inbox:Reject`.
- Add more buckets to processor duration (2s is not enough).

issue: none