### PR TITLE
chore(monitor): track more token balances

### DIFF
--- a/e2e/app/eoa/solver.go
+++ b/e2e/app/eoa/solver.go
@@ -57,11 +57,6 @@ var (
 	}
 )
 
-// SolverNetTokens returns the tokens that have solvernet thresholds.
-func SolverNetTokens() []tokens.Token {
-	return []tokens.Token{tokens.WSTETH}
-}
-
 // SolverNetRoles returns the roles that have solvernet thresholds.
 func SolverNetRoles() []Role {
 	return []Role{RoleSolver, RoleFlowgen}

--- a/e2e/app/eoa/solver_test.go
+++ b/e2e/app/eoa/solver_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/omni-network/omni/lib/evmchain"
 	"github.com/omni-network/omni/lib/netconf"
 	"github.com/omni-network/omni/lib/tutil"
+	stokens "github.com/omni-network/omni/solver/tokens"
 )
 
 //go:generate go test . -run=TestSolverThresholds -golden
@@ -19,7 +20,7 @@ func TestSolverThresholds(t *testing.T) {
 	for _, network := range []netconf.ID{netconf.Devnet, netconf.Staging, netconf.Omega, netconf.Mainnet} {
 		for _, chain := range evmchain.All() {
 			for _, role := range eoa.SolverNetRoles() {
-				for _, token := range eoa.SolverNetTokens() {
+				for _, token := range stokens.UniqueSymbols() {
 					thresholds, ok := eoa.GetSolverNetThreshold(role, network, chain.ChainID, token)
 					if !ok {
 						continue

--- a/e2e/solve/mocktokens.go
+++ b/e2e/solve/mocktokens.go
@@ -28,7 +28,7 @@ type MockToken struct {
 
 var mocks = []MockToken{
 	// staging mock wstETH
-	{Token: tokens.WSTETH, ChainID: evmchain.IDBaseSepolia, NetworkID: netconf.Staging},
+	{Token: tokens.WSTETH, ChainID: evmchain.IDBaseSepolia, NetworkID: netconf.Staging}, // Note this is also used on omega.
 
 	// devnet L1 mock wstETH
 	{Token: tokens.WSTETH, ChainID: evmchain.IDMockL1, NetworkID: netconf.Devnet},

--- a/solver/app/claimants.go
+++ b/solver/app/claimants.go
@@ -17,6 +17,13 @@ var claimants = map[libtokens.Token]map[netconf.ID]common.Address{
 	},
 }
 
+// Claimant returns the address that should claim the order/token, or false if it doesn't exist.
+func Claimant(network netconf.ID, token libtokens.Token) (common.Address, bool) {
+	c, ok := claimants[token][network]
+
+	return c, ok
+}
+
 func getClaimant(network netconf.ID, order Order) (common.Address, bool, error) {
 	minReceived, err := parseMinReceived(order)
 	if err != nil {

--- a/solver/tokens/tokens.go
+++ b/solver/tokens/tokens.go
@@ -130,6 +130,7 @@ var tokens = append([]Token{
 	wstETH(evmchain.IDEthereum, common.HexToAddress("0x7f39c581f595b53c5cb19bd0b3f8da6c935e2ca0")),
 	wstETH(evmchain.IDHolesky, common.HexToAddress("0x8d09a4502cc8cf1547ad300e066060d043f6982d")),
 	wstETH(evmchain.IDSepolia, common.HexToAddress("0xB82381A3fBD3FaFA77B3a7bE693342618240067b")),
+	// Mocks contain wstETH on IDBaseSepolia for omega and staging
 
 	// stETH
 	stETH(evmchain.IDHolesky, common.HexToAddress("0x3f1c547b21f65e10480de3ad8e19faac46c95034")),
@@ -140,6 +141,22 @@ var tokens = append([]Token{
 
 func All() []Token {
 	return tokens
+}
+
+// UniqueSymbols returns the unique set of tokenslib.Tokens in the tokens list.
+func UniqueSymbols() []tokenslib.Token {
+	uniq := make(map[tokenslib.Token]bool)
+
+	for _, t := range tokens {
+		uniq[t.Token] = true
+	}
+
+	var resp []tokenslib.Token
+	for t := range uniq {
+		resp = append(resp, t)
+	}
+
+	return resp
 }
 
 func BySymbol(chainID uint64, symbol string) (Token, bool) {


### PR DESCRIPTION
Adds more cases to `monitor_account_token_balance_ether`:
- Also track all `claimant` balances on all chains for all `solver/tokens`
- Also track `solver` and `flowgen` balances for all chains and all `solver/tokens`. Not only those with `MinThresholds`. 

issue: none
