### PR TITLE
chore(e2e): remove stETH mock token from devnet

### DIFF
--- a/solver/tokens/testdata/TestTokens.golden
+++ b/solver/tokens/testdata/TestTokens.golden
@@ -230,16 +230,6 @@
   "symbol": "stETH"
  },
  {
-  "address": "0x3F1c547b21f65e10480dE3ad8E19fAAC46C95034",
-  "chainId": 1652,
-  "coingeckoId": "lido-staked-ether",
-  "isMock": false,
-  "maxSpend": "nil",
-  "minSpend": "nil",
-  "name": "Lido Staked Ether",
-  "symbol": "stETH"
- },
- {
   "address": "0x6319df7c227e34B967C1903A08a698A3cC43492B",
   "chainId": 84532,
   "coingeckoId": "wrapped-steth",

--- a/solver/tokens/tokens.go
+++ b/solver/tokens/tokens.go
@@ -134,9 +134,6 @@ var tokens = append([]Token{
 
 	// stETH
 	stETH(evmchain.IDHolesky, common.HexToAddress("0x3f1c547b21f65e10480de3ad8e19faac46c95034")),
-
-	// mock l1 copies (for e2e fork testing)
-	stETH(evmchain.IDMockL1, common.HexToAddress("0x3f1c547b21f65e10480de3ad8e19faac46c95034")), // holesky stETH
 }, mocks()...)
 
 func All() []Token {


### PR DESCRIPTION
Remove `stETH` mock token from devnet since it isn't used or deployed.

issue: none