### PR TITLE
fix(monitor/flowgen): account for fees and commissions

### DIFF
--- a/monitor/flowgen/bridging/bridging.go
+++ b/monitor/flowgen/bridging/bridging.go
@@ -152,7 +152,8 @@ func estimateOrderSize(
 		return nil, false, errors.New("no thresholds found", "role", eoa.RoleFlowgen)
 	}
 
-	orderSize := bi.Sub(balance, thresholds.MinBalance())
+	reserved := bi.Ether(0.01) // overhead that should cover solver commission and tx fees
+	orderSize := bi.Sub(balance, thresholds.MinBalance(), reserved)
 
 	// if order size is too small, do nothing
 	if bi.LT(orderSize, conf.minOrderSize) {


### PR DESCRIPTION
When computing the order size, account for commissions and fees.

issue: none