### PR TITLE
chore(e2e): update solver pin

### DIFF
--- a/e2e/manifests/omega.toml
+++ b/e2e/manifests/omega.toml
@@ -8,7 +8,7 @@ prometheus = true
 pinned_halo_tag = "1849471"
 pinned_relayer_tag = "1849471"
 pinned_monitor_tag = "0193725"
-pinned_solver_tag = "5a77b00"
+pinned_solver_tag = "f79a0b9"
 
 [node.validator01]
 [node.validator02]


### PR DESCRIPTION
Update omega solver pin.

Unlocks eigen testnet integration.

issue: none
