### PR TITLE
bug: 🐛 Fix bn.js and node error

### DIFF
--- a/sdk/packages/react/package.json
+++ b/sdk/packages/react/package.json
@@ -43,6 +43,8 @@
   "devDependencies": {
     "@testing-library/dom": "^10.4.0",
     "@testing-library/react": "^16.2.0",
+    "@types/bn.js": "^5.1.6",
+    "@types/node": "^22.13.10",
     "@types/react": "^19.0.8",
     "@types/react-dom": "^19.0.4",
     "@vitest/coverage-v8": "^3.0.7",
@@ -56,7 +58,12 @@
     "url": "git+https://github.com/omni-network/omni.git",
     "directory": "sdk/packages/react"
   },
-  "keywords": ["typescript", "web3", "ethereum", "omni"],
+  "keywords": [
+    "typescript",
+    "web3",
+    "ethereum",
+    "omni"
+  ],
   "author": "Omni Network",
   "homepage": "https://omni.network/"
 }

--- a/sdk/pnpm-lock.yaml
+++ b/sdk/pnpm-lock.yaml
@@ -76,6 +76,12 @@ importers:
       '@testing-library/react':
         specifier: ^16.2.0
         version: 16.2.0(@testing-library/dom@10.4.0)(@types/react-dom@19.0.4(@types/react@19.0.12))(@types/react@19.0.12)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@types/bn.js':
+        specifier: ^5.1.6
+        version: 5.1.6
+      '@types/node':
+        specifier: ^22.13.10
+        version: 22.13.10
       '@types/react':
         specifier: ^19.0.8
         version: 19.0.12
@@ -682,6 +688,9 @@ packages:
 
   '@types/aria-query@5.0.4':
     resolution: {integrity: sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==}
+
+  '@types/bn.js@5.1.6':
+    resolution: {integrity: sha512-Xh8vSwUeMKeYYrj3cX4lGQgFSF/N03r+tv4AiLl1SucqV+uTQpxRcnM8AkXKHwYP9ZPXOYXRr2KPXpVlIvqh9w==}
 
   '@types/debug@4.1.12':
     resolution: {integrity: sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ==}
@@ -2708,6 +2717,10 @@ snapshots:
       '@types/react-dom': 19.0.4(@types/react@19.0.12)
 
   '@types/aria-query@5.0.4': {}
+
+  '@types/bn.js@5.1.6':
+    dependencies:
+      '@types/node': 22.13.10
 
   '@types/debug@4.1.12':
     dependencies:


### PR DESCRIPTION
While trying to run the SDK using Node v22.11.0 and pnpm v10.6.5, I encountered the following error:

```bash
error TS2688: Cannot find type definition file for 'bn.js'.
  The file is in the program because:
    Entry point for implicit type library 'bn.js'

error TS2688: Cannot find type definition file for 'node'.
  The file is in the program because:
    Entry point for implicit type library 'node'


Found 2 errors.

 ELIFECYCLE  Command failed with exit code 2.
 ELIFECYCLE  Command failed with exit code 2.
 ELIFECYCLE  Command failed with exit code 2.
```

After installing `@types/bn.js` and `@types/node`, the issue was resolved.