### PR TITLE
fix(sdk): add missing typescript dependency

### DIFF
--- a/sdk/packages/test-utils/package.json
+++ b/sdk/packages/test-utils/package.json
@@ -29,6 +29,7 @@
     "viem": "^2.23.13"
   },
   "devDependencies": {
-    "@types/node": "^22.13.10"
+    "@types/node": "^22.13.10",
+    "typescript": "^5.7.2"
   }
 }

--- a/sdk/pnpm-lock.yaml
+++ b/sdk/pnpm-lock.yaml
@@ -110,6 +110,9 @@ importers:
       '@types/node':
         specifier: ^22.13.10
         version: 22.13.10
+      typescript:
+        specifier: ^5.7.2
+        version: 5.8.2
 
 packages:
 


### PR DESCRIPTION
Added TS to dev dependencies for the `test-utils` package

issue: none