### PR TITLE
chore(lib/expbackoff): add support for interrupting backoff

### DIFF
--- a/lib/expbackoff/expbackoff_test.go
+++ b/lib/expbackoff/expbackoff_test.go
@@ -135,3 +135,20 @@ func TestNewWithReset(t *testing.T) {
 	backoff()
 	elapsed(t, "16s") // +0s
 }
+
+func TestInterrupt(t *testing.T) {
+	// Test that interrupts work and that we don't block for 1 hour.
+	interrupt := make(chan struct{}, 1)
+	backoff := expbackoff.New(context.Background(), expbackoff.With(expbackoff.Config{
+		BaseDelay:  time.Hour,
+		Multiplier: 1,
+		Jitter:     0,
+		MaxDelay:   time.Hour,
+		Interrupts: interrupt,
+	}))
+
+	interrupt <- struct{}{}
+	backoff()
+	interrupt <- struct{}{}
+	backoff()
+}


### PR DESCRIPTION
Adds support for interrupting exponential backoffs. This aims to support websockets which interrupt "fetch backoff" when a new header is received. When combined with header cache, this will result in immediate processing of logs/blocks as soon as new head is seen. 

Currently, exponential backoff cause blocks to be processed 2s, 4s, sometimes 8s after new block is mined. Especially for L1 which is slow, exp backoff causes slow reaction times.

issue: none