### PR TITLE
chore(lib/ethclient): add websockets to header cache

### DIFF
--- a/lib/ethclient/metrics.go
+++ b/lib/ethclient/metrics.go
@@ -42,6 +42,14 @@ var (
 		Name:      "cache_misses_total",
 		Help:      "Total number of cache misses by chain",
 	}, []string{"chain"})
+
+	// Using gauge for websocket latency is good enough (avoid expensive histogram).
+	websocketLatency = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: "lib",
+		Subsystem: "ethclient",
+		Name:      "wss_header_latency_seconds",
+		Help:      "Last header age in seconds received via websockets by chain",
+	}, []string{"chain"})
 )
 
 // latency returns a function that records the latency of an RPC call.


### PR DESCRIPTION
When streaming headers via websockets, also add them to the headercache.

Add metric that tracks age/latency of headers received via websockets.

issue: none
