### PR TITLE
chore(lib/ethclient): improve reorg metric

### DIFF
--- a/lib/ethclient/headercache.go
+++ b/lib/ethclient/headercache.go
@@ -97,7 +97,12 @@ func (c headerCache) add(ctx context.Context, h *types.Header) {
 		return
 	}
 
-	reorgTotal.WithLabelValues(c.Name()).Add(float64(depth))
+	reorgTotal.WithLabelValues(c.Name()).Inc()
+	// Increment counter instead of adding depth, since one cannot easily distinguish counter
+	// increases when close together. Log the depth instead.
+	if depth > 0 {
+		log.Debug(ctx, "Chain reorg detected", "chain", c.Name(), "depth", depth, "height", h.Number)
+	}
 
 	if _, err := c.db.MaybePrune(ctx, c.limit); err != nil {
 		// Best effort, don't block on cache update.

--- a/lib/ethclient/metrics.go
+++ b/lib/ethclient/metrics.go
@@ -26,7 +26,7 @@ var (
 		Namespace: "lib",
 		Subsystem: "ethclient",
 		Name:      "cache_reorg_total",
-		Help:      "Total number of blocks reorged by chain",
+		Help:      "Total number of reorgs detected by chain",
 	}, []string{"chain"})
 
 	cacheHits = promauto.NewCounterVec(prometheus.CounterOpts{


### PR DESCRIPTION
Improve reorg metric by logging depth instead of incrementing counter since it ins't clear whether holesky is sometimes reorging by 2 or twice by 1.

issue: none