### PR TITLE
chore(e2e): pin solver on omega and mainnet

### DIFF
--- a/e2e/manifests/mainnet.toml
+++ b/e2e/manifests/mainnet.toml
@@ -7,7 +7,7 @@ prometheus   = true
 pinned_halo_tag = "1849471"
 pinned_relayer_tag = "1849471"
 pinned_monitor_tag = "556dcf6"
-pinned_solver_tag = "f79a0b9"
+pinned_solver_tag = "556dcf6"
 
 [node.validator01]
 [node.validator02]

--- a/e2e/manifests/omega.toml
+++ b/e2e/manifests/omega.toml
@@ -7,7 +7,7 @@ prometheus = true
 pinned_halo_tag = "1849471"
 pinned_relayer_tag = "1849471"
 pinned_monitor_tag = "556dcf6"
-pinned_solver_tag = "78a5ae4"
+pinned_solver_tag = "556dcf6"
 
 [node.validator01]
 [node.validator02]


### PR DESCRIPTION
Pin solver on omega and mainnet to version running on staging.

issue: none