### PR TITLE
feat(solver): support usdc

### DIFF
--- a/lib/bi/unit.go
+++ b/lib/bi/unit.go
@@ -87,6 +87,23 @@ func Ether[N number](i N) *big.Int {
 	return wei
 }
 
+// Dec6 converts ether float/int/uint in to big.Int amt with 6 decimals; i * 1e6.
+// Note this can be lossy for large floats.
+func Dec6[N number](i N) *big.Int {
+	if iU64, ok := numToU64(i); ok {
+		return MulRaw(big.NewInt(1e6), iU64)
+	} else if iI64, ok := numToI64(i); ok {
+		return MulRaw(big.NewInt(1e6), iI64)
+	}
+
+	out, _ := new(big.Float).Mul(
+		big.NewFloat(float64(i)),
+		big.NewFloat(1e6)).
+		Int(nil)
+
+	return out
+}
+
 // numToU64 converts a number to uint64 if lossless.
 func numToU64[N number](i N) (uint64, bool) {
 	if i < 0 || float64(i) > math.MaxUint64 {

--- a/lib/bi/unit_test.go
+++ b/lib/bi/unit_test.go
@@ -39,6 +39,27 @@ func TestToWei(t *testing.T) {
 	require.Equal(t, min1G, bi.Ether(-1_000_000_000))
 }
 
+func TestDec6(t *testing.T) {
+	t.Parallel()
+
+	require.Equal(t, bi.Wei(1_000_000), bi.Dec6(1))
+	require.Equal(t, bi.Gwei(1), bi.Dec6(1_000))
+	require.Equal(t, bi.Ether(1), bi.Dec6(1_000_000_000_000))
+
+	require.Equal(t, bi.N(1), bi.Dec6(0.000_001))
+	require.Equal(t, bi.Zero(), bi.Dec6(0.000_000_1))
+
+	min1 := new(big.Int).Mul(bi.Dec6(1), big.NewInt(-1))
+	min1K := new(big.Int).Mul(bi.Dec6(1), big.NewInt(-1_000))
+	min1M := new(big.Int).Mul(bi.Dec6(1), big.NewInt(-1_000_000))
+	min1G := new(big.Int).Mul(bi.Dec6(1), big.NewInt(-1_000_000_000))
+
+	require.Equal(t, min1, bi.Dec6(-1))
+	require.Equal(t, min1K, bi.Dec6(-1_000))
+	require.Equal(t, min1M, bi.Dec6(-1_000_000))
+	require.Equal(t, min1G, bi.Dec6(-1_000_000_000))
+}
+
 //nolint:testifylint // Epsilon comparison not required
 func TestWeiTo(t *testing.T) {
 	t.Parallel()

--- a/lib/tokens/tokens.go
+++ b/lib/tokens/tokens.go
@@ -22,6 +22,13 @@ var (
 		CoingeckoID: "ethereum",
 	}
 
+	USDC = Token{
+		Symbol:      "USDC",
+		Name:        "USD Coin",
+		Decimals:    6,
+		CoingeckoID: "usdc",
+	}
+
 	STETH = Token{
 		Symbol:      "stETH",
 		Name:        "Lido Staked Ether",

--- a/lib/tokens/tokens_test.go
+++ b/lib/tokens/tokens_test.go
@@ -1,0 +1,22 @@
+package tokens_test
+
+import (
+	"testing"
+
+	"github.com/omni-network/omni/lib/tokens"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestDecimals sanity checks token decimals, ensuring we do not add invalid ones.
+func TestDecimals(t *testing.T) {
+	t.Parallel()
+
+	for _, token := range tokens.All() {
+		if token == tokens.USDC {
+			require.Equal(t, uint(6), token.Decimals)
+		} else {
+			require.Equal(t, uint(18), token.Decimals)
+		}
+	}
+}

--- a/solver/app/internal_testutils.go
+++ b/solver/app/internal_testutils.go
@@ -255,6 +255,8 @@ func orderTestCases(t *testing.T, solver common.Address) []orderTestCase {
 
 	omegaOMNIAddr := omniERC20(netconf.Omega).Address
 	holeskySTETH := common.HexToAddress("0x3f1c547b21f65e10480de3ad8e19faac46c95034")
+	arbSepoliaUSDC := common.HexToAddress("0x75faf114eafb1BDbe2F0316DF893fd58CE46AA4d")
+	baseSepoliaUSDC := common.HexToAddress("0x036CbD53842c5426634e7929541eC2318f3dCF7e")
 
 	// dummy calldata / target. unused but for /check calls, and to build valid FillOriginData
 	dummyCallData := hexutil.MustDecode("0x70a08231000000000000000000000000e3481474b23f88a8917dbcb4cbc55efcf0f68cc7")
@@ -535,6 +537,56 @@ func orderTestCases(t *testing.T, solver common.Address) []orderTestCase {
 				mockERC20Allowance(t, clients.Client(t, evmchain.IDHolesky), holeskySTETH)
 			},
 		},
+		{
+			// note USDC has 6 decimals
+			name:   "USDC sufficient deposit",
+			reason: types.RejectNone,
+			reject: false,
+			order: testOrder{
+				srcChainID: evmchain.IDBaseSepolia,
+				dstChainID: evmchain.IDArbSepolia,
+				deposits:   []types.AddrAmt{{Amount: depositFor(bi.Dec6(1), standardFeeBips), Token: baseSepoliaUSDC}},
+				calls:      []types.Call{{Target: common.HexToAddress("0x01"), Data: dummyCallData}}, // does not matter
+				expenses:   []types.Expense{{Amount: bi.Dec6(1), Token: arbSepoliaUSDC}},
+			},
+			mock: func(clients MockClients) {
+				mockERC20Balance(t, clients.Client(t, evmchain.IDArbSepolia), arbSepoliaUSDC, bi.Dec6(1))
+				mockERC20Allowance(t, clients.Client(t, evmchain.IDArbSepolia), arbSepoliaUSDC)
+			},
+		},
+		{
+			// note USDC has 6 decimals
+			name:   "USDC insufficient deposit",
+			reason: types.RejectInsufficientDeposit,
+			reject: true,
+			order: testOrder{
+				srcChainID: evmchain.IDBaseSepolia,
+				dstChainID: evmchain.IDArbSepolia,
+				deposits:   []types.AddrAmt{{Amount: bi.Dec6(1), Token: baseSepoliaUSDC}},
+				calls:      []types.Call{{Target: common.HexToAddress("0x01"), Data: dummyCallData}}, // does not matter
+				expenses:   []types.Expense{{Amount: bi.Dec6(1), Token: arbSepoliaUSDC}},
+			},
+			mock: func(clients MockClients) {
+				mockERC20Balance(t, clients.Client(t, evmchain.IDArbSepolia), arbSepoliaUSDC, bi.Dec6(1))
+				mockERC20Allowance(t, clients.Client(t, evmchain.IDArbSepolia), arbSepoliaUSDC)
+			},
+		},
+		{
+			name:   "USDC expense over max", // note us of ether(1), not bi.Dec6(1)
+			reason: types.RejectExpenseOverMax,
+			reject: true,
+			order: testOrder{
+				srcChainID: evmchain.IDBaseSepolia,
+				dstChainID: evmchain.IDArbSepolia,
+				deposits:   []types.AddrAmt{{Amount: depositFor(ether(1), standardFeeBips), Token: baseSepoliaUSDC}},
+				calls:      []types.Call{{Target: common.HexToAddress("0x01"), Data: dummyCallData}}, // does not matter
+				expenses:   []types.Expense{{Amount: ether(1), Token: arbSepoliaUSDC}},
+			},
+			mock: func(clients MockClients) {
+				mockERC20Balance(t, clients.Client(t, evmchain.IDArbSepolia), arbSepoliaUSDC, ether(1))
+				mockERC20Allowance(t, clients.Client(t, evmchain.IDArbSepolia), arbSepoliaUSDC)
+			},
+		},
 	}
 }
 
@@ -547,6 +599,7 @@ func testBackends(t *testing.T) (ethbackend.Backends, MockClients) {
 		evmchain.IDOmniOmega,
 		evmchain.IDHolesky,
 		evmchain.IDBaseSepolia,
+		evmchain.IDArbSepolia,
 
 		// add one mainnet chain, to make sure testnet ETH cannot be used for mainnet ETH
 		evmchain.IDOptimism,

--- a/solver/app/pnl_internal_test.go
+++ b/solver/app/pnl_internal_test.go
@@ -1,0 +1,31 @@
+package app
+
+import (
+	"testing"
+
+	"github.com/omni-network/omni/lib/bi"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestTknAmtToGweiF64(t *testing.T) {
+	t.Parallel()
+
+	require.InEpsilon(t, 1e9, tknAmtToGweiF64(bi.Ether(1), 18), 1e-9)
+	require.InEpsilon(t, 1e9, tknAmtToGweiF64(bi.Dec6(1), 6), 1e-9)
+
+	require.InEpsilon(t, 5e9, tknAmtToGweiF64(bi.Ether(5), 18), 1e-9)
+	require.InEpsilon(t, 5e9, tknAmtToGweiF64(bi.Dec6(5), 6), 1e-9)
+
+	require.InEpsilon(t, 1e10, tknAmtToGweiF64(bi.Ether(10), 18), 1e-9)
+	require.InEpsilon(t, 1e10, tknAmtToGweiF64(bi.Dec6(10), 6), 1e-9)
+
+	require.InEpsilon(t, 1e8, tknAmtToGweiF64(bi.Ether(0.1), 18), 1e-9)
+	require.InEpsilon(t, 1e8, tknAmtToGweiF64(bi.Dec6(0.1), 6), 1e-9)
+
+	require.InEpsilon(t, 1e7, tknAmtToGweiF64(bi.Ether(0.01), 18), 1e-9)
+	require.InEpsilon(t, 1e7, tknAmtToGweiF64(bi.Dec6(0.01), 6), 1e-9)
+
+	require.InEpsilon(t, 1e10, tknAmtToGweiF64(bi.Ether(1), 17), 1e-9)
+	require.InEpsilon(t, 1e11, tknAmtToGweiF64(bi.Ether(1), 16), 1e-9)
+}

--- a/solver/tokens/testdata/TestTokens.golden
+++ b/solver/tokens/testdata/TestTokens.golden
@@ -140,6 +140,86 @@
   "symbol": "OMNI"
  },
  {
+  "address": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+  "chainId": 1,
+  "coingeckoId": "usdc",
+  "isMock": false,
+  "maxSpend": "0.0000",
+  "minSpend": "0.0000",
+  "name": "USD Coin",
+  "symbol": "USDC"
+ },
+ {
+  "address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+  "chainId": 42161,
+  "coingeckoId": "usdc",
+  "isMock": false,
+  "maxSpend": "0.0000",
+  "minSpend": "0.0000",
+  "name": "USD Coin",
+  "symbol": "USDC"
+ },
+ {
+  "address": "0x0b2C639c533813f4Aa9D7837CAf62653d097Ff85",
+  "chainId": 10,
+  "coingeckoId": "usdc",
+  "isMock": false,
+  "maxSpend": "0.0000",
+  "minSpend": "0.0000",
+  "name": "USD Coin",
+  "symbol": "USDC"
+ },
+ {
+  "address": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+  "chainId": 8453,
+  "coingeckoId": "usdc",
+  "isMock": false,
+  "maxSpend": "0.0000",
+  "minSpend": "0.0000",
+  "name": "USD Coin",
+  "symbol": "USDC"
+ },
+ {
+  "address": "0x1c7D4B196Cb0C7B01d743Fbc6116a902379C7238",
+  "chainId": 11155111,
+  "coingeckoId": "usdc",
+  "isMock": false,
+  "maxSpend": "0.0000",
+  "minSpend": "0.0000",
+  "name": "USD Coin",
+  "symbol": "USDC"
+ },
+ {
+  "address": "0x75faf114eafb1BDbe2F0316DF893fd58CE46AA4d",
+  "chainId": 421614,
+  "coingeckoId": "usdc",
+  "isMock": false,
+  "maxSpend": "0.0000",
+  "minSpend": "0.0000",
+  "name": "USD Coin",
+  "symbol": "USDC"
+ },
+ {
+  "address": "0x5fd84259d66Cd46123540766Be93DFE6D43130D7",
+  "chainId": 11155420,
+  "coingeckoId": "usdc",
+  "isMock": false,
+  "maxSpend": "0.0000",
+  "minSpend": "0.0000",
+  "name": "USD Coin",
+  "symbol": "USDC"
+ },
+ {
+  "address": "0x036CbD53842c5426634e7929541eC2318f3dCF7e",
+  "chainId": 84532,
+  "coingeckoId": "usdc",
+  "isMock": false,
+  "maxSpend": "0.0000",
+  "minSpend": "0.0000",
+  "name": "USD Coin",
+  "symbol": "USDC"
+ },
+ {
   "address": "0x36E66fbBce51e4cD5bd3C62B637Eb411b18949D4",
   "chainId": 1,
   "coingeckoId": "omni-network",

--- a/solver/tokens/tokens.go
+++ b/solver/tokens/tokens.go
@@ -107,6 +107,20 @@ var (
 				MaxSpend: bi.Ether(1),     // 1 stETH
 			},
 		},
+		tokenslib.USDC: {
+			ClassMainnet: {
+				MinSpend: bi.Dec6(0.1),   // 0.1 USDC
+				MaxSpend: bi.Dec6(1_000), // 1k USDC
+			},
+			ClassTestnet: {
+				MinSpend: bi.Dec6(0.1), // 0.1 USDC
+				MaxSpend: bi.Dec6(10),  // 10 USDC
+			},
+			ClassDevent: {
+				MinSpend: bi.Dec6(0.1), // 0.1 USDC
+				MaxSpend: bi.Dec6(10),  // 10 USDC
+			},
+		},
 	}
 )
 
@@ -132,6 +146,18 @@ var tokens = append([]Token{
 	nativeOMNI(evmchain.IDOmniOmega),
 	nativeOMNI(evmchain.IDOmniStaging),
 	nativeOMNI(evmchain.IDOmniDevnet),
+
+	// USDC (mainnet)
+	usdc(evmchain.IDEthereum, common.HexToAddress("0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48")),
+	usdc(evmchain.IDArbitrumOne, common.HexToAddress("0xaf88d065e77c8cC2239327C5EDb3A432268e5831")),
+	usdc(evmchain.IDOptimism, common.HexToAddress("0x0b2c639c533813f4aa9d7837caf62653d097ff85")),
+	usdc(evmchain.IDBase, common.HexToAddress("0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913")),
+
+	// USDC (testnet)
+	usdc(evmchain.IDSepolia, common.HexToAddress("0x1c7D4B196Cb0C7B01d743Fbc6116a902379C7238")),
+	usdc(evmchain.IDArbSepolia, common.HexToAddress("0x75faf114eafb1BDbe2F0316DF893fd58CE46AA4d")),
+	usdc(evmchain.IDOpSepolia, common.HexToAddress("0x5fd84259d66Cd46123540766Be93DFE6D43130D7")),
+	usdc(evmchain.IDBaseSepolia, common.HexToAddress("0x036CbD53842c5426634e7929541eC2318f3dCF7e")),
 
 	// ERC20 OMNI
 	omniERC20(netconf.Mainnet),
@@ -287,6 +313,20 @@ func wstETH(chainID uint64, addr common.Address) Token {
 
 	return Token{
 		Token:      tokenslib.WSTETH,
+		ChainID:    chainID,
+		ChainClass: mustChainClass(chainID),
+		Address:    addr,
+		MaxSpend:   bounds.MaxSpend,
+		MinSpend:   bounds.MinSpend,
+	}
+}
+
+func usdc(chainID uint64, addr common.Address) Token {
+	chainClass := mustChainClass(chainID)
+	bounds := mustSpendBounds(tokenslib.USDC, chainClass)
+
+	return Token{
+		Token:      tokenslib.USDC,
 		ChainID:    chainID,
 		ChainClass: mustChainClass(chainID),
 		Address:    addr,


### PR DESCRIPTION
Supporting usdc in solver.

Notes:
- usdc has 6 dec, this should only matter in spend bounds & pnl logs (i've addressed)
- holesky does not have a canonical usdc

issue: none