### PR TITLE
chore(lib/ethclient): disable header cache

### DIFF
--- a/lib/ethclient/engineclient.go
+++ b/lib/ethclient/engineclient.go
@@ -63,13 +63,8 @@ func NewAuthClient(ctx context.Context, urlAddr string, jwtSecret []byte) (Engin
 		return engineClient{}, errors.Wrap(err, "rpc dial")
 	}
 
-	cl, err := NewClient(rpcClient, "engine", urlAddr)
-	if err != nil {
-		return engineClient{}, errors.Wrap(err, "new client")
-	}
-
 	return engineClient{
-		Client: cl,
+		Client: NewClient(rpcClient, "engine", urlAddr),
 	}, nil
 }
 

--- a/lib/ethclient/ethclient.go
+++ b/lib/ethclient/ethclient.go
@@ -57,12 +57,12 @@ type wrapper struct {
 }
 
 // NewClient wraps an *rpc.Client adding metrics and wrapped errors and a header cache.
-func NewClient(cl *rpc.Client, name, address string) (Client, error) {
-	return newHeaderCache(wrapper{
+func NewClient(cl *rpc.Client, name, address string) Client {
+	return wrapper{
 		cl:      ethclient.NewClient(cl),
 		name:    name,
 		address: address,
-	})
+	}
 }
 
 // Dial connects a client to the given URL. It returns a wrapped  client adding metrics and wrapped errors and a header cache.
@@ -76,11 +76,11 @@ func Dial(chainName string, url string) (Client, error) {
 		return wrapper{}, errors.Wrap(err, "dial", "chain", chainName, "url", url)
 	}
 
-	return newHeaderCache(wrapper{
+	return wrapper{
 		cl:      cl,
 		name:    chainName,
 		address: url,
-	})
+	}, nil
 }
 
 // Close closes the underlying RPC connection.


### PR DESCRIPTION
Disable headercache since it introduces risk of caching (and then using/attesting/solving) reorged blocks if reorg detection fails (or is late) for any reason. This occured on staging relayer since it doesn't query/stream all xblocks, so it doesn't detect reorgs consistently. 

issue: none