### PR TITLE
fix(halo/app): verify tx signing info empty

### DIFF
--- a/solver/app/metrics.go
+++ b/solver/app/metrics.go
@@ -84,6 +84,7 @@ var (
 		Subsystem: "worker",
 		Name:      "job_duration_seconds",
 		Help:      "Job duration in seconds by chain and event status",
+		Buckets:   prometheus.ExponentialBucketsRange(0.1, 60, 10),
 	}, []string{"chain", "status"})
 
 	workErrors = promauto.NewCounterVec(prometheus.CounterOpts{


### PR DESCRIPTION
Ensure that tx signing info is empty. This prevents malicious proposers from adding arbitrary data to the chain, which negatively affects chain operation.

This issue was reported on Immunify

issue: none