### PR TITLE
chore(lib/xchain): add stream lag metric

### DIFF
--- a/lib/xchain/provider/metrics.go
+++ b/lib/xchain/provider/metrics.go
@@ -27,6 +27,13 @@ var (
 		Help:      "Latest successfully streamed height per source chain version and stream type. Alert if not growing.",
 	}, []string{"chain_version", "type"})
 
+	streamLag = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: "lib",
+		Subsystem: "xprovider",
+		Name:      "stream_lag_seconds",
+		Help:      "Latest successfully streamed lag (since timestamp) per source chain version and stream type.",
+	}, []string{"chain_version", "type"})
+
 	callbackLatency = promauto.NewHistogramVec(prometheus.HistogramOpts{
 		Namespace: "lib",
 		Subsystem: "xprovider",

--- a/lib/xchain/provider/provider.go
+++ b/lib/xchain/provider/provider.go
@@ -189,6 +189,9 @@ func (p *Provider) stream(
 				return errors.New("invalid block height")
 			}
 
+			lag := time.Since(block.Timestamp)
+			streamLag.WithLabelValues(chainVersionName, streamTypeXBlock).Set(lag.Seconds())
+
 			return nil
 		},
 		IncFetchErr: func() {

--- a/lib/xchain/provider/streamlogs.go
+++ b/lib/xchain/provider/streamlogs.go
@@ -10,6 +10,7 @@ import (
 	"github.com/omni-network/omni/lib/expbackoff"
 	"github.com/omni-network/omni/lib/stream"
 	"github.com/omni-network/omni/lib/tracer"
+	"github.com/omni-network/omni/lib/umath"
 	"github.com/omni-network/omni/lib/xchain"
 
 	"github.com/ethereum/go-ethereum/core/types"
@@ -81,6 +82,13 @@ func (p *Provider) StreamEventLogs(ctx context.Context, req xchain.EventLogsReq,
 			if e.Header.Number.Uint64() != h {
 				return errors.New("invalid block height")
 			}
+
+			timestamp, err := umath.ToInt64(e.Header.Time)
+			if err != nil {
+				return err
+			}
+			lag := time.Since(time.Unix(timestamp, 0))
+			streamLag.WithLabelValues(chainVersionName, streamTypeEvent).Set(lag.Seconds())
 
 			return nil
 		},


### PR DESCRIPTION
Adds stream lag metric to track how fast we can react to on-chain events. 

issue: none