### PR TITLE
fix(sdk): return an error when encoding order

### DIFF
--- a/sdk/packages/react/src/hooks/useValidateOrder.test.ts
+++ b/sdk/packages/react/src/hooks/useValidateOrder.test.ts
@@ -170,3 +170,23 @@ test.each([
 
   await waitFor(() => result.current.status === 'error')
 })
+
+test('behaviour: returns an error instead of throwing when the order encoding throws', async () => {
+  const invalidOrder = {
+    ...order,
+    calls: [{ ...order.calls[0], args: ['0xinvalid', 0n] }],
+  }
+  const { result } = renderHook(() => {
+    // @ts-expect-error: invalid order
+    return useValidateOrder({ order: invalidOrder, enabled: true })
+  })
+
+  await waitFor(() => {
+    expect(result.current.status).toBe('error')
+    if (result.current.status === 'error') {
+      expect(result.current.error.message).toMatch(
+        'Address "0xinvalid" is invalid',
+      )
+    }
+  })
+})


### PR DESCRIPTION
Wraps the order encoding so we can check and carry the error as needed.

issue: https://github.com/omni-network/omni/issues/3534