### PR TITLE
chore(lib/ethclient): enable header by hash cache

### DIFF
--- a/lib/ethclient/engineclient.go
+++ b/lib/ethclient/engineclient.go
@@ -63,8 +63,13 @@ func NewAuthClient(ctx context.Context, urlAddr string, jwtSecret []byte) (Engin
 		return engineClient{}, errors.Wrap(err, "rpc dial")
 	}
 
+	cl, err := NewClient(rpcClient, "engine", urlAddr)
+	if err != nil {
+		return engineClient{}, errors.Wrap(err, "new client")
+	}
+
 	return engineClient{
-		Client: NewClient(rpcClient, "engine", urlAddr),
+		Client: cl,
 	}, nil
 }
 

--- a/lib/ethclient/ethclient.go
+++ b/lib/ethclient/ethclient.go
@@ -57,12 +57,12 @@ type wrapper struct {
 }
 
 // NewClient wraps an *rpc.Client adding metrics and wrapped errors and a header cache.
-func NewClient(cl *rpc.Client, name, address string) Client {
-	return wrapper{
+func NewClient(cl *rpc.Client, name, address string) (Client, error) {
+	return newHeaderCache(wrapper{
 		cl:      ethclient.NewClient(cl),
 		name:    name,
 		address: address,
-	}
+	})
 }
 
 // Dial connects a client to the given URL. It returns a wrapped  client adding metrics and wrapped errors and a header cache.
@@ -76,11 +76,11 @@ func Dial(chainName string, url string) (Client, error) {
 		return wrapper{}, errors.Wrap(err, "dial", "chain", chainName, "url", url)
 	}
 
-	return wrapper{
+	return newHeaderCache(wrapper{
 		cl:      cl,
 		name:    chainName,
 		address: url,
-	}, nil
+	})
 }
 
 // Close closes the underlying RPC connection.

--- a/lib/ethclient/headercahce_internal_test.go
+++ b/lib/ethclient/headercahce_internal_test.go
@@ -51,17 +51,17 @@ func TestHeaderCache(t *testing.T) {
 	headersEqual(t, h1, h)
 	require.Equal(t, 1, testCl.headerByHash)
 
-	// Fetch h1 by number, ensure cached
+	// Fetch h1 by number, ensure queried
 	h, err = cache.HeaderByNumber(ctx, h1.Number)
 	require.NoError(t, err)
 	headersEqual(t, h1, h)
-	require.Equal(t, 0, testCl.headerByNumber)
+	require.Equal(t, 1, testCl.headerByNumber)
 
 	// Fetch h2 by number, ensure queried
 	h, err = cache.HeaderByNumber(ctx, h2.Number)
 	require.NoError(t, err)
 	headersEqual(t, h2, h)
-	require.Equal(t, 1, testCl.headerByNumber)
+	require.Equal(t, 2, testCl.headerByNumber)
 
 	// Fetch h2 by hash, ensure cached
 	h, err = cache.HeaderByHash(ctx, h2.Hash())
@@ -81,11 +81,11 @@ func TestHeaderCache(t *testing.T) {
 	headersEqual(t, h3, h)
 	require.Equal(t, 2, testCl.headerByType)
 
-	// Fetch h3 by number, ensure cached
+	// Fetch h3 by number, ensure queried
 	h, err = cache.HeaderByNumber(ctx, h3.Number)
 	require.NoError(t, err)
 	headersEqual(t, h3, h)
-	require.Equal(t, 1, testCl.headerByNumber)
+	require.Equal(t, 3, testCl.headerByNumber)
 
 	// Fetch h3 by hash, ensure cached
 	h, err = cache.HeaderByHash(ctx, h3.Hash())


### PR DESCRIPTION
Re-enable headercache, but only for `HeaderByHash` since this has zero risk to return unexpected blocks. 

This also re-enables reorg detection metrics and alerts which is useful.

issue: none