### PR TITLE
ci(e2e): add solver address to testnet

### DIFF
--- a/e2e/app/definition.go
+++ b/e2e/app/definition.go
@@ -375,14 +375,24 @@ func TestnetFromManifest(ctx context.Context, manifest types.Manifest, infd type
 		return types.Testnet{}, err
 	}
 
+	solverInst := infd.Instances["solver"]
+	solverInternalIP := solverInst.IPAddress.String()
+	if infd.Provider == docker.ProviderName {
+		solverInternalIP = "solver" // For docker, we use container names
+	}
+	solverInternalAddr := fmt.Sprintf("http://%s:%d", solverInternalIP, solverInst.Port)
+	solverExternalAddr := fmt.Sprintf("http://%s:%d", solverInst.ExtIPAddress.String(), solverInst.Port)
+
 	return types.Testnet{
-		Manifest:     manifest,
-		Network:      manifest.Network,
-		Testnet:      cmtTestnet,
-		OmniEVMs:     omniEVMS,
-		AnvilChains:  anvils,
-		PublicChains: publics,
-		Perturb:      manifest.Perturb,
+		Manifest:           manifest,
+		Network:            manifest.Network,
+		Testnet:            cmtTestnet,
+		OmniEVMs:           omniEVMS,
+		AnvilChains:        anvils,
+		PublicChains:       publics,
+		Perturb:            manifest.Perturb,
+		SolverInternalAddr: solverInternalAddr,
+		SolverExternalAddr: solverExternalAddr,
 	}, nil
 }
 

--- a/e2e/app/definition_test.go
+++ b/e2e/app/definition_test.go
@@ -29,7 +29,7 @@ func TestManifestServiceReference(t *testing.T) {
 		require.NoError(t, err)
 
 		services := keys(infraData.Instances)
-		services = append(services, "relayer", "monitor", "solver")
+		services = append(services, "relayer", "monitor")
 		sort.Strings(services)
 		ref[manifest.Network] = services
 	}

--- a/e2e/docker/data.go
+++ b/e2e/docker/data.go
@@ -56,7 +56,14 @@ func NewInfraData(manifest types.Manifest) (types.InfrastructureData, error) {
 		}
 	}
 
-	// No IP for relayer required since it doesn't serve an API.
+	// No IP for relayer or monitor required since they doesn't serve an API.
+
+	// Solver IP and port hardcoded in docker/compose.yaml.tmpl
+	infd.Instances["solver"] = e2e.InstanceData{
+		IPAddress:    net.ParseIP("10.186.73.203"),
+		ExtIPAddress: localhost,
+		Port:         26661,
+	}
 
 	return types.InfrastructureData{
 		InfrastructureData: infd,

--- a/e2e/test/bridge_test.go
+++ b/e2e/test/bridge_test.go
@@ -10,8 +10,6 @@ import (
 	"github.com/omni-network/omni/lib/bi"
 	"github.com/omni-network/omni/lib/contracts"
 	"github.com/omni-network/omni/lib/ethclient"
-	"github.com/omni-network/omni/lib/netconf"
-	"github.com/omni-network/omni/lib/xchain"
 
 	"github.com/ethereum/go-ethereum/common"
 
@@ -21,8 +19,11 @@ import (
 // TestBridge ensures that bridge tests cases defined in e2e/app/tokenbridge.go were successful.
 func TestBridge(t *testing.T) {
 	t.Parallel()
-	testNetwork(t, func(ctx context.Context, t *testing.T, network netconf.Network, endpoints xchain.RPCEndpoints) {
+	testNetwork(t, func(ctx context.Context, t *testing.T, deps NetworkDeps) {
 		t.Helper()
+
+		network := deps.Network
+		endpoints := deps.RPCEndpoints
 
 		if _, ok := network.EthereumChain(); !ok {
 			t.Skip("no ethereum chain")

--- a/e2e/test/cli_test.go
+++ b/e2e/test/cli_test.go
@@ -69,9 +69,11 @@ func execCLI(ctx context.Context, args ...string) (string, string, error) {
 func TestCLIOperator(t *testing.T) {
 	t.Parallel()
 
-	testNetwork(t, func(ctx context.Context, t *testing.T, network netconf.Network, endpoints xchain.RPCEndpoints) {
+	testNetwork(t, func(ctx context.Context, t *testing.T, deps NetworkDeps) {
 		t.Helper()
 
+		endpoints := deps.RPCEndpoints
+		network := deps.Network
 		netID := network.ID
 		e, ok := network.OmniEVMChain()
 		require.True(t, ok)

--- a/e2e/test/gaspump_test.go
+++ b/e2e/test/gaspump_test.go
@@ -8,8 +8,6 @@ import (
 	"github.com/omni-network/omni/e2e/app"
 	"github.com/omni-network/omni/lib/bi"
 	"github.com/omni-network/omni/lib/ethclient"
-	"github.com/omni-network/omni/lib/netconf"
-	"github.com/omni-network/omni/lib/xchain"
 
 	"github.com/ethereum/go-ethereum/common"
 
@@ -19,13 +17,14 @@ import (
 // TestGasPumps ensures that bridge tests cases defined in e2e/app/gaspump.go were successful.
 func TestGasPumps(t *testing.T) {
 	t.Parallel()
-	testNetwork(t, func(ctx context.Context, t *testing.T, network netconf.Network, endpoints xchain.RPCEndpoints) {
+	testNetwork(t, func(ctx context.Context, t *testing.T, deps NetworkDeps) {
 		t.Helper()
 
+		network := deps.Network
 		omniEVM, ok := network.OmniEVMChain()
 		require.True(t, ok)
 
-		omniRPC, err := endpoints.ByNameOrID(omniEVM.Name, omniEVM.ID)
+		omniRPC, err := deps.RPCEndpoints.ByNameOrID(omniEVM.Name, omniEVM.ID)
 		require.NoError(t, err)
 
 		omniClient, err := ethclient.Dial(omniEVM.Name, omniRPC)

--- a/e2e/test/module_test.go
+++ b/e2e/test/module_test.go
@@ -6,8 +6,6 @@ import (
 
 	magellan2 "github.com/omni-network/omni/halo/app/upgrades/magellan"
 	"github.com/omni-network/omni/lib/cchain/provider"
-	"github.com/omni-network/omni/lib/netconf"
-	"github.com/omni-network/omni/lib/xchain"
 
 	"github.com/cometbft/cometbft/rpc/client/http"
 
@@ -18,9 +16,10 @@ import (
 
 func TestMint(t *testing.T) {
 	t.Parallel()
-	testNetwork(t, func(ctx context.Context, t *testing.T, network netconf.Network, endpoints xchain.RPCEndpoints) {
+	testNetwork(t, func(ctx context.Context, t *testing.T, deps NetworkDeps) {
 		t.Helper()
 
+		network := deps.Network
 		cl, err := http.New(network.ID.Static().ConsensusRPC(), "/websocket")
 		require.NoError(t, err)
 		cprov := provider.NewABCI(cl, network.ID)
@@ -37,9 +36,10 @@ func TestMint(t *testing.T) {
 
 func TestSlashing(t *testing.T) {
 	t.Parallel()
-	testNetwork(t, func(ctx context.Context, t *testing.T, network netconf.Network, endpoints xchain.RPCEndpoints) {
+	testNetwork(t, func(ctx context.Context, t *testing.T, deps NetworkDeps) {
 		t.Helper()
 
+		network := deps.Network
 		cl, err := http.New(network.ID.Static().ConsensusRPC(), "/websocket")
 		require.NoError(t, err)
 		cprov := provider.NewABCI(cl, network.ID)

--- a/e2e/test/portal_registry_test.go
+++ b/e2e/test/portal_registry_test.go
@@ -7,8 +7,6 @@ import (
 	"github.com/omni-network/omni/contracts/bindings"
 	"github.com/omni-network/omni/halo/genutil/evm/predeploys"
 	"github.com/omni-network/omni/lib/ethclient"
-	"github.com/omni-network/omni/lib/netconf"
-	"github.com/omni-network/omni/lib/xchain"
 
 	"github.com/ethereum/go-ethereum/common"
 
@@ -17,13 +15,14 @@ import (
 
 func TestPortalRegistry(t *testing.T) {
 	t.Parallel()
-	testNetwork(t, func(ctx context.Context, t *testing.T, network netconf.Network, endpoints xchain.RPCEndpoints) {
+	testNetwork(t, func(ctx context.Context, t *testing.T, deps NetworkDeps) {
 		t.Helper()
 
+		network := deps.Network
 		omniEVM, ok := network.OmniEVMChain()
 		require.True(t, ok)
 
-		rpc, err := endpoints.ByNameOrID(omniEVM.Name, omniEVM.ID)
+		rpc, err := deps.RPCEndpoints.ByNameOrID(omniEVM.Name, omniEVM.ID)
 		require.NoError(t, err)
 
 		omniClient, err := ethclient.Dial(omniEVM.Name, rpc)

--- a/e2e/test/sdk_test.go
+++ b/e2e/test/sdk_test.go
@@ -8,8 +8,6 @@ import (
 	"testing"
 
 	"github.com/omni-network/omni/e2e/types"
-	"github.com/omni-network/omni/lib/netconf"
-	"github.com/omni-network/omni/lib/xchain"
 
 	"github.com/stretchr/testify/require"
 )
@@ -19,7 +17,7 @@ func TestSDK(t *testing.T) {
 	skipFunc := func(manifest types.Manifest) bool {
 		return !manifest.DeploySolve
 	}
-	maybeTestNetwork(t, skipFunc, func(ctx context.Context, t *testing.T, network netconf.Network, endpoints xchain.RPCEndpoints) {
+	maybeTestNetwork(t, skipFunc, func(ctx context.Context, t *testing.T, _ NetworkDeps) {
 		t.Helper()
 
 		sdkPath, err := filepath.Abs("../../sdk")

--- a/e2e/test/upgrade_test.go
+++ b/e2e/test/upgrade_test.go
@@ -12,8 +12,6 @@ import (
 	"github.com/omni-network/omni/lib/ethclient"
 	"github.com/omni-network/omni/lib/ethclient/ethbackend"
 	"github.com/omni-network/omni/lib/log"
-	"github.com/omni-network/omni/lib/netconf"
-	"github.com/omni-network/omni/lib/xchain"
 
 	"github.com/cometbft/cometbft/rpc/client/http"
 
@@ -26,9 +24,10 @@ import (
 // TestPlanCancelUpgrade tests planning and canceling a far-future upgrade.
 func TestPlanCancelUpgrade(t *testing.T) {
 	t.Parallel()
-	testNetwork(t, func(ctx context.Context, t *testing.T, network netconf.Network, endpoints xchain.RPCEndpoints) {
+	testNetwork(t, func(ctx context.Context, t *testing.T, deps NetworkDeps) {
 		t.Helper()
 
+		network := deps.Network
 		cl, err := http.New(network.ID.Static().ConsensusRPC(), "/websocket")
 		require.NoError(t, err)
 		cprov := provider.NewABCI(cl, network.ID)
@@ -39,7 +38,7 @@ func TestPlanCancelUpgrade(t *testing.T) {
 
 		omniEVM, ok := network.OmniEVMChain()
 		require.True(t, ok)
-		omniRPC, err := endpoints.ByNameOrID(omniEVM.Name, omniEVM.ID)
+		omniRPC, err := deps.RPCEndpoints.ByNameOrID(omniEVM.Name, omniEVM.ID)
 		require.NoError(t, err)
 		omniClient, err := ethclient.Dial(omniEVM.Name, omniRPC)
 		require.NoError(t, err)

--- a/e2e/types/testnet.go
+++ b/e2e/types/testnet.go
@@ -29,6 +29,9 @@ type Testnet struct {
 	AnvilChains  []AnvilChain
 	PublicChains []PublicChain
 	Perturb      map[string][]Perturb
+
+	SolverInternalAddr string
+	SolverExternalAddr string
 }
 
 // RandomHaloAddr returns a random halo address for cprovider and cometBFT rpc clients.

--- a/e2e/vmcompose/data.go
+++ b/e2e/vmcompose/data.go
@@ -18,9 +18,12 @@ import (
 var omniEvmRegx = regexp.MustCompile(".*_evm")
 
 const (
-	evmPort  = uint32(8545)
-	haloPort = uint32(26657)
-	relayer  = "relayer"
+	evmPort    = uint32(8545)
+	haloPort   = uint32(26657)
+	solverPort = uint32(26661)
+	relayer    = "relayer"
+	monitor    = "monitor"
+	solver     = "solver"
 )
 
 type vmJSON struct {
@@ -87,8 +90,10 @@ func LoadData(ctx context.Context, path string) (types.InfrastructureData, error
 			port = evmPort
 		} else if _, ok := evmchain.MetadataByName(serviceName); ok {
 			port = evmPort
-		} else if serviceName == relayer {
-			port = 0 // No port for relayer
+		} else if serviceName == solver {
+			port = solverPort
+		} else if serviceName == relayer || serviceName == monitor {
+			port = 0 // No port for relayer/monitor
 		}
 
 		instances[serviceName] = e2e.InstanceData{


### PR DESCRIPTION
Adds `SolverAddr` to `Testnet` and use it in e2e/tests.

Populate this from `InfraData`, which is populated in docker and vmcompose respectively.

issue: none