### PR TITLE
chore(solver/app): add rejectCode to check response

### DIFF
--- a/solver/app/handler.go
+++ b/solver/app/handler.go
@@ -77,6 +77,7 @@ func newCheckHandler(checkFunc checkFunc) Handler {
 			if r := new(RejectionError); errors.As(err, &r) {
 				return types.CheckResponse{
 					Rejected:          true,
+					RejectCode:        r.Reason,
 					RejectReason:      r.Reason.String(),
 					RejectDescription: r.Err.Error(),
 				}, nil

--- a/solver/app/testdata/TestCheck/insufficient_deposit/resp_body.json
+++ b/solver/app/testdata/TestCheck/insufficient_deposit/resp_body.json
@@ -1,6 +1,7 @@
 {
   "accepted": false,
   "rejected": true,
+  "rejectCode": 4,
   "rejectReason": "InsufficientDeposit",
   "rejectDescription": "insufficient deposit"
 }

--- a/solver/app/testdata/TestCheck/insufficient_native_balance/resp_body.json
+++ b/solver/app/testdata/TestCheck/insufficient_native_balance/resp_body.json
@@ -1,6 +1,7 @@
 {
   "accepted": false,
   "rejected": true,
+  "rejectCode": 5,
   "rejectReason": "InsufficientInventory",
   "rejectDescription": "insufficient balance"
 }

--- a/solver/app/testdata/TestCheck/sufficient_ERC20_balance/resp_body.json
+++ b/solver/app/testdata/TestCheck/sufficient_ERC20_balance/resp_body.json
@@ -1,6 +1,7 @@
 {
   "accepted": true,
   "rejected": false,
+  "rejectCode": 0,
   "rejectReason": "",
   "rejectDescription": ""
 }

--- a/solver/app/testdata/TestCheck/sufficient_native_balance/resp_body.json
+++ b/solver/app/testdata/TestCheck/sufficient_native_balance/resp_body.json
@@ -1,6 +1,7 @@
 {
   "accepted": true,
   "rejected": false,
+  "rejectCode": 0,
   "rejectReason": "",
   "rejectDescription": ""
 }

--- a/solver/types/api.go
+++ b/solver/types/api.go
@@ -44,10 +44,11 @@ type CheckRequest struct {
 
 // CheckResponse is the response json for the /check endpoint.
 type CheckResponse struct {
-	Accepted          bool   `json:"accepted"`
-	Rejected          bool   `json:"rejected"`
-	RejectReason      string `json:"rejectReason"`
-	RejectDescription string `json:"rejectDescription"`
+	Accepted          bool         `json:"accepted"`
+	Rejected          bool         `json:"rejected"`
+	RejectCode        RejectReason `json:"rejectCode"`
+	RejectReason      string       `json:"rejectReason"`
+	RejectDescription string       `json:"rejectDescription"`
 }
 
 // QuoteRequest is the expected request body for the /api/v1/quote endpoint.

--- a/solver/types/reject.go
+++ b/solver/types/reject.go
@@ -18,4 +18,5 @@ const (
 	RejectExpenseOverMax        RejectReason = 11
 	RejectExpenseUnderMin       RejectReason = 12
 	RejectCallNotAllowed        RejectReason = 13
+	rejectSentinel              RejectReason = 14
 )


### PR DESCRIPTION
Add a `rejectCode` field to `/check` response which allows better programatic comparison of reject reasons (as compared with english string `rejectReason`). Also easier to lookup and reference.

issue: none