### PR TITLE
chore(halo): fix pending blocks attest metric

### DIFF
--- a/halo/attest/keeper/keeper.go
+++ b/halo/attest/keeper/keeper.go
@@ -318,7 +318,7 @@ func (k *Keeper) Approve(ctx context.Context, valset ValSet) error {
 			return errors.Wrap(err, "get att signatures")
 		}
 
-		{
+		if approvedByChain[chainVer] < att.GetAttestOffset() {
 			// Calculate pending blocks; safe to ignore errors since metrics is non-critical.
 			current, _ := umath.ToUint64(sdk.UnwrapSDKContext(ctx).BlockHeight())
 			delta := umath.SubtractOrZero(current, att.GetCreatedHeight())


### PR DESCRIPTION
Do not set pending blocks gauge if attestation has already been approved.

issue: none