### PR TITLE
chore(lib/ethclient): close idle connections periodically

### DIFF
--- a/cli/cmd/devnet.go
+++ b/cli/cmd/devnet.go
@@ -197,7 +197,7 @@ func loadDevnetNetwork(ctx context.Context) (netconf.Network, xchain.RPCEndpoint
 
 	netID := netconf.Devnet
 
-	portalReg, err := makePortalRegistry(netID, endpoints)
+	portalReg, err := makePortalRegistry(ctx, netID, endpoints)
 	if err != nil {
 		return netconf.Network{}, nil, errors.Wrap(err, "make portal registry")
 	}
@@ -278,7 +278,7 @@ func devnetFund(ctx context.Context, cfg devnetFundConfig) error {
 
 // devnetBackend returns a backend populated with the default anvil account 0 private key.
 func devnetBackend(ctx context.Context, rpcURL string) (common.Address, *ethbackend.Backend, error) {
-	ethCl, err := ethclient.Dial("", rpcURL)
+	ethCl, err := ethclient.DialContext(ctx, "", rpcURL)
 	if err != nil {
 		return common.Address{}, nil, errors.Wrap(err, "dial eth client", "url", rpcURL)
 	}
@@ -310,14 +310,14 @@ func homeDir(network netconf.ID) (string, error) {
 	return filepath.Join(homeDir, ".omni", network.String()), nil
 }
 
-func makePortalRegistry(network netconf.ID, endpoints xchain.RPCEndpoints) (*bindings.PortalRegistry, error) {
+func makePortalRegistry(ctx context.Context, network netconf.ID, endpoints xchain.RPCEndpoints) (*bindings.PortalRegistry, error) {
 	meta := netconf.MetadataByID(network, network.Static().OmniExecutionChainID)
 	rpc, err := endpoints.ByNameOrID(meta.Name, meta.ChainID)
 	if err != nil {
 		return nil, err
 	}
 
-	ethCl, err := ethclient.Dial(meta.Name, rpc)
+	ethCl, err := ethclient.DialContext(ctx, meta.Name, rpc)
 	if err != nil {
 		return nil, err
 	}

--- a/cli/cmd/staking.go
+++ b/cli/cmd/staking.go
@@ -162,7 +162,7 @@ func CreateValidator(ctx context.Context, cfg CreateValConfig) error {
 	}
 	opAddr := crypto.PubkeyToAddress(operatorPriv.PublicKey)
 
-	eth, cprov, backend, err := setupClients(cfg.EOAConfig, operatorPriv)
+	eth, cprov, backend, err := setupClients(ctx, cfg.EOAConfig, operatorPriv)
 	if err != nil {
 		return err
 	}
@@ -305,7 +305,7 @@ func Delegate(ctx context.Context, cfg DelegateConfig) error {
 	}
 	delegatorAddr := crypto.PubkeyToAddress(delegatorPriv.PublicKey)
 
-	eth, cprov, backend, err := setupClients(cfg.EOAConfig, delegatorPriv)
+	eth, cprov, backend, err := setupClients(ctx, cfg.EOAConfig, delegatorPriv)
 	if err != nil {
 		return err
 	}
@@ -414,7 +414,7 @@ func unjailValidator(ctx context.Context, cfg EOAConfig) error {
 	}
 	opAddr := crypto.PubkeyToAddress(opPrivKey.PublicKey)
 
-	_, cprov, backend, err := setupClients(cfg, opPrivKey)
+	_, cprov, backend, err := setupClients(ctx, cfg, opPrivKey)
 	if err != nil {
 		return err
 	}
@@ -624,7 +624,7 @@ func EditVal(ctx context.Context, cfg EditValConfig) error {
 	}
 	valAddr := crypto.PubkeyToAddress(valPriv.PublicKey)
 
-	_, cprov, backend, err := setupClients(cfg.EOAConfig, valPriv)
+	_, cprov, backend, err := setupClients(ctx, cfg.EOAConfig, valPriv)
 	if err != nil {
 		return err
 	}
@@ -722,6 +722,7 @@ func EditVal(ctx context.Context, cfg EditValConfig) error {
 // setupClients is a helper that creates the omni evm client,
 // omni consensus client and a backend set with the operator private key.
 func setupClients(
+	ctx context.Context,
 	conf EOAConfig,
 	operatorPriv *ecdsa.PrivateKey,
 ) (ethclient.Client, cchain.Provider, *ethbackend.Backend, error) {
@@ -748,7 +749,7 @@ func setupClients(
 
 	cprov := provider.NewABCI(cl, conf.Network)
 
-	eth, err := ethclient.Dial(chainMeta.Name, conf.ExecutionRPC)
+	eth, err := ethclient.DialContext(ctx, chainMeta.Name, conf.ExecutionRPC)
 	if err != nil {
 		return nil, nil, nil, err
 	}

--- a/e2e/anvilproxy/app/anvil.go
+++ b/e2e/anvilproxy/app/anvil.go
@@ -36,7 +36,7 @@ func (i anvilInstance) Height(ctx context.Context) (uint64, error) {
 	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
 	defer cancel()
 
-	ethCl, err := ethclient.Dial("proxy", i.URL())
+	ethCl, err := ethclient.DialContext(ctx, "proxy", i.URL())
 	if err != nil {
 		return 0, errors.Wrap(err, "dial ethclient")
 	}

--- a/e2e/anvilproxy/app/xmsg.go
+++ b/e2e/anvilproxy/app/xmsg.go
@@ -157,7 +157,7 @@ func isFuzzyXMsgLogFilter(ctx context.Context, perturb types.Perturb, target str
 		return false, 0, errors.New("unexpected perturbation", "perturb", perturb)
 	}
 
-	ethCl, err := ethclient.Dial("proxy", target)
+	ethCl, err := ethclient.DialContext(ctx, "proxy", target)
 	if err != nil {
 		return false, 0, errors.Wrap(err, "dial ethclient")
 	}

--- a/e2e/app/admin/bridgespec.go
+++ b/e2e/app/admin/bridgespec.go
@@ -125,7 +125,7 @@ func ensureNativeBridgeSpec(ctx context.Context, s shared, c chain, specOverride
 		local = *specOverride
 	}
 
-	ethCl, err := ethclient.Dial(c.Name, c.RPCEndpoint)
+	ethCl, err := ethclient.DialContext(ctx, c.Name, c.RPCEndpoint)
 	if err != nil {
 		return errors.Wrap(err, "dial eth client")
 	}
@@ -157,7 +157,7 @@ func ensureL1BridgeSpec(ctx context.Context, s shared, c chain, specOverride *Br
 		local = *specOverride
 	}
 
-	ethCl, err := ethclient.Dial(c.Name, c.RPCEndpoint)
+	ethCl, err := ethclient.DialContext(ctx, c.Name, c.RPCEndpoint)
 	if err != nil {
 		return errors.Wrap(err, "dial eth client")
 	}

--- a/e2e/app/admin/portalspec.go
+++ b/e2e/app/admin/portalspec.go
@@ -107,7 +107,7 @@ func EnsurePortalSpec(ctx context.Context, def app.Definition, cfg Config, local
 			local = *localSpecOverride
 		}
 
-		ethCl, err := ethclient.Dial(c.Name, c.RPCEndpoint)
+		ethCl, err := ethclient.DialContext(ctx, c.Name, c.RPCEndpoint)
 		if err != nil {
 			return errors.Wrap(err, "dial eth client", "chain", c.Name)
 		}

--- a/e2e/app/admin/solvernetspec.go
+++ b/e2e/app/admin/solvernetspec.go
@@ -93,7 +93,7 @@ func EnsureSolverNetSpec(ctx context.Context, def app.Definition, cfg Config, lo
 			local = *localSpecOverride
 		}
 
-		ethCl, err := ethclient.Dial(c.Name, c.RPCEndpoint)
+		ethCl, err := ethclient.DialContext(ctx, c.Name, c.RPCEndpoint)
 		if err != nil {
 			return errors.Wrap(err, "dial eth client", "chain", c.Name)
 		}

--- a/e2e/app/admin/upgrade.go
+++ b/e2e/app/admin/upgrade.go
@@ -153,7 +153,7 @@ func upgradeFeeOracleV1(ctx context.Context, s shared, c chain) error {
 	// FeeOracleV1 contracts were not deployed via Create3
 	// The address must be read from the portal
 
-	client, err := ethclient.Dial(c.Name, c.RPCEndpoint)
+	client, err := ethclient.DialContext(ctx, c.Name, c.RPCEndpoint)
 	if err != nil {
 		return errors.Wrap(err, "dial RPCEndpoint")
 	}

--- a/e2e/app/definition.go
+++ b/e2e/app/definition.go
@@ -172,7 +172,7 @@ func MakeDefinition(ctx context.Context, cfg DefinitionConfig, commandName strin
 func newBackends(ctx context.Context, cfg DefinitionConfig, testnet types.Testnet, commandName string) (ethbackend.Backends, error) {
 	// If no fireblocks API key, use in-memory keys.
 	if cfg.FireAPIKey == "" {
-		return ethbackend.NewBackends(ctx, testnet, cfg.DeployKeyFile)
+		return ethbackend.BackendsFromTestnet(ctx, testnet, cfg.DeployKeyFile)
 	}
 
 	key, err := fireblocks.LoadKey(cfg.FireKeyPath)

--- a/e2e/app/valupdates.go
+++ b/e2e/app/valupdates.go
@@ -130,7 +130,7 @@ func StartValidatorUpdates(ctx context.Context, def Definition) func() error {
 			returnErr(errors.Wrap(err, "get rpc"))
 			return
 		}
-		ethCl, err := ethclient.Dial(omniEVM.Name, rpc)
+		ethCl, err := ethclient.DialContext(ctx, omniEVM.Name, rpc)
 		if err != nil {
 			returnErr(errors.Wrap(err, "dial"))
 			return

--- a/e2e/cmd/util.go
+++ b/e2e/cmd/util.go
@@ -18,7 +18,7 @@ func networkFromDef(ctx context.Context, def app.Definition) (netconf.Network, e
 	endpoints := app.ExternalEndpoints(def)
 	networkID := def.Testnet.Network
 
-	portalReg, err := makePortalRegistry(networkID, endpoints)
+	portalReg, err := makePortalRegistry(ctx, networkID, endpoints)
 	if err != nil {
 		return netconf.Network{}, errors.Wrap(err, "portal registry")
 	}
@@ -31,14 +31,14 @@ func networkFromDef(ctx context.Context, def app.Definition) (netconf.Network, e
 	return network, nil
 }
 
-func makePortalRegistry(network netconf.ID, endpoints xchain.RPCEndpoints) (*bindings.PortalRegistry, error) {
+func makePortalRegistry(ctx context.Context, network netconf.ID, endpoints xchain.RPCEndpoints) (*bindings.PortalRegistry, error) {
 	meta := netconf.MetadataByID(network, network.Static().OmniExecutionChainID)
 	rpc, err := endpoints.ByNameOrID(meta.Name, meta.ChainID)
 	if err != nil {
 		return nil, err
 	}
 
-	ethCl, err := ethclient.Dial(meta.Name, rpc)
+	ethCl, err := ethclient.DialContext(ctx, meta.Name, rpc)
 	if err != nil {
 		return nil, err
 	}

--- a/e2e/solve/test.go
+++ b/e2e/solve/test.go
@@ -76,7 +76,7 @@ func Test(ctx context.Context, network netconf.Network, endpoints xchain.RPCEndp
 
 	// use anvil.DevAccounts instead of eoa.DevAccounts, because eoa.DevAccounts
 	// are used frequently elsewhere in e2e / e2e tests, and nonce issues get annoying
-	backends, err := ethbackend.BackendsFromNetwork(network, endpoints, anvil.DevPrivateKeys()...)
+	backends, err := ethbackend.BackendsFromNetwork(ctx, network, endpoints, anvil.DevPrivateKeys()...)
 	if err != nil {
 		return err
 	}

--- a/e2e/xbridge/test.go
+++ b/e2e/xbridge/test.go
@@ -28,7 +28,7 @@ func Test(ctx context.Context, network netconf.Network, endpoints xchain.RPCEndp
 	}
 
 	pks := append(anvil.DevPrivateKeys(), eoa.DevPrivateKeys()...)
-	backends, err := ethbackend.BackendsFromNetwork(network, endpoints, pks...)
+	backends, err := ethbackend.BackendsFromNetwork(ctx, network, endpoints, pks...)
 	if err != nil {
 		return err
 	}

--- a/halo/app/lazyvoter.go
+++ b/halo/app/lazyvoter.go
@@ -143,10 +143,11 @@ func (l *voterLoader) LazyLoad(
 				return err
 			}
 
-			ethCl, err := ethclient.Dial(chain.Name, rpc)
+			ethCl, err := ethclient.DialContext(ctx, chain.Name, rpc)
 			if err != nil {
 				return err
 			}
+			go ethCl.CloseIdleConnectionsForever(ctx)
 
 			ethClients[chain.ID] = ethCl
 		}

--- a/halo/app/monitor.go
+++ b/halo/app/monitor.go
@@ -109,7 +109,7 @@ func monitorEVMForever(ctx context.Context, cfg Config, ethCl ethclient.Client, 
 	omniEVM := cfg.Network.Static().OmniExecutionChainName()
 	omniEVMRPC, err := cfg.RPCEndpoints.ByNameOrID(omniEVM, cfg.Network.Static().OmniExecutionChainID)
 	if err == nil {
-		newEthCl, err := ethclient.Dial(omniEVM, omniEVMRPC)
+		newEthCl, err := ethclient.DialContext(ctx, omniEVM, omniEVMRPC)
 		if err == nil {
 			ethCl = newEthCl
 			log.Info(ctx, "Using rpc endpoint to monitor attached omni evm", "rpc", omniEVMRPC)

--- a/lib/anvil/anvil.go
+++ b/lib/anvil/anvil.go
@@ -55,7 +55,7 @@ func Start(ctx context.Context, dir string, chainID uint64) (ethclient.Client, f
 
 	endpoint := "http://localhost:" + port
 
-	ethCl, err := ethclient.Dial("anvil", endpoint)
+	ethCl, err := ethclient.DialContext(ctx, "anvil", endpoint)
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "new eth client")
 	}

--- a/lib/contracts/address.go
+++ b/lib/contracts/address.go
@@ -90,7 +90,7 @@ func StagingID(ctx context.Context) (string, error) {
 		rpc = stagingOmniRPC
 	}
 
-	client, err := ethclient.Dial("omni_evm", rpc)
+	client, err := ethclient.DialContext(ctx, "omni_evm", rpc)
 	if err != nil {
 		return "", errors.Wrap(err, "dial omni")
 	}

--- a/lib/ethclient/ethclient.go
+++ b/lib/ethclient/ethclient.go
@@ -2,6 +2,8 @@ package ethclient
 
 import (
 	"context"
+	"net/http"
+	"time"
 
 	"github.com/omni-network/omni/lib/bi"
 	"github.com/omni-network/omni/lib/errors"
@@ -52,6 +54,7 @@ const (
 // wrapper wraps an ethclient.Client adding metrics and wrapped errors.
 type wrapper struct {
 	cl      *ethclient.Client
+	httpCl  *http.Client
 	name    string
 	address string
 }
@@ -65,22 +68,56 @@ func NewClient(cl *rpc.Client, name, address string) (Client, error) {
 	})
 }
 
-// Dial connects a client to the given URL. It returns a wrapped  client adding metrics and wrapped errors and a header cache.
+// Dial calls DialContext with a background context.
+// See DialContext for more details.
+func Dial(chainName string, url string) (Client, error) {
+	return DialContext(context.Background(), chainName, url)
+}
+
+// DialContext connects a client to the given URL. It returns a wrapped client adding metrics and wrapped errors and a header cache.
 //
 // Note if the URL is http(s), it doesn't return an error if it cannot connect to the URL.
-// It will retry connecting on every call to a wrapped method. It will only return an error if the
-// url is invalid.
-func Dial(chainName string, url string) (Client, error) {
-	cl, err := ethclient.Dial(url)
+// It will retry connecting on every call to a wrapped method. In this case, the context is ignored.
+// It will only return an error if the url is invalid.
+func DialContext(ctx context.Context, chainName string, url string) (Client, error) {
+	client := new(http.Client)
+
+	rpcClient, err := rpc.DialOptions(ctx, url, rpc.WithHTTPClient(client))
 	if err != nil {
-		return wrapper{}, errors.Wrap(err, "dial", "chain", chainName, "url", url)
+		return engineClient{}, errors.Wrap(err, "dial", "chain", chainName, "url", url)
 	}
 
 	return newHeaderCache(wrapper{
-		cl:      cl,
+		cl:      ethclient.NewClient(rpcClient),
 		name:    chainName,
 		address: url,
+		httpCl:  client,
 	})
+}
+
+// CloseIdleConnectionsForever blocks and closes idle connections periodically.
+// It returns when the context is canceled.
+// This is useful to close TCP-keep-alive connections to load-balanced RPC servers
+// which could sometimes remain connected to stalled (but alive) servers.
+// Note this is a noop if the client wasn't created by Dial or DialContext.
+func (w wrapper) CloseIdleConnectionsForever(ctx context.Context) {
+	if w.httpCl == nil {
+		return
+	}
+
+	const period = time.Minute * 5
+
+	ticker := time.NewTicker(period)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			w.httpCl.CloseIdleConnections()
+		}
+	}
 }
 
 // Close closes the underlying RPC connection.

--- a/lib/ethclient/ethclient_gen.go
+++ b/lib/ethclient/ethclient_gen.go
@@ -36,6 +36,7 @@ type Client interface {
 	CallContext(ctx context.Context, result interface{}, method string, args ...interface{}) error
 	Address() string
 	Name() string
+	CloseIdleConnectionsForever(ctx context.Context)
 	Close()
 }
 

--- a/lib/ethclient/genwrap/genwrap.go
+++ b/lib/ethclient/genwrap/genwrap.go
@@ -55,6 +55,7 @@ type Client interface {
 	CallContext(ctx context.Context, result interface{}, method string, args ...interface{}) error
 	Address() string
 	Name() string
+	CloseIdleConnectionsForever(ctx context.Context)
 	Close()
 }
 

--- a/lib/ethclient/mock/mock_interfaces.go
+++ b/lib/ethclient/mock/mock_interfaces.go
@@ -180,6 +180,18 @@ func (mr *MockClientMockRecorder) Close() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Close", reflect.TypeOf((*MockClient)(nil).Close))
 }
 
+// CloseIdleConnectionsForever mocks base method.
+func (m *MockClient) CloseIdleConnectionsForever(ctx context.Context) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "CloseIdleConnectionsForever", ctx)
+}
+
+// CloseIdleConnectionsForever indicates an expected call of CloseIdleConnectionsForever.
+func (mr *MockClientMockRecorder) CloseIdleConnectionsForever(ctx any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CloseIdleConnectionsForever", reflect.TypeOf((*MockClient)(nil).CloseIdleConnectionsForever), ctx)
+}
+
 // CodeAt mocks base method.
 func (m *MockClient) CodeAt(ctx context.Context, account common.Address, blockNumber *big.Int) ([]byte, error) {
 	m.ctrl.T.Helper()

--- a/monitor/flowgen/flowgen.go
+++ b/monitor/flowgen/flowgen.go
@@ -10,10 +10,10 @@ import (
 	"github.com/omni-network/omni/lib/contracts"
 	"github.com/omni-network/omni/lib/contracts/solvernet"
 	"github.com/omni-network/omni/lib/errors"
+	"github.com/omni-network/omni/lib/ethclient"
 	"github.com/omni-network/omni/lib/ethclient/ethbackend"
 	"github.com/omni-network/omni/lib/log"
 	"github.com/omni-network/omni/lib/netconf"
-	"github.com/omni-network/omni/lib/xchain"
 	"github.com/omni-network/omni/monitor/flowgen/bridging"
 	"github.com/omni-network/omni/monitor/flowgen/symbiotic"
 	"github.com/omni-network/omni/monitor/flowgen/types"
@@ -27,7 +27,7 @@ import (
 func Start(
 	ctx context.Context,
 	network netconf.Network,
-	rpcEndpoints xchain.RPCEndpoints,
+	ethClients map[uint64]ethclient.Client,
 	keyPath string,
 	solverAddress string,
 ) error {
@@ -40,7 +40,7 @@ func Start(
 		return errors.Wrap(err, "load key", "path", keyPath)
 	}
 
-	backends, err := ethbackend.BackendsFromNetwork(network, rpcEndpoints, privKey)
+	backends, err := ethbackend.BackendsFromClients(ethClients, privKey)
 	if err != nil {
 		return errors.Wrap(err, "backends")
 	}


### PR DESCRIPTION
Add `CloseIdleConnectionsForever` to ethclient. Call it in production use-cases.

This aims to mitigate the problem of TCP-keep-alive maintaining long-lived connections to stalled (but alive) RCP servers. This sometimes occurs with QuickNode, when one of the load-balanced upstream servers/nodes stalled, but we remain connected to it, requiring a restart of the affected service to reconnect to a healthy upstream. 

By periodically closing idle connections, we get best of both worlds, TCP-keep-alive improves performance of most queries since TCP connection doesn't need to be reestablished for each query. But we still reconnect every 5min ensuring good load balancing over time.

This also required some cleanup:
 - Pass in context in production uses of `ethclient.DialContext`.
 - Remove `ethclient` duplication in `monitor`.

issue: none