### PR TITLE
chore(sdk): add integration tests for contracts

### DIFF
--- a/.github/workflows/e2etest.yaml
+++ b/.github/workflows/e2etest.yaml
@@ -14,6 +14,8 @@ jobs:
         with:
           go-version: 'v1.24'
 
+      - name: Install foundry
+        uses: ./.github/actions/setup-foundry
       - name: Install node
         uses: actions/setup-node@v4
         with:

--- a/.github/workflows/pr-e2etest.yaml
+++ b/.github/workflows/pr-e2etest.yaml
@@ -14,6 +14,8 @@ jobs:
         with:
           go-version: 'v1.24'
 
+      - name: Install foundry
+        uses: ./.github/actions/setup-foundry
       - name: Install node
         uses: actions/setup-node@v4
         with:

--- a/e2e/test/sdk_test.go
+++ b/e2e/test/sdk_test.go
@@ -20,12 +20,29 @@ func TestSDK(t *testing.T) {
 	maybeTestNetwork(t, skipFunc, func(ctx context.Context, t *testing.T, _ NetworkDeps) {
 		t.Helper()
 
+		solverContractsPath, err := filepath.Abs("../../contracts/solve")
+		require.NoError(t, err)
+
 		sdkPath, err := filepath.Abs("../../sdk")
 		require.NoError(t, err)
 
-		exe := func(ctx context.Context, name string, args ...string) {
+		writeABI := func(ctx context.Context, contract string) {
+			outfile, err := os.Create(filepath.Join(sdkPath, "integration-tests/assets", contract+".json"))
+			require.NoError(t, err, "failed to create ABI file for contract: %s", contract)
+			defer outfile.Close()
+
+			cmd := exec.CommandContext(ctx, "forge", "inspect", "--json", "src/"+contract+".sol:"+contract, "abi")
+			cmd.Dir = solverContractsPath
+			cmd.Stdout = outfile
+			cmd.Stderr = os.Stderr
+
+			err = cmd.Run()
+			require.NoError(t, err, "failed to write ABI file for contract: %s", contract)
+		}
+
+		exe := func(ctx context.Context, dir string, name string, args ...string) {
 			cmd := exec.CommandContext(ctx, name, args...)
-			cmd.Dir = sdkPath
+			cmd.Dir = dir
 			cmd.Stdout = os.Stdout
 			cmd.Stderr = os.Stderr
 
@@ -33,9 +50,14 @@ func TestSDK(t *testing.T) {
 			require.NoError(t, err, "failed to run command: %s %v", name, args)
 		}
 
-		exe(ctx, "pnpm", "install")
-		exe(ctx, "pnpm", "run", "build")
-		exe(ctx, "pnpm", "run", "test:unit")
-		exe(ctx, "pnpm", "run", "test:integration")
+		exe(ctx, solverContractsPath, "pnpm", "install")
+		writeABI(ctx, "SolverNetInbox")
+		writeABI(ctx, "SolverNetMiddleman")
+		writeABI(ctx, "SolverNetOutbox")
+
+		exe(ctx, sdkPath, "pnpm", "install")
+		exe(ctx, sdkPath, "pnpm", "run", "build")
+		exe(ctx, sdkPath, "pnpm", "run", "test:unit")
+		exe(ctx, sdkPath, "pnpm", "run", "test:integration")
 	})
 }

--- a/sdk/integration-tests/assets/SolverNetInbox.json
+++ b/sdk/integration-tests/assets/SolverNetInbox.json
@@ -1,0 +1,1387 @@
+[
+  {
+    "type": "constructor",
+    "inputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "cancelOwnershipHandover",
+    "inputs": [],
+    "outputs": [],
+    "stateMutability": "payable"
+  },
+  {
+    "type": "function",
+    "name": "claim",
+    "inputs": [
+      {
+        "name": "id",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      },
+      {
+        "name": "to",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "close",
+    "inputs": [
+      {
+        "name": "id",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "completeOwnershipHandover",
+    "inputs": [
+      {
+        "name": "pendingOwner",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "payable"
+  },
+  {
+    "type": "function",
+    "name": "defaultConfLevel",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint8",
+        "internalType": "uint8"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "deployedAt",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getLatestOrderOffset",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint248",
+        "internalType": "uint248"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getNextOrderId",
+    "inputs": [
+      {
+        "name": "user",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getOrder",
+    "inputs": [
+      {
+        "name": "id",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "resolved",
+        "type": "tuple",
+        "internalType": "struct IERC7683.ResolvedCrossChainOrder",
+        "components": [
+          {
+            "name": "user",
+            "type": "address",
+            "internalType": "address"
+          },
+          {
+            "name": "originChainId",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "openDeadline",
+            "type": "uint32",
+            "internalType": "uint32"
+          },
+          {
+            "name": "fillDeadline",
+            "type": "uint32",
+            "internalType": "uint32"
+          },
+          {
+            "name": "orderId",
+            "type": "bytes32",
+            "internalType": "bytes32"
+          },
+          {
+            "name": "maxSpent",
+            "type": "tuple[]",
+            "internalType": "struct IERC7683.Output[]",
+            "components": [
+              {
+                "name": "token",
+                "type": "bytes32",
+                "internalType": "bytes32"
+              },
+              {
+                "name": "amount",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "recipient",
+                "type": "bytes32",
+                "internalType": "bytes32"
+              },
+              {
+                "name": "chainId",
+                "type": "uint256",
+                "internalType": "uint256"
+              }
+            ]
+          },
+          {
+            "name": "minReceived",
+            "type": "tuple[]",
+            "internalType": "struct IERC7683.Output[]",
+            "components": [
+              {
+                "name": "token",
+                "type": "bytes32",
+                "internalType": "bytes32"
+              },
+              {
+                "name": "amount",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "recipient",
+                "type": "bytes32",
+                "internalType": "bytes32"
+              },
+              {
+                "name": "chainId",
+                "type": "uint256",
+                "internalType": "uint256"
+              }
+            ]
+          },
+          {
+            "name": "fillInstructions",
+            "type": "tuple[]",
+            "internalType": "struct IERC7683.FillInstruction[]",
+            "components": [
+              {
+                "name": "destinationChainId",
+                "type": "uint64",
+                "internalType": "uint64"
+              },
+              {
+                "name": "destinationSettler",
+                "type": "bytes32",
+                "internalType": "bytes32"
+              },
+              {
+                "name": "originData",
+                "type": "bytes",
+                "internalType": "bytes"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "name": "state",
+        "type": "tuple",
+        "internalType": "struct ISolverNetInbox.OrderState",
+        "components": [
+          {
+            "name": "status",
+            "type": "uint8",
+            "internalType": "enum ISolverNetInbox.Status"
+          },
+          {
+            "name": "rejectReason",
+            "type": "uint8",
+            "internalType": "uint8"
+          },
+          {
+            "name": "timestamp",
+            "type": "uint32",
+            "internalType": "uint32"
+          },
+          {
+            "name": "updatedBy",
+            "type": "address",
+            "internalType": "address"
+          }
+        ]
+      },
+      {
+        "name": "offset",
+        "type": "uint248",
+        "internalType": "uint248"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getOrderId",
+    "inputs": [
+      {
+        "name": "user",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "nonce",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getUserNonce",
+    "inputs": [
+      {
+        "name": "user",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "grantRoles",
+    "inputs": [
+      {
+        "name": "user",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "roles",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "payable"
+  },
+  {
+    "type": "function",
+    "name": "hasAllRoles",
+    "inputs": [
+      {
+        "name": "user",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "roles",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "hasAnyRole",
+    "inputs": [
+      {
+        "name": "user",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "roles",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "initialize",
+    "inputs": [
+      {
+        "name": "owner_",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "solver_",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "omni_",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "markFilled",
+    "inputs": [
+      {
+        "name": "id",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      },
+      {
+        "name": "fillHash",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      },
+      {
+        "name": "creditedTo",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "omni",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "contract IOmniPortal"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "open",
+    "inputs": [
+      {
+        "name": "order",
+        "type": "tuple",
+        "internalType": "struct IERC7683.OnchainCrossChainOrder",
+        "components": [
+          {
+            "name": "fillDeadline",
+            "type": "uint32",
+            "internalType": "uint32"
+          },
+          {
+            "name": "orderDataType",
+            "type": "bytes32",
+            "internalType": "bytes32"
+          },
+          {
+            "name": "orderData",
+            "type": "bytes",
+            "internalType": "bytes"
+          }
+        ]
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "payable"
+  },
+  {
+    "type": "function",
+    "name": "owner",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "result",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "ownershipHandoverExpiresAt",
+    "inputs": [
+      {
+        "name": "pendingOwner",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "result",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "pauseAll",
+    "inputs": [
+      {
+        "name": "pause",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "pauseClose",
+    "inputs": [
+      {
+        "name": "pause",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "pauseOpen",
+    "inputs": [
+      {
+        "name": "pause",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "pauseState",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint8",
+        "internalType": "uint8"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "reject",
+    "inputs": [
+      {
+        "name": "id",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      },
+      {
+        "name": "reason",
+        "type": "uint8",
+        "internalType": "uint8"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "renounceOwnership",
+    "inputs": [],
+    "outputs": [],
+    "stateMutability": "payable"
+  },
+  {
+    "type": "function",
+    "name": "renounceRoles",
+    "inputs": [
+      {
+        "name": "roles",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "payable"
+  },
+  {
+    "type": "function",
+    "name": "requestOwnershipHandover",
+    "inputs": [],
+    "outputs": [],
+    "stateMutability": "payable"
+  },
+  {
+    "type": "function",
+    "name": "resolve",
+    "inputs": [
+      {
+        "name": "order",
+        "type": "tuple",
+        "internalType": "struct IERC7683.OnchainCrossChainOrder",
+        "components": [
+          {
+            "name": "fillDeadline",
+            "type": "uint32",
+            "internalType": "uint32"
+          },
+          {
+            "name": "orderDataType",
+            "type": "bytes32",
+            "internalType": "bytes32"
+          },
+          {
+            "name": "orderData",
+            "type": "bytes",
+            "internalType": "bytes"
+          }
+        ]
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "tuple",
+        "internalType": "struct IERC7683.ResolvedCrossChainOrder",
+        "components": [
+          {
+            "name": "user",
+            "type": "address",
+            "internalType": "address"
+          },
+          {
+            "name": "originChainId",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "openDeadline",
+            "type": "uint32",
+            "internalType": "uint32"
+          },
+          {
+            "name": "fillDeadline",
+            "type": "uint32",
+            "internalType": "uint32"
+          },
+          {
+            "name": "orderId",
+            "type": "bytes32",
+            "internalType": "bytes32"
+          },
+          {
+            "name": "maxSpent",
+            "type": "tuple[]",
+            "internalType": "struct IERC7683.Output[]",
+            "components": [
+              {
+                "name": "token",
+                "type": "bytes32",
+                "internalType": "bytes32"
+              },
+              {
+                "name": "amount",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "recipient",
+                "type": "bytes32",
+                "internalType": "bytes32"
+              },
+              {
+                "name": "chainId",
+                "type": "uint256",
+                "internalType": "uint256"
+              }
+            ]
+          },
+          {
+            "name": "minReceived",
+            "type": "tuple[]",
+            "internalType": "struct IERC7683.Output[]",
+            "components": [
+              {
+                "name": "token",
+                "type": "bytes32",
+                "internalType": "bytes32"
+              },
+              {
+                "name": "amount",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "recipient",
+                "type": "bytes32",
+                "internalType": "bytes32"
+              },
+              {
+                "name": "chainId",
+                "type": "uint256",
+                "internalType": "uint256"
+              }
+            ]
+          },
+          {
+            "name": "fillInstructions",
+            "type": "tuple[]",
+            "internalType": "struct IERC7683.FillInstruction[]",
+            "components": [
+              {
+                "name": "destinationChainId",
+                "type": "uint64",
+                "internalType": "uint64"
+              },
+              {
+                "name": "destinationSettler",
+                "type": "bytes32",
+                "internalType": "bytes32"
+              },
+              {
+                "name": "originData",
+                "type": "bytes",
+                "internalType": "bytes"
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "revokeRoles",
+    "inputs": [
+      {
+        "name": "user",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "roles",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "payable"
+  },
+  {
+    "type": "function",
+    "name": "rolesOf",
+    "inputs": [
+      {
+        "name": "user",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "roles",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "setOutboxes",
+    "inputs": [
+      {
+        "name": "chainIds",
+        "type": "uint64[]",
+        "internalType": "uint64[]"
+      },
+      {
+        "name": "outboxes",
+        "type": "address[]",
+        "internalType": "address[]"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "transferOwnership",
+    "inputs": [
+      {
+        "name": "newOwner",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "payable"
+  },
+  {
+    "type": "function",
+    "name": "validate",
+    "inputs": [
+      {
+        "name": "order",
+        "type": "tuple",
+        "internalType": "struct IERC7683.OnchainCrossChainOrder",
+        "components": [
+          {
+            "name": "fillDeadline",
+            "type": "uint32",
+            "internalType": "uint32"
+          },
+          {
+            "name": "orderDataType",
+            "type": "bytes32",
+            "internalType": "bytes32"
+          },
+          {
+            "name": "orderData",
+            "type": "bytes",
+            "internalType": "bytes"
+          }
+        ]
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "event",
+    "name": "Claimed",
+    "inputs": [
+      {
+        "name": "id",
+        "type": "bytes32",
+        "indexed": true,
+        "internalType": "bytes32"
+      },
+      {
+        "name": "by",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "to",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "Closed",
+    "inputs": [
+      {
+        "name": "id",
+        "type": "bytes32",
+        "indexed": true,
+        "internalType": "bytes32"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "DefaultConfLevelSet",
+    "inputs": [
+      {
+        "name": "conf",
+        "type": "uint8",
+        "indexed": false,
+        "internalType": "uint8"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "FillOriginData",
+    "inputs": [
+      {
+        "name": "id",
+        "type": "bytes32",
+        "indexed": true,
+        "internalType": "bytes32"
+      },
+      {
+        "name": "fillOriginData",
+        "type": "tuple",
+        "indexed": false,
+        "internalType": "struct SolverNet.FillOriginData",
+        "components": [
+          {
+            "name": "srcChainId",
+            "type": "uint64",
+            "internalType": "uint64"
+          },
+          {
+            "name": "destChainId",
+            "type": "uint64",
+            "internalType": "uint64"
+          },
+          {
+            "name": "fillDeadline",
+            "type": "uint32",
+            "internalType": "uint32"
+          },
+          {
+            "name": "calls",
+            "type": "tuple[]",
+            "internalType": "struct SolverNet.Call[]",
+            "components": [
+              {
+                "name": "target",
+                "type": "address",
+                "internalType": "address"
+              },
+              {
+                "name": "selector",
+                "type": "bytes4",
+                "internalType": "bytes4"
+              },
+              {
+                "name": "value",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "params",
+                "type": "bytes",
+                "internalType": "bytes"
+              }
+            ]
+          },
+          {
+            "name": "expenses",
+            "type": "tuple[]",
+            "internalType": "struct SolverNet.TokenExpense[]",
+            "components": [
+              {
+                "name": "spender",
+                "type": "address",
+                "internalType": "address"
+              },
+              {
+                "name": "token",
+                "type": "address",
+                "internalType": "address"
+              },
+              {
+                "name": "amount",
+                "type": "uint96",
+                "internalType": "uint96"
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "Filled",
+    "inputs": [
+      {
+        "name": "id",
+        "type": "bytes32",
+        "indexed": true,
+        "internalType": "bytes32"
+      },
+      {
+        "name": "fillHash",
+        "type": "bytes32",
+        "indexed": true,
+        "internalType": "bytes32"
+      },
+      {
+        "name": "creditedTo",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "Initialized",
+    "inputs": [
+      {
+        "name": "version",
+        "type": "uint64",
+        "indexed": false,
+        "internalType": "uint64"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "OmniPortalSet",
+    "inputs": [
+      {
+        "name": "omni",
+        "type": "address",
+        "indexed": false,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "Open",
+    "inputs": [
+      {
+        "name": "orderId",
+        "type": "bytes32",
+        "indexed": true,
+        "internalType": "bytes32"
+      },
+      {
+        "name": "resolvedOrder",
+        "type": "tuple",
+        "indexed": false,
+        "internalType": "struct IERC7683.ResolvedCrossChainOrder",
+        "components": [
+          {
+            "name": "user",
+            "type": "address",
+            "internalType": "address"
+          },
+          {
+            "name": "originChainId",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "openDeadline",
+            "type": "uint32",
+            "internalType": "uint32"
+          },
+          {
+            "name": "fillDeadline",
+            "type": "uint32",
+            "internalType": "uint32"
+          },
+          {
+            "name": "orderId",
+            "type": "bytes32",
+            "internalType": "bytes32"
+          },
+          {
+            "name": "maxSpent",
+            "type": "tuple[]",
+            "internalType": "struct IERC7683.Output[]",
+            "components": [
+              {
+                "name": "token",
+                "type": "bytes32",
+                "internalType": "bytes32"
+              },
+              {
+                "name": "amount",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "recipient",
+                "type": "bytes32",
+                "internalType": "bytes32"
+              },
+              {
+                "name": "chainId",
+                "type": "uint256",
+                "internalType": "uint256"
+              }
+            ]
+          },
+          {
+            "name": "minReceived",
+            "type": "tuple[]",
+            "internalType": "struct IERC7683.Output[]",
+            "components": [
+              {
+                "name": "token",
+                "type": "bytes32",
+                "internalType": "bytes32"
+              },
+              {
+                "name": "amount",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "recipient",
+                "type": "bytes32",
+                "internalType": "bytes32"
+              },
+              {
+                "name": "chainId",
+                "type": "uint256",
+                "internalType": "uint256"
+              }
+            ]
+          },
+          {
+            "name": "fillInstructions",
+            "type": "tuple[]",
+            "internalType": "struct IERC7683.FillInstruction[]",
+            "components": [
+              {
+                "name": "destinationChainId",
+                "type": "uint64",
+                "internalType": "uint64"
+              },
+              {
+                "name": "destinationSettler",
+                "type": "bytes32",
+                "internalType": "bytes32"
+              },
+              {
+                "name": "originData",
+                "type": "bytes",
+                "internalType": "bytes"
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "OutboxSet",
+    "inputs": [
+      {
+        "name": "chainId",
+        "type": "uint64",
+        "indexed": true,
+        "internalType": "uint64"
+      },
+      {
+        "name": "outbox",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "OwnershipHandoverCanceled",
+    "inputs": [
+      {
+        "name": "pendingOwner",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "OwnershipHandoverRequested",
+    "inputs": [
+      {
+        "name": "pendingOwner",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "OwnershipTransferred",
+    "inputs": [
+      {
+        "name": "oldOwner",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "newOwner",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "Rejected",
+    "inputs": [
+      {
+        "name": "id",
+        "type": "bytes32",
+        "indexed": true,
+        "internalType": "bytes32"
+      },
+      {
+        "name": "by",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "reason",
+        "type": "uint8",
+        "indexed": true,
+        "internalType": "uint8"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "RolesUpdated",
+    "inputs": [
+      {
+        "name": "user",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "roles",
+        "type": "uint256",
+        "indexed": true,
+        "internalType": "uint256"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "error",
+    "name": "AllPaused",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "AlreadyInitialized",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "InvalidArrayLength",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "InvalidCallTarget",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "InvalidChainId",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "InvalidExpenseAmount",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "InvalidExpenseToken",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "InvalidFillDeadline",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "InvalidInitialization",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "InvalidMissingCalls",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "InvalidNativeDeposit",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "InvalidOrderData",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "InvalidOrderTypehash",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "InvalidReason",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "IsPaused",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "NewOwnerIsZeroAddress",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "NoHandoverRequest",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "NotInitializing",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "OrderNotFilled",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "OrderNotPending",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "OrderStillValid",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "PortalPaused",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "Reentrancy",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "Unauthorized",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "WrongFillHash",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "WrongSourceChain",
+    "inputs": []
+  }
+]

--- a/sdk/integration-tests/assets/SolverNetMiddleman.json
+++ b/sdk/integration-tests/assets/SolverNetMiddleman.json
@@ -1,0 +1,48 @@
+[
+  {
+    "type": "fallback",
+    "stateMutability": "payable"
+  },
+  {
+    "type": "receive",
+    "stateMutability": "payable"
+  },
+  {
+    "type": "function",
+    "name": "executeAndTransfer",
+    "inputs": [
+      {
+        "name": "token",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "to",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "target",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "data",
+        "type": "bytes",
+        "internalType": "bytes"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "payable"
+  },
+  {
+    "type": "error",
+    "name": "CallFailed",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "Reentrancy",
+    "inputs": []
+  }
+]

--- a/sdk/integration-tests/assets/SolverNetOutbox.json
+++ b/sdk/integration-tests/assets/SolverNetOutbox.json
@@ -1,0 +1,700 @@
+[
+  {
+    "type": "constructor",
+    "inputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "cancelOwnershipHandover",
+    "inputs": [],
+    "outputs": [],
+    "stateMutability": "payable"
+  },
+  {
+    "type": "function",
+    "name": "completeOwnershipHandover",
+    "inputs": [
+      {
+        "name": "pendingOwner",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "payable"
+  },
+  {
+    "type": "function",
+    "name": "defaultConfLevel",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint8",
+        "internalType": "uint8"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "deployedAt",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "didFill",
+    "inputs": [
+      {
+        "name": "orderId",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      },
+      {
+        "name": "originData",
+        "type": "bytes",
+        "internalType": "bytes"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "executor",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "fill",
+    "inputs": [
+      {
+        "name": "orderId",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      },
+      {
+        "name": "originData",
+        "type": "bytes",
+        "internalType": "bytes"
+      },
+      {
+        "name": "fillerData",
+        "type": "bytes",
+        "internalType": "bytes"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "payable"
+  },
+  {
+    "type": "function",
+    "name": "fillFee",
+    "inputs": [
+      {
+        "name": "originData",
+        "type": "bytes",
+        "internalType": "bytes"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "grantRoles",
+    "inputs": [
+      {
+        "name": "user",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "roles",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "payable"
+  },
+  {
+    "type": "function",
+    "name": "hasAllRoles",
+    "inputs": [
+      {
+        "name": "user",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "roles",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "hasAnyRole",
+    "inputs": [
+      {
+        "name": "user",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "roles",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "initialize",
+    "inputs": [
+      {
+        "name": "owner_",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "solver_",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "omni_",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "executor_",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "omni",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "contract IOmniPortal"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "owner",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "result",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "ownershipHandoverExpiresAt",
+    "inputs": [
+      {
+        "name": "pendingOwner",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "result",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "renounceOwnership",
+    "inputs": [],
+    "outputs": [],
+    "stateMutability": "payable"
+  },
+  {
+    "type": "function",
+    "name": "renounceRoles",
+    "inputs": [
+      {
+        "name": "roles",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "payable"
+  },
+  {
+    "type": "function",
+    "name": "requestOwnershipHandover",
+    "inputs": [],
+    "outputs": [],
+    "stateMutability": "payable"
+  },
+  {
+    "type": "function",
+    "name": "revokeRoles",
+    "inputs": [
+      {
+        "name": "user",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "roles",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "payable"
+  },
+  {
+    "type": "function",
+    "name": "rolesOf",
+    "inputs": [
+      {
+        "name": "user",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "roles",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "setInboxes",
+    "inputs": [
+      {
+        "name": "chainIds",
+        "type": "uint64[]",
+        "internalType": "uint64[]"
+      },
+      {
+        "name": "inboxes",
+        "type": "address[]",
+        "internalType": "address[]"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "transferOwnership",
+    "inputs": [
+      {
+        "name": "newOwner",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "payable"
+  },
+  {
+    "type": "event",
+    "name": "DefaultConfLevelSet",
+    "inputs": [
+      {
+        "name": "conf",
+        "type": "uint8",
+        "indexed": false,
+        "internalType": "uint8"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "Filled",
+    "inputs": [
+      {
+        "name": "orderId",
+        "type": "bytes32",
+        "indexed": true,
+        "internalType": "bytes32"
+      },
+      {
+        "name": "fillHash",
+        "type": "bytes32",
+        "indexed": true,
+        "internalType": "bytes32"
+      },
+      {
+        "name": "filledBy",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "InboxSet",
+    "inputs": [
+      {
+        "name": "chainId",
+        "type": "uint64",
+        "indexed": true,
+        "internalType": "uint64"
+      },
+      {
+        "name": "inbox",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "Initialized",
+    "inputs": [
+      {
+        "name": "version",
+        "type": "uint64",
+        "indexed": false,
+        "internalType": "uint64"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "OmniPortalSet",
+    "inputs": [
+      {
+        "name": "omni",
+        "type": "address",
+        "indexed": false,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "Open",
+    "inputs": [
+      {
+        "name": "orderId",
+        "type": "bytes32",
+        "indexed": true,
+        "internalType": "bytes32"
+      },
+      {
+        "name": "resolvedOrder",
+        "type": "tuple",
+        "indexed": false,
+        "internalType": "struct IERC7683.ResolvedCrossChainOrder",
+        "components": [
+          {
+            "name": "user",
+            "type": "address",
+            "internalType": "address"
+          },
+          {
+            "name": "originChainId",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "openDeadline",
+            "type": "uint32",
+            "internalType": "uint32"
+          },
+          {
+            "name": "fillDeadline",
+            "type": "uint32",
+            "internalType": "uint32"
+          },
+          {
+            "name": "orderId",
+            "type": "bytes32",
+            "internalType": "bytes32"
+          },
+          {
+            "name": "maxSpent",
+            "type": "tuple[]",
+            "internalType": "struct IERC7683.Output[]",
+            "components": [
+              {
+                "name": "token",
+                "type": "bytes32",
+                "internalType": "bytes32"
+              },
+              {
+                "name": "amount",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "recipient",
+                "type": "bytes32",
+                "internalType": "bytes32"
+              },
+              {
+                "name": "chainId",
+                "type": "uint256",
+                "internalType": "uint256"
+              }
+            ]
+          },
+          {
+            "name": "minReceived",
+            "type": "tuple[]",
+            "internalType": "struct IERC7683.Output[]",
+            "components": [
+              {
+                "name": "token",
+                "type": "bytes32",
+                "internalType": "bytes32"
+              },
+              {
+                "name": "amount",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "recipient",
+                "type": "bytes32",
+                "internalType": "bytes32"
+              },
+              {
+                "name": "chainId",
+                "type": "uint256",
+                "internalType": "uint256"
+              }
+            ]
+          },
+          {
+            "name": "fillInstructions",
+            "type": "tuple[]",
+            "internalType": "struct IERC7683.FillInstruction[]",
+            "components": [
+              {
+                "name": "destinationChainId",
+                "type": "uint64",
+                "internalType": "uint64"
+              },
+              {
+                "name": "destinationSettler",
+                "type": "bytes32",
+                "internalType": "bytes32"
+              },
+              {
+                "name": "originData",
+                "type": "bytes",
+                "internalType": "bytes"
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "OwnershipHandoverCanceled",
+    "inputs": [
+      {
+        "name": "pendingOwner",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "OwnershipHandoverRequested",
+    "inputs": [
+      {
+        "name": "pendingOwner",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "OwnershipTransferred",
+    "inputs": [
+      {
+        "name": "oldOwner",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "newOwner",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "RolesUpdated",
+    "inputs": [
+      {
+        "name": "user",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "roles",
+        "type": "uint256",
+        "indexed": true,
+        "internalType": "uint256"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "error",
+    "name": "AlreadyFilled",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "AlreadyInitialized",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "BadFillerData",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "FillDeadlinePassed",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "InsufficientFee",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "InvalidArrayLength",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "InvalidInitialization",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "NewOwnerIsZeroAddress",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "NoHandoverRequest",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "NotInitializing",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "Reentrancy",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "Unauthorized",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "WrongDestChain",
+    "inputs": []
+  }
+]

--- a/sdk/integration-tests/suites/contracts.ts
+++ b/sdk/integration-tests/suites/contracts.ts
@@ -1,0 +1,34 @@
+import { readFile } from 'node:fs/promises'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { expect, test } from 'vitest'
+
+import {
+  inboxABI,
+  middlemanABI,
+  outboxABI,
+} from '../../packages/react/src/constants/abis'
+
+const ASSETS_PATH = fileURLToPath(new URL('./assets', dirname(import.meta.url)))
+
+async function readContractFile(
+  name: string,
+): Promise<Array<Record<string, unknown>>> {
+  const contents = await readFile(join(ASSETS_PATH, `${name}.json`), 'utf8')
+  return JSON.parse(contents)
+}
+
+test.each([
+  ['SolverNetInbox', inboxABI],
+  ['SolverNetMiddleman', middlemanABI],
+  ['SolverNetOutbox', outboxABI],
+])(
+  '%s contract contains all the ABIs expected by the SDK',
+  async (name, expectedABI) => {
+    const contract = await readContractFile(name)
+    for (const expected of expectedABI) {
+      const match = contract.find((abi) => abi.name === expected.name)
+      expect(match).toEqual(expected)
+    }
+  },
+)

--- a/sdk/packages/react/src/constants/abis.ts
+++ b/sdk/packages/react/src/constants/abis.ts
@@ -19,74 +19,154 @@ export const inboxABI = [
   },
   {
     type: 'function',
-    inputs: [{ name: 'id', internalType: 'bytes32', type: 'bytes32' }],
     name: 'getOrder',
+    inputs: [
+      {
+        name: 'id',
+        type: 'bytes32',
+        internalType: 'bytes32',
+      },
+    ],
     outputs: [
       {
         name: 'resolved',
-        internalType: 'struct IERC7683.ResolvedCrossChainOrder',
         type: 'tuple',
+        internalType: 'struct IERC7683.ResolvedCrossChainOrder',
         components: [
-          { name: 'user', internalType: 'address', type: 'address' },
-          { name: 'originChainId', internalType: 'uint256', type: 'uint256' },
-          { name: 'openDeadline', internalType: 'uint32', type: 'uint32' },
-          { name: 'fillDeadline', internalType: 'uint32', type: 'uint32' },
-          { name: 'orderId', internalType: 'bytes32', type: 'bytes32' },
+          {
+            name: 'user',
+            type: 'address',
+            internalType: 'address',
+          },
+          {
+            name: 'originChainId',
+            type: 'uint256',
+            internalType: 'uint256',
+          },
+          {
+            name: 'openDeadline',
+            type: 'uint32',
+            internalType: 'uint32',
+          },
+          {
+            name: 'fillDeadline',
+            type: 'uint32',
+            internalType: 'uint32',
+          },
+          {
+            name: 'orderId',
+            type: 'bytes32',
+            internalType: 'bytes32',
+          },
           {
             name: 'maxSpent',
-            internalType: 'struct IERC7683.Output[]',
             type: 'tuple[]',
+            internalType: 'struct IERC7683.Output[]',
             components: [
-              { name: 'token', internalType: 'bytes32', type: 'bytes32' },
-              { name: 'amount', internalType: 'uint256', type: 'uint256' },
-              { name: 'recipient', internalType: 'bytes32', type: 'bytes32' },
-              { name: 'chainId', internalType: 'uint256', type: 'uint256' },
+              {
+                name: 'token',
+                type: 'bytes32',
+                internalType: 'bytes32',
+              },
+              {
+                name: 'amount',
+                type: 'uint256',
+                internalType: 'uint256',
+              },
+              {
+                name: 'recipient',
+                type: 'bytes32',
+                internalType: 'bytes32',
+              },
+              {
+                name: 'chainId',
+                type: 'uint256',
+                internalType: 'uint256',
+              },
             ],
           },
           {
             name: 'minReceived',
-            internalType: 'struct IERC7683.Output[]',
             type: 'tuple[]',
+            internalType: 'struct IERC7683.Output[]',
             components: [
-              { name: 'token', internalType: 'bytes32', type: 'bytes32' },
-              { name: 'amount', internalType: 'uint256', type: 'uint256' },
-              { name: 'recipient', internalType: 'bytes32', type: 'bytes32' },
-              { name: 'chainId', internalType: 'uint256', type: 'uint256' },
+              {
+                name: 'token',
+                type: 'bytes32',
+                internalType: 'bytes32',
+              },
+              {
+                name: 'amount',
+                type: 'uint256',
+                internalType: 'uint256',
+              },
+              {
+                name: 'recipient',
+                type: 'bytes32',
+                internalType: 'bytes32',
+              },
+              {
+                name: 'chainId',
+                type: 'uint256',
+                internalType: 'uint256',
+              },
             ],
           },
           {
             name: 'fillInstructions',
-            internalType: 'struct IERC7683.FillInstruction[]',
             type: 'tuple[]',
+            internalType: 'struct IERC7683.FillInstruction[]',
             components: [
               {
                 name: 'destinationChainId',
-                internalType: 'uint64',
                 type: 'uint64',
+                internalType: 'uint64',
               },
               {
                 name: 'destinationSettler',
-                internalType: 'bytes32',
                 type: 'bytes32',
+                internalType: 'bytes32',
               },
-              { name: 'originData', internalType: 'bytes', type: 'bytes' },
+              {
+                name: 'originData',
+                type: 'bytes',
+                internalType: 'bytes',
+              },
             ],
           },
         ],
       },
       {
         name: 'state',
-        internalType: 'struct ISolverNetInbox.OrderState',
         type: 'tuple',
+        internalType: 'struct ISolverNetInbox.OrderState',
         components: [
           {
             name: 'status',
-            internalType: 'enum ISolverNetInbox.Status',
             type: 'uint8',
+            internalType: 'enum ISolverNetInbox.Status',
           },
-          { name: 'timestamp', internalType: 'uint32', type: 'uint32' },
-          { name: 'claimant', internalType: 'address', type: 'address' },
+          {
+            name: 'rejectReason',
+            type: 'uint8',
+            internalType: 'uint8',
+          },
+          {
+            name: 'timestamp',
+            type: 'uint32',
+            internalType: 'uint32',
+          },
+          {
+            name: 'updatedBy',
+            type: 'address',
+            internalType: 'address',
+          },
         ],
+      },
+      {
+        name: 'offset',
+        type: 'uint248',
+        internalType: 'uint248',
       },
     ],
     stateMutability: 'view',

--- a/sdk/packages/react/src/hooks/useGetOrder.test.ts
+++ b/sdk/packages/react/src/hooks/useGetOrder.test.ts
@@ -39,7 +39,13 @@ test('default: returns order when contract read returns an order', async () => {
     createMockReadContractResult<ReturnType<typeof useGetOrder>>({
       data: [
         resolvedOrder,
-        { status: 1, claimant: '0x123', timestamp: 1 } as const,
+        {
+          status: 1,
+          updatedBy: '0x123',
+          timestamp: 1,
+          rejectReason: 0,
+        } as const,
+        0n,
       ],
       isSuccess: true,
       status: 'success',

--- a/sdk/packages/react/src/hooks/useInboxStatus.test.ts
+++ b/sdk/packages/react/src/hooks/useInboxStatus.test.ts
@@ -5,7 +5,12 @@ import { createMockReadContractResult } from '../../test/mocks.js'
 import { useGetOrder } from './useGetOrder.js'
 import { useInboxStatus } from './useInboxStatus.js'
 
-const data = { status: 1, claimant: '0x123', timestamp: 1 } as const
+const data = {
+  status: 1,
+  updatedBy: '0x123',
+  timestamp: 1,
+  rejectReason: 0,
+} as const
 
 const { mockUseGetOrder } = vi.hoisted(() => {
   return {
@@ -41,7 +46,7 @@ test('default: returns appropriate inbox status when order is resolved', async (
 
   mockUseGetOrder.mockReturnValue(
     createMockReadContractResult<ReturnType<typeof useGetOrder>>({
-      data: [resolvedOrder, data],
+      data: [resolvedOrder, data, 0n],
       isSuccess: true,
       status: 'success',
     }),
@@ -66,7 +71,7 @@ test('parameters: status unknown', () => {
 test('parameters: status open', () => {
   mockUseGetOrder.mockReturnValue(
     createMockReadContractResult<ReturnType<typeof useGetOrder>>({
-      data: [resolvedOrder, data],
+      data: [resolvedOrder, data, 0n],
     }),
   )
 
@@ -80,7 +85,7 @@ test('parameters: status open', () => {
 test('parameters: status rejected', () => {
   mockUseGetOrder.mockReturnValue(
     createMockReadContractResult<ReturnType<typeof useGetOrder>>({
-      data: [resolvedOrder, { ...data, status: 2 }],
+      data: [resolvedOrder, { ...data, status: 2 }, 0n],
     }),
   )
 
@@ -94,7 +99,7 @@ test('parameters: status rejected', () => {
 test('parameters: status closed', () => {
   mockUseGetOrder.mockReturnValue(
     createMockReadContractResult<ReturnType<typeof useGetOrder>>({
-      data: [resolvedOrder, { ...data, status: 3 }],
+      data: [resolvedOrder, { ...data, status: 3 }, 0n],
     }),
   )
 
@@ -108,7 +113,7 @@ test('parameters: status closed', () => {
 test('parameters: status filled', () => {
   mockUseGetOrder.mockReturnValue(
     createMockReadContractResult<ReturnType<typeof useGetOrder>>({
-      data: [resolvedOrder, { ...data, status: 4 }],
+      data: [resolvedOrder, { ...data, status: 4 }, 0n],
     }),
   )
 
@@ -122,7 +127,7 @@ test('parameters: status filled', () => {
 test('parameters: status claimed', () => {
   mockUseGetOrder.mockReturnValue(
     createMockReadContractResult<ReturnType<typeof useGetOrder>>({
-      data: [resolvedOrder, { ...data, status: 5 }],
+      data: [resolvedOrder, { ...data, status: 5 }, 0n],
     }),
   )
 


### PR DESCRIPTION
The integration tests import the ABIs used in the source of the SDK and ensure they match the JSON files generated by forge.
In CI, these JSON files are always generated before running the tests, so any change should be captured even if the reference files in the integration tests assets folder haven't been updated.

issue: https://github.com/omni-network/omni/issues/3559
