### PR TITLE
refactor(monitor/flowgen): split bridge orders

### DIFF
--- a/lib/contracts/solvernet/types.go
+++ b/lib/contracts/solvernet/types.go
@@ -3,6 +3,7 @@ package solvernet
 import (
 	"encoding/hex"
 	"math/big"
+	"slices"
 
 	"github.com/omni-network/omni/contracts/bindings"
 
@@ -92,6 +93,14 @@ func CallsToBindings(calls []Call) []bindings.SolverNetCall {
 	}
 
 	return out
+}
+
+func CallFromBinding(c bindings.SolverNetCall) Call {
+	return Call{
+		Target: c.Target,
+		Value:  c.Value,
+		Data:   slices.Concat(c.Selector[:], c.Params),
+	}
 }
 
 // FilterNativeExpenses filters out native expenses.

--- a/monitor/flowgen/bridging/bridging_internal_test.go
+++ b/monitor/flowgen/bridging/bridging_internal_test.go
@@ -1,0 +1,91 @@
+package bridging
+
+import (
+	"testing"
+
+	"github.com/omni-network/omni/lib/bi"
+	stokens "github.com/omni-network/omni/solver/tokens"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestSplitOrderAmounts(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		Name     string
+		MinSpend float64
+		MaxSpend float64
+		Total    float64
+		Parallel int
+		Expected []float64
+	}{
+		{
+			Name:     "empty",
+			MinSpend: 1,
+			MaxSpend: 10,
+			Total:    0,
+			Parallel: 1,
+			Expected: nil,
+		},
+		{
+			Name:     "single",
+			MinSpend: 1,
+			MaxSpend: 10,
+			Total:    5,
+			Parallel: 1,
+			Expected: []float64{5},
+		},
+		{
+			Name:     "single too small",
+			MinSpend: 10,
+			MaxSpend: 100,
+			Total:    5,
+			Parallel: 1,
+			Expected: nil,
+		},
+		{
+			Name:     "single too big",
+			MinSpend: 1,
+			MaxSpend: 10,
+			Total:    15,
+			Parallel: 1,
+			Expected: []float64{10},
+		},
+		{
+			Name:     "multiple 2",
+			MinSpend: 1,
+			MaxSpend: 10,
+			Total:    22.2,
+			Parallel: 2,
+			Expected: []float64{10, 10},
+		},
+		{
+			Name:     "multiple 3",
+			MinSpend: 1,
+			MaxSpend: 10,
+			Total:    22.2,
+			Parallel: 3,
+			Expected: []float64{7.4, 7.4, 7.4},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.Name, func(t *testing.T) {
+			t.Parallel()
+
+			tkn := stokens.Token{
+				MinSpend: bi.Ether(test.MinSpend),
+				MaxSpend: bi.Ether(test.MaxSpend),
+			}
+			actual := splitOrderAmounts(tkn, bi.Ether(test.Total), test.Parallel)
+
+			var actualFloats []float64
+			for _, amt := range actual {
+				actualFloats = append(actualFloats, bi.ToEtherF64(amt))
+			}
+
+			require.Equal(t, test.Expected, actualFloats)
+		})
+	}
+}

--- a/monitor/flowgen/bridging/config.go
+++ b/monitor/flowgen/bridging/config.go
@@ -10,6 +10,13 @@ type flowConfig struct {
 	dstChain uint64
 }
 
+func (c flowConfig) Flip() flowConfig {
+	return flowConfig{
+		srcChain: c.dstChain,
+		dstChain: c.srcChain,
+	}
+}
+
 var config = map[netconf.ID]flowConfig{
 	netconf.Devnet: {
 		srcChain: evmchain.IDMockL1,

--- a/monitor/flowgen/types/types.go
+++ b/monitor/flowgen/types/types.go
@@ -4,28 +4,26 @@ import (
 	"context"
 	"time"
 
+	"github.com/omni-network/omni/contracts/bindings"
 	"github.com/omni-network/omni/lib/contracts/solvernet"
-	"github.com/omni-network/omni/lib/ethclient/ethbackend"
-	"github.com/omni-network/omni/lib/netconf"
-	solver "github.com/omni-network/omni/solver/app"
 )
 
 type Result struct {
 	OrderID solvernet.OrderID
-	Expense solver.TokenAmt
+	Data    bindings.SolverNetOrderData
 }
 
 type Job struct {
 	// Name is the friendly name of the job
 	Name string
 
-	// Cadence is intrerval at which to run the job
+	// Cadence is interval at which to run the job
 	Cadence time.Duration
 
-	NetworkID netconf.ID
+	// SrcChainID is chain ID of the inbox.
+	SrcChainID uint64
 
-	SrcChainBackend *ethbackend.Backend
-
-	// OpenOrderFunc opens an order and returns the result, or false if the order wasn't opened, or an error.
-	OpenOrderFunc func(ctx context.Context) (Result, bool, error)
+	// OpenOrdersFunc opens multiple orders and returns their results.
+	// Note it may open no orders.
+	OpenOrdersFunc func(ctx context.Context) ([]Result, error)
 }


### PR DESCRIPTION
Split flowgen bridge orders into 64 smaller order to also do some load testing.

issue: #3540 