### PR TITLE
fix(ethclient/headerdb): prevent deadlock

### DIFF
--- a/lib/ethclient/headerdb/headerdb_internal_test.go
+++ b/lib/ethclient/headerdb/headerdb_internal_test.go
@@ -10,3 +10,8 @@ import (
 func (db *DB) Set(ctx context.Context, h *types.Header) error {
 	return db.set(ctx, h)
 }
+
+// DeleteFrom exports the deleteFrom method for testing.
+func (db *DB) DeleteFrom(ctx context.Context, height uint64) (int, error) {
+	return db.deleteFrom(ctx, height)
+}

--- a/monitor/xmonitor/monitor.go
+++ b/monitor/xmonitor/monitor.go
@@ -7,7 +7,6 @@ import (
 	"github.com/omni-network/omni/lib/cchain"
 	"github.com/omni-network/omni/lib/errors"
 	"github.com/omni-network/omni/lib/ethclient"
-	"github.com/omni-network/omni/lib/evmchain"
 	"github.com/omni-network/omni/lib/log"
 	"github.com/omni-network/omni/lib/netconf"
 	"github.com/omni-network/omni/lib/xchain"
@@ -21,18 +20,6 @@ func Start(
 	cprovider cchain.Provider,
 	rpcClients map[uint64]ethclient.Client,
 ) error {
-	{
-		meta, _ := evmchain.MetadataByID(evmchain.IDHolesky)
-		holesky := netconf.Chain{ID: meta.ChainID, Name: meta.Name}
-		if cl, ok := rpcClients[holesky.ID]; ok && evmchain.IsDisabled(holesky.ID) {
-			log.Info(ctx, "Starting head monitoring of disabled Holesky")
-			headsFunc := func(ctx context.Context) map[ethclient.HeadType]uint64 {
-				return getEVMHeads(ctx, cl)
-			}
-			go monitorHeadsForever(ctx, holesky, headsFunc)
-		}
-	}
-
 	// Monitor the head of all chains, including consensus.
 	for _, srcChain := range network.Chains {
 		headsFunc := func(ctx context.Context) map[ethclient.HeadType]uint64 {


### PR DESCRIPTION
Fixes deadlock in `headercachedb` since `cosmos-db.MemDB` deosn't support iterating and writing. It can deadlock when iteration is large.

issue: none
