### PR TITLE
chore(monitor/flowgen): use solver quote endpoint

### DIFF
--- a/monitor/flowgen/flowgen.go
+++ b/monitor/flowgen/flowgen.go
@@ -20,6 +20,7 @@ import (
 	"github.com/omni-network/omni/monitor/flowgen/bridging"
 	"github.com/omni-network/omni/monitor/flowgen/symbiotic"
 	"github.com/omni-network/omni/monitor/flowgen/types"
+	sclient "github.com/omni-network/omni/solver/client"
 	stokens "github.com/omni-network/omni/solver/tokens"
 	stypes "github.com/omni-network/omni/solver/types"
 
@@ -51,7 +52,9 @@ func Start(
 
 	owner := eoa.MustAddress(network.ID, eoa.RoleFlowgen)
 
-	return startWithBackends(ctx, network, backends, owner, solverAddress)
+	scl := sclient.New(solverAddress)
+
+	return startWithBackends(ctx, network, backends, owner, scl)
 }
 
 func startWithBackends(
@@ -59,11 +62,11 @@ func startWithBackends(
 	network netconf.Network,
 	backends ethbackend.Backends,
 	owner common.Address,
-	solverAddress string,
+	scl sclient.Client,
 ) error {
-	j1 := bridging.Jobs(network.ID, backends, owner, solverAddress)
+	j1 := bridging.Jobs(network.ID, backends, owner, scl)
 
-	j2, err := symbiotic.Jobs(ctx, backends, network.ID, owner)
+	j2, err := symbiotic.Jobs(ctx, backends, network.ID, owner, scl)
 	if err != nil {
 		return errors.Wrap(err, "symbiotic jobs")
 	}

--- a/monitor/flowgen/symbiotic/config.go
+++ b/monitor/flowgen/symbiotic/config.go
@@ -12,18 +12,18 @@ import (
 )
 
 type flowConfig struct {
-	srcChain  uint64
-	dstChain  uint64
-	vaultAddr common.Address
-	orderSize *big.Int
+	srcChain    uint64
+	dstChain    uint64
+	vaultAddr   common.Address
+	orderAmount *big.Int
 }
 
 var config = map[netconf.ID]flowConfig{
 	netconf.Devnet: {
-		srcChain:  evmchain.IDMockL1,
-		dstChain:  evmchain.IDMockL2,
-		vaultAddr: solve.MockVaultAddress(netconf.Devnet),
-		orderSize: bi.Ether(0.02),
+		srcChain:    evmchain.IDMockL1,
+		dstChain:    evmchain.IDMockL2,
+		vaultAddr:   solve.MockVaultAddress(netconf.Devnet),
+		orderAmount: bi.Ether(0.02),
 	},
 
 	// TODO(christian): enable once this is needed.
@@ -31,6 +31,6 @@ var config = map[netconf.ID]flowConfig{
 	// 	srcChain:     evmchain.IDBaseSepolia,
 	// 	dstChain:     evmchain.IDHolesky,
 	// 	vaultAddr:    targets.SymbioticHoleskyWSTETHVault1,
-	//  orderSize: 	  bi.Ether(0.2),
+	//  orderAmount: 	  bi.Ether(0.2),
 	// },
 }


### PR DESCRIPTION
Refactor flowgen to use solver client for quotes. This decouples flowgen from internal solver logic, which is going to become much more complex with addition of swaps.

issue: none