### PR TITLE
test(sdk): continued useOrder test cases

### DIFF
--- a/sdk/packages/react/src/hooks/useDidFillOutbox.test.ts
+++ b/sdk/packages/react/src/hooks/useDidFillOutbox.test.ts
@@ -1,29 +1,14 @@
 import { waitFor } from '@testing-library/react'
-import { beforeEach, expect, test, vi } from 'vitest'
+import { expect, test } from 'vitest'
 import { resolvedOrder } from '../../test/index.js'
-import { createMockReadContractResult } from '../../test/mocks.js'
+import {
+  createMockReadContractResult,
+  mockWagmiHooks,
+} from '../../test/mocks.js'
 import { renderHook } from '../../test/react.js'
 import { useDidFillOutbox } from './useDidFillOutbox.js'
 
-const { useReadContract } = vi.hoisted(() => {
-  return {
-    useReadContract: vi.fn().mockImplementation(() => {
-      return createMockReadContractResult()
-    }),
-  }
-})
-
-vi.mock('wagmi', async () => {
-  const actual = await vi.importActual('wagmi')
-  return {
-    ...actual,
-    useReadContract,
-  }
-})
-
-beforeEach(() => {
-  useReadContract.mockReturnValue(createMockReadContractResult())
-})
+const { useReadContract } = mockWagmiHooks()
 
 test('default: returns true when outbox read is truthy', async () => {
   const { result, rerender } = renderHook(

--- a/sdk/packages/react/src/hooks/useGetOrder.test.ts
+++ b/sdk/packages/react/src/hooks/useGetOrder.test.ts
@@ -1,28 +1,13 @@
 import { waitFor } from '@testing-library/react'
-import { beforeEach, expect, test, vi } from 'vitest'
+import { expect, test } from 'vitest'
 import { orderId, renderHook, resolvedOrder } from '../../test/index.js'
-import { createMockReadContractResult } from '../../test/mocks.js'
+import {
+  createMockReadContractResult,
+  mockWagmiHooks,
+} from '../../test/mocks.js'
 import { useGetOrder } from './useGetOrder.js'
 
-const { useReadContract } = vi.hoisted(() => {
-  return {
-    useReadContract: vi.fn().mockImplementation(() => {
-      return createMockReadContractResult()
-    }),
-  }
-})
-
-vi.mock('wagmi', async () => {
-  const actual = await vi.importActual('wagmi')
-  return {
-    ...actual,
-    useReadContract,
-  }
-})
-
-beforeEach(() => {
-  useReadContract.mockReturnValue(createMockReadContractResult())
-})
+const { useReadContract } = mockWagmiHooks()
 
 test('default: returns order when contract read returns an order', async () => {
   const { result, rerender } = renderHook(

--- a/sdk/packages/react/src/hooks/useOrder.test.ts
+++ b/sdk/packages/react/src/hooks/useOrder.test.ts
@@ -1,70 +1,229 @@
 import { waitFor } from '@testing-library/react'
-import { expect, test, vi } from 'vitest'
+import { beforeEach, expect, test, vi } from 'vitest'
 import {
   createMockWaitForTransactionReceiptResult,
   createMockWriteContractResult,
+  mockWagmiHooks,
 } from '../../test/mocks.js'
 import { renderHook } from '../../test/react.js'
-import { order } from '../../test/shared.js'
+import { contracts, order, resolvedOrder } from '../../test/shared.js'
+import {
+  DidFillError,
+  GetOrderError,
+  LoadContractsError,
+  OpenError,
+  ParseOpenEventError,
+  TxReceiptError,
+  ValidateOrderError,
+} from '../errors/base.js'
 import { useOrder } from './useOrder.js'
 
+const { useWriteContract, useWaitForTransactionReceipt } = mockWagmiHooks()
+
 const {
-  mockUseValidateOrder,
-  mockUseGetOrderStatus,
-  mockUseWriteContract,
-  mockUseWaitForTransactionReceipt,
+  useValidateOrder,
+  useGetOrderStatus,
+  useOmniContracts,
+  useParseOpenEvent,
 } = vi.hoisted(() => {
   return {
-    mockUseValidateOrder: vi.fn(),
-    mockUseGetOrderStatus: vi.fn(),
-    mockUseWaitForTransactionReceipt: vi.fn().mockImplementation(() => {
-      return createMockWaitForTransactionReceiptResult({
-        isPending: true,
-        isSuccess: false,
-        data: undefined,
-        status: 'pending',
-      })
+    useValidateOrder: vi.fn(),
+    useParseOpenEvent: vi.fn(),
+    useGetOrderStatus: vi.fn(),
+    useOmniContracts: vi.fn().mockImplementation(() => {
+      return {
+        data: {
+          ...contracts,
+        },
+      }
     }),
-    mockUseWriteContract: vi.fn().mockImplementation(() => {
-      return createMockWriteContractResult({
-        isPending: true,
-        isSuccess: false,
-        data: undefined,
-        isIdle: true,
-        status: 'pending',
-      })
-    }),
-  }
-})
-
-vi.mock('wagmi', async () => {
-  const actual = await vi.importActual('wagmi')
-  return {
-    ...actual,
-    useWriteContract: mockUseWriteContract,
-    useWaitForTransactionReceipt: mockUseWaitForTransactionReceipt,
   }
 })
 
 vi.mock('./useValidateOrder.js', async () => {
   return {
-    useValidateOrder: mockUseValidateOrder,
+    useValidateOrder: useValidateOrder,
+  }
+})
+
+vi.mock('./useOmniContracts.js', async () => {
+  return {
+    useOmniContracts: useOmniContracts,
   }
 })
 
 vi.mock('./useGetOrderStatus.js', async () => {
   return {
-    useGetOrderStatus: mockUseGetOrderStatus,
+    useGetOrderStatus: useGetOrderStatus,
   }
 })
 
+vi.mock('./useParseOpenEvent.js', async () => {
+  return {
+    useParseOpenEvent: useParseOpenEvent,
+  }
+})
+
+beforeEach(() => {
+  useParseOpenEvent.mockReturnValue({
+    resolvedOrder,
+    error: null,
+  })
+  useGetOrderStatus.mockReturnValue({
+    status: 'not-found',
+  })
+  useValidateOrder.mockReturnValue({
+    status: 'accepted',
+  })
+  useWriteContract.mockReturnValue(
+    createMockWriteContractResult({
+      isPending: true,
+      isSuccess: false,
+      data: undefined,
+      isIdle: false,
+      status: 'pending',
+    }),
+  )
+  useWaitForTransactionReceipt.mockReturnValue(
+    createMockWaitForTransactionReceiptResult({
+      isPending: true,
+      isSuccess: false,
+      data: undefined,
+      status: 'pending',
+    }),
+  )
+})
+
 test(`default: validates, opens, and transitions order through it's lifecycle`, async () => {
-  mockUseValidateOrder.mockReturnValue({
-    status: 'pending',
+  const { result, rerender } = renderHook(
+    ({ validateEnabled }: { validateEnabled: boolean }) =>
+      useOrder({ ...order, validateEnabled }),
+    { mockContractsCall: true, initialProps: { validateEnabled: true } },
+  )
+
+  await waitFor(() => {
+    expect(result.current.isReady).toBe(true)
+    expect(result.current.isValidated).toBe(true)
+    expect(result.current.isError).toBe(false)
+    expect(result.current.isTxPending).toBe(true)
+    expect(result.current.isTxSubmitted).toBe(false)
+    expect(result.current.txMutation.data).toBeUndefined()
+    expect(result.current.isOpen).toBe(false)
+    expect(result.current.txHash).toBeUndefined()
+    expect(result.current.error).toBeUndefined()
   })
 
-  mockUseGetOrderStatus.mockReturnValue({
-    status: 'not-found',
+  useValidateOrder.mockReturnValue({
+    status: 'accepted',
+  })
+
+  useGetOrderStatus.mockReturnValue({
+    status: 'open',
+  })
+
+  useWriteContract.mockImplementation(() => createMockWriteContractResult())
+
+  useWaitForTransactionReceipt.mockImplementation(() =>
+    createMockWaitForTransactionReceiptResult(),
+  )
+
+  rerender({ validateEnabled: true })
+
+  const res = await result.current.open()
+
+  await waitFor(() => {
+    expect(result.current.isOpen).toBe(true)
+    expect(result.current.isTxPending).toBe(false)
+    expect(result.current.isTxSubmitted).toBe(true)
+    expect(result.current.txMutation.data).toBe('0xTxHash')
+    expect(result.current.txMutation.isSuccess).toBe(true)
+    expect(res).toBe('0xTxHash')
+  })
+
+  useGetOrderStatus.mockReturnValue({
+    status: 'filled',
+  })
+
+  rerender({ validateEnabled: true })
+
+  await waitFor(() => expect(result.current.status).toBe('filled'))
+})
+
+test('behaviour: handles order rejection', async () => {
+  const { result, rerender } = renderHook(
+    () => useOrder({ ...order, validateEnabled: false }),
+    { mockContractsCall: true },
+  )
+
+  useWriteContract.mockImplementation(() => createMockWriteContractResult())
+
+  useWaitForTransactionReceipt.mockImplementation(() =>
+    createMockWaitForTransactionReceiptResult(),
+  )
+
+  await result.current.open()
+
+  useGetOrderStatus.mockReturnValue({
+    status: 'rejected',
+  })
+
+  rerender()
+
+  await waitFor(() => {
+    expect(result.current.status).toBe('rejected')
+    expect(result.current.isOpen).toBe(false)
+  })
+})
+
+test('behaviour: closed order is handled', async () => {
+  const { result, rerender } = renderHook(
+    () => useOrder({ ...order, validateEnabled: false }),
+    { mockContractsCall: true },
+  )
+
+  useWriteContract.mockImplementation(() => createMockWriteContractResult())
+
+  useWaitForTransactionReceipt.mockImplementation(() =>
+    createMockWaitForTransactionReceiptResult(),
+  )
+
+  await result.current.open()
+
+  useGetOrderStatus.mockReturnValue({
+    status: 'closed',
+  })
+
+  rerender()
+
+  await waitFor(() => {
+    expect(result.current.status).toBe('closed')
+    expect(result.current.isOpen).toBe(false)
+  })
+})
+
+test('behaviour: handles tx mutation error', async () => {
+  useWriteContract.mockImplementation(() =>
+    createMockWriteContractResult({
+      isError: true,
+      error: new Error('Transaction failed'),
+      status: 'error',
+    }),
+  )
+
+  const { result } = renderHook(
+    () => useOrder({ ...order, validateEnabled: false }),
+    { mockContractsCall: true },
+  )
+
+  await waitFor(() => {
+    expect(result.current.isError).toBe(true)
+    expect(result.current.error).toBeInstanceOf(OpenError)
+  })
+})
+
+test('behaviour: validate false/true: toggles validation behavior', async () => {
+  useValidateOrder.mockReturnValue({
+    status: 'pending',
   })
 
   const { result, rerender } = renderHook(
@@ -74,55 +233,193 @@ test(`default: validates, opens, and transitions order through it's lifecycle`, 
   )
 
   await waitFor(() => {
-    expect(result.current.isReady).toBeFalsy()
-    expect(result.current.isError).toBeFalsy()
-    expect(result.current.isTxPending).toBeTruthy()
-    expect(result.current.isTxSubmitted).toBeFalsy()
-    expect(result.current.txMutation.data).toBeUndefined()
-    expect(result.current.isOpen).toBeFalsy()
-    expect(result.current.orderId).toBeUndefined()
-    expect(result.current.txHash).toBeUndefined()
-    expect(result.current.error).toBeUndefined()
+    expect(result.current.isValidated).toBe(false)
   })
 
-  mockUseValidateOrder.mockReturnValue({
+  useValidateOrder.mockReturnValue({
     status: 'accepted',
   })
 
-  mockUseGetOrderStatus.mockReturnValue({
-    status: 'open',
-  })
-
   rerender({ validateEnabled: true })
-
-  await waitFor(() => expect(result.current.isValidated).toBeTruthy())
-
-  mockUseWriteContract
-    .mockReset()
-    .mockImplementation(() => createMockWriteContractResult())
-
-  mockUseWaitForTransactionReceipt.mockImplementation(() =>
-    createMockWaitForTransactionReceiptResult(),
-  )
-
-  rerender({ validateEnabled: true })
-
-  const res = await result.current.open()
 
   await waitFor(() => {
-    expect(result.current.isOpen).toBeTruthy()
-    expect(result.current.isTxPending).toBeFalsy()
-    expect(result.current.isTxSubmitted).toBeTruthy()
-    expect(result.current.txMutation.data).toBe('0xTxHash')
-    expect(result.current.txMutation.isSuccess).toBeTruthy()
-    expect(res).toBe('0xTxHash')
+    expect(result.current.isValidated).toBe(true)
+  })
+})
+
+test('behaviour:  handles validation error', async () => {
+  useValidateOrder.mockReturnValue({
+    status: 'error',
+    error: new Error('Validation failed'),
   })
 
-  mockUseGetOrderStatus.mockReturnValue({
-    status: 'filled',
+  const { result } = renderHook(
+    () => useOrder({ ...order, validateEnabled: true }),
+    { mockContractsCall: true },
+  )
+
+  await waitFor(() => {
+    expect(result.current.isError).toBe(true)
+    expect(result.current.error).toBeInstanceOf(ValidateOrderError)
+  })
+})
+
+test('behaviour: handles transaction receipt error', async () => {
+  useWriteContract.mockImplementation(() =>
+    createMockWriteContractResult({
+      error: null,
+    }),
+  )
+
+  useWaitForTransactionReceipt.mockImplementation(() =>
+    createMockWaitForTransactionReceiptResult({
+      isError: true,
+      error: new Error('Receipt fetch failed'),
+      status: 'error',
+    }),
+  )
+
+  const { result } = renderHook(
+    () => useOrder({ ...order, validateEnabled: false }),
+    { mockContractsCall: true },
+  )
+
+  await waitFor(() => {
+    expect(result.current.isError).toBe(true)
+    expect(result.current.error).toBeInstanceOf(TxReceiptError)
+    expect(result.current.status).toBe('error')
+  })
+})
+
+test('behaviour: handles parse open event error', async () => {
+  useParseOpenEvent.mockReturnValue({
+    status: 'error',
+    error: new ParseOpenEventError('Failed to parse open event'),
   })
 
-  rerender({ validateEnabled: true })
+  useWaitForTransactionReceipt.mockImplementation(() =>
+    createMockWaitForTransactionReceiptResult({
+      error: null,
+    }),
+  )
 
-  await waitFor(() => expect(result.current.status).toBe('filled'))
+  useWriteContract.mockReset().mockImplementation(() =>
+    createMockWriteContractResult({
+      isSuccess: true,
+      status: 'success',
+      error: null,
+    }),
+  )
+
+  const { result } = renderHook(
+    () => useOrder({ ...order, validateEnabled: false }),
+    { mockContractsCall: true },
+  )
+
+  await waitFor(() => {
+    expect(result.current.isError).toBe(true)
+    expect(result.current.error).toBeInstanceOf(ParseOpenEventError)
+  })
+})
+
+test('behaviour: handles order status error', async () => {
+  useGetOrderStatus.mockReturnValue({
+    status: 'error',
+    error: new DidFillError('Failed to get order status'),
+  })
+
+  useWriteContract.mockReset().mockImplementation(() =>
+    createMockWriteContractResult({
+      isSuccess: true,
+      status: 'success',
+    }),
+  )
+
+  useWaitForTransactionReceipt.mockImplementation(() =>
+    createMockWaitForTransactionReceiptResult({
+      isSuccess: true,
+      status: 'success',
+    }),
+  )
+
+  const { result } = renderHook(
+    () => useOrder({ ...order, validateEnabled: false }),
+    { mockContractsCall: true },
+  )
+
+  await waitFor(() => {
+    expect(result.current.isError).toBe(true)
+    expect(result.current.error).toBeInstanceOf(DidFillError)
+  })
+})
+
+test('behaviour: handles wait success but order not found', async () => {
+  useWriteContract.mockReset().mockImplementation(() =>
+    createMockWriteContractResult({
+      isSuccess: true,
+      status: 'success',
+    }),
+  )
+
+  useWaitForTransactionReceipt.mockImplementation(() =>
+    createMockWaitForTransactionReceiptResult({
+      isSuccess: true,
+      status: 'success',
+    }),
+  )
+
+  const { result } = renderHook(
+    () => useOrder({ ...order, validateEnabled: true }),
+    { mockContractsCall: true },
+  )
+
+  await waitFor(() => {
+    expect(result.current.isError).toBe(true)
+    expect(result.current.error).toBeInstanceOf(GetOrderError)
+  })
+})
+
+test('behaviour: handles contracts load error', async () => {
+  useOmniContracts.mockImplementation(() => {
+    return {
+      data: {
+        inbox: undefined,
+      },
+      error: new Error('Failed to load contracts'),
+      isError: true,
+    }
+  })
+
+  const { result } = renderHook(
+    () => useOrder({ ...order, validateEnabled: true }),
+    { mockContractsCallFailure: true },
+  )
+
+  await waitFor(() => {
+    expect(result.current.isError).toBe(true)
+    expect(result.current.error).toBeInstanceOf(LoadContractsError)
+    expect(result.current.status).toBe('error')
+  })
+})
+
+test('behaviour: open rejects when inbox contract not loaded', async () => {
+  const { result, rerender } = renderHook(() =>
+    useOrder({ ...order, validateEnabled: false }),
+  )
+
+  useOmniContracts.mockImplementation(() => {
+    return {
+      data: {
+        inbox: undefined,
+      },
+    }
+  })
+
+  rerender()
+
+  await expect(
+    result.current.open(),
+  ).rejects.toThrowErrorMatchingInlineSnapshot(
+    '[LoadContractsError: Inbox contract address needs to be loaded]',
+  )
 })

--- a/sdk/packages/react/src/hooks/useOrder.ts
+++ b/sdk/packages/react/src/hooks/useOrder.ts
@@ -160,7 +160,7 @@ export function useOrder<abis extends OptionalAbis>(
     isValidated: validation?.status === 'accepted',
     isTxPending: txMutation.isPending,
     isTxSubmitted: txMutation.isSuccess,
-    isOpen: !!wait.data,
+    isOpen: !!wait.data && status !== 'closed' && status !== 'rejected',
     isReady: !!inboxAddress,
     txMutation,
     waitForTx: wait,

--- a/sdk/packages/react/test/mocks.ts
+++ b/sdk/packages/react/test/mocks.ts
@@ -1,4 +1,4 @@
-import { vi } from 'vitest'
+import { beforeEach, vi } from 'vitest'
 import type {
   useReadContract,
   useWaitForTransactionReceipt,
@@ -142,4 +142,35 @@ export function createMockWaitForTransactionReceiptResult<
     error: null,
     ...overrides,
   }
+}
+
+export function mockWagmiHooks() {
+  const { useReadContract, useWriteContract, useWaitForTransactionReceipt } =
+    vi.hoisted(() => {
+      return {
+        useReadContract: vi.fn(),
+        useWriteContract: vi.fn(),
+        useWaitForTransactionReceipt: vi.fn(),
+      }
+    })
+
+  vi.mock('wagmi', async () => {
+    const actual = await vi.importActual('wagmi')
+    return {
+      ...actual,
+      useReadContract,
+      useWriteContract,
+      useWaitForTransactionReceipt,
+    }
+  })
+
+  beforeEach(() => {
+    useReadContract.mockReturnValue(createMockReadContractResult())
+    useWriteContract.mockReturnValue(createMockWriteContractResult())
+    useWaitForTransactionReceipt.mockReturnValue(
+      createMockWaitForTransactionReceiptResult(),
+    )
+  })
+
+  return { useReadContract, useWriteContract, useWaitForTransactionReceipt }
 }


### PR DESCRIPTION
- continued useOrder test cases
- move wagmi mocks into shared mocks module

issue: #3170 