### PR TITLE
chore(lib/uniswap): init swap to usdc

### DIFF
--- a/lib/uniswap/addrs.go
+++ b/lib/uniswap/addrs.go
@@ -1,0 +1,39 @@
+package uniswap
+
+import (
+	"github.com/omni-network/omni/lib/evmchain"
+
+	"github.com/ethereum/go-ethereum/common"
+)
+
+var (
+	// routers maps chainID to Uniswap SwapRouter02 addreses
+	// Reference: https://docs.uniswap.org/contracts/v3/reference/deployments/[]
+	routers = map[uint64]common.Address{
+		evmchain.IDEthereum:    addr("0x68b3465833fb72A70ecDF485E0e4C7bD8665Fc45"),
+		evmchain.IDArbitrumOne: addr("0x68b3465833fb72A70ecDF485E0e4C7bD8665Fc45"),
+		evmchain.IDBase:        addr("0x2626664c2603336E57B271c5C0b26F421741e481"),
+		evmchain.IDOptimism:    addr("0x68b3465833fb72A70ecDF485E0e4C7bD8665Fc45"),
+		evmchain.IDSepolia:     addr("0x3bFA4769FB09eefC5a80d6E87c3B9C650f7Ae48E"),
+		evmchain.IDArbSepolia:  addr("0x101F443B4d1b059569D643917553c771E1b9663E"),
+		evmchain.IDBaseSepolia: addr("0x94cC0AaC535CCDB3C01d6787D6413C739ae12bc4"),
+		evmchain.IDOpSepolia:   addr("0x94cC0AaC535CCDB3C01d6787D6413C739ae12bc4"),
+	}
+
+	// quoter maps chainID to Uniswap QuoterV2 addreses
+	// Reference: https://docs.uniswap.org/contracts/v3/reference/deployments/
+	quoters = map[uint64]common.Address{
+		evmchain.IDEthereum:    addr("0x61fFE014bA17989E743c5F6cB21bF9697530B21e"),
+		evmchain.IDArbitrumOne: addr("0x61fFE014bA17989E743c5F6cB21bF9697530B21e"),
+		evmchain.IDOptimism:    addr("0x61fFE014bA17989E743c5F6cB21bF9697530B21e"),
+		evmchain.IDBase:        addr("0x3d4e44Eb1374240CE5F1B871ab261CD16335B76a"),
+		evmchain.IDSepolia:     addr("0xEd1f6473345F45b75F8179591dd5bA1888cf2FB3"),
+		evmchain.IDArbSepolia:  addr("0x2779a0CC1c3e0E44D2542EC3e79e3864Ae93Ef0B"),
+		evmchain.IDBaseSepolia: addr("0xC5290058841028F1614F3A6F0F5816cAd0df5E27"),
+		evmchain.IDOpSepolia:   addr("0x0FBEa6cf957d95ee9313490050F6A0DA68039404"),
+	}
+)
+
+func addr(hex string) common.Address {
+	return common.HexToAddress(hex)
+}

--- a/lib/uniswap/genbindings.go
+++ b/lib/uniswap/genbindings.go
@@ -1,0 +1,5 @@
+package uniswap
+
+// Generates bindings for the Uniswap's SwapRouter02 contract.
+//go:generate abigen --abi uniswaprouter02.json --type UniSwapRouter02 --pkg uniswap --out uniswaprouter02_bindings.go
+//go:generate abigen --abi uniquoterv2.json --type UniQuoterV2 --pkg uniswap --out uniquoterv2_bindings.go

--- a/lib/uniswap/pools.go
+++ b/lib/uniswap/pools.go
@@ -1,0 +1,51 @@
+//nolint:unused // skeleton code
+package uniswap
+
+import (
+	"github.com/omni-network/omni/lib/tokens"
+)
+
+const (
+	// FeeBips30 is the 0.3% fee tier.
+	FeeBips30 uint = 3000
+
+	// FeeBips5 is the 0.05% fee tier.
+	FeeBips5 uint = 500
+
+	// FeeBips1 is the 0.01% fee tier.
+	FeeBips1 uint = 100
+)
+
+// PoolMeta defines an asset pair and fee bips for a uniswap v3 pool.
+// Asset0 and Asset1 are unordered, unlike pool Token0 and Token1 (ordered by address).
+type PoolMeta struct {
+	Asset0 tokens.Asset
+	Asset1 tokens.Asset
+	Fee    uint
+}
+
+// IsPair checks if the given tokenIn / tokenOut pair is in the pool.
+func (p PoolMeta) IsPair(tokenIn, tokenOut tokens.Token) bool {
+	return tokenIn.Is(p.Asset0) && tokenOut.Is(p.Asset1) || tokenIn.Is(p.Asset1) && tokenOut.Is(p.Asset0)
+}
+
+// pools is a static list of uniswap v3 pool meta data (reference: https://app.uniswap.org/explore/pools)
+var pools = []PoolMeta{
+	newPool(tokens.WETH, tokens.USDC, FeeBips5),   // WETH / UDSC, 0.05%
+	newPool(tokens.WSTETH, tokens.WETH, FeeBips1), // WSTETH / WETH, 0.01%
+}
+
+func newPool(asset0, asset1 tokens.Asset, fee uint) PoolMeta {
+	return PoolMeta{Asset0: asset0, Asset1: asset1, Fee: fee}
+}
+
+// poolFee returns the pool fee for the given tokenIn / tokenOut pair.
+func poolFee(tokenIn tokens.Token, tokenOut tokens.Token) (uint, bool) {
+	for _, pool := range pools {
+		if pool.IsPair(tokenIn, tokenOut) {
+			return pool.Fee, true
+		}
+	}
+
+	return 0, false
+}

--- a/lib/uniswap/swap.go
+++ b/lib/uniswap/swap.go
@@ -1,0 +1,152 @@
+//nolint:unparam // skeleton code
+package uniswap
+
+import (
+	"context"
+	"math/big"
+
+	"github.com/omni-network/omni/lib/bi"
+	"github.com/omni-network/omni/lib/errors"
+	"github.com/omni-network/omni/lib/ethclient/ethbackend"
+	"github.com/omni-network/omni/lib/tokens"
+)
+
+// SwapToUSDC swaps the given token to USDC.
+func SwapToUSDC(
+	ctx context.Context,
+	backend *ethbackend.Backend,
+	token tokens.Token,
+	amount *big.Int,
+) (*big.Int, error) {
+	if token.Is(tokens.USDC) { // Already USDC
+		return amount, nil
+	}
+
+	swaps, err := routeToUSDC(token)
+	if err != nil {
+		return nil, errors.Wrap(err, "route to USDC")
+	}
+
+	if len(swaps) == 1 {
+		return singleSwap(ctx, backend, swaps[0], amount)
+	}
+
+	return mulitSwap(ctx, backend, swaps, amount)
+}
+
+type Swap struct {
+	TokenIn  tokens.Token
+	TokenOut tokens.Token
+}
+
+// routeToUSDC returns a list of swap to get USDC.
+// Routes defined statically, dynamic route optimization not (yet) worth the complexity.
+func routeToUSDC(tkn tokens.Token) ([]Swap, error) {
+	usdc, ok := tokens.ByAsset(tkn.ChainID, tokens.USDC)
+	if !ok {
+		return nil, errors.New("no USDC", "chain", tkn.ChainID)
+	}
+
+	// WETH required native ETH -> USDC. SwapRouter02 wraps ETH to WETH.
+	weth, ok := tokens.ByAsset(tkn.ChainID, tokens.WETH)
+	if !ok {
+		return nil, errors.New("no WETH", "chain", tkn.ChainID)
+	}
+
+	if tkn.Is(tokens.ETH) { // Swap ETH to USDC directly.
+		return []Swap{
+			{TokenIn: weth, TokenOut: usdc},
+		}, nil
+	}
+
+	if tkn.Is(tokens.WSTETH) { // Swap WSTETH to USDC via WETH.
+		return []Swap{
+			{TokenIn: tkn, TokenOut: weth},
+			{TokenIn: weth, TokenOut: usdc},
+		}, nil
+	}
+
+	return nil, errors.New("no route to USDC", "token", tkn.Asset, "chain", tkn.ChainID)
+}
+
+// singleSwap executes a single swap.
+func singleSwap(
+	ctx context.Context,
+	backend *ethbackend.Backend,
+	swap Swap,
+	amountIn *big.Int,
+) (*big.Int, error) {
+	chainID := swap.TokenIn.ChainID
+
+	router, err := newRouter(chainID, backend)
+	if err != nil {
+		return nil, errors.Wrap(err, "new router")
+	}
+
+	quoter, err := newQuoter(chainID, backend)
+	if err != nil {
+		return nil, errors.Wrap(err, "new quoter")
+	}
+
+	_ = ctx
+	_ = amountIn
+	_ = swap
+	_ = quoter
+	_ = router
+
+	// TODO
+
+	return bi.Zero(), nil
+}
+
+// mulitSwap executes a multi hop swap.
+func mulitSwap(
+	ctx context.Context,
+	backend *ethbackend.Backend,
+	swaps []Swap,
+	amountIn *big.Int,
+) (*big.Int, error) {
+	if len(swaps) < 2 {
+		return nil, errors.New("no multi hop", "swaps", len(swaps))
+	}
+
+	chainID := swaps[0].TokenIn.ChainID
+
+	router, err := newRouter(chainID, backend)
+	if err != nil {
+		return nil, errors.Wrap(err, "new router")
+	}
+
+	quoter, err := newQuoter(chainID, backend)
+	if err != nil {
+		return nil, errors.Wrap(err, "new quoter")
+	}
+
+	_ = ctx
+	_ = amountIn
+	_ = swaps
+	_ = quoter
+	_ = router
+
+	// TODO
+
+	return bi.Zero(), nil
+}
+
+func newRouter(chainID uint64, backend *ethbackend.Backend) (*UniSwapRouter02, error) {
+	addr, ok := routers[chainID]
+	if !ok {
+		return nil, errors.New("no router", "chain", chainID)
+	}
+
+	return NewUniSwapRouter02(addr, backend)
+}
+
+func newQuoter(chainID uint64, backend *ethbackend.Backend) (*UniQuoterV2, error) {
+	addr, ok := quoters[chainID]
+	if !ok {
+		return nil, errors.New("no quoter", "chain", chainID)
+	}
+
+	return NewUniQuoterV2(addr, backend)
+}

--- a/lib/uniswap/uniquoterv2.json
+++ b/lib/uniswap/uniquoterv2.json
@@ -1,0 +1,115 @@
+[
+  {
+    "inputs": [
+      { "internalType": "address", "name": "_factory", "type": "address" },
+      { "internalType": "address", "name": "_WETH9", "type": "address" }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "constructor"
+  },
+  {
+    "inputs": [],
+    "name": "WETH9",
+    "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "factory",
+    "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "bytes", "name": "path", "type": "bytes" },
+      { "internalType": "uint256", "name": "amountIn", "type": "uint256" }
+    ],
+    "name": "quoteExactInput",
+    "outputs": [
+      { "internalType": "uint256", "name": "amountOut", "type": "uint256" },
+      { "internalType": "uint160[]", "name": "sqrtPriceX96AfterList", "type": "uint160[]" },
+      { "internalType": "uint32[]", "name": "initializedTicksCrossedList", "type": "uint32[]" },
+      { "internalType": "uint256", "name": "gasEstimate", "type": "uint256" }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "components": [
+          { "internalType": "address", "name": "tokenIn", "type": "address" },
+          { "internalType": "address", "name": "tokenOut", "type": "address" },
+          { "internalType": "uint256", "name": "amountIn", "type": "uint256" },
+          { "internalType": "uint24", "name": "fee", "type": "uint24" },
+          { "internalType": "uint160", "name": "sqrtPriceLimitX96", "type": "uint160" }
+        ],
+        "internalType": "struct IQuoterV2.QuoteExactInputSingleParams",
+        "name": "params",
+        "type": "tuple"
+      }
+    ],
+    "name": "quoteExactInputSingle",
+    "outputs": [
+      { "internalType": "uint256", "name": "amountOut", "type": "uint256" },
+      { "internalType": "uint160", "name": "sqrtPriceX96After", "type": "uint160" },
+      { "internalType": "uint32", "name": "initializedTicksCrossed", "type": "uint32" },
+      { "internalType": "uint256", "name": "gasEstimate", "type": "uint256" }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "bytes", "name": "path", "type": "bytes" },
+      { "internalType": "uint256", "name": "amountOut", "type": "uint256" }
+    ],
+    "name": "quoteExactOutput",
+    "outputs": [
+      { "internalType": "uint256", "name": "amountIn", "type": "uint256" },
+      { "internalType": "uint160[]", "name": "sqrtPriceX96AfterList", "type": "uint160[]" },
+      { "internalType": "uint32[]", "name": "initializedTicksCrossedList", "type": "uint32[]" },
+      { "internalType": "uint256", "name": "gasEstimate", "type": "uint256" }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "components": [
+          { "internalType": "address", "name": "tokenIn", "type": "address" },
+          { "internalType": "address", "name": "tokenOut", "type": "address" },
+          { "internalType": "uint256", "name": "amount", "type": "uint256" },
+          { "internalType": "uint24", "name": "fee", "type": "uint24" },
+          { "internalType": "uint160", "name": "sqrtPriceLimitX96", "type": "uint160" }
+        ],
+        "internalType": "struct IQuoterV2.QuoteExactOutputSingleParams",
+        "name": "params",
+        "type": "tuple"
+      }
+    ],
+    "name": "quoteExactOutputSingle",
+    "outputs": [
+      { "internalType": "uint256", "name": "amountIn", "type": "uint256" },
+      { "internalType": "uint160", "name": "sqrtPriceX96After", "type": "uint160" },
+      { "internalType": "uint32", "name": "initializedTicksCrossed", "type": "uint32" },
+      { "internalType": "uint256", "name": "gasEstimate", "type": "uint256" }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "int256", "name": "amount0Delta", "type": "int256" },
+      { "internalType": "int256", "name": "amount1Delta", "type": "int256" },
+      { "internalType": "bytes", "name": "path", "type": "bytes" }
+    ],
+    "name": "uniswapV3SwapCallback",
+    "outputs": [],
+    "stateMutability": "view",
+    "type": "function"
+  }
+]

--- a/lib/uniswap/uniquoterv2_bindings.go
+++ b/lib/uniswap/uniquoterv2_bindings.go
@@ -1,0 +1,374 @@
+// Code generated - DO NOT EDIT.
+// This file is a generated binding and any manual changes will be lost.
+
+package uniswap
+
+import (
+	"errors"
+	"math/big"
+	"strings"
+
+	ethereum "github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/event"
+)
+
+// Reference imports to suppress errors if they are not otherwise used.
+var (
+	_ = errors.New
+	_ = big.NewInt
+	_ = strings.NewReader
+	_ = ethereum.NotFound
+	_ = bind.Bind
+	_ = common.Big1
+	_ = types.BloomLookup
+	_ = event.NewSubscription
+	_ = abi.ConvertType
+)
+
+// IQuoterV2QuoteExactInputSingleParams is an auto generated low-level Go binding around an user-defined struct.
+type IQuoterV2QuoteExactInputSingleParams struct {
+	TokenIn           common.Address
+	TokenOut          common.Address
+	AmountIn          *big.Int
+	Fee               *big.Int
+	SqrtPriceLimitX96 *big.Int
+}
+
+// IQuoterV2QuoteExactOutputSingleParams is an auto generated low-level Go binding around an user-defined struct.
+type IQuoterV2QuoteExactOutputSingleParams struct {
+	TokenIn           common.Address
+	TokenOut          common.Address
+	Amount            *big.Int
+	Fee               *big.Int
+	SqrtPriceLimitX96 *big.Int
+}
+
+// UniQuoterV2MetaData contains all meta data concerning the UniQuoterV2 contract.
+var UniQuoterV2MetaData = &bind.MetaData{
+	ABI: "[{\"inputs\":[{\"internalType\":\"address\",\"name\":\"_factory\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"_WETH9\",\"type\":\"address\"}],\"stateMutability\":\"nonpayable\",\"type\":\"constructor\"},{\"inputs\":[],\"name\":\"WETH9\",\"outputs\":[{\"internalType\":\"address\",\"name\":\"\",\"type\":\"address\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"factory\",\"outputs\":[{\"internalType\":\"address\",\"name\":\"\",\"type\":\"address\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"bytes\",\"name\":\"path\",\"type\":\"bytes\"},{\"internalType\":\"uint256\",\"name\":\"amountIn\",\"type\":\"uint256\"}],\"name\":\"quoteExactInput\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"amountOut\",\"type\":\"uint256\"},{\"internalType\":\"uint160[]\",\"name\":\"sqrtPriceX96AfterList\",\"type\":\"uint160[]\"},{\"internalType\":\"uint32[]\",\"name\":\"initializedTicksCrossedList\",\"type\":\"uint32[]\"},{\"internalType\":\"uint256\",\"name\":\"gasEstimate\",\"type\":\"uint256\"}],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"components\":[{\"internalType\":\"address\",\"name\":\"tokenIn\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"tokenOut\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"amountIn\",\"type\":\"uint256\"},{\"internalType\":\"uint24\",\"name\":\"fee\",\"type\":\"uint24\"},{\"internalType\":\"uint160\",\"name\":\"sqrtPriceLimitX96\",\"type\":\"uint160\"}],\"internalType\":\"structIQuoterV2.QuoteExactInputSingleParams\",\"name\":\"params\",\"type\":\"tuple\"}],\"name\":\"quoteExactInputSingle\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"amountOut\",\"type\":\"uint256\"},{\"internalType\":\"uint160\",\"name\":\"sqrtPriceX96After\",\"type\":\"uint160\"},{\"internalType\":\"uint32\",\"name\":\"initializedTicksCrossed\",\"type\":\"uint32\"},{\"internalType\":\"uint256\",\"name\":\"gasEstimate\",\"type\":\"uint256\"}],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"bytes\",\"name\":\"path\",\"type\":\"bytes\"},{\"internalType\":\"uint256\",\"name\":\"amountOut\",\"type\":\"uint256\"}],\"name\":\"quoteExactOutput\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"amountIn\",\"type\":\"uint256\"},{\"internalType\":\"uint160[]\",\"name\":\"sqrtPriceX96AfterList\",\"type\":\"uint160[]\"},{\"internalType\":\"uint32[]\",\"name\":\"initializedTicksCrossedList\",\"type\":\"uint32[]\"},{\"internalType\":\"uint256\",\"name\":\"gasEstimate\",\"type\":\"uint256\"}],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"components\":[{\"internalType\":\"address\",\"name\":\"tokenIn\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"tokenOut\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"amount\",\"type\":\"uint256\"},{\"internalType\":\"uint24\",\"name\":\"fee\",\"type\":\"uint24\"},{\"internalType\":\"uint160\",\"name\":\"sqrtPriceLimitX96\",\"type\":\"uint160\"}],\"internalType\":\"structIQuoterV2.QuoteExactOutputSingleParams\",\"name\":\"params\",\"type\":\"tuple\"}],\"name\":\"quoteExactOutputSingle\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"amountIn\",\"type\":\"uint256\"},{\"internalType\":\"uint160\",\"name\":\"sqrtPriceX96After\",\"type\":\"uint160\"},{\"internalType\":\"uint32\",\"name\":\"initializedTicksCrossed\",\"type\":\"uint32\"},{\"internalType\":\"uint256\",\"name\":\"gasEstimate\",\"type\":\"uint256\"}],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"int256\",\"name\":\"amount0Delta\",\"type\":\"int256\"},{\"internalType\":\"int256\",\"name\":\"amount1Delta\",\"type\":\"int256\"},{\"internalType\":\"bytes\",\"name\":\"path\",\"type\":\"bytes\"}],\"name\":\"uniswapV3SwapCallback\",\"outputs\":[],\"stateMutability\":\"view\",\"type\":\"function\"}]",
+}
+
+// UniQuoterV2ABI is the input ABI used to generate the binding from.
+// Deprecated: Use UniQuoterV2MetaData.ABI instead.
+var UniQuoterV2ABI = UniQuoterV2MetaData.ABI
+
+// UniQuoterV2 is an auto generated Go binding around an Ethereum contract.
+type UniQuoterV2 struct {
+	UniQuoterV2Caller     // Read-only binding to the contract
+	UniQuoterV2Transactor // Write-only binding to the contract
+	UniQuoterV2Filterer   // Log filterer for contract events
+}
+
+// UniQuoterV2Caller is an auto generated read-only Go binding around an Ethereum contract.
+type UniQuoterV2Caller struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// UniQuoterV2Transactor is an auto generated write-only Go binding around an Ethereum contract.
+type UniQuoterV2Transactor struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// UniQuoterV2Filterer is an auto generated log filtering Go binding around an Ethereum contract events.
+type UniQuoterV2Filterer struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// UniQuoterV2Session is an auto generated Go binding around an Ethereum contract,
+// with pre-set call and transact options.
+type UniQuoterV2Session struct {
+	Contract     *UniQuoterV2      // Generic contract binding to set the session for
+	CallOpts     bind.CallOpts     // Call options to use throughout this session
+	TransactOpts bind.TransactOpts // Transaction auth options to use throughout this session
+}
+
+// UniQuoterV2CallerSession is an auto generated read-only Go binding around an Ethereum contract,
+// with pre-set call options.
+type UniQuoterV2CallerSession struct {
+	Contract *UniQuoterV2Caller // Generic contract caller binding to set the session for
+	CallOpts bind.CallOpts      // Call options to use throughout this session
+}
+
+// UniQuoterV2TransactorSession is an auto generated write-only Go binding around an Ethereum contract,
+// with pre-set transact options.
+type UniQuoterV2TransactorSession struct {
+	Contract     *UniQuoterV2Transactor // Generic contract transactor binding to set the session for
+	TransactOpts bind.TransactOpts      // Transaction auth options to use throughout this session
+}
+
+// UniQuoterV2Raw is an auto generated low-level Go binding around an Ethereum contract.
+type UniQuoterV2Raw struct {
+	Contract *UniQuoterV2 // Generic contract binding to access the raw methods on
+}
+
+// UniQuoterV2CallerRaw is an auto generated low-level read-only Go binding around an Ethereum contract.
+type UniQuoterV2CallerRaw struct {
+	Contract *UniQuoterV2Caller // Generic read-only contract binding to access the raw methods on
+}
+
+// UniQuoterV2TransactorRaw is an auto generated low-level write-only Go binding around an Ethereum contract.
+type UniQuoterV2TransactorRaw struct {
+	Contract *UniQuoterV2Transactor // Generic write-only contract binding to access the raw methods on
+}
+
+// NewUniQuoterV2 creates a new instance of UniQuoterV2, bound to a specific deployed contract.
+func NewUniQuoterV2(address common.Address, backend bind.ContractBackend) (*UniQuoterV2, error) {
+	contract, err := bindUniQuoterV2(address, backend, backend, backend)
+	if err != nil {
+		return nil, err
+	}
+	return &UniQuoterV2{UniQuoterV2Caller: UniQuoterV2Caller{contract: contract}, UniQuoterV2Transactor: UniQuoterV2Transactor{contract: contract}, UniQuoterV2Filterer: UniQuoterV2Filterer{contract: contract}}, nil
+}
+
+// NewUniQuoterV2Caller creates a new read-only instance of UniQuoterV2, bound to a specific deployed contract.
+func NewUniQuoterV2Caller(address common.Address, caller bind.ContractCaller) (*UniQuoterV2Caller, error) {
+	contract, err := bindUniQuoterV2(address, caller, nil, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &UniQuoterV2Caller{contract: contract}, nil
+}
+
+// NewUniQuoterV2Transactor creates a new write-only instance of UniQuoterV2, bound to a specific deployed contract.
+func NewUniQuoterV2Transactor(address common.Address, transactor bind.ContractTransactor) (*UniQuoterV2Transactor, error) {
+	contract, err := bindUniQuoterV2(address, nil, transactor, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &UniQuoterV2Transactor{contract: contract}, nil
+}
+
+// NewUniQuoterV2Filterer creates a new log filterer instance of UniQuoterV2, bound to a specific deployed contract.
+func NewUniQuoterV2Filterer(address common.Address, filterer bind.ContractFilterer) (*UniQuoterV2Filterer, error) {
+	contract, err := bindUniQuoterV2(address, nil, nil, filterer)
+	if err != nil {
+		return nil, err
+	}
+	return &UniQuoterV2Filterer{contract: contract}, nil
+}
+
+// bindUniQuoterV2 binds a generic wrapper to an already deployed contract.
+func bindUniQuoterV2(address common.Address, caller bind.ContractCaller, transactor bind.ContractTransactor, filterer bind.ContractFilterer) (*bind.BoundContract, error) {
+	parsed, err := UniQuoterV2MetaData.GetAbi()
+	if err != nil {
+		return nil, err
+	}
+	return bind.NewBoundContract(address, *parsed, caller, transactor, filterer), nil
+}
+
+// Call invokes the (constant) contract method with params as input values and
+// sets the output to result. The result type might be a single field for simple
+// returns, a slice of interfaces for anonymous returns and a struct for named
+// returns.
+func (_UniQuoterV2 *UniQuoterV2Raw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
+	return _UniQuoterV2.Contract.UniQuoterV2Caller.contract.Call(opts, result, method, params...)
+}
+
+// Transfer initiates a plain transaction to move funds to the contract, calling
+// its default method if one is available.
+func (_UniQuoterV2 *UniQuoterV2Raw) Transfer(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _UniQuoterV2.Contract.UniQuoterV2Transactor.contract.Transfer(opts)
+}
+
+// Transact invokes the (paid) contract method with params as input values.
+func (_UniQuoterV2 *UniQuoterV2Raw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (*types.Transaction, error) {
+	return _UniQuoterV2.Contract.UniQuoterV2Transactor.contract.Transact(opts, method, params...)
+}
+
+// Call invokes the (constant) contract method with params as input values and
+// sets the output to result. The result type might be a single field for simple
+// returns, a slice of interfaces for anonymous returns and a struct for named
+// returns.
+func (_UniQuoterV2 *UniQuoterV2CallerRaw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
+	return _UniQuoterV2.Contract.contract.Call(opts, result, method, params...)
+}
+
+// Transfer initiates a plain transaction to move funds to the contract, calling
+// its default method if one is available.
+func (_UniQuoterV2 *UniQuoterV2TransactorRaw) Transfer(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _UniQuoterV2.Contract.contract.Transfer(opts)
+}
+
+// Transact invokes the (paid) contract method with params as input values.
+func (_UniQuoterV2 *UniQuoterV2TransactorRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (*types.Transaction, error) {
+	return _UniQuoterV2.Contract.contract.Transact(opts, method, params...)
+}
+
+// WETH9 is a free data retrieval call binding the contract method 0x4aa4a4fc.
+//
+// Solidity: function WETH9() view returns(address)
+func (_UniQuoterV2 *UniQuoterV2Caller) WETH9(opts *bind.CallOpts) (common.Address, error) {
+	var out []interface{}
+	err := _UniQuoterV2.contract.Call(opts, &out, "WETH9")
+
+	if err != nil {
+		return *new(common.Address), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(common.Address)).(*common.Address)
+
+	return out0, err
+
+}
+
+// WETH9 is a free data retrieval call binding the contract method 0x4aa4a4fc.
+//
+// Solidity: function WETH9() view returns(address)
+func (_UniQuoterV2 *UniQuoterV2Session) WETH9() (common.Address, error) {
+	return _UniQuoterV2.Contract.WETH9(&_UniQuoterV2.CallOpts)
+}
+
+// WETH9 is a free data retrieval call binding the contract method 0x4aa4a4fc.
+//
+// Solidity: function WETH9() view returns(address)
+func (_UniQuoterV2 *UniQuoterV2CallerSession) WETH9() (common.Address, error) {
+	return _UniQuoterV2.Contract.WETH9(&_UniQuoterV2.CallOpts)
+}
+
+// Factory is a free data retrieval call binding the contract method 0xc45a0155.
+//
+// Solidity: function factory() view returns(address)
+func (_UniQuoterV2 *UniQuoterV2Caller) Factory(opts *bind.CallOpts) (common.Address, error) {
+	var out []interface{}
+	err := _UniQuoterV2.contract.Call(opts, &out, "factory")
+
+	if err != nil {
+		return *new(common.Address), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(common.Address)).(*common.Address)
+
+	return out0, err
+
+}
+
+// Factory is a free data retrieval call binding the contract method 0xc45a0155.
+//
+// Solidity: function factory() view returns(address)
+func (_UniQuoterV2 *UniQuoterV2Session) Factory() (common.Address, error) {
+	return _UniQuoterV2.Contract.Factory(&_UniQuoterV2.CallOpts)
+}
+
+// Factory is a free data retrieval call binding the contract method 0xc45a0155.
+//
+// Solidity: function factory() view returns(address)
+func (_UniQuoterV2 *UniQuoterV2CallerSession) Factory() (common.Address, error) {
+	return _UniQuoterV2.Contract.Factory(&_UniQuoterV2.CallOpts)
+}
+
+// UniswapV3SwapCallback is a free data retrieval call binding the contract method 0xfa461e33.
+//
+// Solidity: function uniswapV3SwapCallback(int256 amount0Delta, int256 amount1Delta, bytes path) view returns()
+func (_UniQuoterV2 *UniQuoterV2Caller) UniswapV3SwapCallback(opts *bind.CallOpts, amount0Delta *big.Int, amount1Delta *big.Int, path []byte) error {
+	var out []interface{}
+	err := _UniQuoterV2.contract.Call(opts, &out, "uniswapV3SwapCallback", amount0Delta, amount1Delta, path)
+
+	if err != nil {
+		return err
+	}
+
+	return err
+
+}
+
+// UniswapV3SwapCallback is a free data retrieval call binding the contract method 0xfa461e33.
+//
+// Solidity: function uniswapV3SwapCallback(int256 amount0Delta, int256 amount1Delta, bytes path) view returns()
+func (_UniQuoterV2 *UniQuoterV2Session) UniswapV3SwapCallback(amount0Delta *big.Int, amount1Delta *big.Int, path []byte) error {
+	return _UniQuoterV2.Contract.UniswapV3SwapCallback(&_UniQuoterV2.CallOpts, amount0Delta, amount1Delta, path)
+}
+
+// UniswapV3SwapCallback is a free data retrieval call binding the contract method 0xfa461e33.
+//
+// Solidity: function uniswapV3SwapCallback(int256 amount0Delta, int256 amount1Delta, bytes path) view returns()
+func (_UniQuoterV2 *UniQuoterV2CallerSession) UniswapV3SwapCallback(amount0Delta *big.Int, amount1Delta *big.Int, path []byte) error {
+	return _UniQuoterV2.Contract.UniswapV3SwapCallback(&_UniQuoterV2.CallOpts, amount0Delta, amount1Delta, path)
+}
+
+// QuoteExactInput is a paid mutator transaction binding the contract method 0xcdca1753.
+//
+// Solidity: function quoteExactInput(bytes path, uint256 amountIn) returns(uint256 amountOut, uint160[] sqrtPriceX96AfterList, uint32[] initializedTicksCrossedList, uint256 gasEstimate)
+func (_UniQuoterV2 *UniQuoterV2Transactor) QuoteExactInput(opts *bind.TransactOpts, path []byte, amountIn *big.Int) (*types.Transaction, error) {
+	return _UniQuoterV2.contract.Transact(opts, "quoteExactInput", path, amountIn)
+}
+
+// QuoteExactInput is a paid mutator transaction binding the contract method 0xcdca1753.
+//
+// Solidity: function quoteExactInput(bytes path, uint256 amountIn) returns(uint256 amountOut, uint160[] sqrtPriceX96AfterList, uint32[] initializedTicksCrossedList, uint256 gasEstimate)
+func (_UniQuoterV2 *UniQuoterV2Session) QuoteExactInput(path []byte, amountIn *big.Int) (*types.Transaction, error) {
+	return _UniQuoterV2.Contract.QuoteExactInput(&_UniQuoterV2.TransactOpts, path, amountIn)
+}
+
+// QuoteExactInput is a paid mutator transaction binding the contract method 0xcdca1753.
+//
+// Solidity: function quoteExactInput(bytes path, uint256 amountIn) returns(uint256 amountOut, uint160[] sqrtPriceX96AfterList, uint32[] initializedTicksCrossedList, uint256 gasEstimate)
+func (_UniQuoterV2 *UniQuoterV2TransactorSession) QuoteExactInput(path []byte, amountIn *big.Int) (*types.Transaction, error) {
+	return _UniQuoterV2.Contract.QuoteExactInput(&_UniQuoterV2.TransactOpts, path, amountIn)
+}
+
+// QuoteExactInputSingle is a paid mutator transaction binding the contract method 0xc6a5026a.
+//
+// Solidity: function quoteExactInputSingle((address,address,uint256,uint24,uint160) params) returns(uint256 amountOut, uint160 sqrtPriceX96After, uint32 initializedTicksCrossed, uint256 gasEstimate)
+func (_UniQuoterV2 *UniQuoterV2Transactor) QuoteExactInputSingle(opts *bind.TransactOpts, params IQuoterV2QuoteExactInputSingleParams) (*types.Transaction, error) {
+	return _UniQuoterV2.contract.Transact(opts, "quoteExactInputSingle", params)
+}
+
+// QuoteExactInputSingle is a paid mutator transaction binding the contract method 0xc6a5026a.
+//
+// Solidity: function quoteExactInputSingle((address,address,uint256,uint24,uint160) params) returns(uint256 amountOut, uint160 sqrtPriceX96After, uint32 initializedTicksCrossed, uint256 gasEstimate)
+func (_UniQuoterV2 *UniQuoterV2Session) QuoteExactInputSingle(params IQuoterV2QuoteExactInputSingleParams) (*types.Transaction, error) {
+	return _UniQuoterV2.Contract.QuoteExactInputSingle(&_UniQuoterV2.TransactOpts, params)
+}
+
+// QuoteExactInputSingle is a paid mutator transaction binding the contract method 0xc6a5026a.
+//
+// Solidity: function quoteExactInputSingle((address,address,uint256,uint24,uint160) params) returns(uint256 amountOut, uint160 sqrtPriceX96After, uint32 initializedTicksCrossed, uint256 gasEstimate)
+func (_UniQuoterV2 *UniQuoterV2TransactorSession) QuoteExactInputSingle(params IQuoterV2QuoteExactInputSingleParams) (*types.Transaction, error) {
+	return _UniQuoterV2.Contract.QuoteExactInputSingle(&_UniQuoterV2.TransactOpts, params)
+}
+
+// QuoteExactOutput is a paid mutator transaction binding the contract method 0x2f80bb1d.
+//
+// Solidity: function quoteExactOutput(bytes path, uint256 amountOut) returns(uint256 amountIn, uint160[] sqrtPriceX96AfterList, uint32[] initializedTicksCrossedList, uint256 gasEstimate)
+func (_UniQuoterV2 *UniQuoterV2Transactor) QuoteExactOutput(opts *bind.TransactOpts, path []byte, amountOut *big.Int) (*types.Transaction, error) {
+	return _UniQuoterV2.contract.Transact(opts, "quoteExactOutput", path, amountOut)
+}
+
+// QuoteExactOutput is a paid mutator transaction binding the contract method 0x2f80bb1d.
+//
+// Solidity: function quoteExactOutput(bytes path, uint256 amountOut) returns(uint256 amountIn, uint160[] sqrtPriceX96AfterList, uint32[] initializedTicksCrossedList, uint256 gasEstimate)
+func (_UniQuoterV2 *UniQuoterV2Session) QuoteExactOutput(path []byte, amountOut *big.Int) (*types.Transaction, error) {
+	return _UniQuoterV2.Contract.QuoteExactOutput(&_UniQuoterV2.TransactOpts, path, amountOut)
+}
+
+// QuoteExactOutput is a paid mutator transaction binding the contract method 0x2f80bb1d.
+//
+// Solidity: function quoteExactOutput(bytes path, uint256 amountOut) returns(uint256 amountIn, uint160[] sqrtPriceX96AfterList, uint32[] initializedTicksCrossedList, uint256 gasEstimate)
+func (_UniQuoterV2 *UniQuoterV2TransactorSession) QuoteExactOutput(path []byte, amountOut *big.Int) (*types.Transaction, error) {
+	return _UniQuoterV2.Contract.QuoteExactOutput(&_UniQuoterV2.TransactOpts, path, amountOut)
+}
+
+// QuoteExactOutputSingle is a paid mutator transaction binding the contract method 0xbd21704a.
+//
+// Solidity: function quoteExactOutputSingle((address,address,uint256,uint24,uint160) params) returns(uint256 amountIn, uint160 sqrtPriceX96After, uint32 initializedTicksCrossed, uint256 gasEstimate)
+func (_UniQuoterV2 *UniQuoterV2Transactor) QuoteExactOutputSingle(opts *bind.TransactOpts, params IQuoterV2QuoteExactOutputSingleParams) (*types.Transaction, error) {
+	return _UniQuoterV2.contract.Transact(opts, "quoteExactOutputSingle", params)
+}
+
+// QuoteExactOutputSingle is a paid mutator transaction binding the contract method 0xbd21704a.
+//
+// Solidity: function quoteExactOutputSingle((address,address,uint256,uint24,uint160) params) returns(uint256 amountIn, uint160 sqrtPriceX96After, uint32 initializedTicksCrossed, uint256 gasEstimate)
+func (_UniQuoterV2 *UniQuoterV2Session) QuoteExactOutputSingle(params IQuoterV2QuoteExactOutputSingleParams) (*types.Transaction, error) {
+	return _UniQuoterV2.Contract.QuoteExactOutputSingle(&_UniQuoterV2.TransactOpts, params)
+}
+
+// QuoteExactOutputSingle is a paid mutator transaction binding the contract method 0xbd21704a.
+//
+// Solidity: function quoteExactOutputSingle((address,address,uint256,uint24,uint160) params) returns(uint256 amountIn, uint160 sqrtPriceX96After, uint32 initializedTicksCrossed, uint256 gasEstimate)
+func (_UniQuoterV2 *UniQuoterV2TransactorSession) QuoteExactOutputSingle(params IQuoterV2QuoteExactOutputSingleParams) (*types.Transaction, error) {
+	return _UniQuoterV2.Contract.QuoteExactOutputSingle(&_UniQuoterV2.TransactOpts, params)
+}

--- a/lib/uniswap/uniswaprouter02.json
+++ b/lib/uniswap/uniswaprouter02.json
@@ -1,0 +1,464 @@
+[
+  {
+    "inputs": [
+      { "internalType": "address", "name": "_factoryV2", "type": "address" },
+      { "internalType": "address", "name": "factoryV3", "type": "address" },
+      { "internalType": "address", "name": "_positionManager", "type": "address" },
+      { "internalType": "address", "name": "_WETH9", "type": "address" }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "constructor"
+  },
+  {
+    "inputs": [],
+    "name": "WETH9",
+    "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "address", "name": "token", "type": "address" }],
+    "name": "approveMax",
+    "outputs": [],
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "address", "name": "token", "type": "address" }],
+    "name": "approveMaxMinusOne",
+    "outputs": [],
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "address", "name": "token", "type": "address" }],
+    "name": "approveZeroThenMax",
+    "outputs": [],
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "address", "name": "token", "type": "address" }],
+    "name": "approveZeroThenMaxMinusOne",
+    "outputs": [],
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "bytes", "name": "data", "type": "bytes" }],
+    "name": "callPositionManager",
+    "outputs": [{ "internalType": "bytes", "name": "result", "type": "bytes" }],
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "bytes[]", "name": "paths", "type": "bytes[]" },
+      { "internalType": "uint128[]", "name": "amounts", "type": "uint128[]" },
+      { "internalType": "uint24", "name": "maximumTickDivergence", "type": "uint24" },
+      { "internalType": "uint32", "name": "secondsAgo", "type": "uint32" }
+    ],
+    "name": "checkOracleSlippage",
+    "outputs": [],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "bytes", "name": "path", "type": "bytes" },
+      { "internalType": "uint24", "name": "maximumTickDivergence", "type": "uint24" },
+      { "internalType": "uint32", "name": "secondsAgo", "type": "uint32" }
+    ],
+    "name": "checkOracleSlippage",
+    "outputs": [],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "components": [
+          { "internalType": "bytes", "name": "path", "type": "bytes" },
+          { "internalType": "address", "name": "recipient", "type": "address" },
+          { "internalType": "uint256", "name": "amountIn", "type": "uint256" },
+          { "internalType": "uint256", "name": "amountOutMinimum", "type": "uint256" }
+        ],
+        "internalType": "struct IV3SwapRouter.ExactInputParams",
+        "name": "params",
+        "type": "tuple"
+      }
+    ],
+    "name": "exactInput",
+    "outputs": [{ "internalType": "uint256", "name": "amountOut", "type": "uint256" }],
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "components": [
+          { "internalType": "address", "name": "tokenIn", "type": "address" },
+          { "internalType": "address", "name": "tokenOut", "type": "address" },
+          { "internalType": "uint24", "name": "fee", "type": "uint24" },
+          { "internalType": "address", "name": "recipient", "type": "address" },
+          { "internalType": "uint256", "name": "amountIn", "type": "uint256" },
+          { "internalType": "uint256", "name": "amountOutMinimum", "type": "uint256" },
+          { "internalType": "uint160", "name": "sqrtPriceLimitX96", "type": "uint160" }
+        ],
+        "internalType": "struct IV3SwapRouter.ExactInputSingleParams",
+        "name": "params",
+        "type": "tuple"
+      }
+    ],
+    "name": "exactInputSingle",
+    "outputs": [{ "internalType": "uint256", "name": "amountOut", "type": "uint256" }],
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "components": [
+          { "internalType": "bytes", "name": "path", "type": "bytes" },
+          { "internalType": "address", "name": "recipient", "type": "address" },
+          { "internalType": "uint256", "name": "amountOut", "type": "uint256" },
+          { "internalType": "uint256", "name": "amountInMaximum", "type": "uint256" }
+        ],
+        "internalType": "struct IV3SwapRouter.ExactOutputParams",
+        "name": "params",
+        "type": "tuple"
+      }
+    ],
+    "name": "exactOutput",
+    "outputs": [{ "internalType": "uint256", "name": "amountIn", "type": "uint256" }],
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "components": [
+          { "internalType": "address", "name": "tokenIn", "type": "address" },
+          { "internalType": "address", "name": "tokenOut", "type": "address" },
+          { "internalType": "uint24", "name": "fee", "type": "uint24" },
+          { "internalType": "address", "name": "recipient", "type": "address" },
+          { "internalType": "uint256", "name": "amountOut", "type": "uint256" },
+          { "internalType": "uint256", "name": "amountInMaximum", "type": "uint256" },
+          { "internalType": "uint160", "name": "sqrtPriceLimitX96", "type": "uint160" }
+        ],
+        "internalType": "struct IV3SwapRouter.ExactOutputSingleParams",
+        "name": "params",
+        "type": "tuple"
+      }
+    ],
+    "name": "exactOutputSingle",
+    "outputs": [{ "internalType": "uint256", "name": "amountIn", "type": "uint256" }],
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "factory",
+    "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "factoryV2",
+    "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "token", "type": "address" },
+      { "internalType": "uint256", "name": "amount", "type": "uint256" }
+    ],
+    "name": "getApprovalType",
+    "outputs": [
+      { "internalType": "enum IApproveAndCall.ApprovalType", "name": "", "type": "uint8" }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "components": [
+          { "internalType": "address", "name": "token0", "type": "address" },
+          { "internalType": "address", "name": "token1", "type": "address" },
+          { "internalType": "uint256", "name": "tokenId", "type": "uint256" },
+          { "internalType": "uint256", "name": "amount0Min", "type": "uint256" },
+          { "internalType": "uint256", "name": "amount1Min", "type": "uint256" }
+        ],
+        "internalType": "struct IApproveAndCall.IncreaseLiquidityParams",
+        "name": "params",
+        "type": "tuple"
+      }
+    ],
+    "name": "increaseLiquidity",
+    "outputs": [{ "internalType": "bytes", "name": "result", "type": "bytes" }],
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "components": [
+          { "internalType": "address", "name": "token0", "type": "address" },
+          { "internalType": "address", "name": "token1", "type": "address" },
+          { "internalType": "uint24", "name": "fee", "type": "uint24" },
+          { "internalType": "int24", "name": "tickLower", "type": "int24" },
+          { "internalType": "int24", "name": "tickUpper", "type": "int24" },
+          { "internalType": "uint256", "name": "amount0Min", "type": "uint256" },
+          { "internalType": "uint256", "name": "amount1Min", "type": "uint256" },
+          { "internalType": "address", "name": "recipient", "type": "address" }
+        ],
+        "internalType": "struct IApproveAndCall.MintParams",
+        "name": "params",
+        "type": "tuple"
+      }
+    ],
+    "name": "mint",
+    "outputs": [{ "internalType": "bytes", "name": "result", "type": "bytes" }],
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "bytes32", "name": "previousBlockhash", "type": "bytes32" },
+      { "internalType": "bytes[]", "name": "data", "type": "bytes[]" }
+    ],
+    "name": "multicall",
+    "outputs": [{ "internalType": "bytes[]", "name": "", "type": "bytes[]" }],
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "uint256", "name": "deadline", "type": "uint256" },
+      { "internalType": "bytes[]", "name": "data", "type": "bytes[]" }
+    ],
+    "name": "multicall",
+    "outputs": [{ "internalType": "bytes[]", "name": "", "type": "bytes[]" }],
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "bytes[]", "name": "data", "type": "bytes[]" }],
+    "name": "multicall",
+    "outputs": [{ "internalType": "bytes[]", "name": "results", "type": "bytes[]" }],
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "positionManager",
+    "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "token", "type": "address" },
+      { "internalType": "uint256", "name": "value", "type": "uint256" }
+    ],
+    "name": "pull",
+    "outputs": [],
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "refundETH",
+    "outputs": [],
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "token", "type": "address" },
+      { "internalType": "uint256", "name": "value", "type": "uint256" },
+      { "internalType": "uint256", "name": "deadline", "type": "uint256" },
+      { "internalType": "uint8", "name": "v", "type": "uint8" },
+      { "internalType": "bytes32", "name": "r", "type": "bytes32" },
+      { "internalType": "bytes32", "name": "s", "type": "bytes32" }
+    ],
+    "name": "selfPermit",
+    "outputs": [],
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "token", "type": "address" },
+      { "internalType": "uint256", "name": "nonce", "type": "uint256" },
+      { "internalType": "uint256", "name": "expiry", "type": "uint256" },
+      { "internalType": "uint8", "name": "v", "type": "uint8" },
+      { "internalType": "bytes32", "name": "r", "type": "bytes32" },
+      { "internalType": "bytes32", "name": "s", "type": "bytes32" }
+    ],
+    "name": "selfPermitAllowed",
+    "outputs": [],
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "token", "type": "address" },
+      { "internalType": "uint256", "name": "nonce", "type": "uint256" },
+      { "internalType": "uint256", "name": "expiry", "type": "uint256" },
+      { "internalType": "uint8", "name": "v", "type": "uint8" },
+      { "internalType": "bytes32", "name": "r", "type": "bytes32" },
+      { "internalType": "bytes32", "name": "s", "type": "bytes32" }
+    ],
+    "name": "selfPermitAllowedIfNecessary",
+    "outputs": [],
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "token", "type": "address" },
+      { "internalType": "uint256", "name": "value", "type": "uint256" },
+      { "internalType": "uint256", "name": "deadline", "type": "uint256" },
+      { "internalType": "uint8", "name": "v", "type": "uint8" },
+      { "internalType": "bytes32", "name": "r", "type": "bytes32" },
+      { "internalType": "bytes32", "name": "s", "type": "bytes32" }
+    ],
+    "name": "selfPermitIfNecessary",
+    "outputs": [],
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "uint256", "name": "amountIn", "type": "uint256" },
+      { "internalType": "uint256", "name": "amountOutMin", "type": "uint256" },
+      { "internalType": "address[]", "name": "path", "type": "address[]" },
+      { "internalType": "address", "name": "to", "type": "address" }
+    ],
+    "name": "swapExactTokensForTokens",
+    "outputs": [{ "internalType": "uint256", "name": "amountOut", "type": "uint256" }],
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "uint256", "name": "amountOut", "type": "uint256" },
+      { "internalType": "uint256", "name": "amountInMax", "type": "uint256" },
+      { "internalType": "address[]", "name": "path", "type": "address[]" },
+      { "internalType": "address", "name": "to", "type": "address" }
+    ],
+    "name": "swapTokensForExactTokens",
+    "outputs": [{ "internalType": "uint256", "name": "amountIn", "type": "uint256" }],
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "token", "type": "address" },
+      { "internalType": "uint256", "name": "amountMinimum", "type": "uint256" },
+      { "internalType": "address", "name": "recipient", "type": "address" }
+    ],
+    "name": "sweepToken",
+    "outputs": [],
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "token", "type": "address" },
+      { "internalType": "uint256", "name": "amountMinimum", "type": "uint256" }
+    ],
+    "name": "sweepToken",
+    "outputs": [],
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "token", "type": "address" },
+      { "internalType": "uint256", "name": "amountMinimum", "type": "uint256" },
+      { "internalType": "uint256", "name": "feeBips", "type": "uint256" },
+      { "internalType": "address", "name": "feeRecipient", "type": "address" }
+    ],
+    "name": "sweepTokenWithFee",
+    "outputs": [],
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "token", "type": "address" },
+      { "internalType": "uint256", "name": "amountMinimum", "type": "uint256" },
+      { "internalType": "address", "name": "recipient", "type": "address" },
+      { "internalType": "uint256", "name": "feeBips", "type": "uint256" },
+      { "internalType": "address", "name": "feeRecipient", "type": "address" }
+    ],
+    "name": "sweepTokenWithFee",
+    "outputs": [],
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "int256", "name": "amount0Delta", "type": "int256" },
+      { "internalType": "int256", "name": "amount1Delta", "type": "int256" },
+      { "internalType": "bytes", "name": "_data", "type": "bytes" }
+    ],
+    "name": "uniswapV3SwapCallback",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "uint256", "name": "amountMinimum", "type": "uint256" },
+      { "internalType": "address", "name": "recipient", "type": "address" }
+    ],
+    "name": "unwrapWETH9",
+    "outputs": [],
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "uint256", "name": "amountMinimum", "type": "uint256" }],
+    "name": "unwrapWETH9",
+    "outputs": [],
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "uint256", "name": "amountMinimum", "type": "uint256" },
+      { "internalType": "address", "name": "recipient", "type": "address" },
+      { "internalType": "uint256", "name": "feeBips", "type": "uint256" },
+      { "internalType": "address", "name": "feeRecipient", "type": "address" }
+    ],
+    "name": "unwrapWETH9WithFee",
+    "outputs": [],
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "uint256", "name": "amountMinimum", "type": "uint256" },
+      { "internalType": "uint256", "name": "feeBips", "type": "uint256" },
+      { "internalType": "address", "name": "feeRecipient", "type": "address" }
+    ],
+    "name": "unwrapWETH9WithFee",
+    "outputs": [],
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "uint256", "name": "value", "type": "uint256" }],
+    "name": "wrapETH",
+    "outputs": [],
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  { "stateMutability": "payable", "type": "receive" }
+]

--- a/lib/uniswap/uniswaprouter02_bindings.go
+++ b/lib/uniswap/uniswaprouter02_bindings.go
@@ -1,0 +1,1136 @@
+// Code generated - DO NOT EDIT.
+// This file is a generated binding and any manual changes will be lost.
+
+package uniswap
+
+import (
+	"errors"
+	"math/big"
+	"strings"
+
+	ethereum "github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/event"
+)
+
+// Reference imports to suppress errors if they are not otherwise used.
+var (
+	_ = errors.New
+	_ = big.NewInt
+	_ = strings.NewReader
+	_ = ethereum.NotFound
+	_ = bind.Bind
+	_ = common.Big1
+	_ = types.BloomLookup
+	_ = event.NewSubscription
+	_ = abi.ConvertType
+)
+
+// IApproveAndCallIncreaseLiquidityParams is an auto generated low-level Go binding around an user-defined struct.
+type IApproveAndCallIncreaseLiquidityParams struct {
+	Token0     common.Address
+	Token1     common.Address
+	TokenId    *big.Int
+	Amount0Min *big.Int
+	Amount1Min *big.Int
+}
+
+// IApproveAndCallMintParams is an auto generated low-level Go binding around an user-defined struct.
+type IApproveAndCallMintParams struct {
+	Token0     common.Address
+	Token1     common.Address
+	Fee        *big.Int
+	TickLower  *big.Int
+	TickUpper  *big.Int
+	Amount0Min *big.Int
+	Amount1Min *big.Int
+	Recipient  common.Address
+}
+
+// IV3SwapRouterExactInputParams is an auto generated low-level Go binding around an user-defined struct.
+type IV3SwapRouterExactInputParams struct {
+	Path             []byte
+	Recipient        common.Address
+	AmountIn         *big.Int
+	AmountOutMinimum *big.Int
+}
+
+// IV3SwapRouterExactInputSingleParams is an auto generated low-level Go binding around an user-defined struct.
+type IV3SwapRouterExactInputSingleParams struct {
+	TokenIn           common.Address
+	TokenOut          common.Address
+	Fee               *big.Int
+	Recipient         common.Address
+	AmountIn          *big.Int
+	AmountOutMinimum  *big.Int
+	SqrtPriceLimitX96 *big.Int
+}
+
+// IV3SwapRouterExactOutputParams is an auto generated low-level Go binding around an user-defined struct.
+type IV3SwapRouterExactOutputParams struct {
+	Path            []byte
+	Recipient       common.Address
+	AmountOut       *big.Int
+	AmountInMaximum *big.Int
+}
+
+// IV3SwapRouterExactOutputSingleParams is an auto generated low-level Go binding around an user-defined struct.
+type IV3SwapRouterExactOutputSingleParams struct {
+	TokenIn           common.Address
+	TokenOut          common.Address
+	Fee               *big.Int
+	Recipient         common.Address
+	AmountOut         *big.Int
+	AmountInMaximum   *big.Int
+	SqrtPriceLimitX96 *big.Int
+}
+
+// UniSwapRouter02MetaData contains all meta data concerning the UniSwapRouter02 contract.
+var UniSwapRouter02MetaData = &bind.MetaData{
+	ABI: "[{\"inputs\":[{\"internalType\":\"address\",\"name\":\"_factoryV2\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"factoryV3\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"_positionManager\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"_WETH9\",\"type\":\"address\"}],\"stateMutability\":\"nonpayable\",\"type\":\"constructor\"},{\"inputs\":[],\"name\":\"WETH9\",\"outputs\":[{\"internalType\":\"address\",\"name\":\"\",\"type\":\"address\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"token\",\"type\":\"address\"}],\"name\":\"approveMax\",\"outputs\":[],\"stateMutability\":\"payable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"token\",\"type\":\"address\"}],\"name\":\"approveMaxMinusOne\",\"outputs\":[],\"stateMutability\":\"payable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"token\",\"type\":\"address\"}],\"name\":\"approveZeroThenMax\",\"outputs\":[],\"stateMutability\":\"payable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"token\",\"type\":\"address\"}],\"name\":\"approveZeroThenMaxMinusOne\",\"outputs\":[],\"stateMutability\":\"payable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"bytes\",\"name\":\"data\",\"type\":\"bytes\"}],\"name\":\"callPositionManager\",\"outputs\":[{\"internalType\":\"bytes\",\"name\":\"result\",\"type\":\"bytes\"}],\"stateMutability\":\"payable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"bytes[]\",\"name\":\"paths\",\"type\":\"bytes[]\"},{\"internalType\":\"uint128[]\",\"name\":\"amounts\",\"type\":\"uint128[]\"},{\"internalType\":\"uint24\",\"name\":\"maximumTickDivergence\",\"type\":\"uint24\"},{\"internalType\":\"uint32\",\"name\":\"secondsAgo\",\"type\":\"uint32\"}],\"name\":\"checkOracleSlippage\",\"outputs\":[],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"bytes\",\"name\":\"path\",\"type\":\"bytes\"},{\"internalType\":\"uint24\",\"name\":\"maximumTickDivergence\",\"type\":\"uint24\"},{\"internalType\":\"uint32\",\"name\":\"secondsAgo\",\"type\":\"uint32\"}],\"name\":\"checkOracleSlippage\",\"outputs\":[],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"components\":[{\"internalType\":\"bytes\",\"name\":\"path\",\"type\":\"bytes\"},{\"internalType\":\"address\",\"name\":\"recipient\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"amountIn\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"amountOutMinimum\",\"type\":\"uint256\"}],\"internalType\":\"structIV3SwapRouter.ExactInputParams\",\"name\":\"params\",\"type\":\"tuple\"}],\"name\":\"exactInput\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"amountOut\",\"type\":\"uint256\"}],\"stateMutability\":\"payable\",\"type\":\"function\"},{\"inputs\":[{\"components\":[{\"internalType\":\"address\",\"name\":\"tokenIn\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"tokenOut\",\"type\":\"address\"},{\"internalType\":\"uint24\",\"name\":\"fee\",\"type\":\"uint24\"},{\"internalType\":\"address\",\"name\":\"recipient\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"amountIn\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"amountOutMinimum\",\"type\":\"uint256\"},{\"internalType\":\"uint160\",\"name\":\"sqrtPriceLimitX96\",\"type\":\"uint160\"}],\"internalType\":\"structIV3SwapRouter.ExactInputSingleParams\",\"name\":\"params\",\"type\":\"tuple\"}],\"name\":\"exactInputSingle\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"amountOut\",\"type\":\"uint256\"}],\"stateMutability\":\"payable\",\"type\":\"function\"},{\"inputs\":[{\"components\":[{\"internalType\":\"bytes\",\"name\":\"path\",\"type\":\"bytes\"},{\"internalType\":\"address\",\"name\":\"recipient\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"amountOut\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"amountInMaximum\",\"type\":\"uint256\"}],\"internalType\":\"structIV3SwapRouter.ExactOutputParams\",\"name\":\"params\",\"type\":\"tuple\"}],\"name\":\"exactOutput\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"amountIn\",\"type\":\"uint256\"}],\"stateMutability\":\"payable\",\"type\":\"function\"},{\"inputs\":[{\"components\":[{\"internalType\":\"address\",\"name\":\"tokenIn\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"tokenOut\",\"type\":\"address\"},{\"internalType\":\"uint24\",\"name\":\"fee\",\"type\":\"uint24\"},{\"internalType\":\"address\",\"name\":\"recipient\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"amountOut\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"amountInMaximum\",\"type\":\"uint256\"},{\"internalType\":\"uint160\",\"name\":\"sqrtPriceLimitX96\",\"type\":\"uint160\"}],\"internalType\":\"structIV3SwapRouter.ExactOutputSingleParams\",\"name\":\"params\",\"type\":\"tuple\"}],\"name\":\"exactOutputSingle\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"amountIn\",\"type\":\"uint256\"}],\"stateMutability\":\"payable\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"factory\",\"outputs\":[{\"internalType\":\"address\",\"name\":\"\",\"type\":\"address\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"factoryV2\",\"outputs\":[{\"internalType\":\"address\",\"name\":\"\",\"type\":\"address\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"token\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"amount\",\"type\":\"uint256\"}],\"name\":\"getApprovalType\",\"outputs\":[{\"internalType\":\"enumIApproveAndCall.ApprovalType\",\"name\":\"\",\"type\":\"uint8\"}],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"components\":[{\"internalType\":\"address\",\"name\":\"token0\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"token1\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"tokenId\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"amount0Min\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"amount1Min\",\"type\":\"uint256\"}],\"internalType\":\"structIApproveAndCall.IncreaseLiquidityParams\",\"name\":\"params\",\"type\":\"tuple\"}],\"name\":\"increaseLiquidity\",\"outputs\":[{\"internalType\":\"bytes\",\"name\":\"result\",\"type\":\"bytes\"}],\"stateMutability\":\"payable\",\"type\":\"function\"},{\"inputs\":[{\"components\":[{\"internalType\":\"address\",\"name\":\"token0\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"token1\",\"type\":\"address\"},{\"internalType\":\"uint24\",\"name\":\"fee\",\"type\":\"uint24\"},{\"internalType\":\"int24\",\"name\":\"tickLower\",\"type\":\"int24\"},{\"internalType\":\"int24\",\"name\":\"tickUpper\",\"type\":\"int24\"},{\"internalType\":\"uint256\",\"name\":\"amount0Min\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"amount1Min\",\"type\":\"uint256\"},{\"internalType\":\"address\",\"name\":\"recipient\",\"type\":\"address\"}],\"internalType\":\"structIApproveAndCall.MintParams\",\"name\":\"params\",\"type\":\"tuple\"}],\"name\":\"mint\",\"outputs\":[{\"internalType\":\"bytes\",\"name\":\"result\",\"type\":\"bytes\"}],\"stateMutability\":\"payable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"bytes32\",\"name\":\"previousBlockhash\",\"type\":\"bytes32\"},{\"internalType\":\"bytes[]\",\"name\":\"data\",\"type\":\"bytes[]\"}],\"name\":\"multicall\",\"outputs\":[{\"internalType\":\"bytes[]\",\"name\":\"\",\"type\":\"bytes[]\"}],\"stateMutability\":\"payable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"deadline\",\"type\":\"uint256\"},{\"internalType\":\"bytes[]\",\"name\":\"data\",\"type\":\"bytes[]\"}],\"name\":\"multicall\",\"outputs\":[{\"internalType\":\"bytes[]\",\"name\":\"\",\"type\":\"bytes[]\"}],\"stateMutability\":\"payable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"bytes[]\",\"name\":\"data\",\"type\":\"bytes[]\"}],\"name\":\"multicall\",\"outputs\":[{\"internalType\":\"bytes[]\",\"name\":\"results\",\"type\":\"bytes[]\"}],\"stateMutability\":\"payable\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"positionManager\",\"outputs\":[{\"internalType\":\"address\",\"name\":\"\",\"type\":\"address\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"token\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"value\",\"type\":\"uint256\"}],\"name\":\"pull\",\"outputs\":[],\"stateMutability\":\"payable\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"refundETH\",\"outputs\":[],\"stateMutability\":\"payable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"token\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"value\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"deadline\",\"type\":\"uint256\"},{\"internalType\":\"uint8\",\"name\":\"v\",\"type\":\"uint8\"},{\"internalType\":\"bytes32\",\"name\":\"r\",\"type\":\"bytes32\"},{\"internalType\":\"bytes32\",\"name\":\"s\",\"type\":\"bytes32\"}],\"name\":\"selfPermit\",\"outputs\":[],\"stateMutability\":\"payable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"token\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"nonce\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"expiry\",\"type\":\"uint256\"},{\"internalType\":\"uint8\",\"name\":\"v\",\"type\":\"uint8\"},{\"internalType\":\"bytes32\",\"name\":\"r\",\"type\":\"bytes32\"},{\"internalType\":\"bytes32\",\"name\":\"s\",\"type\":\"bytes32\"}],\"name\":\"selfPermitAllowed\",\"outputs\":[],\"stateMutability\":\"payable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"token\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"nonce\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"expiry\",\"type\":\"uint256\"},{\"internalType\":\"uint8\",\"name\":\"v\",\"type\":\"uint8\"},{\"internalType\":\"bytes32\",\"name\":\"r\",\"type\":\"bytes32\"},{\"internalType\":\"bytes32\",\"name\":\"s\",\"type\":\"bytes32\"}],\"name\":\"selfPermitAllowedIfNecessary\",\"outputs\":[],\"stateMutability\":\"payable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"token\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"value\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"deadline\",\"type\":\"uint256\"},{\"internalType\":\"uint8\",\"name\":\"v\",\"type\":\"uint8\"},{\"internalType\":\"bytes32\",\"name\":\"r\",\"type\":\"bytes32\"},{\"internalType\":\"bytes32\",\"name\":\"s\",\"type\":\"bytes32\"}],\"name\":\"selfPermitIfNecessary\",\"outputs\":[],\"stateMutability\":\"payable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"amountIn\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"amountOutMin\",\"type\":\"uint256\"},{\"internalType\":\"address[]\",\"name\":\"path\",\"type\":\"address[]\"},{\"internalType\":\"address\",\"name\":\"to\",\"type\":\"address\"}],\"name\":\"swapExactTokensForTokens\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"amountOut\",\"type\":\"uint256\"}],\"stateMutability\":\"payable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"amountOut\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"amountInMax\",\"type\":\"uint256\"},{\"internalType\":\"address[]\",\"name\":\"path\",\"type\":\"address[]\"},{\"internalType\":\"address\",\"name\":\"to\",\"type\":\"address\"}],\"name\":\"swapTokensForExactTokens\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"amountIn\",\"type\":\"uint256\"}],\"stateMutability\":\"payable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"token\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"amountMinimum\",\"type\":\"uint256\"},{\"internalType\":\"address\",\"name\":\"recipient\",\"type\":\"address\"}],\"name\":\"sweepToken\",\"outputs\":[],\"stateMutability\":\"payable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"token\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"amountMinimum\",\"type\":\"uint256\"}],\"name\":\"sweepToken\",\"outputs\":[],\"stateMutability\":\"payable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"token\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"amountMinimum\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"feeBips\",\"type\":\"uint256\"},{\"internalType\":\"address\",\"name\":\"feeRecipient\",\"type\":\"address\"}],\"name\":\"sweepTokenWithFee\",\"outputs\":[],\"stateMutability\":\"payable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"token\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"amountMinimum\",\"type\":\"uint256\"},{\"internalType\":\"address\",\"name\":\"recipient\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"feeBips\",\"type\":\"uint256\"},{\"internalType\":\"address\",\"name\":\"feeRecipient\",\"type\":\"address\"}],\"name\":\"sweepTokenWithFee\",\"outputs\":[],\"stateMutability\":\"payable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"int256\",\"name\":\"amount0Delta\",\"type\":\"int256\"},{\"internalType\":\"int256\",\"name\":\"amount1Delta\",\"type\":\"int256\"},{\"internalType\":\"bytes\",\"name\":\"_data\",\"type\":\"bytes\"}],\"name\":\"uniswapV3SwapCallback\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"amountMinimum\",\"type\":\"uint256\"},{\"internalType\":\"address\",\"name\":\"recipient\",\"type\":\"address\"}],\"name\":\"unwrapWETH9\",\"outputs\":[],\"stateMutability\":\"payable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"amountMinimum\",\"type\":\"uint256\"}],\"name\":\"unwrapWETH9\",\"outputs\":[],\"stateMutability\":\"payable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"amountMinimum\",\"type\":\"uint256\"},{\"internalType\":\"address\",\"name\":\"recipient\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"feeBips\",\"type\":\"uint256\"},{\"internalType\":\"address\",\"name\":\"feeRecipient\",\"type\":\"address\"}],\"name\":\"unwrapWETH9WithFee\",\"outputs\":[],\"stateMutability\":\"payable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"amountMinimum\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"feeBips\",\"type\":\"uint256\"},{\"internalType\":\"address\",\"name\":\"feeRecipient\",\"type\":\"address\"}],\"name\":\"unwrapWETH9WithFee\",\"outputs\":[],\"stateMutability\":\"payable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"value\",\"type\":\"uint256\"}],\"name\":\"wrapETH\",\"outputs\":[],\"stateMutability\":\"payable\",\"type\":\"function\"},{\"stateMutability\":\"payable\",\"type\":\"receive\"}]",
+}
+
+// UniSwapRouter02ABI is the input ABI used to generate the binding from.
+// Deprecated: Use UniSwapRouter02MetaData.ABI instead.
+var UniSwapRouter02ABI = UniSwapRouter02MetaData.ABI
+
+// UniSwapRouter02 is an auto generated Go binding around an Ethereum contract.
+type UniSwapRouter02 struct {
+	UniSwapRouter02Caller     // Read-only binding to the contract
+	UniSwapRouter02Transactor // Write-only binding to the contract
+	UniSwapRouter02Filterer   // Log filterer for contract events
+}
+
+// UniSwapRouter02Caller is an auto generated read-only Go binding around an Ethereum contract.
+type UniSwapRouter02Caller struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// UniSwapRouter02Transactor is an auto generated write-only Go binding around an Ethereum contract.
+type UniSwapRouter02Transactor struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// UniSwapRouter02Filterer is an auto generated log filtering Go binding around an Ethereum contract events.
+type UniSwapRouter02Filterer struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// UniSwapRouter02Session is an auto generated Go binding around an Ethereum contract,
+// with pre-set call and transact options.
+type UniSwapRouter02Session struct {
+	Contract     *UniSwapRouter02  // Generic contract binding to set the session for
+	CallOpts     bind.CallOpts     // Call options to use throughout this session
+	TransactOpts bind.TransactOpts // Transaction auth options to use throughout this session
+}
+
+// UniSwapRouter02CallerSession is an auto generated read-only Go binding around an Ethereum contract,
+// with pre-set call options.
+type UniSwapRouter02CallerSession struct {
+	Contract *UniSwapRouter02Caller // Generic contract caller binding to set the session for
+	CallOpts bind.CallOpts          // Call options to use throughout this session
+}
+
+// UniSwapRouter02TransactorSession is an auto generated write-only Go binding around an Ethereum contract,
+// with pre-set transact options.
+type UniSwapRouter02TransactorSession struct {
+	Contract     *UniSwapRouter02Transactor // Generic contract transactor binding to set the session for
+	TransactOpts bind.TransactOpts          // Transaction auth options to use throughout this session
+}
+
+// UniSwapRouter02Raw is an auto generated low-level Go binding around an Ethereum contract.
+type UniSwapRouter02Raw struct {
+	Contract *UniSwapRouter02 // Generic contract binding to access the raw methods on
+}
+
+// UniSwapRouter02CallerRaw is an auto generated low-level read-only Go binding around an Ethereum contract.
+type UniSwapRouter02CallerRaw struct {
+	Contract *UniSwapRouter02Caller // Generic read-only contract binding to access the raw methods on
+}
+
+// UniSwapRouter02TransactorRaw is an auto generated low-level write-only Go binding around an Ethereum contract.
+type UniSwapRouter02TransactorRaw struct {
+	Contract *UniSwapRouter02Transactor // Generic write-only contract binding to access the raw methods on
+}
+
+// NewUniSwapRouter02 creates a new instance of UniSwapRouter02, bound to a specific deployed contract.
+func NewUniSwapRouter02(address common.Address, backend bind.ContractBackend) (*UniSwapRouter02, error) {
+	contract, err := bindUniSwapRouter02(address, backend, backend, backend)
+	if err != nil {
+		return nil, err
+	}
+	return &UniSwapRouter02{UniSwapRouter02Caller: UniSwapRouter02Caller{contract: contract}, UniSwapRouter02Transactor: UniSwapRouter02Transactor{contract: contract}, UniSwapRouter02Filterer: UniSwapRouter02Filterer{contract: contract}}, nil
+}
+
+// NewUniSwapRouter02Caller creates a new read-only instance of UniSwapRouter02, bound to a specific deployed contract.
+func NewUniSwapRouter02Caller(address common.Address, caller bind.ContractCaller) (*UniSwapRouter02Caller, error) {
+	contract, err := bindUniSwapRouter02(address, caller, nil, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &UniSwapRouter02Caller{contract: contract}, nil
+}
+
+// NewUniSwapRouter02Transactor creates a new write-only instance of UniSwapRouter02, bound to a specific deployed contract.
+func NewUniSwapRouter02Transactor(address common.Address, transactor bind.ContractTransactor) (*UniSwapRouter02Transactor, error) {
+	contract, err := bindUniSwapRouter02(address, nil, transactor, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &UniSwapRouter02Transactor{contract: contract}, nil
+}
+
+// NewUniSwapRouter02Filterer creates a new log filterer instance of UniSwapRouter02, bound to a specific deployed contract.
+func NewUniSwapRouter02Filterer(address common.Address, filterer bind.ContractFilterer) (*UniSwapRouter02Filterer, error) {
+	contract, err := bindUniSwapRouter02(address, nil, nil, filterer)
+	if err != nil {
+		return nil, err
+	}
+	return &UniSwapRouter02Filterer{contract: contract}, nil
+}
+
+// bindUniSwapRouter02 binds a generic wrapper to an already deployed contract.
+func bindUniSwapRouter02(address common.Address, caller bind.ContractCaller, transactor bind.ContractTransactor, filterer bind.ContractFilterer) (*bind.BoundContract, error) {
+	parsed, err := UniSwapRouter02MetaData.GetAbi()
+	if err != nil {
+		return nil, err
+	}
+	return bind.NewBoundContract(address, *parsed, caller, transactor, filterer), nil
+}
+
+// Call invokes the (constant) contract method with params as input values and
+// sets the output to result. The result type might be a single field for simple
+// returns, a slice of interfaces for anonymous returns and a struct for named
+// returns.
+func (_UniSwapRouter02 *UniSwapRouter02Raw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
+	return _UniSwapRouter02.Contract.UniSwapRouter02Caller.contract.Call(opts, result, method, params...)
+}
+
+// Transfer initiates a plain transaction to move funds to the contract, calling
+// its default method if one is available.
+func (_UniSwapRouter02 *UniSwapRouter02Raw) Transfer(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _UniSwapRouter02.Contract.UniSwapRouter02Transactor.contract.Transfer(opts)
+}
+
+// Transact invokes the (paid) contract method with params as input values.
+func (_UniSwapRouter02 *UniSwapRouter02Raw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (*types.Transaction, error) {
+	return _UniSwapRouter02.Contract.UniSwapRouter02Transactor.contract.Transact(opts, method, params...)
+}
+
+// Call invokes the (constant) contract method with params as input values and
+// sets the output to result. The result type might be a single field for simple
+// returns, a slice of interfaces for anonymous returns and a struct for named
+// returns.
+func (_UniSwapRouter02 *UniSwapRouter02CallerRaw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
+	return _UniSwapRouter02.Contract.contract.Call(opts, result, method, params...)
+}
+
+// Transfer initiates a plain transaction to move funds to the contract, calling
+// its default method if one is available.
+func (_UniSwapRouter02 *UniSwapRouter02TransactorRaw) Transfer(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _UniSwapRouter02.Contract.contract.Transfer(opts)
+}
+
+// Transact invokes the (paid) contract method with params as input values.
+func (_UniSwapRouter02 *UniSwapRouter02TransactorRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (*types.Transaction, error) {
+	return _UniSwapRouter02.Contract.contract.Transact(opts, method, params...)
+}
+
+// WETH9 is a free data retrieval call binding the contract method 0x4aa4a4fc.
+//
+// Solidity: function WETH9() view returns(address)
+func (_UniSwapRouter02 *UniSwapRouter02Caller) WETH9(opts *bind.CallOpts) (common.Address, error) {
+	var out []interface{}
+	err := _UniSwapRouter02.contract.Call(opts, &out, "WETH9")
+
+	if err != nil {
+		return *new(common.Address), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(common.Address)).(*common.Address)
+
+	return out0, err
+
+}
+
+// WETH9 is a free data retrieval call binding the contract method 0x4aa4a4fc.
+//
+// Solidity: function WETH9() view returns(address)
+func (_UniSwapRouter02 *UniSwapRouter02Session) WETH9() (common.Address, error) {
+	return _UniSwapRouter02.Contract.WETH9(&_UniSwapRouter02.CallOpts)
+}
+
+// WETH9 is a free data retrieval call binding the contract method 0x4aa4a4fc.
+//
+// Solidity: function WETH9() view returns(address)
+func (_UniSwapRouter02 *UniSwapRouter02CallerSession) WETH9() (common.Address, error) {
+	return _UniSwapRouter02.Contract.WETH9(&_UniSwapRouter02.CallOpts)
+}
+
+// CheckOracleSlippage is a free data retrieval call binding the contract method 0xefdeed8e.
+//
+// Solidity: function checkOracleSlippage(bytes[] paths, uint128[] amounts, uint24 maximumTickDivergence, uint32 secondsAgo) view returns()
+func (_UniSwapRouter02 *UniSwapRouter02Caller) CheckOracleSlippage(opts *bind.CallOpts, paths [][]byte, amounts []*big.Int, maximumTickDivergence *big.Int, secondsAgo uint32) error {
+	var out []interface{}
+	err := _UniSwapRouter02.contract.Call(opts, &out, "checkOracleSlippage", paths, amounts, maximumTickDivergence, secondsAgo)
+
+	if err != nil {
+		return err
+	}
+
+	return err
+
+}
+
+// CheckOracleSlippage is a free data retrieval call binding the contract method 0xefdeed8e.
+//
+// Solidity: function checkOracleSlippage(bytes[] paths, uint128[] amounts, uint24 maximumTickDivergence, uint32 secondsAgo) view returns()
+func (_UniSwapRouter02 *UniSwapRouter02Session) CheckOracleSlippage(paths [][]byte, amounts []*big.Int, maximumTickDivergence *big.Int, secondsAgo uint32) error {
+	return _UniSwapRouter02.Contract.CheckOracleSlippage(&_UniSwapRouter02.CallOpts, paths, amounts, maximumTickDivergence, secondsAgo)
+}
+
+// CheckOracleSlippage is a free data retrieval call binding the contract method 0xefdeed8e.
+//
+// Solidity: function checkOracleSlippage(bytes[] paths, uint128[] amounts, uint24 maximumTickDivergence, uint32 secondsAgo) view returns()
+func (_UniSwapRouter02 *UniSwapRouter02CallerSession) CheckOracleSlippage(paths [][]byte, amounts []*big.Int, maximumTickDivergence *big.Int, secondsAgo uint32) error {
+	return _UniSwapRouter02.Contract.CheckOracleSlippage(&_UniSwapRouter02.CallOpts, paths, amounts, maximumTickDivergence, secondsAgo)
+}
+
+// CheckOracleSlippage0 is a free data retrieval call binding the contract method 0xf25801a7.
+//
+// Solidity: function checkOracleSlippage(bytes path, uint24 maximumTickDivergence, uint32 secondsAgo) view returns()
+func (_UniSwapRouter02 *UniSwapRouter02Caller) CheckOracleSlippage0(opts *bind.CallOpts, path []byte, maximumTickDivergence *big.Int, secondsAgo uint32) error {
+	var out []interface{}
+	err := _UniSwapRouter02.contract.Call(opts, &out, "checkOracleSlippage0", path, maximumTickDivergence, secondsAgo)
+
+	if err != nil {
+		return err
+	}
+
+	return err
+
+}
+
+// CheckOracleSlippage0 is a free data retrieval call binding the contract method 0xf25801a7.
+//
+// Solidity: function checkOracleSlippage(bytes path, uint24 maximumTickDivergence, uint32 secondsAgo) view returns()
+func (_UniSwapRouter02 *UniSwapRouter02Session) CheckOracleSlippage0(path []byte, maximumTickDivergence *big.Int, secondsAgo uint32) error {
+	return _UniSwapRouter02.Contract.CheckOracleSlippage0(&_UniSwapRouter02.CallOpts, path, maximumTickDivergence, secondsAgo)
+}
+
+// CheckOracleSlippage0 is a free data retrieval call binding the contract method 0xf25801a7.
+//
+// Solidity: function checkOracleSlippage(bytes path, uint24 maximumTickDivergence, uint32 secondsAgo) view returns()
+func (_UniSwapRouter02 *UniSwapRouter02CallerSession) CheckOracleSlippage0(path []byte, maximumTickDivergence *big.Int, secondsAgo uint32) error {
+	return _UniSwapRouter02.Contract.CheckOracleSlippage0(&_UniSwapRouter02.CallOpts, path, maximumTickDivergence, secondsAgo)
+}
+
+// Factory is a free data retrieval call binding the contract method 0xc45a0155.
+//
+// Solidity: function factory() view returns(address)
+func (_UniSwapRouter02 *UniSwapRouter02Caller) Factory(opts *bind.CallOpts) (common.Address, error) {
+	var out []interface{}
+	err := _UniSwapRouter02.contract.Call(opts, &out, "factory")
+
+	if err != nil {
+		return *new(common.Address), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(common.Address)).(*common.Address)
+
+	return out0, err
+
+}
+
+// Factory is a free data retrieval call binding the contract method 0xc45a0155.
+//
+// Solidity: function factory() view returns(address)
+func (_UniSwapRouter02 *UniSwapRouter02Session) Factory() (common.Address, error) {
+	return _UniSwapRouter02.Contract.Factory(&_UniSwapRouter02.CallOpts)
+}
+
+// Factory is a free data retrieval call binding the contract method 0xc45a0155.
+//
+// Solidity: function factory() view returns(address)
+func (_UniSwapRouter02 *UniSwapRouter02CallerSession) Factory() (common.Address, error) {
+	return _UniSwapRouter02.Contract.Factory(&_UniSwapRouter02.CallOpts)
+}
+
+// FactoryV2 is a free data retrieval call binding the contract method 0x68e0d4e1.
+//
+// Solidity: function factoryV2() view returns(address)
+func (_UniSwapRouter02 *UniSwapRouter02Caller) FactoryV2(opts *bind.CallOpts) (common.Address, error) {
+	var out []interface{}
+	err := _UniSwapRouter02.contract.Call(opts, &out, "factoryV2")
+
+	if err != nil {
+		return *new(common.Address), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(common.Address)).(*common.Address)
+
+	return out0, err
+
+}
+
+// FactoryV2 is a free data retrieval call binding the contract method 0x68e0d4e1.
+//
+// Solidity: function factoryV2() view returns(address)
+func (_UniSwapRouter02 *UniSwapRouter02Session) FactoryV2() (common.Address, error) {
+	return _UniSwapRouter02.Contract.FactoryV2(&_UniSwapRouter02.CallOpts)
+}
+
+// FactoryV2 is a free data retrieval call binding the contract method 0x68e0d4e1.
+//
+// Solidity: function factoryV2() view returns(address)
+func (_UniSwapRouter02 *UniSwapRouter02CallerSession) FactoryV2() (common.Address, error) {
+	return _UniSwapRouter02.Contract.FactoryV2(&_UniSwapRouter02.CallOpts)
+}
+
+// PositionManager is a free data retrieval call binding the contract method 0x791b98bc.
+//
+// Solidity: function positionManager() view returns(address)
+func (_UniSwapRouter02 *UniSwapRouter02Caller) PositionManager(opts *bind.CallOpts) (common.Address, error) {
+	var out []interface{}
+	err := _UniSwapRouter02.contract.Call(opts, &out, "positionManager")
+
+	if err != nil {
+		return *new(common.Address), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(common.Address)).(*common.Address)
+
+	return out0, err
+
+}
+
+// PositionManager is a free data retrieval call binding the contract method 0x791b98bc.
+//
+// Solidity: function positionManager() view returns(address)
+func (_UniSwapRouter02 *UniSwapRouter02Session) PositionManager() (common.Address, error) {
+	return _UniSwapRouter02.Contract.PositionManager(&_UniSwapRouter02.CallOpts)
+}
+
+// PositionManager is a free data retrieval call binding the contract method 0x791b98bc.
+//
+// Solidity: function positionManager() view returns(address)
+func (_UniSwapRouter02 *UniSwapRouter02CallerSession) PositionManager() (common.Address, error) {
+	return _UniSwapRouter02.Contract.PositionManager(&_UniSwapRouter02.CallOpts)
+}
+
+// ApproveMax is a paid mutator transaction binding the contract method 0x571ac8b0.
+//
+// Solidity: function approveMax(address token) payable returns()
+func (_UniSwapRouter02 *UniSwapRouter02Transactor) ApproveMax(opts *bind.TransactOpts, token common.Address) (*types.Transaction, error) {
+	return _UniSwapRouter02.contract.Transact(opts, "approveMax", token)
+}
+
+// ApproveMax is a paid mutator transaction binding the contract method 0x571ac8b0.
+//
+// Solidity: function approveMax(address token) payable returns()
+func (_UniSwapRouter02 *UniSwapRouter02Session) ApproveMax(token common.Address) (*types.Transaction, error) {
+	return _UniSwapRouter02.Contract.ApproveMax(&_UniSwapRouter02.TransactOpts, token)
+}
+
+// ApproveMax is a paid mutator transaction binding the contract method 0x571ac8b0.
+//
+// Solidity: function approveMax(address token) payable returns()
+func (_UniSwapRouter02 *UniSwapRouter02TransactorSession) ApproveMax(token common.Address) (*types.Transaction, error) {
+	return _UniSwapRouter02.Contract.ApproveMax(&_UniSwapRouter02.TransactOpts, token)
+}
+
+// ApproveMaxMinusOne is a paid mutator transaction binding the contract method 0xcab372ce.
+//
+// Solidity: function approveMaxMinusOne(address token) payable returns()
+func (_UniSwapRouter02 *UniSwapRouter02Transactor) ApproveMaxMinusOne(opts *bind.TransactOpts, token common.Address) (*types.Transaction, error) {
+	return _UniSwapRouter02.contract.Transact(opts, "approveMaxMinusOne", token)
+}
+
+// ApproveMaxMinusOne is a paid mutator transaction binding the contract method 0xcab372ce.
+//
+// Solidity: function approveMaxMinusOne(address token) payable returns()
+func (_UniSwapRouter02 *UniSwapRouter02Session) ApproveMaxMinusOne(token common.Address) (*types.Transaction, error) {
+	return _UniSwapRouter02.Contract.ApproveMaxMinusOne(&_UniSwapRouter02.TransactOpts, token)
+}
+
+// ApproveMaxMinusOne is a paid mutator transaction binding the contract method 0xcab372ce.
+//
+// Solidity: function approveMaxMinusOne(address token) payable returns()
+func (_UniSwapRouter02 *UniSwapRouter02TransactorSession) ApproveMaxMinusOne(token common.Address) (*types.Transaction, error) {
+	return _UniSwapRouter02.Contract.ApproveMaxMinusOne(&_UniSwapRouter02.TransactOpts, token)
+}
+
+// ApproveZeroThenMax is a paid mutator transaction binding the contract method 0x639d71a9.
+//
+// Solidity: function approveZeroThenMax(address token) payable returns()
+func (_UniSwapRouter02 *UniSwapRouter02Transactor) ApproveZeroThenMax(opts *bind.TransactOpts, token common.Address) (*types.Transaction, error) {
+	return _UniSwapRouter02.contract.Transact(opts, "approveZeroThenMax", token)
+}
+
+// ApproveZeroThenMax is a paid mutator transaction binding the contract method 0x639d71a9.
+//
+// Solidity: function approveZeroThenMax(address token) payable returns()
+func (_UniSwapRouter02 *UniSwapRouter02Session) ApproveZeroThenMax(token common.Address) (*types.Transaction, error) {
+	return _UniSwapRouter02.Contract.ApproveZeroThenMax(&_UniSwapRouter02.TransactOpts, token)
+}
+
+// ApproveZeroThenMax is a paid mutator transaction binding the contract method 0x639d71a9.
+//
+// Solidity: function approveZeroThenMax(address token) payable returns()
+func (_UniSwapRouter02 *UniSwapRouter02TransactorSession) ApproveZeroThenMax(token common.Address) (*types.Transaction, error) {
+	return _UniSwapRouter02.Contract.ApproveZeroThenMax(&_UniSwapRouter02.TransactOpts, token)
+}
+
+// ApproveZeroThenMaxMinusOne is a paid mutator transaction binding the contract method 0xab3fdd50.
+//
+// Solidity: function approveZeroThenMaxMinusOne(address token) payable returns()
+func (_UniSwapRouter02 *UniSwapRouter02Transactor) ApproveZeroThenMaxMinusOne(opts *bind.TransactOpts, token common.Address) (*types.Transaction, error) {
+	return _UniSwapRouter02.contract.Transact(opts, "approveZeroThenMaxMinusOne", token)
+}
+
+// ApproveZeroThenMaxMinusOne is a paid mutator transaction binding the contract method 0xab3fdd50.
+//
+// Solidity: function approveZeroThenMaxMinusOne(address token) payable returns()
+func (_UniSwapRouter02 *UniSwapRouter02Session) ApproveZeroThenMaxMinusOne(token common.Address) (*types.Transaction, error) {
+	return _UniSwapRouter02.Contract.ApproveZeroThenMaxMinusOne(&_UniSwapRouter02.TransactOpts, token)
+}
+
+// ApproveZeroThenMaxMinusOne is a paid mutator transaction binding the contract method 0xab3fdd50.
+//
+// Solidity: function approveZeroThenMaxMinusOne(address token) payable returns()
+func (_UniSwapRouter02 *UniSwapRouter02TransactorSession) ApproveZeroThenMaxMinusOne(token common.Address) (*types.Transaction, error) {
+	return _UniSwapRouter02.Contract.ApproveZeroThenMaxMinusOne(&_UniSwapRouter02.TransactOpts, token)
+}
+
+// CallPositionManager is a paid mutator transaction binding the contract method 0xb3a2af13.
+//
+// Solidity: function callPositionManager(bytes data) payable returns(bytes result)
+func (_UniSwapRouter02 *UniSwapRouter02Transactor) CallPositionManager(opts *bind.TransactOpts, data []byte) (*types.Transaction, error) {
+	return _UniSwapRouter02.contract.Transact(opts, "callPositionManager", data)
+}
+
+// CallPositionManager is a paid mutator transaction binding the contract method 0xb3a2af13.
+//
+// Solidity: function callPositionManager(bytes data) payable returns(bytes result)
+func (_UniSwapRouter02 *UniSwapRouter02Session) CallPositionManager(data []byte) (*types.Transaction, error) {
+	return _UniSwapRouter02.Contract.CallPositionManager(&_UniSwapRouter02.TransactOpts, data)
+}
+
+// CallPositionManager is a paid mutator transaction binding the contract method 0xb3a2af13.
+//
+// Solidity: function callPositionManager(bytes data) payable returns(bytes result)
+func (_UniSwapRouter02 *UniSwapRouter02TransactorSession) CallPositionManager(data []byte) (*types.Transaction, error) {
+	return _UniSwapRouter02.Contract.CallPositionManager(&_UniSwapRouter02.TransactOpts, data)
+}
+
+// ExactInput is a paid mutator transaction binding the contract method 0xb858183f.
+//
+// Solidity: function exactInput((bytes,address,uint256,uint256) params) payable returns(uint256 amountOut)
+func (_UniSwapRouter02 *UniSwapRouter02Transactor) ExactInput(opts *bind.TransactOpts, params IV3SwapRouterExactInputParams) (*types.Transaction, error) {
+	return _UniSwapRouter02.contract.Transact(opts, "exactInput", params)
+}
+
+// ExactInput is a paid mutator transaction binding the contract method 0xb858183f.
+//
+// Solidity: function exactInput((bytes,address,uint256,uint256) params) payable returns(uint256 amountOut)
+func (_UniSwapRouter02 *UniSwapRouter02Session) ExactInput(params IV3SwapRouterExactInputParams) (*types.Transaction, error) {
+	return _UniSwapRouter02.Contract.ExactInput(&_UniSwapRouter02.TransactOpts, params)
+}
+
+// ExactInput is a paid mutator transaction binding the contract method 0xb858183f.
+//
+// Solidity: function exactInput((bytes,address,uint256,uint256) params) payable returns(uint256 amountOut)
+func (_UniSwapRouter02 *UniSwapRouter02TransactorSession) ExactInput(params IV3SwapRouterExactInputParams) (*types.Transaction, error) {
+	return _UniSwapRouter02.Contract.ExactInput(&_UniSwapRouter02.TransactOpts, params)
+}
+
+// ExactInputSingle is a paid mutator transaction binding the contract method 0x04e45aaf.
+//
+// Solidity: function exactInputSingle((address,address,uint24,address,uint256,uint256,uint160) params) payable returns(uint256 amountOut)
+func (_UniSwapRouter02 *UniSwapRouter02Transactor) ExactInputSingle(opts *bind.TransactOpts, params IV3SwapRouterExactInputSingleParams) (*types.Transaction, error) {
+	return _UniSwapRouter02.contract.Transact(opts, "exactInputSingle", params)
+}
+
+// ExactInputSingle is a paid mutator transaction binding the contract method 0x04e45aaf.
+//
+// Solidity: function exactInputSingle((address,address,uint24,address,uint256,uint256,uint160) params) payable returns(uint256 amountOut)
+func (_UniSwapRouter02 *UniSwapRouter02Session) ExactInputSingle(params IV3SwapRouterExactInputSingleParams) (*types.Transaction, error) {
+	return _UniSwapRouter02.Contract.ExactInputSingle(&_UniSwapRouter02.TransactOpts, params)
+}
+
+// ExactInputSingle is a paid mutator transaction binding the contract method 0x04e45aaf.
+//
+// Solidity: function exactInputSingle((address,address,uint24,address,uint256,uint256,uint160) params) payable returns(uint256 amountOut)
+func (_UniSwapRouter02 *UniSwapRouter02TransactorSession) ExactInputSingle(params IV3SwapRouterExactInputSingleParams) (*types.Transaction, error) {
+	return _UniSwapRouter02.Contract.ExactInputSingle(&_UniSwapRouter02.TransactOpts, params)
+}
+
+// ExactOutput is a paid mutator transaction binding the contract method 0x09b81346.
+//
+// Solidity: function exactOutput((bytes,address,uint256,uint256) params) payable returns(uint256 amountIn)
+func (_UniSwapRouter02 *UniSwapRouter02Transactor) ExactOutput(opts *bind.TransactOpts, params IV3SwapRouterExactOutputParams) (*types.Transaction, error) {
+	return _UniSwapRouter02.contract.Transact(opts, "exactOutput", params)
+}
+
+// ExactOutput is a paid mutator transaction binding the contract method 0x09b81346.
+//
+// Solidity: function exactOutput((bytes,address,uint256,uint256) params) payable returns(uint256 amountIn)
+func (_UniSwapRouter02 *UniSwapRouter02Session) ExactOutput(params IV3SwapRouterExactOutputParams) (*types.Transaction, error) {
+	return _UniSwapRouter02.Contract.ExactOutput(&_UniSwapRouter02.TransactOpts, params)
+}
+
+// ExactOutput is a paid mutator transaction binding the contract method 0x09b81346.
+//
+// Solidity: function exactOutput((bytes,address,uint256,uint256) params) payable returns(uint256 amountIn)
+func (_UniSwapRouter02 *UniSwapRouter02TransactorSession) ExactOutput(params IV3SwapRouterExactOutputParams) (*types.Transaction, error) {
+	return _UniSwapRouter02.Contract.ExactOutput(&_UniSwapRouter02.TransactOpts, params)
+}
+
+// ExactOutputSingle is a paid mutator transaction binding the contract method 0x5023b4df.
+//
+// Solidity: function exactOutputSingle((address,address,uint24,address,uint256,uint256,uint160) params) payable returns(uint256 amountIn)
+func (_UniSwapRouter02 *UniSwapRouter02Transactor) ExactOutputSingle(opts *bind.TransactOpts, params IV3SwapRouterExactOutputSingleParams) (*types.Transaction, error) {
+	return _UniSwapRouter02.contract.Transact(opts, "exactOutputSingle", params)
+}
+
+// ExactOutputSingle is a paid mutator transaction binding the contract method 0x5023b4df.
+//
+// Solidity: function exactOutputSingle((address,address,uint24,address,uint256,uint256,uint160) params) payable returns(uint256 amountIn)
+func (_UniSwapRouter02 *UniSwapRouter02Session) ExactOutputSingle(params IV3SwapRouterExactOutputSingleParams) (*types.Transaction, error) {
+	return _UniSwapRouter02.Contract.ExactOutputSingle(&_UniSwapRouter02.TransactOpts, params)
+}
+
+// ExactOutputSingle is a paid mutator transaction binding the contract method 0x5023b4df.
+//
+// Solidity: function exactOutputSingle((address,address,uint24,address,uint256,uint256,uint160) params) payable returns(uint256 amountIn)
+func (_UniSwapRouter02 *UniSwapRouter02TransactorSession) ExactOutputSingle(params IV3SwapRouterExactOutputSingleParams) (*types.Transaction, error) {
+	return _UniSwapRouter02.Contract.ExactOutputSingle(&_UniSwapRouter02.TransactOpts, params)
+}
+
+// GetApprovalType is a paid mutator transaction binding the contract method 0xdee00f35.
+//
+// Solidity: function getApprovalType(address token, uint256 amount) returns(uint8)
+func (_UniSwapRouter02 *UniSwapRouter02Transactor) GetApprovalType(opts *bind.TransactOpts, token common.Address, amount *big.Int) (*types.Transaction, error) {
+	return _UniSwapRouter02.contract.Transact(opts, "getApprovalType", token, amount)
+}
+
+// GetApprovalType is a paid mutator transaction binding the contract method 0xdee00f35.
+//
+// Solidity: function getApprovalType(address token, uint256 amount) returns(uint8)
+func (_UniSwapRouter02 *UniSwapRouter02Session) GetApprovalType(token common.Address, amount *big.Int) (*types.Transaction, error) {
+	return _UniSwapRouter02.Contract.GetApprovalType(&_UniSwapRouter02.TransactOpts, token, amount)
+}
+
+// GetApprovalType is a paid mutator transaction binding the contract method 0xdee00f35.
+//
+// Solidity: function getApprovalType(address token, uint256 amount) returns(uint8)
+func (_UniSwapRouter02 *UniSwapRouter02TransactorSession) GetApprovalType(token common.Address, amount *big.Int) (*types.Transaction, error) {
+	return _UniSwapRouter02.Contract.GetApprovalType(&_UniSwapRouter02.TransactOpts, token, amount)
+}
+
+// IncreaseLiquidity is a paid mutator transaction binding the contract method 0xf100b205.
+//
+// Solidity: function increaseLiquidity((address,address,uint256,uint256,uint256) params) payable returns(bytes result)
+func (_UniSwapRouter02 *UniSwapRouter02Transactor) IncreaseLiquidity(opts *bind.TransactOpts, params IApproveAndCallIncreaseLiquidityParams) (*types.Transaction, error) {
+	return _UniSwapRouter02.contract.Transact(opts, "increaseLiquidity", params)
+}
+
+// IncreaseLiquidity is a paid mutator transaction binding the contract method 0xf100b205.
+//
+// Solidity: function increaseLiquidity((address,address,uint256,uint256,uint256) params) payable returns(bytes result)
+func (_UniSwapRouter02 *UniSwapRouter02Session) IncreaseLiquidity(params IApproveAndCallIncreaseLiquidityParams) (*types.Transaction, error) {
+	return _UniSwapRouter02.Contract.IncreaseLiquidity(&_UniSwapRouter02.TransactOpts, params)
+}
+
+// IncreaseLiquidity is a paid mutator transaction binding the contract method 0xf100b205.
+//
+// Solidity: function increaseLiquidity((address,address,uint256,uint256,uint256) params) payable returns(bytes result)
+func (_UniSwapRouter02 *UniSwapRouter02TransactorSession) IncreaseLiquidity(params IApproveAndCallIncreaseLiquidityParams) (*types.Transaction, error) {
+	return _UniSwapRouter02.Contract.IncreaseLiquidity(&_UniSwapRouter02.TransactOpts, params)
+}
+
+// Mint is a paid mutator transaction binding the contract method 0x11ed56c9.
+//
+// Solidity: function mint((address,address,uint24,int24,int24,uint256,uint256,address) params) payable returns(bytes result)
+func (_UniSwapRouter02 *UniSwapRouter02Transactor) Mint(opts *bind.TransactOpts, params IApproveAndCallMintParams) (*types.Transaction, error) {
+	return _UniSwapRouter02.contract.Transact(opts, "mint", params)
+}
+
+// Mint is a paid mutator transaction binding the contract method 0x11ed56c9.
+//
+// Solidity: function mint((address,address,uint24,int24,int24,uint256,uint256,address) params) payable returns(bytes result)
+func (_UniSwapRouter02 *UniSwapRouter02Session) Mint(params IApproveAndCallMintParams) (*types.Transaction, error) {
+	return _UniSwapRouter02.Contract.Mint(&_UniSwapRouter02.TransactOpts, params)
+}
+
+// Mint is a paid mutator transaction binding the contract method 0x11ed56c9.
+//
+// Solidity: function mint((address,address,uint24,int24,int24,uint256,uint256,address) params) payable returns(bytes result)
+func (_UniSwapRouter02 *UniSwapRouter02TransactorSession) Mint(params IApproveAndCallMintParams) (*types.Transaction, error) {
+	return _UniSwapRouter02.Contract.Mint(&_UniSwapRouter02.TransactOpts, params)
+}
+
+// Multicall is a paid mutator transaction binding the contract method 0x1f0464d1.
+//
+// Solidity: function multicall(bytes32 previousBlockhash, bytes[] data) payable returns(bytes[])
+func (_UniSwapRouter02 *UniSwapRouter02Transactor) Multicall(opts *bind.TransactOpts, previousBlockhash [32]byte, data [][]byte) (*types.Transaction, error) {
+	return _UniSwapRouter02.contract.Transact(opts, "multicall", previousBlockhash, data)
+}
+
+// Multicall is a paid mutator transaction binding the contract method 0x1f0464d1.
+//
+// Solidity: function multicall(bytes32 previousBlockhash, bytes[] data) payable returns(bytes[])
+func (_UniSwapRouter02 *UniSwapRouter02Session) Multicall(previousBlockhash [32]byte, data [][]byte) (*types.Transaction, error) {
+	return _UniSwapRouter02.Contract.Multicall(&_UniSwapRouter02.TransactOpts, previousBlockhash, data)
+}
+
+// Multicall is a paid mutator transaction binding the contract method 0x1f0464d1.
+//
+// Solidity: function multicall(bytes32 previousBlockhash, bytes[] data) payable returns(bytes[])
+func (_UniSwapRouter02 *UniSwapRouter02TransactorSession) Multicall(previousBlockhash [32]byte, data [][]byte) (*types.Transaction, error) {
+	return _UniSwapRouter02.Contract.Multicall(&_UniSwapRouter02.TransactOpts, previousBlockhash, data)
+}
+
+// Multicall0 is a paid mutator transaction binding the contract method 0x5ae401dc.
+//
+// Solidity: function multicall(uint256 deadline, bytes[] data) payable returns(bytes[])
+func (_UniSwapRouter02 *UniSwapRouter02Transactor) Multicall0(opts *bind.TransactOpts, deadline *big.Int, data [][]byte) (*types.Transaction, error) {
+	return _UniSwapRouter02.contract.Transact(opts, "multicall0", deadline, data)
+}
+
+// Multicall0 is a paid mutator transaction binding the contract method 0x5ae401dc.
+//
+// Solidity: function multicall(uint256 deadline, bytes[] data) payable returns(bytes[])
+func (_UniSwapRouter02 *UniSwapRouter02Session) Multicall0(deadline *big.Int, data [][]byte) (*types.Transaction, error) {
+	return _UniSwapRouter02.Contract.Multicall0(&_UniSwapRouter02.TransactOpts, deadline, data)
+}
+
+// Multicall0 is a paid mutator transaction binding the contract method 0x5ae401dc.
+//
+// Solidity: function multicall(uint256 deadline, bytes[] data) payable returns(bytes[])
+func (_UniSwapRouter02 *UniSwapRouter02TransactorSession) Multicall0(deadline *big.Int, data [][]byte) (*types.Transaction, error) {
+	return _UniSwapRouter02.Contract.Multicall0(&_UniSwapRouter02.TransactOpts, deadline, data)
+}
+
+// Multicall1 is a paid mutator transaction binding the contract method 0xac9650d8.
+//
+// Solidity: function multicall(bytes[] data) payable returns(bytes[] results)
+func (_UniSwapRouter02 *UniSwapRouter02Transactor) Multicall1(opts *bind.TransactOpts, data [][]byte) (*types.Transaction, error) {
+	return _UniSwapRouter02.contract.Transact(opts, "multicall1", data)
+}
+
+// Multicall1 is a paid mutator transaction binding the contract method 0xac9650d8.
+//
+// Solidity: function multicall(bytes[] data) payable returns(bytes[] results)
+func (_UniSwapRouter02 *UniSwapRouter02Session) Multicall1(data [][]byte) (*types.Transaction, error) {
+	return _UniSwapRouter02.Contract.Multicall1(&_UniSwapRouter02.TransactOpts, data)
+}
+
+// Multicall1 is a paid mutator transaction binding the contract method 0xac9650d8.
+//
+// Solidity: function multicall(bytes[] data) payable returns(bytes[] results)
+func (_UniSwapRouter02 *UniSwapRouter02TransactorSession) Multicall1(data [][]byte) (*types.Transaction, error) {
+	return _UniSwapRouter02.Contract.Multicall1(&_UniSwapRouter02.TransactOpts, data)
+}
+
+// Pull is a paid mutator transaction binding the contract method 0xf2d5d56b.
+//
+// Solidity: function pull(address token, uint256 value) payable returns()
+func (_UniSwapRouter02 *UniSwapRouter02Transactor) Pull(opts *bind.TransactOpts, token common.Address, value *big.Int) (*types.Transaction, error) {
+	return _UniSwapRouter02.contract.Transact(opts, "pull", token, value)
+}
+
+// Pull is a paid mutator transaction binding the contract method 0xf2d5d56b.
+//
+// Solidity: function pull(address token, uint256 value) payable returns()
+func (_UniSwapRouter02 *UniSwapRouter02Session) Pull(token common.Address, value *big.Int) (*types.Transaction, error) {
+	return _UniSwapRouter02.Contract.Pull(&_UniSwapRouter02.TransactOpts, token, value)
+}
+
+// Pull is a paid mutator transaction binding the contract method 0xf2d5d56b.
+//
+// Solidity: function pull(address token, uint256 value) payable returns()
+func (_UniSwapRouter02 *UniSwapRouter02TransactorSession) Pull(token common.Address, value *big.Int) (*types.Transaction, error) {
+	return _UniSwapRouter02.Contract.Pull(&_UniSwapRouter02.TransactOpts, token, value)
+}
+
+// RefundETH is a paid mutator transaction binding the contract method 0x12210e8a.
+//
+// Solidity: function refundETH() payable returns()
+func (_UniSwapRouter02 *UniSwapRouter02Transactor) RefundETH(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _UniSwapRouter02.contract.Transact(opts, "refundETH")
+}
+
+// RefundETH is a paid mutator transaction binding the contract method 0x12210e8a.
+//
+// Solidity: function refundETH() payable returns()
+func (_UniSwapRouter02 *UniSwapRouter02Session) RefundETH() (*types.Transaction, error) {
+	return _UniSwapRouter02.Contract.RefundETH(&_UniSwapRouter02.TransactOpts)
+}
+
+// RefundETH is a paid mutator transaction binding the contract method 0x12210e8a.
+//
+// Solidity: function refundETH() payable returns()
+func (_UniSwapRouter02 *UniSwapRouter02TransactorSession) RefundETH() (*types.Transaction, error) {
+	return _UniSwapRouter02.Contract.RefundETH(&_UniSwapRouter02.TransactOpts)
+}
+
+// SelfPermit is a paid mutator transaction binding the contract method 0xf3995c67.
+//
+// Solidity: function selfPermit(address token, uint256 value, uint256 deadline, uint8 v, bytes32 r, bytes32 s) payable returns()
+func (_UniSwapRouter02 *UniSwapRouter02Transactor) SelfPermit(opts *bind.TransactOpts, token common.Address, value *big.Int, deadline *big.Int, v uint8, r [32]byte, s [32]byte) (*types.Transaction, error) {
+	return _UniSwapRouter02.contract.Transact(opts, "selfPermit", token, value, deadline, v, r, s)
+}
+
+// SelfPermit is a paid mutator transaction binding the contract method 0xf3995c67.
+//
+// Solidity: function selfPermit(address token, uint256 value, uint256 deadline, uint8 v, bytes32 r, bytes32 s) payable returns()
+func (_UniSwapRouter02 *UniSwapRouter02Session) SelfPermit(token common.Address, value *big.Int, deadline *big.Int, v uint8, r [32]byte, s [32]byte) (*types.Transaction, error) {
+	return _UniSwapRouter02.Contract.SelfPermit(&_UniSwapRouter02.TransactOpts, token, value, deadline, v, r, s)
+}
+
+// SelfPermit is a paid mutator transaction binding the contract method 0xf3995c67.
+//
+// Solidity: function selfPermit(address token, uint256 value, uint256 deadline, uint8 v, bytes32 r, bytes32 s) payable returns()
+func (_UniSwapRouter02 *UniSwapRouter02TransactorSession) SelfPermit(token common.Address, value *big.Int, deadline *big.Int, v uint8, r [32]byte, s [32]byte) (*types.Transaction, error) {
+	return _UniSwapRouter02.Contract.SelfPermit(&_UniSwapRouter02.TransactOpts, token, value, deadline, v, r, s)
+}
+
+// SelfPermitAllowed is a paid mutator transaction binding the contract method 0x4659a494.
+//
+// Solidity: function selfPermitAllowed(address token, uint256 nonce, uint256 expiry, uint8 v, bytes32 r, bytes32 s) payable returns()
+func (_UniSwapRouter02 *UniSwapRouter02Transactor) SelfPermitAllowed(opts *bind.TransactOpts, token common.Address, nonce *big.Int, expiry *big.Int, v uint8, r [32]byte, s [32]byte) (*types.Transaction, error) {
+	return _UniSwapRouter02.contract.Transact(opts, "selfPermitAllowed", token, nonce, expiry, v, r, s)
+}
+
+// SelfPermitAllowed is a paid mutator transaction binding the contract method 0x4659a494.
+//
+// Solidity: function selfPermitAllowed(address token, uint256 nonce, uint256 expiry, uint8 v, bytes32 r, bytes32 s) payable returns()
+func (_UniSwapRouter02 *UniSwapRouter02Session) SelfPermitAllowed(token common.Address, nonce *big.Int, expiry *big.Int, v uint8, r [32]byte, s [32]byte) (*types.Transaction, error) {
+	return _UniSwapRouter02.Contract.SelfPermitAllowed(&_UniSwapRouter02.TransactOpts, token, nonce, expiry, v, r, s)
+}
+
+// SelfPermitAllowed is a paid mutator transaction binding the contract method 0x4659a494.
+//
+// Solidity: function selfPermitAllowed(address token, uint256 nonce, uint256 expiry, uint8 v, bytes32 r, bytes32 s) payable returns()
+func (_UniSwapRouter02 *UniSwapRouter02TransactorSession) SelfPermitAllowed(token common.Address, nonce *big.Int, expiry *big.Int, v uint8, r [32]byte, s [32]byte) (*types.Transaction, error) {
+	return _UniSwapRouter02.Contract.SelfPermitAllowed(&_UniSwapRouter02.TransactOpts, token, nonce, expiry, v, r, s)
+}
+
+// SelfPermitAllowedIfNecessary is a paid mutator transaction binding the contract method 0xa4a78f0c.
+//
+// Solidity: function selfPermitAllowedIfNecessary(address token, uint256 nonce, uint256 expiry, uint8 v, bytes32 r, bytes32 s) payable returns()
+func (_UniSwapRouter02 *UniSwapRouter02Transactor) SelfPermitAllowedIfNecessary(opts *bind.TransactOpts, token common.Address, nonce *big.Int, expiry *big.Int, v uint8, r [32]byte, s [32]byte) (*types.Transaction, error) {
+	return _UniSwapRouter02.contract.Transact(opts, "selfPermitAllowedIfNecessary", token, nonce, expiry, v, r, s)
+}
+
+// SelfPermitAllowedIfNecessary is a paid mutator transaction binding the contract method 0xa4a78f0c.
+//
+// Solidity: function selfPermitAllowedIfNecessary(address token, uint256 nonce, uint256 expiry, uint8 v, bytes32 r, bytes32 s) payable returns()
+func (_UniSwapRouter02 *UniSwapRouter02Session) SelfPermitAllowedIfNecessary(token common.Address, nonce *big.Int, expiry *big.Int, v uint8, r [32]byte, s [32]byte) (*types.Transaction, error) {
+	return _UniSwapRouter02.Contract.SelfPermitAllowedIfNecessary(&_UniSwapRouter02.TransactOpts, token, nonce, expiry, v, r, s)
+}
+
+// SelfPermitAllowedIfNecessary is a paid mutator transaction binding the contract method 0xa4a78f0c.
+//
+// Solidity: function selfPermitAllowedIfNecessary(address token, uint256 nonce, uint256 expiry, uint8 v, bytes32 r, bytes32 s) payable returns()
+func (_UniSwapRouter02 *UniSwapRouter02TransactorSession) SelfPermitAllowedIfNecessary(token common.Address, nonce *big.Int, expiry *big.Int, v uint8, r [32]byte, s [32]byte) (*types.Transaction, error) {
+	return _UniSwapRouter02.Contract.SelfPermitAllowedIfNecessary(&_UniSwapRouter02.TransactOpts, token, nonce, expiry, v, r, s)
+}
+
+// SelfPermitIfNecessary is a paid mutator transaction binding the contract method 0xc2e3140a.
+//
+// Solidity: function selfPermitIfNecessary(address token, uint256 value, uint256 deadline, uint8 v, bytes32 r, bytes32 s) payable returns()
+func (_UniSwapRouter02 *UniSwapRouter02Transactor) SelfPermitIfNecessary(opts *bind.TransactOpts, token common.Address, value *big.Int, deadline *big.Int, v uint8, r [32]byte, s [32]byte) (*types.Transaction, error) {
+	return _UniSwapRouter02.contract.Transact(opts, "selfPermitIfNecessary", token, value, deadline, v, r, s)
+}
+
+// SelfPermitIfNecessary is a paid mutator transaction binding the contract method 0xc2e3140a.
+//
+// Solidity: function selfPermitIfNecessary(address token, uint256 value, uint256 deadline, uint8 v, bytes32 r, bytes32 s) payable returns()
+func (_UniSwapRouter02 *UniSwapRouter02Session) SelfPermitIfNecessary(token common.Address, value *big.Int, deadline *big.Int, v uint8, r [32]byte, s [32]byte) (*types.Transaction, error) {
+	return _UniSwapRouter02.Contract.SelfPermitIfNecessary(&_UniSwapRouter02.TransactOpts, token, value, deadline, v, r, s)
+}
+
+// SelfPermitIfNecessary is a paid mutator transaction binding the contract method 0xc2e3140a.
+//
+// Solidity: function selfPermitIfNecessary(address token, uint256 value, uint256 deadline, uint8 v, bytes32 r, bytes32 s) payable returns()
+func (_UniSwapRouter02 *UniSwapRouter02TransactorSession) SelfPermitIfNecessary(token common.Address, value *big.Int, deadline *big.Int, v uint8, r [32]byte, s [32]byte) (*types.Transaction, error) {
+	return _UniSwapRouter02.Contract.SelfPermitIfNecessary(&_UniSwapRouter02.TransactOpts, token, value, deadline, v, r, s)
+}
+
+// SwapExactTokensForTokens is a paid mutator transaction binding the contract method 0x472b43f3.
+//
+// Solidity: function swapExactTokensForTokens(uint256 amountIn, uint256 amountOutMin, address[] path, address to) payable returns(uint256 amountOut)
+func (_UniSwapRouter02 *UniSwapRouter02Transactor) SwapExactTokensForTokens(opts *bind.TransactOpts, amountIn *big.Int, amountOutMin *big.Int, path []common.Address, to common.Address) (*types.Transaction, error) {
+	return _UniSwapRouter02.contract.Transact(opts, "swapExactTokensForTokens", amountIn, amountOutMin, path, to)
+}
+
+// SwapExactTokensForTokens is a paid mutator transaction binding the contract method 0x472b43f3.
+//
+// Solidity: function swapExactTokensForTokens(uint256 amountIn, uint256 amountOutMin, address[] path, address to) payable returns(uint256 amountOut)
+func (_UniSwapRouter02 *UniSwapRouter02Session) SwapExactTokensForTokens(amountIn *big.Int, amountOutMin *big.Int, path []common.Address, to common.Address) (*types.Transaction, error) {
+	return _UniSwapRouter02.Contract.SwapExactTokensForTokens(&_UniSwapRouter02.TransactOpts, amountIn, amountOutMin, path, to)
+}
+
+// SwapExactTokensForTokens is a paid mutator transaction binding the contract method 0x472b43f3.
+//
+// Solidity: function swapExactTokensForTokens(uint256 amountIn, uint256 amountOutMin, address[] path, address to) payable returns(uint256 amountOut)
+func (_UniSwapRouter02 *UniSwapRouter02TransactorSession) SwapExactTokensForTokens(amountIn *big.Int, amountOutMin *big.Int, path []common.Address, to common.Address) (*types.Transaction, error) {
+	return _UniSwapRouter02.Contract.SwapExactTokensForTokens(&_UniSwapRouter02.TransactOpts, amountIn, amountOutMin, path, to)
+}
+
+// SwapTokensForExactTokens is a paid mutator transaction binding the contract method 0x42712a67.
+//
+// Solidity: function swapTokensForExactTokens(uint256 amountOut, uint256 amountInMax, address[] path, address to) payable returns(uint256 amountIn)
+func (_UniSwapRouter02 *UniSwapRouter02Transactor) SwapTokensForExactTokens(opts *bind.TransactOpts, amountOut *big.Int, amountInMax *big.Int, path []common.Address, to common.Address) (*types.Transaction, error) {
+	return _UniSwapRouter02.contract.Transact(opts, "swapTokensForExactTokens", amountOut, amountInMax, path, to)
+}
+
+// SwapTokensForExactTokens is a paid mutator transaction binding the contract method 0x42712a67.
+//
+// Solidity: function swapTokensForExactTokens(uint256 amountOut, uint256 amountInMax, address[] path, address to) payable returns(uint256 amountIn)
+func (_UniSwapRouter02 *UniSwapRouter02Session) SwapTokensForExactTokens(amountOut *big.Int, amountInMax *big.Int, path []common.Address, to common.Address) (*types.Transaction, error) {
+	return _UniSwapRouter02.Contract.SwapTokensForExactTokens(&_UniSwapRouter02.TransactOpts, amountOut, amountInMax, path, to)
+}
+
+// SwapTokensForExactTokens is a paid mutator transaction binding the contract method 0x42712a67.
+//
+// Solidity: function swapTokensForExactTokens(uint256 amountOut, uint256 amountInMax, address[] path, address to) payable returns(uint256 amountIn)
+func (_UniSwapRouter02 *UniSwapRouter02TransactorSession) SwapTokensForExactTokens(amountOut *big.Int, amountInMax *big.Int, path []common.Address, to common.Address) (*types.Transaction, error) {
+	return _UniSwapRouter02.Contract.SwapTokensForExactTokens(&_UniSwapRouter02.TransactOpts, amountOut, amountInMax, path, to)
+}
+
+// SweepToken is a paid mutator transaction binding the contract method 0xdf2ab5bb.
+//
+// Solidity: function sweepToken(address token, uint256 amountMinimum, address recipient) payable returns()
+func (_UniSwapRouter02 *UniSwapRouter02Transactor) SweepToken(opts *bind.TransactOpts, token common.Address, amountMinimum *big.Int, recipient common.Address) (*types.Transaction, error) {
+	return _UniSwapRouter02.contract.Transact(opts, "sweepToken", token, amountMinimum, recipient)
+}
+
+// SweepToken is a paid mutator transaction binding the contract method 0xdf2ab5bb.
+//
+// Solidity: function sweepToken(address token, uint256 amountMinimum, address recipient) payable returns()
+func (_UniSwapRouter02 *UniSwapRouter02Session) SweepToken(token common.Address, amountMinimum *big.Int, recipient common.Address) (*types.Transaction, error) {
+	return _UniSwapRouter02.Contract.SweepToken(&_UniSwapRouter02.TransactOpts, token, amountMinimum, recipient)
+}
+
+// SweepToken is a paid mutator transaction binding the contract method 0xdf2ab5bb.
+//
+// Solidity: function sweepToken(address token, uint256 amountMinimum, address recipient) payable returns()
+func (_UniSwapRouter02 *UniSwapRouter02TransactorSession) SweepToken(token common.Address, amountMinimum *big.Int, recipient common.Address) (*types.Transaction, error) {
+	return _UniSwapRouter02.Contract.SweepToken(&_UniSwapRouter02.TransactOpts, token, amountMinimum, recipient)
+}
+
+// SweepToken0 is a paid mutator transaction binding the contract method 0xe90a182f.
+//
+// Solidity: function sweepToken(address token, uint256 amountMinimum) payable returns()
+func (_UniSwapRouter02 *UniSwapRouter02Transactor) SweepToken0(opts *bind.TransactOpts, token common.Address, amountMinimum *big.Int) (*types.Transaction, error) {
+	return _UniSwapRouter02.contract.Transact(opts, "sweepToken0", token, amountMinimum)
+}
+
+// SweepToken0 is a paid mutator transaction binding the contract method 0xe90a182f.
+//
+// Solidity: function sweepToken(address token, uint256 amountMinimum) payable returns()
+func (_UniSwapRouter02 *UniSwapRouter02Session) SweepToken0(token common.Address, amountMinimum *big.Int) (*types.Transaction, error) {
+	return _UniSwapRouter02.Contract.SweepToken0(&_UniSwapRouter02.TransactOpts, token, amountMinimum)
+}
+
+// SweepToken0 is a paid mutator transaction binding the contract method 0xe90a182f.
+//
+// Solidity: function sweepToken(address token, uint256 amountMinimum) payable returns()
+func (_UniSwapRouter02 *UniSwapRouter02TransactorSession) SweepToken0(token common.Address, amountMinimum *big.Int) (*types.Transaction, error) {
+	return _UniSwapRouter02.Contract.SweepToken0(&_UniSwapRouter02.TransactOpts, token, amountMinimum)
+}
+
+// SweepTokenWithFee is a paid mutator transaction binding the contract method 0x3068c554.
+//
+// Solidity: function sweepTokenWithFee(address token, uint256 amountMinimum, uint256 feeBips, address feeRecipient) payable returns()
+func (_UniSwapRouter02 *UniSwapRouter02Transactor) SweepTokenWithFee(opts *bind.TransactOpts, token common.Address, amountMinimum *big.Int, feeBips *big.Int, feeRecipient common.Address) (*types.Transaction, error) {
+	return _UniSwapRouter02.contract.Transact(opts, "sweepTokenWithFee", token, amountMinimum, feeBips, feeRecipient)
+}
+
+// SweepTokenWithFee is a paid mutator transaction binding the contract method 0x3068c554.
+//
+// Solidity: function sweepTokenWithFee(address token, uint256 amountMinimum, uint256 feeBips, address feeRecipient) payable returns()
+func (_UniSwapRouter02 *UniSwapRouter02Session) SweepTokenWithFee(token common.Address, amountMinimum *big.Int, feeBips *big.Int, feeRecipient common.Address) (*types.Transaction, error) {
+	return _UniSwapRouter02.Contract.SweepTokenWithFee(&_UniSwapRouter02.TransactOpts, token, amountMinimum, feeBips, feeRecipient)
+}
+
+// SweepTokenWithFee is a paid mutator transaction binding the contract method 0x3068c554.
+//
+// Solidity: function sweepTokenWithFee(address token, uint256 amountMinimum, uint256 feeBips, address feeRecipient) payable returns()
+func (_UniSwapRouter02 *UniSwapRouter02TransactorSession) SweepTokenWithFee(token common.Address, amountMinimum *big.Int, feeBips *big.Int, feeRecipient common.Address) (*types.Transaction, error) {
+	return _UniSwapRouter02.Contract.SweepTokenWithFee(&_UniSwapRouter02.TransactOpts, token, amountMinimum, feeBips, feeRecipient)
+}
+
+// SweepTokenWithFee0 is a paid mutator transaction binding the contract method 0xe0e189a0.
+//
+// Solidity: function sweepTokenWithFee(address token, uint256 amountMinimum, address recipient, uint256 feeBips, address feeRecipient) payable returns()
+func (_UniSwapRouter02 *UniSwapRouter02Transactor) SweepTokenWithFee0(opts *bind.TransactOpts, token common.Address, amountMinimum *big.Int, recipient common.Address, feeBips *big.Int, feeRecipient common.Address) (*types.Transaction, error) {
+	return _UniSwapRouter02.contract.Transact(opts, "sweepTokenWithFee0", token, amountMinimum, recipient, feeBips, feeRecipient)
+}
+
+// SweepTokenWithFee0 is a paid mutator transaction binding the contract method 0xe0e189a0.
+//
+// Solidity: function sweepTokenWithFee(address token, uint256 amountMinimum, address recipient, uint256 feeBips, address feeRecipient) payable returns()
+func (_UniSwapRouter02 *UniSwapRouter02Session) SweepTokenWithFee0(token common.Address, amountMinimum *big.Int, recipient common.Address, feeBips *big.Int, feeRecipient common.Address) (*types.Transaction, error) {
+	return _UniSwapRouter02.Contract.SweepTokenWithFee0(&_UniSwapRouter02.TransactOpts, token, amountMinimum, recipient, feeBips, feeRecipient)
+}
+
+// SweepTokenWithFee0 is a paid mutator transaction binding the contract method 0xe0e189a0.
+//
+// Solidity: function sweepTokenWithFee(address token, uint256 amountMinimum, address recipient, uint256 feeBips, address feeRecipient) payable returns()
+func (_UniSwapRouter02 *UniSwapRouter02TransactorSession) SweepTokenWithFee0(token common.Address, amountMinimum *big.Int, recipient common.Address, feeBips *big.Int, feeRecipient common.Address) (*types.Transaction, error) {
+	return _UniSwapRouter02.Contract.SweepTokenWithFee0(&_UniSwapRouter02.TransactOpts, token, amountMinimum, recipient, feeBips, feeRecipient)
+}
+
+// UniswapV3SwapCallback is a paid mutator transaction binding the contract method 0xfa461e33.
+//
+// Solidity: function uniswapV3SwapCallback(int256 amount0Delta, int256 amount1Delta, bytes _data) returns()
+func (_UniSwapRouter02 *UniSwapRouter02Transactor) UniswapV3SwapCallback(opts *bind.TransactOpts, amount0Delta *big.Int, amount1Delta *big.Int, _data []byte) (*types.Transaction, error) {
+	return _UniSwapRouter02.contract.Transact(opts, "uniswapV3SwapCallback", amount0Delta, amount1Delta, _data)
+}
+
+// UniswapV3SwapCallback is a paid mutator transaction binding the contract method 0xfa461e33.
+//
+// Solidity: function uniswapV3SwapCallback(int256 amount0Delta, int256 amount1Delta, bytes _data) returns()
+func (_UniSwapRouter02 *UniSwapRouter02Session) UniswapV3SwapCallback(amount0Delta *big.Int, amount1Delta *big.Int, _data []byte) (*types.Transaction, error) {
+	return _UniSwapRouter02.Contract.UniswapV3SwapCallback(&_UniSwapRouter02.TransactOpts, amount0Delta, amount1Delta, _data)
+}
+
+// UniswapV3SwapCallback is a paid mutator transaction binding the contract method 0xfa461e33.
+//
+// Solidity: function uniswapV3SwapCallback(int256 amount0Delta, int256 amount1Delta, bytes _data) returns()
+func (_UniSwapRouter02 *UniSwapRouter02TransactorSession) UniswapV3SwapCallback(amount0Delta *big.Int, amount1Delta *big.Int, _data []byte) (*types.Transaction, error) {
+	return _UniSwapRouter02.Contract.UniswapV3SwapCallback(&_UniSwapRouter02.TransactOpts, amount0Delta, amount1Delta, _data)
+}
+
+// UnwrapWETH9 is a paid mutator transaction binding the contract method 0x49404b7c.
+//
+// Solidity: function unwrapWETH9(uint256 amountMinimum, address recipient) payable returns()
+func (_UniSwapRouter02 *UniSwapRouter02Transactor) UnwrapWETH9(opts *bind.TransactOpts, amountMinimum *big.Int, recipient common.Address) (*types.Transaction, error) {
+	return _UniSwapRouter02.contract.Transact(opts, "unwrapWETH9", amountMinimum, recipient)
+}
+
+// UnwrapWETH9 is a paid mutator transaction binding the contract method 0x49404b7c.
+//
+// Solidity: function unwrapWETH9(uint256 amountMinimum, address recipient) payable returns()
+func (_UniSwapRouter02 *UniSwapRouter02Session) UnwrapWETH9(amountMinimum *big.Int, recipient common.Address) (*types.Transaction, error) {
+	return _UniSwapRouter02.Contract.UnwrapWETH9(&_UniSwapRouter02.TransactOpts, amountMinimum, recipient)
+}
+
+// UnwrapWETH9 is a paid mutator transaction binding the contract method 0x49404b7c.
+//
+// Solidity: function unwrapWETH9(uint256 amountMinimum, address recipient) payable returns()
+func (_UniSwapRouter02 *UniSwapRouter02TransactorSession) UnwrapWETH9(amountMinimum *big.Int, recipient common.Address) (*types.Transaction, error) {
+	return _UniSwapRouter02.Contract.UnwrapWETH9(&_UniSwapRouter02.TransactOpts, amountMinimum, recipient)
+}
+
+// UnwrapWETH90 is a paid mutator transaction binding the contract method 0x49616997.
+//
+// Solidity: function unwrapWETH9(uint256 amountMinimum) payable returns()
+func (_UniSwapRouter02 *UniSwapRouter02Transactor) UnwrapWETH90(opts *bind.TransactOpts, amountMinimum *big.Int) (*types.Transaction, error) {
+	return _UniSwapRouter02.contract.Transact(opts, "unwrapWETH90", amountMinimum)
+}
+
+// UnwrapWETH90 is a paid mutator transaction binding the contract method 0x49616997.
+//
+// Solidity: function unwrapWETH9(uint256 amountMinimum) payable returns()
+func (_UniSwapRouter02 *UniSwapRouter02Session) UnwrapWETH90(amountMinimum *big.Int) (*types.Transaction, error) {
+	return _UniSwapRouter02.Contract.UnwrapWETH90(&_UniSwapRouter02.TransactOpts, amountMinimum)
+}
+
+// UnwrapWETH90 is a paid mutator transaction binding the contract method 0x49616997.
+//
+// Solidity: function unwrapWETH9(uint256 amountMinimum) payable returns()
+func (_UniSwapRouter02 *UniSwapRouter02TransactorSession) UnwrapWETH90(amountMinimum *big.Int) (*types.Transaction, error) {
+	return _UniSwapRouter02.Contract.UnwrapWETH90(&_UniSwapRouter02.TransactOpts, amountMinimum)
+}
+
+// UnwrapWETH9WithFee is a paid mutator transaction binding the contract method 0x9b2c0a37.
+//
+// Solidity: function unwrapWETH9WithFee(uint256 amountMinimum, address recipient, uint256 feeBips, address feeRecipient) payable returns()
+func (_UniSwapRouter02 *UniSwapRouter02Transactor) UnwrapWETH9WithFee(opts *bind.TransactOpts, amountMinimum *big.Int, recipient common.Address, feeBips *big.Int, feeRecipient common.Address) (*types.Transaction, error) {
+	return _UniSwapRouter02.contract.Transact(opts, "unwrapWETH9WithFee", amountMinimum, recipient, feeBips, feeRecipient)
+}
+
+// UnwrapWETH9WithFee is a paid mutator transaction binding the contract method 0x9b2c0a37.
+//
+// Solidity: function unwrapWETH9WithFee(uint256 amountMinimum, address recipient, uint256 feeBips, address feeRecipient) payable returns()
+func (_UniSwapRouter02 *UniSwapRouter02Session) UnwrapWETH9WithFee(amountMinimum *big.Int, recipient common.Address, feeBips *big.Int, feeRecipient common.Address) (*types.Transaction, error) {
+	return _UniSwapRouter02.Contract.UnwrapWETH9WithFee(&_UniSwapRouter02.TransactOpts, amountMinimum, recipient, feeBips, feeRecipient)
+}
+
+// UnwrapWETH9WithFee is a paid mutator transaction binding the contract method 0x9b2c0a37.
+//
+// Solidity: function unwrapWETH9WithFee(uint256 amountMinimum, address recipient, uint256 feeBips, address feeRecipient) payable returns()
+func (_UniSwapRouter02 *UniSwapRouter02TransactorSession) UnwrapWETH9WithFee(amountMinimum *big.Int, recipient common.Address, feeBips *big.Int, feeRecipient common.Address) (*types.Transaction, error) {
+	return _UniSwapRouter02.Contract.UnwrapWETH9WithFee(&_UniSwapRouter02.TransactOpts, amountMinimum, recipient, feeBips, feeRecipient)
+}
+
+// UnwrapWETH9WithFee0 is a paid mutator transaction binding the contract method 0xd4ef38de.
+//
+// Solidity: function unwrapWETH9WithFee(uint256 amountMinimum, uint256 feeBips, address feeRecipient) payable returns()
+func (_UniSwapRouter02 *UniSwapRouter02Transactor) UnwrapWETH9WithFee0(opts *bind.TransactOpts, amountMinimum *big.Int, feeBips *big.Int, feeRecipient common.Address) (*types.Transaction, error) {
+	return _UniSwapRouter02.contract.Transact(opts, "unwrapWETH9WithFee0", amountMinimum, feeBips, feeRecipient)
+}
+
+// UnwrapWETH9WithFee0 is a paid mutator transaction binding the contract method 0xd4ef38de.
+//
+// Solidity: function unwrapWETH9WithFee(uint256 amountMinimum, uint256 feeBips, address feeRecipient) payable returns()
+func (_UniSwapRouter02 *UniSwapRouter02Session) UnwrapWETH9WithFee0(amountMinimum *big.Int, feeBips *big.Int, feeRecipient common.Address) (*types.Transaction, error) {
+	return _UniSwapRouter02.Contract.UnwrapWETH9WithFee0(&_UniSwapRouter02.TransactOpts, amountMinimum, feeBips, feeRecipient)
+}
+
+// UnwrapWETH9WithFee0 is a paid mutator transaction binding the contract method 0xd4ef38de.
+//
+// Solidity: function unwrapWETH9WithFee(uint256 amountMinimum, uint256 feeBips, address feeRecipient) payable returns()
+func (_UniSwapRouter02 *UniSwapRouter02TransactorSession) UnwrapWETH9WithFee0(amountMinimum *big.Int, feeBips *big.Int, feeRecipient common.Address) (*types.Transaction, error) {
+	return _UniSwapRouter02.Contract.UnwrapWETH9WithFee0(&_UniSwapRouter02.TransactOpts, amountMinimum, feeBips, feeRecipient)
+}
+
+// WrapETH is a paid mutator transaction binding the contract method 0x1c58db4f.
+//
+// Solidity: function wrapETH(uint256 value) payable returns()
+func (_UniSwapRouter02 *UniSwapRouter02Transactor) WrapETH(opts *bind.TransactOpts, value *big.Int) (*types.Transaction, error) {
+	return _UniSwapRouter02.contract.Transact(opts, "wrapETH", value)
+}
+
+// WrapETH is a paid mutator transaction binding the contract method 0x1c58db4f.
+//
+// Solidity: function wrapETH(uint256 value) payable returns()
+func (_UniSwapRouter02 *UniSwapRouter02Session) WrapETH(value *big.Int) (*types.Transaction, error) {
+	return _UniSwapRouter02.Contract.WrapETH(&_UniSwapRouter02.TransactOpts, value)
+}
+
+// WrapETH is a paid mutator transaction binding the contract method 0x1c58db4f.
+//
+// Solidity: function wrapETH(uint256 value) payable returns()
+func (_UniSwapRouter02 *UniSwapRouter02TransactorSession) WrapETH(value *big.Int) (*types.Transaction, error) {
+	return _UniSwapRouter02.Contract.WrapETH(&_UniSwapRouter02.TransactOpts, value)
+}
+
+// Receive is a paid mutator transaction binding the contract receive function.
+//
+// Solidity: receive() payable returns()
+func (_UniSwapRouter02 *UniSwapRouter02Transactor) Receive(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _UniSwapRouter02.contract.RawTransact(opts, nil) // calldata is disallowed for receive function
+}
+
+// Receive is a paid mutator transaction binding the contract receive function.
+//
+// Solidity: receive() payable returns()
+func (_UniSwapRouter02 *UniSwapRouter02Session) Receive() (*types.Transaction, error) {
+	return _UniSwapRouter02.Contract.Receive(&_UniSwapRouter02.TransactOpts)
+}
+
+// Receive is a paid mutator transaction binding the contract receive function.
+//
+// Solidity: receive() payable returns()
+func (_UniSwapRouter02 *UniSwapRouter02TransactorSession) Receive() (*types.Transaction, error) {
+	return _UniSwapRouter02.Contract.Receive(&_UniSwapRouter02.TransactOpts)
+}


### PR DESCRIPTION
Init SwapToUsdc skeleton

- define pool fees and swap routes statically, based on mainnet [pools](https://app.uniswap.org/explore/pools). dynamic pool / route discovery not worth it atm
- add Quoter and SwapRouter02 bindings
- add skeleton SwapToUSDC entrypoint

issue: none
