### PR TITLE
fix(e2e): temporal fix of foundry docker image

### DIFF
--- a/.github/actions/setup-foundry/action.yaml
+++ b/.github/actions/setup-foundry/action.yaml
@@ -23,4 +23,5 @@ runs:
     - name: Install docker
       shell: bash
       if: ${{ inputs.docker == 'true' }}
-      run: docker pull ghcr.io/foundry-rs/foundry:${{ steps.foundry_version.outputs.version}}
+      run: docker pull docker.io/chrmllr/foundry-stable
+      # run: docker pull ghcr.io/foundry-rs/foundry:${{ steps.foundry_version.outputs.version}}

--- a/e2e/anvilproxy/Dockerfile
+++ b/e2e/anvilproxy/Dockerfile
@@ -1,5 +1,6 @@
 ARG FOUNDRY_VERSION
-FROM ghcr.io/foundry-rs/foundry:${FOUNDRY_VERSION}
+FROM docker.io/chrmllr/foundry-${FOUNDRY_VERSION}
+# FROM ghcr.io/foundry-rs/foundry:${FOUNDRY_VERSION}
 
 # Need wget for localhost perturbations
 # apk for apline (https://github.com/foundry-rs/foundry/blob/master/Dockerfile)

--- a/lib/anvil/compose.yaml.tmpl
+++ b/lib/anvil/compose.yaml.tmpl
@@ -4,7 +4,7 @@ services:
   anvil:
     labels:
       anvil: true
-    image: ghcr.io/foundry-rs/foundry:{{ if .Version }}{{ .Version }}{{ else }}latest{{ end }}
+    image: docker.io/chrmllr/foundry-stable
     platform: linux/amd64
     entrypoint:
       - anvil


### PR DESCRIPTION
Replaces the foundry docker image with a `stable` build hosted by my account. We should roll this back as soon as the official one gets fixed.

issue: none