### PR TITLE
ci(e2e): bump omega mainnet web2

### DIFF
--- a/e2e/manifests/mainnet.toml
+++ b/e2e/manifests/mainnet.toml
@@ -5,9 +5,9 @@ multi_omni_evms = true
 prometheus   = true
 
 pinned_halo_tag = "1849471"
-pinned_relayer_tag = "1849471"
-pinned_monitor_tag = "8c5e456"
-pinned_solver_tag = "8c5e456"
+pinned_relayer_tag = "577a73c"
+pinned_monitor_tag = "577a73c"
+pinned_solver_tag = "577a73c"
 
 [node.validator01]
 [node.validator02]

--- a/e2e/manifests/omega.toml
+++ b/e2e/manifests/omega.toml
@@ -5,9 +5,9 @@ multi_omni_evms = true
 prometheus = true
 
 pinned_halo_tag = "v0.14.0"
-pinned_relayer_tag = "v0.14.0"
-pinned_monitor_tag = "v0.14.0"
-pinned_solver_tag = "v0.14.0"
+pinned_relayer_tag = "577a73c"
+pinned_monitor_tag = "577a73c"
+pinned_solver_tag = "577a73c"
 
 [node.validator01]
 [node.validator02]


### PR DESCRIPTION
Roll out latest monitor and solver changes to mainnet and omega.

issue: none