### PR TITLE
refactor(lib/tokenpricer): rename to USDPrice

### DIFF
--- a/lib/contracts/feeoraclev1/feeparams.go
+++ b/lib/contracts/feeoraclev1/feeparams.go
@@ -104,7 +104,7 @@ func conversionRate(ctx context.Context, pricer tokenpricer.Pricer, from, to tok
 		return 1, nil
 	}
 
-	prices, err := pricer.Prices(ctx, from, to)
+	prices, err := pricer.USDPrices(ctx, from, to)
 	if err != nil {
 		return 0, errors.Wrap(err, "get price", "from", from, "to", to)
 	}

--- a/lib/contracts/feeoraclev2/feeparams.go
+++ b/lib/contracts/feeoraclev2/feeparams.go
@@ -204,7 +204,7 @@ func conversionRate(ctx context.Context, pricer tokenpricer.Pricer, from, to tok
 		return 1, nil
 	}
 
-	prices, err := pricer.Prices(ctx, from, to)
+	prices, err := pricer.USDPrices(ctx, from, to)
 	if err != nil {
 		return 0, errors.Wrap(err, "get price", "from", from, "to", to)
 	}

--- a/lib/tokenpricer/coingecko/coingecko.go
+++ b/lib/tokenpricer/coingecko/coingecko.go
@@ -39,9 +39,9 @@ func New(opts ...func(*options)) Client {
 	}
 }
 
-// Price returns the price of the token in USD.
-func (c Client) Price(ctx context.Context, tkn tokens.Asset) (float64, error) {
-	prices, err := c.Prices(ctx, tkn)
+// USDPrice returns the price of the token in USD.
+func (c Client) USDPrice(ctx context.Context, tkn tokens.Asset) (float64, error) {
+	prices, err := c.USDPrices(ctx, tkn)
 	if err != nil {
 		return 0, err
 	}
@@ -55,7 +55,7 @@ func (c Client) Price(ctx context.Context, tkn tokens.Asset) (float64, error) {
 }
 
 // Prices returns the price of each coin in USD.
-func (c Client) Prices(ctx context.Context, tkns ...tokens.Asset) (map[tokens.Asset]float64, error) {
+func (c Client) USDPrices(ctx context.Context, tkns ...tokens.Asset) (map[tokens.Asset]float64, error) {
 	return c.getPrice(ctx, "usd", tkns...)
 }
 

--- a/lib/tokenpricer/coingecko/coingecko_test.go
+++ b/lib/tokenpricer/coingecko/coingecko_test.go
@@ -29,7 +29,7 @@ func TestIntegration(t *testing.T) {
 	require.True(t, ok)
 
 	c := coingecko.New(coingecko.WithAPIKey(apikey))
-	prices, err := c.Prices(t.Context(), tokens.OMNI, tokens.ETH)
+	prices, err := c.USDPrices(t.Context(), tokens.OMNI, tokens.ETH)
 	tutil.RequireNoError(t, err)
 	require.NotEmpty(t, prices)
 }
@@ -79,7 +79,7 @@ func TestGetPrice(t *testing.T) {
 			defer server.Close()
 
 			c := coingecko.New(coingecko.WithHost(server.URL), coingecko.WithAPIKey(token))
-			prices, err := c.Prices(t.Context(), tokens.OMNI, tokens.ETH)
+			prices, err := c.USDPrices(t.Context(), tokens.OMNI, tokens.ETH)
 
 			if shouldErr(t, test) {
 				require.Error(t, err)

--- a/lib/tokenpricer/mock.go
+++ b/lib/tokenpricer/mock.go
@@ -23,14 +23,14 @@ func NewMock(prices map[tokens.Asset]float64) *Mock {
 	return &Mock{prices: cloned}
 }
 
-func (m *Mock) Price(_ context.Context, tkn tokens.Asset) (float64, error) {
+func (m *Mock) USDPrice(_ context.Context, tkn tokens.Asset) (float64, error) {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 
 	return m.prices[tkn], nil
 }
 
-func (m *Mock) Prices(_ context.Context, tkns ...tokens.Asset) (map[tokens.Asset]float64, error) {
+func (m *Mock) USDPrices(_ context.Context, tkns ...tokens.Asset) (map[tokens.Asset]float64, error) {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 

--- a/lib/tokenpricer/tokenpricer_test.go
+++ b/lib/tokenpricer/tokenpricer_test.go
@@ -23,7 +23,7 @@ func TestCachedPricer(t *testing.T) {
 
 	cached := tokenpricer.NewCached(pricer)
 
-	prices, err := cached.Prices(t.Context(), ETH, OMNI)
+	prices, err := cached.USDPrices(t.Context(), ETH, OMNI)
 	require.NoError(t, err)
 	require.InEpsilon(t, 100.0, prices[ETH], epsilon)
 	require.InEpsilon(t, 200.0, prices[OMNI], epsilon)
@@ -33,7 +33,7 @@ func TestCachedPricer(t *testing.T) {
 	pricer.SetPrice(OMNI, 250)
 
 	// prices should still be cached
-	prices, err = cached.Prices(t.Context(), ETH, OMNI)
+	prices, err = cached.USDPrices(t.Context(), ETH, OMNI)
 	require.NoError(t, err)
 	require.InEpsilon(t, 100.0, prices[ETH], epsilon)
 	require.InEpsilon(t, 200.0, prices[OMNI], epsilon)
@@ -42,7 +42,7 @@ func TestCachedPricer(t *testing.T) {
 	cached.ClearCache()
 
 	// prices should be updated
-	prices, err = cached.Prices(t.Context(), ETH, OMNI)
+	prices, err = cached.USDPrices(t.Context(), ETH, OMNI)
 	require.NoError(t, err)
 	require.InEpsilon(t, 150.0, prices[ETH], epsilon)
 	require.InEpsilon(t, 250.0, prices[OMNI], epsilon)

--- a/monitor/xfeemngr/tokenprice/buffer.go
+++ b/monitor/xfeemngr/tokenprice/buffer.go
@@ -64,7 +64,7 @@ func (b *buffer) Stream(ctx context.Context) {
 // stream starts streaming prices for all tokens into the buffer.
 func (b *buffer) stream(ctx context.Context) {
 	callback := func(ctx context.Context) {
-		prices, err := b.pricer.Prices(ctx, b.tokens...)
+		prices, err := b.pricer.USDPrices(ctx, b.tokens...)
 		if err != nil {
 			log.Warn(ctx, "Failed to get prices (will retry)", err)
 			return

--- a/monitor/xfeemngr/tokenprice/buffer_test.go
+++ b/monitor/xfeemngr/tokenprice/buffer_test.go
@@ -48,7 +48,7 @@ func TestBufferStream(t *testing.T) {
 
 		tick.Tick()
 
-		live, err := pricer.Prices(ctx, tokens.OMNI, tokens.ETH)
+		live, err := pricer.USDPrices(ctx, tokens.OMNI, tokens.ETH)
 		require.NoError(t, err)
 
 		// check if any live price is outside threshold

--- a/relayer/app/pnl.go
+++ b/relayer/app/pnl.go
@@ -63,7 +63,7 @@ func (l pnlLogger) logE(ctx context.Context, tx *ethtypes.Transaction, receipt *
 	spendGwei := totalSpendGwei(tx, receipt)
 	spendTotal.WithLabelValues(dest.Name, dest.NativeToken.Symbol).Add(spendGwei)
 
-	prices, err := l.pricer.Prices(ctx, tokens.OMNI, tokens.ETH)
+	prices, err := l.pricer.USDPrices(ctx, tokens.OMNI, tokens.ETH)
 	if err != nil {
 		return errors.Wrap(err, "get prices")
 	}

--- a/solver/app/pnl.go
+++ b/solver/app/pnl.go
@@ -174,7 +174,7 @@ func maybeParseXCallFee(rec *ethclient.Receipt) (*big.Int, bool) {
 // usdPnL logs the USD equivalent PnL.
 // This is best effort.
 func usdPnL(ctx context.Context, pricer tokenpricer.Pricer, token tokens.Asset, p pnl.LogP) {
-	usdPrice, err := pricer.Price(ctx, token)
+	usdPrice, err := pricer.USDPrice(ctx, token)
 	if err != nil {
 		log.Warn(ctx, "Failed to get token USD price (will retry)", err, "token", token.Name)
 		return


### PR DESCRIPTION
Rename tokenpricer functions to USDPrice since we need to add non-usd price functions for swaps.

issue: none