### PR TITLE
ci(e2e): fix admin test

### DIFF
--- a/e2e/cmd/admin.go
+++ b/e2e/cmd/admin.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"github.com/omni-network/omni/e2e/app"
 	"github.com/omni-network/omni/e2e/app/admin"
+	"github.com/omni-network/omni/e2e/bridge"
 	"github.com/omni-network/omni/lib/errors"
 	"github.com/omni-network/omni/lib/netconf"
 
@@ -303,6 +304,10 @@ func newAdminTestCmd(def *app.Definition) *cobra.Command {
 					PingPongP: 0,
 					PingPongL: 0}); err != nil {
 					return errors.Wrap(err, "deploy")
+				}
+
+				if err := bridge.DeployBridge(ctx, def.Testnet, def.Backends()); err != nil {
+					return errors.Wrap(err, "deploy bridge")
 				}
 			}
 


### PR DESCRIPTION
Bridge isn't always deployed anymore, so deploy it explicitly in e2e-admin test.

issue: none