### PR TITLE
chore(lib/txmgr): handle nonce too high

### DIFF
--- a/lib/txmgr/txmgr.go
+++ b/lib/txmgr/txmgr.go
@@ -390,6 +390,7 @@ func (m *simple) publishTx(ctx context.Context, tx *types.Transaction, sendState
 			if attempt < retryNonceTooHigh {
 				log.DebugErr(ctx, "Nonce too high (will retry)", err)
 				bumpFeesImmediately = false
+				backoff()
 
 				continue // retry without fee bump, since this is probably a race
 			}


### PR DESCRIPTION
Handle `nonce too high` errors by simply retrying a few times (with backoff).

This mitigates races when multiple concurrent submissions reserve nonces and reach upstream geth nodes out of order.

issue: none