### PR TITLE
chore(solver/app): debug reverted txs

### DIFF
--- a/lib/contracts/solvernet/bindings.go
+++ b/lib/contracts/solvernet/bindings.go
@@ -31,7 +31,7 @@ var (
 type EventMeta struct {
 	Topic   common.Hash
 	Status  OrderStatus
-	ParseID func(contract bindings.SolverNetInboxFilterer, log types.Log) (OrderID, error)
+	ParseID func(log types.Log) (OrderID, error)
 }
 
 var (
@@ -100,13 +100,7 @@ func ParseEvent(l types.Log) (OrderID, OrderStatus, error) {
 		return OrderID{}, 0, errors.New("unknown event")
 	}
 
-	// Safe to use dummy address and backend since we only parse events.
-	parser, err := bindings.NewSolverNetInbox(common.Address{}, nil)
-	if err != nil {
-		return OrderID{}, 0, errors.New("new solver inbox")
-	}
-
-	orderID, err := e.ParseID(parser.SolverNetInboxFilterer, l)
+	orderID, err := e.ParseID(l)
 	if err != nil {
 		return OrderID{}, 0, errors.Wrap(err, "parse id")
 	}
@@ -114,7 +108,13 @@ func ParseEvent(l types.Log) (OrderID, OrderStatus, error) {
 	return orderID, e.Status, nil
 }
 
-func ParseOpened(contract bindings.SolverNetInboxFilterer, log types.Log) (OrderID, error) {
+func ParseOpened(log types.Log) (OrderID, error) {
+	// Safe to use dummy values since we only parse events.
+	contract, err := bindings.NewSolverNetInbox(common.Address{}, nil)
+	if err != nil {
+		return OrderID{}, errors.New("dummy solver inbox")
+	}
+
 	e, err := contract.ParseOpen(log)
 	if err != nil {
 		return OrderID{}, errors.Wrap(err, "parse opened")
@@ -123,7 +123,13 @@ func ParseOpened(contract bindings.SolverNetInboxFilterer, log types.Log) (Order
 	return e.OrderId, nil
 }
 
-func ParseRejected(contract bindings.SolverNetInboxFilterer, log types.Log) (OrderID, error) {
+func ParseRejected(log types.Log) (OrderID, error) {
+	// Safe to use dummy values since we only parse events.
+	contract, err := bindings.NewSolverNetInbox(common.Address{}, nil)
+	if err != nil {
+		return OrderID{}, errors.New("dummy solver inbox")
+	}
+
 	e, err := contract.ParseRejected(log)
 	if err != nil {
 		return OrderID{}, errors.Wrap(err, "parse rejected")
@@ -132,7 +138,13 @@ func ParseRejected(contract bindings.SolverNetInboxFilterer, log types.Log) (Ord
 	return e.Id, nil
 }
 
-func ParseClosed(contract bindings.SolverNetInboxFilterer, log types.Log) (OrderID, error) {
+func ParseClosed(log types.Log) (OrderID, error) {
+	// Safe to use dummy values since we only parse events.
+	contract, err := bindings.NewSolverNetInbox(common.Address{}, nil)
+	if err != nil {
+		return OrderID{}, errors.New("dummy solver inbox")
+	}
+
 	e, err := contract.ParseClosed(log)
 	if err != nil {
 		return OrderID{}, errors.Wrap(err, "parse closed")
@@ -141,7 +153,13 @@ func ParseClosed(contract bindings.SolverNetInboxFilterer, log types.Log) (Order
 	return e.Id, nil
 }
 
-func ParseFilled(contract bindings.SolverNetInboxFilterer, log types.Log) (OrderID, error) {
+func ParseFilled(log types.Log) (OrderID, error) {
+	// Safe to use dummy values since we only parse events.
+	contract, err := bindings.NewSolverNetInbox(common.Address{}, nil)
+	if err != nil {
+		return OrderID{}, errors.New("dummy solver inbox")
+	}
+
 	e, err := contract.ParseFilled(log)
 	if err != nil {
 		return OrderID{}, errors.Wrap(err, "parse filled")
@@ -150,7 +168,13 @@ func ParseFilled(contract bindings.SolverNetInboxFilterer, log types.Log) (Order
 	return e.Id, nil
 }
 
-func ParseClaimed(contract bindings.SolverNetInboxFilterer, log types.Log) (OrderID, error) {
+func ParseClaimed(log types.Log) (OrderID, error) {
+	// Safe to use dummy values since we only parse events.
+	contract, err := bindings.NewSolverNetInbox(common.Address{}, nil)
+	if err != nil {
+		return OrderID{}, errors.New("dummy solver inbox")
+	}
+
 	e, err := contract.ParseClaimed(log)
 	if err != nil {
 		return OrderID{}, errors.Wrap(err, "parse claimed")

--- a/lib/ethclient/ethbackend/backend.go
+++ b/lib/ethclient/ethbackend/backend.go
@@ -298,7 +298,8 @@ func (b *Backend) EnsureSynced(ctx context.Context) error {
 func (b *Backend) WaitConfirmed(ctx context.Context, tx *ethtypes.Transaction) (*ethclient.Receipt, error) {
 	rec, err := b.WaitMined(ctx, tx)
 	if err != nil {
-		return nil, errors.Wrap(err, "wait mined")
+		// Return receipt with error, in case it was mined but reverted
+		return rec, errors.Wrap(err, "wait mined")
 	}
 
 	meta, ok := evmchain.MetadataByID(b.chainID)

--- a/relayer/app/sender.go
+++ b/relayer/app/sender.go
@@ -180,8 +180,7 @@ func (s Sender) SendAsync(ctx context.Context, sub xchain.Submission) <-chan err
 			go s.onSubmit(ctx, tx, rec, sub)
 		}
 
-		const statusReverted = 0
-		if rec.Status == statusReverted {
+		if rec.Status == ethtypes.ReceiptStatusFailed {
 			// Try and get debug information of the reverted transaction
 			resp, err := s.ethCl.CallContract(ctx, callFromTx(s.txMgr.From(), tx), rec.BlockNumber)
 

--- a/solver/app/app.go
+++ b/solver/app/app.go
@@ -309,7 +309,7 @@ func startProcessingEvents(
 		}
 
 		deps := procDeps{
-			ParseID:       newIDParser(inboxContracts),
+			ParseID:       newIDParser(),
 			GetOrder:      newOrderGetter(inboxContracts),
 			ShouldReject:  newShouldRejector(backends, callAllower, priceFunc, solverAddr, addrs.SolverNetOutbox),
 			DidFill:       newDidFiller(outboxContracts),

--- a/solver/app/processor.go
+++ b/solver/app/processor.go
@@ -23,7 +23,7 @@ func newEventProcFunc(deps procDeps, chainID uint64) eventProcFunc {
 			return errors.New("unknown event [BUG]")
 		}
 
-		orderID, err := deps.ParseID(chainID, elog)
+		orderID, err := deps.ParseID(elog)
 		if err != nil {
 			return errors.Wrap(err, "parse id")
 		}

--- a/solver/app/processor_internal_test.go
+++ b/solver/app/processor_internal_test.go
@@ -81,7 +81,7 @@ func TestEventProcessor(t *testing.T) {
 			actual := ignored
 
 			deps := procDeps{
-				ParseID: func(_ uint64, log types.Log) (OrderID, error) {
+				ParseID: func(log types.Log) (OrderID, error) {
 					return OrderID(log.Topics[1]), nil // Return second topic as order ID
 				},
 				GetOrder: func(ctx context.Context, chainID uint64, id OrderID) (Order, bool, error) {

--- a/solver/app/worker.go
+++ b/solver/app/worker.go
@@ -65,7 +65,7 @@ func newAsyncWorkerFunc(
 					return
 				}
 
-				log.Warn(ctx, "Failed to process job (will retry)", err, "job_id", j.GetId(), "order_id", orderID.String(), "status", status)
+				log.Warn(ctx, "Failed to process job (will retry)", err, "job_id", j.GetId(), "order_id", orderID, "status", status)
 				workErrors.WithLabelValues(chainName, status.String()).Inc()
 				backoff()
 			}

--- a/solver/app/worker.go
+++ b/solver/app/worker.go
@@ -31,11 +31,10 @@ func newAsyncWorkerFunc(
 			return errors.Wrap(err, "parse event log [BUG]")
 		}
 
-		event, ok := solvernet.EventByTopic(elog.Topics[0])
-		if !ok {
-			return errors.New("unknown event [BUG]")
+		orderID, status, err := solvernet.ParseEvent(elog)
+		if err != nil {
+			return errors.Wrap(err, "parse event [BUG]")
 		}
-		status := event.Status.String()
 
 		proc, ok := procs[j.GetChainId()]
 		if !ok {
@@ -61,13 +60,13 @@ func newAsyncWorkerFunc(
 				} else if err == nil {
 					// Done
 					duration := time.Since(j.GetCreatedAt().AsTime()).Seconds()
-					workDuration.WithLabelValues(chainName, status).Observe(duration)
+					workDuration.WithLabelValues(chainName, status.String()).Observe(duration)
 
 					return
 				}
 
-				log.Warn(ctx, "Failed to process job (will retry)", err, "job_id", j.GetId())
-				workErrors.WithLabelValues(chainName, status).Inc()
+				log.Warn(ctx, "Failed to process job (will retry)", err, "job_id", j.GetId(), "order_id", orderID.String(), "status", status)
+				workErrors.WithLabelValues(chainName, status.String()).Inc()
 				backoff()
 			}
 		}()


### PR DESCRIPTION
Best effort debugging of reverted txs by doing `Call` and custom error conversions.

Also improve `Failed job` logs (adding `order_id`). 
Also improve ID parsing.

issue: none
