### PR TITLE
fix(ethclient/headerdb): prevent deadlock

### DIFF
--- a/lib/ethclient/headerdb/headerdb_internal_test.go
+++ b/lib/ethclient/headerdb/headerdb_internal_test.go
@@ -10,3 +10,8 @@ import (
 func (db *DB) Set(ctx context.Context, h *types.Header) error {
 	return db.set(ctx, h)
 }
+
+// DeleteFrom exports the deleteFrom method for testing.
+func (db *DB) DeleteFrom(ctx context.Context, height uint64) (int, error) {
+	return db.deleteFrom(ctx, height)
+}


### PR DESCRIPTION
Fixes deadlock in `headercachedb` since `cosmos-db.MemDB` deosn't support iterating and writing. It can deadlock when iteration is large.

issue: #3615 