### PR TITLE
fix(halo): relax block validation around upgrades

### DIFF
--- a/octane/evmengine/keeper/abci_internal_test.go
+++ b/octane/evmengine/keeper/abci_internal_test.go
@@ -695,6 +695,7 @@ func (m mockEngineAPI) nextBlock(
 	parentHash common.Hash,
 	feeRecipient common.Address,
 	beaconRoot *common.Hash,
+	withdrawals ...*types.Withdrawal,
 ) (*types.Block, eengine.ExecutableData) {
 	t.Helper()
 	var header types.Header
@@ -709,7 +710,7 @@ func (m mockEngineAPI) nextBlock(
 	// Convert header to block
 	block := types.NewBlock(
 		&header,
-		&types.Body{Withdrawals: []*types.Withdrawal{}},
+		&types.Body{Withdrawals: withdrawals},
 		nil,
 		trie.NewStackTrie(nil),
 	)

--- a/octane/evmengine/keeper/keeper.go
+++ b/octane/evmengine/keeper/keeper.go
@@ -183,8 +183,8 @@ func (k *Keeper) parseAndVerifyProposedPayload(ctx context.Context, msg *types.M
 		return engine.ExecutableData{}, errors.Wrap(err, "eligible withdrawals")
 	}
 
-	// Allow 0 payload withdrawals for first block after drake upgrade.
-	// Since block built and verified by magellen, but executed by drake.
+	// Allow 0 payload withdrawals until then ext release after drake.
+	// Since block built and verified by magellan, but executed by drake.
 	// So do strict validation unless in FinalizeBlock and payload is empty.
 	strictWithdrawals := sdk.UnwrapSDKContext(ctx).ExecMode() == sdk.ExecModeProcessProposal || len(payload.Withdrawals) > 0
 

--- a/octane/evmengine/keeper/keeper.go
+++ b/octane/evmengine/keeper/keeper.go
@@ -183,9 +183,13 @@ func (k *Keeper) parseAndVerifyProposedPayload(ctx context.Context, msg *types.M
 		return engine.ExecutableData{}, errors.Wrap(err, "eligible withdrawals")
 	}
 
-	if !withdrawalsEqual(payload.Withdrawals, eligibleWithdrawals) {
-		height := sdk.UnwrapSDKContext(ctx).BlockHeight()
-		return engine.ExecutableData{}, errors.New("mismatch with eligible withdrawals", "height", height)
+	// Allow 0 payload withdrawals for first block after drake upgrade.
+	// Since block built and verified by magellen, but executed by drake.
+	// So do strict validation unless in FinalizeBlock and payload is empty.
+	strictWithdrawals := sdk.UnwrapSDKContext(ctx).ExecMode() == sdk.ExecModeProcessProposal || len(payload.Withdrawals) > 0
+
+	if !withdrawalsEqual(payload.Withdrawals, eligibleWithdrawals) && strictWithdrawals {
+		return engine.ExecutableData{}, errors.New("mismatch with eligible withdrawals")
 	}
 
 	// Ensure no witness

--- a/octane/evmengine/keeper/msg_server_internal_test.go
+++ b/octane/evmengine/keeper/msg_server_internal_test.go
@@ -41,7 +41,8 @@ func Test_msgServer_ExecutionPayload(t *testing.T) {
 
 	// TODO(remove after drake): this test should pass both for empty withdrawals and the correct
 	// list of withdrawals. This is required because when we upgrade to drake, we execute a block
-	// without withdrawals created by the previous binary.
+	// without withdrawals created by the previous binary. With presence of at least one honest
+	// blockmaker, this is fine to do in general.
 	for _, withdrawals := range []etypes.Withdrawals{{withdrawal}, {}} {
 		cdc := getCodec(t)
 		txConfig := authtx.NewTxConfig(cdc, nil)


### PR DESCRIPTION
Introduces the `strictMode` flag to the block payload validation which defines whether the payload should be rejected if it contains no withdrawals, even though we have some eligible ones. This is required, because after we upgrade the network to a new binary, the first block it executes is built by the previous binary, which cannot include the withdrawals.

This change should be deleted after drake is rolled out.

issue: none