### PR TITLE
chore(solver): add price endpoint

### DIFF
--- a/monitor/flowgen/bridging/bridging_internal_test.go
+++ b/monitor/flowgen/bridging/bridging_internal_test.go
@@ -1,41 +1,13 @@
 package bridging
 
 import (
-	"flag"
 	"testing"
 
 	"github.com/omni-network/omni/lib/bi"
-	"github.com/omni-network/omni/lib/evmchain"
-	"github.com/omni-network/omni/lib/netconf"
-	"github.com/omni-network/omni/lib/tokens"
-	"github.com/omni-network/omni/lib/xchain/connect"
 	solver "github.com/omni-network/omni/solver/app"
 
 	"github.com/stretchr/testify/require"
 )
-
-var integration = flag.Bool("integration", false, "enable integration test")
-
-func TestSolverAvailable(t *testing.T) {
-	t.Parallel()
-	if !*integration {
-		t.Skip("skipping integration test")
-	}
-
-	network := netconf.Staging
-	conn, err := connect.New(t.Context(), network, connect.WithInfuraENV("INFURA_SECRET"))
-	require.NoError(t, err)
-
-	srcToken, ok := tokens.ByAsset(evmchain.IDOmniStaging, tokens.OMNI)
-	require.True(t, ok)
-	dstToken, ok := tokens.ByAsset(evmchain.IDOpSepolia, tokens.ETH)
-	require.True(t, ok)
-
-	avail, err := solverAvailable(t.Context(), network, conn.Backends, conn.SolverCl, srcToken, dstToken)
-	require.NoError(t, err)
-
-	t.Logf("available: %v", srcToken.FormatAmt(avail))
-}
 
 func TestSplitOrderAmounts(t *testing.T) {
 	t.Parallel()

--- a/solver/app/app.go
+++ b/solver/app/app.go
@@ -138,6 +138,7 @@ func Run(ctx context.Context, cfg Config) error {
 		newCheckHandler(newChecker(backends, callAllower, priceFunc, solverAddr, addrs.SolverNetOutbox)),
 		newContractsHandler(addrs),
 		newQuoteHandler(newQuoter(priceFunc)),
+		newPriceHandler(wrapPriceHandlerFunc(priceFunc)),
 	)
 	defer apiCancel()
 

--- a/solver/app/handler.go
+++ b/solver/app/handler.go
@@ -123,6 +123,26 @@ func newQuoteHandler(quoteFunc quoteFunc) Handler {
 	}
 }
 
+func newPriceHandler(priceFunc priceHandlerFunc) Handler {
+	return Handler{
+		Endpoint: endpointPrice,
+		ZeroReq:  func() any { return &types.PriceRequest{} },
+		HandleFunc: func(ctx context.Context, request any) (any, error) {
+			req, ok := request.(*types.PriceRequest)
+			if !ok {
+				return nil, errors.New("invalid request type [BUG]", "type", fmt.Sprintf("%T", request))
+			}
+
+			res, err := priceFunc(ctx, req)
+			if err != nil {
+				return types.PriceResponse{}, err
+			}
+
+			return res, nil
+		},
+	}
+}
+
 var gatewayTimeout = time.Second * 10
 
 func handlerAdapter(h Handler) http.Handler {

--- a/solver/app/server.go
+++ b/solver/app/server.go
@@ -19,6 +19,7 @@ const (
 	endpointQuote     = "/api/v1/quote"
 	endpointContracts = "/api/v1/contracts"
 	endpointCheck     = "/api/v1/check"
+	endpointPrice     = "/api/v1/price"
 )
 
 // serveAPI starts the API server, returning a async error and shutdown function.

--- a/solver/app/tokens.go
+++ b/solver/app/tokens.go
@@ -26,6 +26,15 @@ type SpendBounds struct {
 	MaxSpend *big.Int // maximum spend amount
 }
 
+// DepositBounds returns the equivalent deposit bounds
+// by multiplies the spend bounds by the given price.
+func (b SpendBounds) DepositBounds(price float64) SpendBounds {
+	return SpendBounds{
+		MinSpend: bi.MulF64(b.MinSpend, price),
+		MaxSpend: bi.MulF64(b.MaxSpend, price),
+	}
+}
+
 var (
 	tokenSpendBounds = map[tokens.Asset]map[tokens.ChainClass]SpendBounds{
 		tokens.ETH: {

--- a/solver/client/client.go
+++ b/solver/client/client.go
@@ -15,6 +15,7 @@ import (
 const (
 	endpointCheck = "/api/v1/check"
 	endpointQuote = "/api/v1/quote"
+	endpointPrice = "/api/v1/price"
 )
 
 // New creates a new solver Client.
@@ -65,6 +66,17 @@ func (c Client) Quote(ctx context.Context, req types.QuoteRequest) (types.QuoteR
 	}
 
 	return res, nil
+}
+
+// expense amount = deposit amount / price.
+func (c Client) Price(ctx context.Context, req types.PriceRequest) (float64, error) {
+	var res types.PriceResponse
+
+	if err := c.do(ctx, endpointPrice, req, &res); err != nil {
+		return 0, err
+	}
+
+	return res.Price, nil
 }
 
 func (c Client) do(ctx context.Context, endpoint string, req any, res any) error {

--- a/solver/types/api.go
+++ b/solver/types/api.go
@@ -63,6 +63,20 @@ type QuoteRequest struct {
 	Expense            AddrAmt `json:"expense"`
 }
 
+type PriceRequest struct {
+	SourceChainID      uint64         `json:"sourceChainId"`
+	DestinationChainID uint64         `json:"destChainId"`
+	DepositToken       common.Address `json:"depositToken"`
+	ExpenseToken       common.Address `json:"expenseToken"`
+}
+
+type PriceResponse struct {
+	// Price of 1 unit of deposit token denominated in expense tokens.
+	// deposit amount = expense amount * price
+	// expense amount = deposit amount / price
+	Price float64 `json:"price"`
+}
+
 type addrAmtJSON struct {
 	Token  common.Address `json:"token"`
 	Amount *hexutil.Big   `json:"amount,omitempty"`


### PR DESCRIPTION
Add `api/v1/price` endpoint to solver. This allows flowgen to calculate what size deposits are allows, since `SpendBounds` are defined on expenses, not deposits.

issue: none
