### PR TITLE
test(sdk): increase integration test coverage

### DIFF
--- a/sdk/integration-tests/suites/hooks.tsx
+++ b/sdk/integration-tests/suites/hooks.tsx
@@ -395,8 +395,8 @@ describe('useGetOrder()', () => {
   })
 })
 
-describe('useValidateOrder()', () => {
-  test('default: returns true when the order is filled', async () => {
+describe('useOmniContracts()', () => {
+  test('default: returns the expected contract addresses', async () => {
     const renderHook = createRenderHook()
 
     const omniContractsHook = renderHook(() => {

--- a/sdk/integration-tests/suites/hooks.tsx
+++ b/sdk/integration-tests/suites/hooks.tsx
@@ -1,22 +1,51 @@
-import { useQuote, useValidateOrder } from '@omni-network/react'
 import {
-  ETHER,
-  INVALID_CHAIN_ID,
-  INVALID_TOKEN_ADDRESS,
-  MOCK_L1_ID,
-  MOCK_L2_ID,
-  TOKEN_ADDRESS,
-  ZERO_ADDRESS,
+  useGetOrder,
+  useOmniContracts,
+  useParseOpenEvent,
+  useQuote,
+  useValidateOrder,
+} from '@omni-network/react'
+import {
+  invalidChainId,
+  invalidTokenAddress,
+  mockL1Id,
+  mockL2Id,
   testAccount,
+  tokenAddress,
 } from '@omni-network/test-utils'
-import { renderHook, waitFor } from '@testing-library/react'
+import { act, renderHook, waitFor } from '@testing-library/react'
+import { pad, parseEther, zeroAddress } from 'viem'
 import { describe, expect, test } from 'vitest'
-
 import {
   type AnyOrder,
   ContextProvider,
+  assertResolvedOrder,
+  createRenderHook,
   executeTestOrder,
+  testConnector,
+  useOrderRef,
 } from '../test-utils.js'
+
+async function execOrder() {
+  const orderParams = {
+    deposit: { token: zeroAddress, amount: parseEther('2') },
+    expense: { token: zeroAddress, amount: parseEther('1') },
+    calls: [{ target: testAccount.address, value: parseEther('1') }],
+    srcChainId: mockL2Id,
+    destChainId: mockL1Id,
+    validateEnabled: false,
+  }
+
+  const orderRef = useOrderRef(testConnector, orderParams)
+
+  await waitFor(() => expect(orderRef.current?.isReady).toBe(true))
+
+  act(() => {
+    orderRef.current?.open()
+  })
+
+  return orderRef
+}
 
 describe('useQuote()', () => {
   test('parameters: gets a quote in expense mode', async () => {
@@ -25,8 +54,8 @@ describe('useQuote()', () => {
         return useQuote({
           enabled: true,
           mode: 'expense',
-          srcChainId: MOCK_L1_ID,
-          destChainId: MOCK_L2_ID,
+          srcChainId: mockL1Id,
+          destChainId: mockL2Id,
           deposit: {
             amount: 1n,
             isNative: true,
@@ -40,11 +69,14 @@ describe('useQuote()', () => {
       { wrapper: ContextProvider },
     )
 
-    await waitFor(() => expect(result.current.isSuccess).toBe(true))
-
-    expect(result.current.query.data).toEqual({
-      deposit: { token: ZERO_ADDRESS, amount: 1n },
-      expense: { token: ZERO_ADDRESS, amount: 0n },
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true)
+      expect(result.current.isError).toBe(false)
+      expect(result.current.isPending).toBe(false)
+      expect(result.current.query.data).toEqual({
+        deposit: { token: zeroAddress, amount: 1n },
+        expense: { token: zeroAddress, amount: 0n },
+      })
     })
   })
 
@@ -54,8 +86,8 @@ describe('useQuote()', () => {
         return useQuote({
           enabled: true,
           mode: 'deposit',
-          srcChainId: MOCK_L1_ID,
-          destChainId: MOCK_L2_ID,
+          srcChainId: mockL1Id,
+          destChainId: mockL2Id,
           deposit: {
             amount: 1n,
             isNative: true,
@@ -69,11 +101,14 @@ describe('useQuote()', () => {
       { wrapper: ContextProvider },
     )
 
-    await waitFor(() => expect(result.current.isSuccess).toBe(true))
-
-    expect(result.current.query.data).toEqual({
-      deposit: { token: ZERO_ADDRESS, amount: 2n },
-      expense: { token: ZERO_ADDRESS, amount: 1n },
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true)
+      expect(result.current.isError).toBe(false)
+      expect(result.current.isPending).toBe(false)
+      expect(result.current.query.data).toEqual({
+        deposit: { token: zeroAddress, amount: 2n },
+        expense: { token: zeroAddress, amount: 1n },
+      })
     })
   })
 
@@ -86,7 +121,7 @@ describe('useQuote()', () => {
           mode: 'expense',
           srcChainId: 1,
           destChainId: 17000,
-          deposit: { isNative: true, amount: ETHER },
+          deposit: { isNative: true, amount: parseEther('1') },
           expense: { isNative: true },
         })
       },
@@ -94,14 +129,15 @@ describe('useQuote()', () => {
     )
 
     await waitFor(() => expect(result.current.isError).toBe(true))
-    if (result.current.isError) {
-      expect(result.current.error).toEqual({
-        code: 400,
-        status: 'Bad Request',
-        message:
-          'InvalidDeposit: deposit and expense must be of the same chain class (e.g. mainnet, testnet) [deposit=1 ETH, expense=ETH]',
-      })
-    }
+
+    if (!result.current.isError) throw new Error('We expect an error')
+
+    expect(result.current.error).toEqual({
+      code: 400,
+      status: 'Bad Request',
+      message:
+        'InvalidDeposit: deposit and expense must be of the same chain class (e.g. mainnet, testnet) [deposit=1 ETH, expense=ETH]',
+    })
   })
 
   // Test vector folder: solver/app/testdata/TestQuote/no_deposit_of_expense_amount_specified
@@ -121,25 +157,26 @@ describe('useQuote()', () => {
     )
 
     await waitFor(() => expect(result.current.isError).toBe(true))
-    if (result.current.isError) {
-      expect(result.current.error).toEqual({
-        code: 400,
-        status: 'Bad Request',
-        message:
-          'deposit and expense amount cannot be both zero or both non-zero',
-      })
-    }
+
+    if (!result.current.isError) throw new Error('We expect an error')
+
+    expect(result.current.error).toEqual({
+      code: 400,
+      status: 'Bad Request',
+      message:
+        'deposit and expense amount cannot be both zero or both non-zero',
+    })
   })
 })
 
 describe('useValidateOrder()', () => {
   test('default: returns the "accepted" status if the validation is successful', async () => {
-    const amount = ETHER / 2n
+    const amount = parseEther('1') / 2n
     const order: AnyOrder = {
-      srcChainId: MOCK_L1_ID,
-      destChainId: MOCK_L2_ID,
-      expense: { token: ZERO_ADDRESS, amount },
-      deposit: { token: ZERO_ADDRESS, amount: ETHER },
+      srcChainId: mockL1Id,
+      destChainId: mockL2Id,
+      expense: { token: zeroAddress, amount },
+      deposit: { token: zeroAddress, amount: parseEther('1') },
       calls: [{ target: testAccount.address, value: amount }],
     }
 
@@ -152,12 +189,12 @@ describe('useValidateOrder()', () => {
   })
 
   test('behaviour: returns the "rejected" status with a rejection reason and description', async () => {
-    const amount = ETHER / 2n
+    const amount = parseEther('1') / 2n
     const order: AnyOrder = {
-      srcChainId: INVALID_CHAIN_ID,
-      destChainId: MOCK_L2_ID,
-      expense: { token: ZERO_ADDRESS, amount },
-      deposit: { token: ZERO_ADDRESS, amount: ETHER },
+      srcChainId: invalidChainId,
+      destChainId: mockL2Id,
+      expense: { token: zeroAddress, amount },
+      deposit: { token: zeroAddress, amount: parseEther('1') },
       calls: [{ target: testAccount.address, value: amount }],
     }
 
@@ -167,23 +204,24 @@ describe('useValidateOrder()', () => {
     )
 
     await waitFor(() => expect(result.current.status).toBe('rejected'))
-    if (result.current.status === 'rejected') {
-      expect(result.current.rejectReason).toBe('UnsupportedSrcChain')
-      expect(result.current.rejectDescription).toBe(
-        'unsupported source chain [chain_id=1234]',
-      )
-    }
+
+    if (result.current.status !== 'rejected')
+      throw new Error('We expect an error')
+    expect(result.current.rejectReason).toBe('UnsupportedSrcChain')
+    expect(result.current.rejectDescription).toBe(
+      'unsupported source chain [chain_id=1234]',
+    )
   })
 })
 
 describe('useOrder()', () => {
   test('default: succeeds with valid order', async () => {
-    const amount = ETHER / 2n
+    const amount = parseEther('1') / 2n
     const order: AnyOrder = {
-      srcChainId: MOCK_L1_ID,
-      destChainId: MOCK_L2_ID,
-      expense: { token: ZERO_ADDRESS, amount },
-      deposit: { token: ZERO_ADDRESS, amount: ETHER },
+      srcChainId: mockL1Id,
+      destChainId: mockL2Id,
+      expense: { token: zeroAddress, amount },
+      deposit: { token: zeroAddress, amount: parseEther('1') },
       calls: [{ target: testAccount.address, value: amount }],
     }
     await executeTestOrder(order)
@@ -191,10 +229,10 @@ describe('useOrder()', () => {
 
   test('behaviour: rejects when using invalid source chain', async () => {
     const order: AnyOrder = {
-      srcChainId: INVALID_CHAIN_ID,
-      destChainId: MOCK_L1_ID,
-      expense: { token: ZERO_ADDRESS, amount: 1n },
-      deposit: { token: ZERO_ADDRESS, amount: 1n },
+      srcChainId: invalidChainId,
+      destChainId: mockL1Id,
+      expense: { token: zeroAddress, amount: 1n },
+      deposit: { token: zeroAddress, amount: 1n },
       calls: [{ target: testAccount.address, value: 1n }],
     }
     await executeTestOrder(order, 'UnsupportedSrcChain')
@@ -202,10 +240,10 @@ describe('useOrder()', () => {
 
   test('behaviour: rejects when using invalid destination chain', async () => {
     const order: AnyOrder = {
-      srcChainId: MOCK_L1_ID,
-      destChainId: INVALID_CHAIN_ID,
-      expense: { token: ZERO_ADDRESS, amount: 1n },
-      deposit: { token: ZERO_ADDRESS, amount: 1n },
+      srcChainId: mockL1Id,
+      destChainId: invalidChainId,
+      expense: { token: zeroAddress, amount: 1n },
+      deposit: { token: zeroAddress, amount: 1n },
       calls: [{ target: testAccount.address, value: 1n }],
     }
     await executeTestOrder(order, 'UnsupportedDestChain')
@@ -213,10 +251,10 @@ describe('useOrder()', () => {
 
   test('behaviour: rejects when source and destination chains are the same', async () => {
     const order: AnyOrder = {
-      srcChainId: MOCK_L1_ID,
-      destChainId: MOCK_L1_ID,
-      expense: { token: ZERO_ADDRESS, amount: 1n },
-      deposit: { token: ZERO_ADDRESS, amount: 1n },
+      srcChainId: mockL1Id,
+      destChainId: mockL1Id,
+      expense: { token: zeroAddress, amount: 1n },
+      deposit: { token: zeroAddress, amount: 1n },
       calls: [{ target: testAccount.address, value: 1n }],
     }
     await executeTestOrder(order, 'SameChain')
@@ -224,12 +262,155 @@ describe('useOrder()', () => {
 
   test('behaviour: rejects when using an unsupported expense token', async () => {
     const order: AnyOrder = {
-      srcChainId: MOCK_L1_ID,
-      destChainId: MOCK_L2_ID,
-      expense: { token: INVALID_TOKEN_ADDRESS, amount: 1n },
-      deposit: { token: TOKEN_ADDRESS, amount: 1n },
+      srcChainId: mockL1Id,
+      destChainId: mockL2Id,
+      expense: { token: invalidTokenAddress, amount: 1n },
+      deposit: { token: tokenAddress, amount: 1n },
       calls: [{ target: testAccount.address, value: 1n }],
     }
     await executeTestOrder(order, 'UnsupportedExpense')
+  })
+})
+
+describe('useParseOpenEvent()', () => {
+  test('default: returns order details from the open event logs', async () => {
+    const renderHook = createRenderHook()
+
+    const orderRef = await execOrder()
+
+    await waitFor(
+      () => expect(orderRef.current?.waitForTx.status).toBe('success'),
+      { timeout: 5_000 },
+    )
+
+    const parseOpenEventHook = renderHook(() => {
+      return useParseOpenEvent({
+        // type assertion is safe due to throwing condition above
+        status: orderRef.current?.waitForTx.status as 'success',
+        logs: orderRef.current?.waitForTx.data?.logs,
+      })
+    })
+
+    await waitFor(() => {
+      expect(parseOpenEventHook.result.current.resolvedOrder).toBeDefined()
+      expect(parseOpenEventHook.result.current.error).toBeUndefined()
+    })
+
+    // biome-ignore lint/style/noNonNullAssertion: safe due throwing condition above
+    const resolvedOrder = parseOpenEventHook.result.current.resolvedOrder!
+
+    // assert shape of return
+    assertResolvedOrder(resolvedOrder)
+  })
+})
+
+describe('useGetOrder()', () => {
+  test('default: returns expected order data from the getOrder inbox contract method', async () => {
+    const renderHook = createRenderHook()
+
+    const orderRef = await execOrder()
+
+    await waitFor(
+      () => expect(orderRef.current?.waitForTx.status).toBe('success'),
+      { timeout: 5_000 },
+    )
+
+    const parseOpenEventHook = renderHook(() => {
+      return useParseOpenEvent({
+        // type assertion is safe due to throwing condition above
+        status: orderRef.current?.waitForTx.status as 'success',
+        logs: orderRef.current?.waitForTx.data?.logs,
+      })
+    })
+
+    await waitFor(() => {
+      expect(parseOpenEventHook.result.current.resolvedOrder).toBeDefined()
+      expect(parseOpenEventHook.result.current.error).toBeUndefined()
+    })
+
+    // biome-ignore lint/style/noNonNullAssertion: safe due throwing condition above
+    const orderId = parseOpenEventHook.result.current.resolvedOrder?.orderId!
+
+    const getOrderHook = renderHook(() => {
+      return useGetOrder({
+        chainId: mockL2Id,
+        orderId: orderId,
+      })
+    })
+
+    await waitFor(() => {
+      expect(getOrderHook.result.current.data).toBeDefined()
+    })
+
+    // biome-ignore lint/style/noNonNullAssertion: safe due to throwing condition above
+    const orderDetails = getOrderHook.result.current.data!
+
+    // assert shape of return
+    expect(orderDetails).toBeInstanceOf(Array)
+    expect(orderDetails).toHaveLength(3)
+
+    const resolvedOrder = orderDetails[0]
+    assertResolvedOrder(resolvedOrder)
+
+    // order state
+    expect(orderDetails[1]).toBeInstanceOf(Object)
+    expect(orderDetails[1].status).toBeOneOf([1, 4, 5]) // open / filled / claimed
+    expect(orderDetails[1].rejectReason).toBe(0)
+    expect(orderDetails[1].timestamp).toBeTypeOf('number')
+    expect(orderDetails[1].updatedBy).toBeTypeOf('string')
+    expect(orderDetails[1].updatedBy).toContain('0x')
+
+    // offset
+    expect(orderDetails[2]).toBeTypeOf('bigint')
+  })
+
+  test('behaviour: returns not found when an invalid order id is provided', async () => {
+    const renderHook = createRenderHook()
+
+    const getOrderHook = renderHook(() => {
+      return useGetOrder({
+        chainId: mockL2Id,
+        orderId: pad('0x', { size: 32, dir: 'left' }),
+      })
+    })
+
+    await waitFor(() => {
+      expect(getOrderHook.result.current.isFetched).toBe(true)
+      expect(getOrderHook.result.current.isError).toBe(false)
+      expect(getOrderHook.result.current.data).toBeDefined()
+    })
+
+    // biome-ignore lint/style/noNonNullAssertion: safe due to throwing condition above
+    const orderDetails = getOrderHook.result.current.data!
+
+    expect(orderDetails).toBeInstanceOf(Array)
+    expect(orderDetails).toHaveLength(3)
+
+    const resolvedOrder = orderDetails[0]
+    expect(resolvedOrder.orderId).toBe(pad('0x', { size: 32, dir: 'left' }))
+    expect(resolvedOrder.user).toBe(zeroAddress)
+
+    const orderState = orderDetails[1]
+    expect(orderState.status).toBe(0) // not-found
+  })
+})
+
+describe('useValidateOrder()', () => {
+  test('default: returns true when the order is filled', async () => {
+    const renderHook = createRenderHook()
+
+    const omniContractsHook = renderHook(() => {
+      return useOmniContracts()
+    })
+
+    await waitFor(() => {
+      expect(omniContractsHook.result.current.data).toBeDefined()
+    })
+
+    // biome-ignore lint/style/noNonNullAssertion: safe due to throwing condition above
+    const omniContracts = omniContractsHook.result.current.data!
+
+    const expectedKeys = ['portal', 'inbox', 'outbox', 'middleman', 'executor']
+    expect(Object.keys(omniContracts).sort()).toEqual(expectedKeys.sort())
   })
 })

--- a/sdk/packages/test-utils/src/account.ts
+++ b/sdk/packages/test-utils/src/account.ts
@@ -6,17 +6,12 @@ import {
   type PublicActions,
   type WalletClient,
   createWalletClient,
+  parseEther,
   publicActions,
 } from 'viem'
 import { type PrivateKeyAccount, privateKeyToAccount } from 'viem/accounts'
 
-import {
-  ETHER,
-  MOCK_L1_CHAIN,
-  OMNI_TOKEN_ABI,
-  SOLVERNET_INBOX_ADDRESS,
-  TOKEN_ADDRESS,
-} from './constants.js'
+import { inbox, mockL1Chain, omniTokenAbi, tokenAddress } from './constants.js'
 
 export const testAccount: PrivateKeyAccount = privateKeyToAccount(
   '0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80',
@@ -38,29 +33,26 @@ export function createClient<ChainType extends Chain>({
   }).extend(publicActions)
 }
 
-export const mockL1Client: Client<typeof MOCK_L1_CHAIN> = createClient({
-  chain: MOCK_L1_CHAIN,
+export const mockL1Client: Client<typeof mockL1Chain> = createClient({
+  chain: mockL1Chain,
 })
 
 export async function mintOMNI(): Promise<void> {
-  // mint token
+  const amount = parseEther('100')
   const mintHash = await mockL1Client.writeContract({
     account: testAccount.address,
-    address: TOKEN_ADDRESS,
-    abi: OMNI_TOKEN_ABI,
+    address: tokenAddress,
+    abi: omniTokenAbi,
     functionName: 'mint',
-    args: [testAccount.address, 100n * ETHER],
+    args: [testAccount.address, amount],
   })
-  // wait for transaction to be mined
   await mockL1Client.waitForTransactionReceipt({ hash: mintHash })
-  // approve transfers to inbox contract
   const approveHash = await mockL1Client.writeContract({
     account: testAccount.address,
-    address: TOKEN_ADDRESS,
-    abi: OMNI_TOKEN_ABI,
+    address: tokenAddress,
+    abi: omniTokenAbi,
     functionName: 'approve',
-    args: [SOLVERNET_INBOX_ADDRESS, 100n * ETHER],
+    args: [inbox, amount],
   })
-  // wait for transaction to be mined
   await mockL1Client.waitForTransactionReceipt({ hash: approveHash })
 }

--- a/sdk/packages/test-utils/src/constants.ts
+++ b/sdk/packages/test-utils/src/constants.ts
@@ -7,73 +7,69 @@ type RPCEndpoints = {
   mock_l2: string
 }
 
-let RPC_ENDPOINTS: RPCEndpoints = {
+let rpcEndpoints: RPCEndpoints = {
   omni_evm: 'http://127.0.0.1:8001',
   mock_l1: 'http://127.0.0.1:8003',
   mock_l2: 'http://127.0.0.1:8004',
 }
 const endpointsFilePath = process.env.E2E_RPC_ENDPOINTS
 if (endpointsFilePath != null && endpointsFilePath.trim() !== '') {
-  RPC_ENDPOINTS = JSON.parse(readFileSync(endpointsFilePath, 'utf-8'))
+  rpcEndpoints = JSON.parse(readFileSync(endpointsFilePath, 'utf-8'))
 }
 
-export const ETHER = 1_000_000_000_000_000_000n // 18 decimals
-
-export const INVALID_CHAIN_ID = 1234
-export const OMNI_DEVNET_ID = 1651
-export const MOCK_L1_ID = 1652
-export const MOCK_L2_ID = 1654
+export const invalidChainId = 1234
+export const omniDevnetId = 1651
+export const mockL1Id = 1652
+export const mockL2Id = 1654
 
 // Addresses from lib/contracts/testdata/TestContractAddressReference.golden
-export const SOLVERNET_INBOX_ADDRESS =
-  '0x7c7759b801078ecb2c41c9caecc2db13c3079c76' as const
-export const TOKEN_ADDRESS =
+export const inbox = '0x7c7759b801078ecb2c41c9caecc2db13c3079c76' as const
+export const tokenAddress =
   '0x73cc960fb6705e9a6a3d9eaf4de94a828cfa6d2a' as const
-export const INVALID_TOKEN_ADDRESS =
+export const invalidTokenAddress =
   '0x1234000000000000000000000000000000000000' as const
-export const ZERO_ADDRESS =
-  '0x0000000000000000000000000000000000000000' as const
+export const outbox = '0x29d9e8faa760841aacbe79a8632c1f42e0a858e6' as const
 
-export const MOCK_L1_CHAIN: Chain = {
-  id: MOCK_L1_ID,
+export const mockL1Chain: Chain = {
+  id: mockL1Id,
   name: 'Mock L1',
   nativeCurrency: { decimals: 18, name: 'Ether', symbol: 'ETH' },
   rpcUrls: {
     default: {
-      http: [RPC_ENDPOINTS.mock_l1],
+      http: [rpcEndpoints.mock_l1],
     },
   },
 }
 
-export const MOCK_L2_CHAIN: Chain = {
-  id: MOCK_L2_ID,
+export const mockL2Chain: Chain = {
+  id: mockL2Id,
   name: 'Mock L2',
   nativeCurrency: { decimals: 18, name: 'Ether', symbol: 'ETH' },
   rpcUrls: {
     default: {
-      http: [RPC_ENDPOINTS.mock_l2],
+      http: [rpcEndpoints.mock_l2],
     },
   },
 }
 
-export const OMNI_DEVNET_CHAIN: Chain = {
-  id: OMNI_DEVNET_ID,
+export const omniDevnetChain: Chain = {
+  id: omniDevnetId,
   name: 'Omni Devnet',
   nativeCurrency: { decimals: 18, name: 'Ether', symbol: 'ETH' },
   rpcUrls: {
     default: {
-      http: [RPC_ENDPOINTS.omni_evm],
+      http: [rpcEndpoints.omni_evm],
     },
   },
 }
 
-export const MOCK_CHAINS: Record<number, Chain> = {
-  [MOCK_L1_ID]: MOCK_L1_CHAIN,
-  [MOCK_L2_ID]: MOCK_L2_CHAIN,
-  [OMNI_DEVNET_ID]: OMNI_DEVNET_CHAIN,
+export const mockChains: Record<number, Chain> = {
+  [mockL1Id]: mockL1Chain,
+  [mockL2Id]: mockL2Chain,
+  [omniDevnetId]: omniDevnetChain,
 }
 
-export const OMNI_TOKEN_ABI = [
+export const omniTokenAbi = [
   {
     type: 'function',
     name: 'approve',


### PR DESCRIPTION
- move to camel case naming
- add balance checks to filled lifecycle test
- add more assertions to existing tests
- replace some if(condition) checks in tests with throwing condition, otherwise the tests may be false positive
- tests for `useParseOpenEvent`, `useGetOrder`, `useOmniContracts` - remaining hooks are tested implicitly already (as are these, but wanted to add explicit testing of return types)
- assert data shape of returned value from various hooks to bolster defence against contract changes

issue: #3618 