### PR TITLE
chore(solver): maintain min safe eth balance

### DIFF
--- a/solver/app/internal_testutils.go
+++ b/solver/app/internal_testutils.go
@@ -475,7 +475,23 @@ func orderTestCases(t *testing.T, solver common.Address) []orderTestCase {
 				expenses: []types.Expense{{Amount: ether(1)}},
 			},
 			mock: func(clients MockClients) {
-				mockNativeBalance(t, clients.Client(t, evmchain.IDHolesky), solver, ether(1))
+				mockNativeBalance(t, clients.Client(t, evmchain.IDHolesky), solver, bi.Add(bi.Ether(1), minSafeETH)) // add min safe eth
+			},
+		},
+		{
+			name:   "spend below min safe eth",
+			reason: types.RejectInsufficientInventory,
+			reject: true,
+			order: testOrder{
+				srcChainID: evmchain.IDBaseSepolia,
+				dstChainID: evmchain.IDHolesky,
+				// includes fee
+				deposits: []types.AddrAmt{{Amount: depositFor(ether(1), standardFeeBips)}},
+				calls:    []types.Call{{Value: ether(1)}},
+				expenses: []types.Expense{{Amount: ether(1)}},
+			},
+			mock: func(clients MockClients) {
+				mockNativeBalance(t, clients.Client(t, evmchain.IDHolesky), solver, bi.Ether(1)) // do not add min safe eth
 			},
 		},
 		{

--- a/solver/app/reject.go
+++ b/solver/app/reject.go
@@ -304,9 +304,14 @@ func checkLiquidity(ctx context.Context, expenses []TokenAmt, backend *ethbacken
 			return errors.Wrap(err, "get balance", "token", expense.Token.Symbol)
 		}
 
+		minSafe := bi.Zero()
+		if expense.Token.Is(tokens.ETH) {
+			minSafe = minSafeETH
+		}
+
 		// TODO: for native tokens, even if we have enough, we don't want to
 		// spend out whole balance. we'll need to keep some for gas
-		if bi.LT(bal, expense.Amount) {
+		if bi.LT(bal, bi.Add(expense.Amount, minSafe)) {
 			if expense.Token.IsOMNI() && expense.Token.IsNative() {
 				// for native OMNI, instead of rejecting, we error. the solver
 				// will retry this order. this is a special case "fix" to handle

--- a/solver/app/tokens.go
+++ b/solver/app/tokens.go
@@ -21,6 +21,10 @@ var (
 		tokens.STETH:  true,
 		tokens.USDC:   true,
 	}
+
+	// minSafeETH is the minimum amount of ETH the solver can leave itself with post-fill,
+	// to ensure it can pay for gas of other orders.
+	minSafeETH = bi.Ether(0.05)
 )
 
 func IsSupportedToken(token tokens.Token) bool {


### PR DESCRIPTION
Reject orders that will bring solver balance below a safe minimum.

issue: none