### PR TITLE
refactor(solver): no more float64 prices

### DIFF
--- a/e2e/manifests/ci.toml
+++ b/e2e/manifests/ci.toml
@@ -4,6 +4,7 @@ anvil_chains = ["mock_l2", "mock_l1"]
 multi_omni_evms = true
 pingpong_n = 5 # Increased ping pong to span validator updates
 evidence = 1 # Slash a validator for double signing
+all_e2e_tests = true
 
 [node.validator01]
 [node.validator02]

--- a/e2e/solve/test.go
+++ b/e2e/solve/test.go
@@ -523,10 +523,19 @@ func mustTokenByAsset(chainID uint64, asset tokens.Asset) tokens.Token {
 
 func mustDepositAmount(expenseAmount *big.Int, srcToken tokens.Token, dstToken tokens.Token) *big.Int {
 	pricer := tokenpricer.NewDevnetMock()
-	price, err := pricer.Price(context.TODO(), dstToken.Asset, srcToken.Asset)
+	price, err := pricer.Price(context.TODO(), srcToken.Asset, dstToken.Asset)
 	if err != nil {
 		panic(err)
 	}
 
-	return bi.MulF64(bi.MulF64(expenseAmount, price), 1.01) // Mul by 1.01 again to cover 30bips fee
+	sprice := solver.Price{
+		Price:   price,
+		Deposit: srcToken.Asset,
+		Expense: dstToken.Asset,
+	}
+
+	// Add fee bips
+	sprice = sprice.WithFeeBips(30)
+
+	return sprice.ToDeposit(expenseAmount)
 }

--- a/lib/bi/big.go
+++ b/lib/bi/big.go
@@ -70,6 +70,40 @@ func MulRaw[I constraints.Integer](a *big.Int, bs ...I) *big.Int {
 	return resp
 }
 
+// MulRatFloor returns a * b0 [* b1 * b2 ...]
+// It rounds down (toward zero).
+func MulRatFloor(a *big.Int, bs ...*big.Rat) *big.Int {
+	rat := new(big.Rat).SetInt(a)
+	for _, b := range bs {
+		rat = new(big.Rat).Mul(rat, b)
+	}
+
+	return new(big.Int).Quo(rat.Num(), rat.Denom())
+}
+
+// MulRatCeil returns a * b0 [* b1 * b2 ...]
+// It rounded up (toward +∞).
+func MulRatCeil(a *big.Int, bs ...*big.Rat) *big.Int {
+	rat := new(big.Rat).SetInt(a)
+	for _, b := range bs {
+		rat.Mul(rat, b)
+	}
+
+	num := rat.Num()
+	den := rat.Denom()
+
+	// result = num / den
+	quotient := new(big.Int).Quo(num, den)
+	remainder := new(big.Int).Rem(num, den)
+
+	// if there's a remainder, we need to add 1 to round up if the result is positive
+	if remainder.Sign() != 0 && rat.Sign() > 0 {
+		quotient.Add(quotient, big.NewInt(1))
+	}
+
+	return quotient
+}
+
 // MulF64 returns a * b0 [* b1 * b2 ...].
 // Note that floats are not accurate.
 func MulF64(a *big.Int, bs ...float64) *big.Int {

--- a/lib/bi/unit.go
+++ b/lib/bi/unit.go
@@ -61,11 +61,22 @@ func ToF64(amt *big.Int, dec uint) float64 {
 
 // ToWei converts an amt with dec decimals to wei big.Int with 18 decimals.
 func ToWei(amt *big.Int, dec uint) *big.Int {
-	if dec < 18 {
-		return MulRaw(amt, int(math.Pow10(18-int(dec))))
+	return Rebase(amt, dec, 18)
+}
+
+// Rebase converts an amt from one decimal to another.
+//
+//nolint:gosec // Decimals don't overflow
+func Rebase(amt *big.Int, from, to uint) *big.Int {
+	if from == to {
+		return amt
 	}
 
-	return amt
+	if from < to {
+		return MulRaw(amt, int(math.Pow10(int(to)-int(from))))
+	}
+
+	return DivRaw(amt, int(math.Pow10(int(from)-int(to))))
 }
 
 // Gwei converts gwei float/int/uint in to wei big.Int; i * 1e9.

--- a/lib/tokenpricer/coingecko/coingecko_internal_test.go
+++ b/lib/tokenpricer/coingecko/coingecko_internal_test.go
@@ -2,6 +2,7 @@ package coingecko
 
 import (
 	"context"
+	"math/big"
 
 	"github.com/omni-network/omni/lib/tokens"
 )
@@ -12,6 +13,6 @@ func GetAPIKeyHeader() string {
 }
 
 // GetPrice exports the getPrice method for testing purposes.
-func (c Client) GetPrice(ctx context.Context, currency string, bases ...tokens.Asset) (map[tokens.Asset]float64, error) {
+func (c Client) GetPrice(ctx context.Context, currency string, bases ...tokens.Asset) (map[tokens.Asset]*big.Rat, error) {
 	return c.getPrice(ctx, currency, bases...)
 }

--- a/lib/tokenpricer/coingecko/coingecko_test.go
+++ b/lib/tokenpricer/coingecko/coingecko_test.go
@@ -3,6 +3,7 @@ package coingecko_test
 import (
 	"encoding/json"
 	"flag"
+	"math/big"
 	"math/rand"
 	"net/http"
 	"net/http/httptest"
@@ -31,29 +32,29 @@ func TestIntegration(t *testing.T) {
 	c := coingecko.New(coingecko.WithAPIKey(apikey))
 
 	// USD prices for omni and eth
-	prices, err := c.USDPrices(t.Context(), tokens.OMNI, tokens.ETH)
+	usdPrices, err := c.USDPrices(t.Context(), tokens.OMNI, tokens.ETH)
 	tutil.RequireNoError(t, err)
-	require.NotEmpty(t, prices)
+	require.NotEmpty(t, usdPrices)
 
 	// eth price in omni
 	price1, err := c.Price(t.Context(), tokens.ETH, tokens.OMNI)
 	tutil.RequireNoError(t, err)
-	t.Logf("ETH/OMNI: %f", price1)
+	t.Logf("ETH/OMNI: %v", price1)
 
 	// omni price in eth
 	price2, err := c.Price(t.Context(), tokens.OMNI, tokens.ETH)
 	tutil.RequireNoError(t, err)
-	t.Logf("OMNI/ETH: %f", price2)
+	t.Logf("OMNI/ETH: %v", price2)
 
 	// alternate way to get omni price in eth (since eth is a supported currency)
-	prices, err = c.GetPrice(t.Context(), "eth", tokens.OMNI)
+	prices, err := c.GetPrice(t.Context(), "eth", tokens.OMNI)
 	tutil.RequireNoError(t, err)
 	require.NotEmpty(t, prices)
 	price3 := prices[tokens.OMNI]
-	t.Logf("OMNI/eth: %f", price3)
+	t.Logf("OMNI/eth: %v", price3)
 
-	require.InEpsilon(t, 1/price2, price1, 0.01)
-	require.InEpsilon(t, price2, price3, 0.01)
+	require.Equal(t, new(big.Rat).Inv(price2), price1)
+	require.Equal(t, price2, price3)
 }
 
 type testCase struct {

--- a/lib/tokenpricer/mock.go
+++ b/lib/tokenpricer/mock.go
@@ -2,6 +2,7 @@ package tokenpricer
 
 import (
 	"context"
+	"math/big"
 	"sync"
 
 	"github.com/omni-network/omni/lib/errors"
@@ -10,31 +11,33 @@ import (
 
 type Mock struct {
 	mu     sync.RWMutex
-	prices map[pair]float64
+	prices map[pair]*big.Rat
 }
 
 var _ Pricer = (*Mock)(nil)
 
 // NewDevnetMock only supports OMNI/wstETH/ETH/USDC swaps.
 func NewDevnetMock() *Mock {
-	m := &Mock{prices: make(map[pair]float64)}
-	m.SetPrice(tokens.WSTETH, tokens.USDC, 4000)
-	m.SetPrice(tokens.ETH, tokens.USDC, 3000)
-	m.SetPrice(tokens.OMNI, tokens.USDC, 5)
+	m := &Mock{prices: make(map[pair]*big.Rat)}
+	m.SetPrice(tokens.WSTETH, tokens.USDC, big.NewRat(4000, 1)) // 1 WSTETH = 4000 USDC
+	m.SetPrice(tokens.ETH, tokens.USDC, big.NewRat(3000, 1))    // 1 ETH = 3000 USDC
+	m.SetPrice(tokens.OMNI, tokens.USDC, big.NewRat(5, 1))      // 1 OMNI = 5 USDC
 
 	return m
 }
 
 func NewUSDMock(prices map[tokens.Asset]float64) *Mock {
-	cloned := make(map[pair]float64)
+	cloned := make(map[pair]*big.Rat)
 	for k, v := range prices {
-		cloned[pair{Base: k, Quote: tokens.USDC}] = v
+		cloned[pair{Base: k, Quote: tokens.USDC}] = new(big.Rat).SetFloat64(v)
 	}
 
 	return &Mock{prices: cloned}
 }
 
-func (m *Mock) Price(_ context.Context, base, quote tokens.Asset) (float64, error) {
+// Price returns the price of the base asset denominated in the quote asset.
+// Note that for canonical solver prices, base=deposit and quote=expense.
+func (m *Mock) Price(_ context.Context, base, quote tokens.Asset) (*big.Rat, error) {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 
@@ -46,35 +49,57 @@ func (m *Mock) Price(_ context.Context, base, quote tokens.Asset) (float64, erro
 	// Try via USDC
 	usdBase, ok := m.prices[pair{Base: base, Quote: tokens.USDC}]
 	if !ok {
-		return 0, errors.New("mock price not found", "base", base, "quote", quote)
+		return nil, errors.New("mock price not found", "base", base, "quote", quote)
 	}
 
 	usdQuote, ok := m.prices[pair{Base: quote, Quote: tokens.USDC}]
 	if !ok {
-		return 0, errors.New("mock price not found", "base", base, "quote", quote)
+		return nil, errors.New("mock price not found", "base", base, "quote", quote)
 	}
 
-	return usdBase / usdQuote, nil
+	return new(big.Rat).Quo(usdBase, usdQuote), nil
 }
 
-func (m *Mock) USDPrice(_ context.Context, tkn tokens.Asset) (float64, error) {
+func (m *Mock) USDPrice(ctx context.Context, tkn tokens.Asset) (float64, error) {
+	prices, err := m.USDPrices(ctx, tkn)
+	if err != nil {
+		return 0, errors.Wrap(err, "get price")
+	}
+
+	return prices[tkn], nil
+}
+
+func (m *Mock) USDPriceRat(ctx context.Context, tkn tokens.Asset) (*big.Rat, error) {
+	prices, err := m.USDPricesRat(ctx, tkn)
+	if err != nil {
+		return nil, errors.Wrap(err, "get price")
+	}
+
+	return prices[tkn], nil
+}
+
+// USDPrices returns the price of each coin in USD.
+func (m *Mock) USDPrices(ctx context.Context, assets ...tokens.Asset) (map[tokens.Asset]float64, error) {
+	rats, err := m.USDPricesRat(ctx, assets...)
+	if err != nil {
+		return nil, errors.Wrap(err, "get price")
+	}
+
+	prices := make(map[tokens.Asset]float64)
+	for asset, price := range rats {
+		f, _ := price.Float64()
+		prices[asset] = f
+	}
+
+	return prices, nil
+}
+
+func (m *Mock) USDPricesRat(_ context.Context, assets ...tokens.Asset) (map[tokens.Asset]*big.Rat, error) {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 
-	price, ok := m.prices[pair{Base: tkn, Quote: tokens.USDC}]
-	if !ok {
-		return 0, errors.New("mock usd price not found", "token", tkn)
-	}
-
-	return price, nil
-}
-
-func (m *Mock) USDPrices(_ context.Context, tkns ...tokens.Asset) (map[tokens.Asset]float64, error) {
-	m.mu.RLock()
-	defer m.mu.RUnlock()
-
-	resp := make(map[tokens.Asset]float64)
-	for _, t := range tkns {
+	resp := make(map[tokens.Asset]*big.Rat)
+	for _, t := range assets {
 		var ok bool
 		resp[t], ok = m.prices[pair{Base: t, Quote: tokens.USDC}]
 		if !ok {
@@ -89,16 +114,16 @@ func (m *Mock) SetUSDPrice(token tokens.Asset, price float64) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	m.prices[pair{Base: token, Quote: tokens.USDC}] = price
+	m.prices[pair{Base: token, Quote: tokens.USDC}] = new(big.Rat).SetFloat64(price)
 }
 
-func (m *Mock) SetPrice(base, quote tokens.Asset, price float64) {
+func (m *Mock) SetPrice(base, quote tokens.Asset, price *big.Rat) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
 	m.prices[pair{Base: base, Quote: quote}] = price
-	m.prices[pair{Base: quote, Quote: base}] = 1 / price
+	m.prices[pair{Base: quote, Quote: base}] = new(big.Rat).Inv(price)
 
-	m.prices[pair{Base: base, Quote: base}] = 1
-	m.prices[pair{Base: quote, Quote: quote}] = 1
+	m.prices[pair{Base: base, Quote: base}] = big.NewRat(1, 1)
+	m.prices[pair{Base: quote, Quote: quote}] = big.NewRat(1, 1)
 }

--- a/lib/tokenpricer/mock_internal_test.go
+++ b/lib/tokenpricer/mock_internal_test.go
@@ -1,6 +1,7 @@
 package tokenpricer
 
 import (
+	"math/big"
 	"testing"
 
 	"github.com/omni-network/omni/lib/tokens"
@@ -15,5 +16,5 @@ func TestDevnetPricer(t *testing.T) {
 
 	price, err := pricer.Price(t.Context(), tokens.OMNI, tokens.ETH)
 	require.NoError(t, err)
-	require.InEpsilon(t, 5.0/3000.0, price, 0.0001)
+	require.Equal(t, big.NewRat(5.0, 3000.0), price)
 }

--- a/lib/tokenpricer/tokenpricer.go
+++ b/lib/tokenpricer/tokenpricer.go
@@ -2,6 +2,7 @@ package tokenpricer
 
 import (
 	"context"
+	"math/big"
 	"sync"
 	"time"
 
@@ -13,16 +14,21 @@ import (
 type Pricer interface {
 	// USDPrice returns the price of the token in USD.
 	USDPrice(ctx context.Context, tokens tokens.Asset) (float64, error)
+	// USDPriceRat returns the price of the token in USD.
+	USDPriceRat(ctx context.Context, tokens tokens.Asset) (*big.Rat, error)
 	// USDPrices returns the price of each provided token in USD.
 	USDPrices(ctx context.Context, tokens ...tokens.Asset) (map[tokens.Asset]float64, error)
+	// USDPricesRat returns the price of each provided token in USD.
+	USDPricesRat(ctx context.Context, tokens ...tokens.Asset) (map[tokens.Asset]*big.Rat, error)
 	// Price returns the price of the base asset denominated in the quote asset.
-	Price(ctx context.Context, base, quote tokens.Asset) (float64, error)
+	// Note that for canonical solver prices, base=deposit and quote=expense.
+	Price(ctx context.Context, base, quote tokens.Asset) (*big.Rat, error)
 }
 
 type Cached struct {
 	p     Pricer
 	mu    sync.RWMutex
-	cache map[pair]float64
+	cache map[pair]*big.Rat
 }
 
 type pair struct {
@@ -33,11 +39,11 @@ type pair struct {
 func NewCached(p Pricer) *Cached {
 	return &Cached{
 		p:     p,
-		cache: make(map[pair]float64),
+		cache: make(map[pair]*big.Rat),
 	}
 }
 
-func (c *Cached) get(base, quote tokens.Asset) (float64, bool) {
+func (c *Cached) get(base, quote tokens.Asset) (*big.Rat, bool) {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
 
@@ -46,16 +52,18 @@ func (c *Cached) get(base, quote tokens.Asset) (float64, bool) {
 	return price, ok
 }
 
-func (c *Cached) set(base, quote tokens.Asset, price float64) {
+func (c *Cached) set(base, quote tokens.Asset, price *big.Rat) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
 	c.cache[pair{Base: base, Quote: quote}] = price
 }
 
-func (c *Cached) Price(ctx context.Context, base, quote tokens.Asset) (float64, error) {
+// Price returns the price of the base asset denominated in the quote asset.
+// Note that for canonical solver prices, base=deposit and quote=expense.
+func (c *Cached) Price(ctx context.Context, base, quote tokens.Asset) (*big.Rat, error) {
 	if base == quote {
-		return 1, nil
+		return big.NewRat(1, 1), nil
 	}
 
 	price, ok := c.get(base, quote)
@@ -65,7 +73,7 @@ func (c *Cached) Price(ctx context.Context, base, quote tokens.Asset) (float64, 
 
 	price, err := c.p.Price(ctx, base, quote)
 	if err != nil {
-		return 0, err
+		return nil, err
 	}
 
 	c.set(base, quote, price)
@@ -87,8 +95,33 @@ func (c *Cached) USDPrice(ctx context.Context, token tokens.Asset) (float64, err
 	return price, nil
 }
 
+// USDPrices returns the price of each coin in USD.
 func (c *Cached) USDPrices(ctx context.Context, assets ...tokens.Asset) (map[tokens.Asset]float64, error) {
+	rats, err := c.USDPricesRat(ctx, assets...)
+	if err != nil {
+		return nil, errors.Wrap(err, "get price")
+	}
+
 	prices := make(map[tokens.Asset]float64)
+	for asset, price := range rats {
+		f, _ := price.Float64()
+		prices[asset] = f
+	}
+
+	return prices, nil
+}
+
+func (c *Cached) USDPriceRat(ctx context.Context, asset tokens.Asset) (*big.Rat, error) {
+	prices, err := c.USDPricesRat(ctx, asset)
+	if err != nil {
+		return nil, err
+	}
+
+	return prices[asset], nil
+}
+
+func (c *Cached) USDPricesRat(ctx context.Context, assets ...tokens.Asset) (map[tokens.Asset]*big.Rat, error) {
+	prices := make(map[tokens.Asset]*big.Rat)
 
 	var uncached []tokens.Asset
 
@@ -104,7 +137,7 @@ func (c *Cached) USDPrices(ctx context.Context, assets ...tokens.Asset) (map[tok
 		return prices, nil
 	}
 
-	newPrices, err := c.p.USDPrices(ctx, uncached...)
+	newPrices, err := c.p.USDPricesRat(ctx, uncached...)
 	if err != nil {
 		return nil, err
 	}
@@ -121,7 +154,7 @@ func (c *Cached) ClearCache() {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
-	c.cache = make(map[pair]float64)
+	c.cache = make(map[pair]*big.Rat)
 }
 
 func (c *Cached) ClearCacheForever(ctx context.Context, evictInterval time.Duration) {

--- a/lib/tokens/asset.go
+++ b/lib/tokens/asset.go
@@ -7,6 +7,7 @@ import (
 	"strconv"
 
 	"github.com/omni-network/omni/lib/bi"
+	"github.com/omni-network/omni/lib/errors"
 )
 
 // Asset represents the canonical definition of a token,
@@ -68,6 +69,16 @@ var (
 		CoingeckoID: "wrapped-steth",
 	}
 )
+
+func AssetBySymbol(symbol string) (Asset, error) {
+	for _, t := range tokens {
+		if t.Symbol == symbol {
+			return t.Asset, nil
+		}
+	}
+
+	return Asset{}, errors.New("unknown asset", "symbol", symbol)
+}
 
 // UniqueAssets returns all unique assets of all tokens.
 func UniqueAssets() []Asset {

--- a/sdk/integration-tests/suites/hooks.tsx
+++ b/sdk/integration-tests/suites/hooks.tsx
@@ -136,7 +136,7 @@ describe('useQuote()', () => {
       code: 400,
       status: 'Bad Request',
       message:
-        'InvalidDeposit: deposit and expense must be of the same chain class (e.g. mainnet, testnet) [deposit=1 ETH, expense=ETH]',
+        'InvalidDeposit: deposit and expense must be of the same chain class (e.g. mainnet, testnet) [deposit=mainnet, expense=testnet]',
     })
   })
 

--- a/solver/app/check.go
+++ b/solver/app/check.go
@@ -45,13 +45,7 @@ func newChecker(backends ethbackend.Backends, isAllowedCall callAllowFunc, price
 			return err
 		}
 
-		quote, err := getQuote(ctx, priceFunc, []tokens.Token{deposit.Token}, expenses)
-		if err != nil {
-			return err
-		}
-
-		err = coversQuote([]TokenAmt{deposit}, quote)
-		if err != nil {
+		if err := checkQuote(ctx, priceFunc, []TokenAmt{deposit}, expenses); err != nil {
 			return err
 		}
 

--- a/solver/app/handler.go
+++ b/solver/app/handler.go
@@ -133,9 +133,9 @@ func newPriceHandler(priceFunc priceHandlerFunc) Handler {
 				return nil, errors.New("invalid request type [BUG]", "type", fmt.Sprintf("%T", request))
 			}
 
-			res, err := priceFunc(ctx, req)
+			res, err := priceFunc(ctx, *req)
 			if err != nil {
-				return types.PriceResponse{}, err
+				return nil, err
 			}
 
 			return res, nil

--- a/solver/app/pricer_internal_test.go
+++ b/solver/app/pricer_internal_test.go
@@ -1,0 +1,95 @@
+package app
+
+import (
+	"fmt"
+	"math/big"
+	"testing"
+
+	"github.com/omni-network/omni/lib/evmchain"
+	"github.com/omni-network/omni/lib/tokenpricer"
+	"github.com/omni-network/omni/lib/tokens"
+	"github.com/omni-network/omni/solver/types"
+
+	"github.com/stretchr/testify/require"
+)
+
+func must(token tokens.Token, ok bool) tokens.Token {
+	if !ok {
+		panic("token not found")
+	}
+
+	return token
+}
+
+func TestPriceHandler(t *testing.T) {
+	t.Parallel()
+
+	omniNative := must(tokens.Native(evmchain.IDOmniDevnet))
+	l1Native := must(tokens.Native(evmchain.IDMockL1))
+	l2Native := must(tokens.Native(evmchain.IDMockL2))
+	l1OMNI := must(tokens.ByAsset(evmchain.IDMockL1, tokens.OMNI))
+	l1USDC := must(tokens.ByAsset(evmchain.IDMockL1, tokens.USDC))
+	l2wstETH := must(tokens.ByAsset(evmchain.IDMockL2, tokens.WSTETH))
+	l1wstETH := must(tokens.ByAsset(evmchain.IDMockL1, tokens.WSTETH))
+
+	handlerFunc := wrapPriceHandlerFunc(newPriceFunc(tokenpricer.NewDevnetMock()))
+
+	tests := []struct {
+		Deposit tokens.Token
+		Expense tokens.Token
+		Price   *big.Rat // See tokenpricer.NewDevnetMock for prices
+		NoFees  bool
+	}{
+		{
+			Deposit: l1OMNI,
+			Expense: omniNative,
+			Price:   big.NewRat(1, 1),
+			NoFees:  true,
+		},
+		{
+			Deposit: l1Native,
+			Expense: omniNative,
+			Price:   big.NewRat(3000.0, 5.0), // 1 unit ETH in OMNI =  3000 / 5 = 600 OMNI/ETH
+		},
+		{
+			Deposit: l2wstETH,
+			Expense: l1wstETH,
+			Price:   big.NewRat(1, 1), // 1 unit WSTETH in OMNI = 1 WSTETH
+		},
+		{
+			Deposit: l1wstETH,
+			Expense: l2Native,
+			Price:   big.NewRat(4000.0, 3000.0), //  1 unit WSTETH in ETH = 4000 / 3000 = 4/3 WSTETH/ETH
+		},
+		{
+			Deposit: l1USDC,
+			Expense: l2Native,
+			Price:   big.NewRat(1.0, 3000.0), // 1 unit USDC in ETH = 1 / 3000  USDC/ETH
+		},
+	}
+
+	for i, test := range tests {
+		t.Run(fmt.Sprintf("%d-%s-%s", i, test.Deposit, test.Expense), func(t *testing.T) {
+			t.Parallel()
+			actual, err := handlerFunc(t.Context(), types.PriceRequest{
+				SourceChainID:      test.Deposit.ChainID,
+				DestinationChainID: test.Expense.ChainID,
+				DepositToken:       test.Deposit.Address,
+				ExpenseToken:       test.Expense.Address,
+			})
+			require.NoError(t, err)
+
+			// Add the expected fees to the test price above
+			expected := types.Price{
+				Price:   test.Price,
+				Deposit: test.Deposit.Asset,
+				Expense: test.Expense.Asset,
+			}
+			if !test.NoFees {
+				expected = expected.WithFeeBips(feeBips(test.Deposit.Asset, test.Expense.Asset))
+			}
+
+			require.Equalf(t, expected, actual, "expected=%v, actual=%v", expected, actual)
+		})
+	}
+}

--- a/solver/app/reject.go
+++ b/solver/app/reject.go
@@ -286,7 +286,7 @@ func nativeAmt(ps []TokenAmt) *big.Int {
 }
 
 // checkQuote checks if deposits match or exceed quote for expenses.
-// only single expense supported with matching deposit is supported.
+// Only a single deposit and expense supported.
 func checkQuote(ctx context.Context, priceFunc priceFunc, deposits, expenses []TokenAmt) error {
 	quote, err := getQuote(ctx, priceFunc, tkns(deposits), expenses)
 	if err != nil {

--- a/solver/app/testdata/TestQuote/invalid_deposit_(chain_mismatch)/resp_body.json
+++ b/solver/app/testdata/TestQuote/invalid_deposit_(chain_mismatch)/resp_body.json
@@ -2,6 +2,6 @@
   "error": {
     "code": 400,
     "status": "Bad Request",
-    "message": "InvalidDeposit: deposit and expense must be of the same chain class (e.g. mainnet, testnet) [deposit=1 ETH, expense=ETH]"
+    "message": "InvalidDeposit: deposit and expense must be of the same chain class (e.g. mainnet, testnet) [deposit=mainnet, expense=testnet]"
   }
 }

--- a/solver/app/tokens.go
+++ b/solver/app/tokens.go
@@ -38,11 +38,11 @@ type SpendBounds struct {
 }
 
 // DepositBounds returns the equivalent deposit bounds
-// by multiplies the spend bounds by the given price.
-func (b SpendBounds) DepositBounds(price float64) SpendBounds {
+// by dividing the spend bounds (expense) by the given price.
+func (b SpendBounds) DepositBounds(price types.Price) SpendBounds {
 	return SpendBounds{
-		MinSpend: bi.MulF64(b.MinSpend, price),
-		MaxSpend: bi.MulF64(b.MaxSpend, price),
+		MinSpend: price.ToDeposit(b.MinSpend),
+		MaxSpend: price.ToDeposit(b.MaxSpend),
 	}
 }
 

--- a/solver/client/client.go
+++ b/solver/client/client.go
@@ -68,15 +68,14 @@ func (c Client) Quote(ctx context.Context, req types.QuoteRequest) (types.QuoteR
 	return res, nil
 }
 
-// expense amount = deposit amount / price.
-func (c Client) Price(ctx context.Context, req types.PriceRequest) (float64, error) {
-	var res types.PriceResponse
+func (c Client) Price(ctx context.Context, req types.PriceRequest) (types.Price, error) {
+	var res types.Price
 
 	if err := c.do(ctx, endpointPrice, req, &res); err != nil {
-		return 0, err
+		return types.Price{}, err
 	}
 
-	return res.Price, nil
+	return res, nil
 }
 
 func (c Client) do(ctx context.Context, endpoint string, req any, res any) error {

--- a/solver/types/api.go
+++ b/solver/types/api.go
@@ -70,13 +70,6 @@ type PriceRequest struct {
 	ExpenseToken       common.Address `json:"expenseToken"`
 }
 
-type PriceResponse struct {
-	// Price of 1 unit of deposit token denominated in expense tokens.
-	// deposit amount = expense amount * price
-	// expense amount = deposit amount / price
-	Price float64 `json:"price"`
-}
-
 type TokensResponse struct {
 	Tokens []TokenResponse `json:"tokens"`
 }

--- a/solver/types/price.go
+++ b/solver/types/price.go
@@ -1,0 +1,160 @@
+package types
+
+import (
+	"encoding/json"
+	"fmt"
+	"math/big"
+	"strings"
+
+	"github.com/omni-network/omni/lib/bi"
+	"github.com/omni-network/omni/lib/errors"
+	"github.com/omni-network/omni/lib/tokens"
+
+	"github.com/ethereum/go-ethereum/common/hexutil"
+)
+
+// Price represents the canonical solver price.
+// It is 1 unit of deposit token denominated in expense tokens. A valid price is always > 0.
+//
+// Given a price of 800 OMNI/ETH, when depositing 1 ETH the expense amount is 800 OMNI.
+//
+//	expense amount = deposit amount * price
+//	deposit amount = expense amount / price
+type Price struct {
+	Price   *big.Rat
+	Deposit tokens.Asset
+	Expense tokens.Asset
+}
+
+// WithFeeBips returns a new price with the fee in basis points subtracted from the price.
+//
+// Fees decrease the expense tokens received
+// So it decreases the price (since price denominated in expense tokens).
+// E.g. given a real price (pre-fees) of 800 OMNI/ETH,
+// when depositing 1 ETH the expense amount (post-fees) is less than 800 OMNI.
+func (p Price) WithFeeBips(fee int64) Price {
+	clone := p
+	if fee > 0 {
+		feeRat := big.NewRat(10_000, 10_000+fee)
+		clone.Price = new(big.Rat).Mul(clone.Price, feeRat)
+	}
+
+	return clone
+}
+
+func (p Price) String() string {
+	// Convert *big.Rat to big.Float with high precision
+	f := new(big.Float).SetPrec(256).SetRat(p.Price)
+
+	// Format with up to 6 decimal places
+	s := f.Text('f', -1)
+
+	// Trim trailing zeroes and dot if needed
+	s = strings.TrimRight(s, "0")
+	s = strings.TrimRight(s, ".")
+
+	return fmt.Sprintf("%s %s/%s",
+		s,
+		p.Expense.Symbol,
+		p.Deposit.Symbol,
+	)
+}
+
+func (p Price) Inverse() Price {
+	return Price{
+		Price:   new(big.Rat).Inv(p.Price),
+		Deposit: p.Expense,
+		Expense: p.Deposit,
+	}
+}
+
+type priceJSON struct {
+	Numerator   *hexutil.Big `json:"numerator"`
+	Denominator *hexutil.Big `json:"denominator"`
+	Rate        float64      `json:"imprecise_rate"`
+	Deposit     string       `json:"deposit"`
+	Expense     string       `json:"expense"`
+}
+
+// MarshalJSON implements the json.Marshaler interface.
+func (p Price) MarshalJSON() ([]byte, error) {
+	rate, _ := p.Price.Float64()
+	priceData := priceJSON{
+		Numerator:   (*hexutil.Big)(p.Price.Num()),
+		Denominator: (*hexutil.Big)(p.Price.Denom()),
+		Rate:        rate,
+		Deposit:     p.Deposit.Symbol,
+		Expense:     p.Expense.Symbol,
+	}
+
+	resp, err := json.Marshal(priceData)
+	if err != nil {
+		return nil, errors.Wrap(err, "marshal price")
+	}
+
+	return resp, nil
+}
+
+// UnmarshalJSON implements the json.Unmarshaler interface.
+func (p *Price) UnmarshalJSON(data []byte) error {
+	var priceData priceJSON
+	if err := json.Unmarshal(data, &priceData); err != nil {
+		return errors.Wrap(err, "unmarshal price")
+	}
+
+	if priceData.Deposit == "" {
+		return errors.New("missing price deposit")
+	} else if priceData.Expense == "" {
+		return errors.New("missing price expense")
+	} else if priceData.Numerator == nil {
+		return errors.New("missing price numerator")
+	} else if priceData.Denominator == nil {
+		return errors.New("missing price denominator")
+	} else if priceData.Rate == 0 {
+		return errors.New("missing price rate")
+	}
+
+	rat := new(big.Rat)
+	rat.SetFrac(priceData.Numerator.ToInt(), priceData.Denominator.ToInt())
+	rate, _ := rat.Float64()
+
+	if rat.Sign() <= 0 {
+		return errors.New("price must be greater than zero")
+	} else if rate != priceData.Rate {
+		return errors.New("price rate does not match numerator/denominator")
+	}
+
+	deposit, err := tokens.AssetBySymbol(priceData.Deposit)
+	if err != nil {
+		return err
+	}
+
+	expense, err := tokens.AssetBySymbol(priceData.Expense)
+	if err != nil {
+		return err
+	}
+
+	*p = Price{
+		Price:   rat,
+		Deposit: deposit,
+		Expense: expense,
+	}
+
+	return nil
+}
+
+// ToExpense converts a deposit amount to an expense amount using the price.
+// It also rebases to the correct token decimals.
+func (p Price) ToExpense(depositAmount *big.Int) *big.Int {
+	rebasedDeposit := bi.Rebase(depositAmount, p.Deposit.Decimals, p.Expense.Decimals)
+
+	return bi.MulRatFloor(rebasedDeposit, p.Price)
+}
+
+// ToDeposit converts an expense amount to a deposit amount using the price.
+// It also rebases to the correct token decimals.
+func (p Price) ToDeposit(expenseAmount *big.Int) *big.Int {
+	rebasedExpense := bi.Rebase(expenseAmount, p.Expense.Decimals, p.Deposit.Decimals)
+
+	return bi.MulRatCeil(rebasedExpense, p.Inverse().Price)
+}

--- a/solver/types/price_test.go
+++ b/solver/types/price_test.go
@@ -1,0 +1,106 @@
+package types_test
+
+import (
+	"fmt"
+	"math/big"
+	"testing"
+
+	"github.com/omni-network/omni/lib/bi"
+	"github.com/omni-network/omni/lib/tokens"
+	"github.com/omni-network/omni/solver/types"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestPriceBips(t *testing.T) {
+	t.Parallel()
+
+	// Unit price with fees
+	price := types.Price{
+		Price:   big.NewRat(1, 1),
+		Deposit: tokens.ETH,
+		Expense: tokens.ETH,
+	}.WithFeeBips(30) // 0.3% fee
+
+	deposit := bi.Ether(1)
+	expense := price.ToExpense(deposit)
+	deposit2 := price.ToDeposit(expense)
+	require.Equal(t, deposit, deposit2)
+}
+
+func TestPriceConvert(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		Price         float64
+		Deposit       tokens.Asset
+		Expense       tokens.Asset
+		DepositAmount float64
+		ExpenseAmount float64
+	}{
+		{
+			Price:         800.0, // OMNI/ETH
+			Deposit:       tokens.ETH,
+			Expense:       tokens.OMNI,
+			DepositAmount: 2.0,
+			ExpenseAmount: 1600.0,
+		},
+		{
+			Price:         1000.0, // USDC/ETH
+			Deposit:       tokens.ETH,
+			Expense:       tokens.USDC,
+			DepositAmount: 1.0,
+			ExpenseAmount: 1000.0,
+		},
+		{
+			Price:         1001.001, // USDC/ETH
+			Deposit:       tokens.ETH,
+			Expense:       tokens.USDC,
+			DepositAmount: 2.2,
+			ExpenseAmount: 2202.2022,
+		},
+	}
+
+	for i, test := range tests {
+		t.Run(fmt.Sprintf("%d-%s-%s", i, test.Deposit.Symbol, test.Expense.Symbol), func(t *testing.T) {
+			t.Parallel()
+			price := types.Price{
+				Price:   new(big.Rat).SetFloat64(test.Price),
+				Deposit: test.Deposit,
+				Expense: test.Expense,
+			}
+
+			actualExpense := price.ToExpense(test.Deposit.F64ToAmt(test.DepositAmount))
+			require.InEpsilonf(t,
+				test.ExpenseAmount,
+				test.Expense.AmtToF64(actualExpense),
+				0.001,
+				"expected %v, got %v", test.ExpenseAmount, test.Expense.AmtToF64(actualExpense),
+			)
+
+			actualDeposit := price.ToDeposit(test.Expense.F64ToAmt(test.ExpenseAmount))
+			require.InEpsilonf(t,
+				test.DepositAmount,
+				test.Deposit.AmtToF64(actualDeposit),
+				0.001,
+				"expected %v, got %v", test.DepositAmount, test.Deposit.AmtToF64(actualDeposit),
+			)
+
+			price2 := price.WithFeeBips(100) // 1% fee
+			actualExpense2 := price2.ToExpense(test.Deposit.F64ToAmt(test.DepositAmount))
+			require.InEpsilonf(t,
+				test.ExpenseAmount*0.99,
+				test.Expense.AmtToF64(actualExpense2),
+				0.001,
+				"expected %v, got %v", test.ExpenseAmount, test.Expense.AmtToF64(actualExpense),
+			)
+
+			actualDeposit2 := price2.ToDeposit(test.Expense.F64ToAmt(test.ExpenseAmount))
+			require.InEpsilonf(t,
+				test.DepositAmount*1.01,
+				test.Deposit.AmtToF64(actualDeposit2),
+				0.001,
+				"expected %v, got %v", test.DepositAmount, test.Deposit.AmtToF64(actualDeposit),
+			)
+		})
+	}
+}


### PR DESCRIPTION
Remove all uses of float64 prices, instead use `*big.Rat` in token.Pricer.
For amount conversions (ensuring correct decimals), introduce a `solver/types.Price`.
Refactor fees to be added price price.

Fix flowgen amount calculations by using new prices.

issue: none