### PR TITLE
feat(lib/cctp): audit db with finalized messages

### DIFF
--- a/lib/cctp/audit.go
+++ b/lib/cctp/audit.go
@@ -8,6 +8,7 @@ import (
 	"github.com/omni-network/omni/lib/cctp/types"
 	"github.com/omni-network/omni/lib/errors"
 	"github.com/omni-network/omni/lib/ethclient"
+	"github.com/omni-network/omni/lib/evmchain"
 	"github.com/omni-network/omni/lib/expbackoff"
 	"github.com/omni-network/omni/lib/log"
 	"github.com/omni-network/omni/lib/xchain"
@@ -19,34 +20,52 @@ import (
 
 type getMessageSentFunc func(logs []ethtypes.Log) (*MessageTransmitterMessageSent, bool, error)
 type getDepositForBurnFunc func(logs []ethtypes.Log) (*TokenMessengerDepositForBurn, bool, error)
+type isReceivedFunc func(ctx context.Context, msg types.MsgSendUSDC) (bool, error)
 
-// StoreMessagesForever streams CCTP SendUSDC messages, and saves them to the database.
-func StoreMessagesForever(
+// AuditForever streams finalized CCTP SendUSDC messages to `recipient`, and reconiles them db state.
+// - messages missed are inserted
+// - messages with incorrect fields are corrected
+// - messages marked as `minted` are cofirmed minted, else re-marked as `submitted`.
+// The audit process progresses db cursors.
+func AuditForever(
 	ctx context.Context,
 	db *db.DB,
-	chainVer xchain.ChainVersion,
-	client ethclient.Client,
 	xprov xchain.Provider,
+	clients map[uint64]ethclient.Client,
+	chain evmchain.Metadata,
 	recipient common.Address,
 ) error {
-	msgTransmitter, msgTransmitterAddr, err := newMessageTransmitter(chainVer.ID, client)
+	chainID := chain.ChainID
+
+	ctx = log.WithCtx(ctx,
+		"process", "cctp.AuditForever",
+		"chain", chain.Name,
+		"recipient", recipient)
+
+	client, ok := clients[chainID]
+	if !ok {
+		return errors.New("chain client not found", "chain_id", chainID)
+	}
+
+	msgTransmitter, msgTransmitterAddr, err := newMessageTransmitter(chainID, client)
 	if err != nil {
 		return errors.Wrap(err, "message transmitter")
 	}
 
-	tknMessenger, tknMessengerAddr, err := newTokenMessenger(chainVer.ID, client)
+	tknMessenger, tknMessengerAddr, err := newTokenMessenger(chainID, client)
 	if err != nil {
 		return errors.Wrap(err, "token messenger")
 	}
 
-	proc := newEventProc(db, chainVer,
+	proc := newEventProc(db, chainID,
+		newIsReceived(clients),
 		newDepositForBurnGetter(tknMessenger, tknMessengerAddr, recipient),
 		newMessageSentGetter(msgTransmitter, msgTransmitterAddr),
 	)
 
 	backoff := expbackoff.New(ctx)
 	for {
-		from, ok, err := db.GetCursor(ctx, chainVer.ID)
+		from, ok, err := db.GetCursor(ctx, chainID)
 		if !ok || err != nil {
 			log.Warn(ctx, "Failed reading cursor (will retry)", err)
 			backoff()
@@ -55,9 +74,9 @@ func StoreMessagesForever(
 		}
 
 		req := xchain.EventLogsReq{
-			ChainID:         chainVer.ID,
+			ChainID:         chainID,
 			Height:          from,
-			ConfLevel:       chainVer.ConfLevel,
+			ConfLevel:       xchain.ConfFinalized,
 			FilterAddresses: []common.Address{tknMessengerAddr, msgTransmitterAddr},
 			FilterTopics:    []common.Hash{depositForBurnEvent.ID, messageSentEvent.ID},
 		}
@@ -77,7 +96,8 @@ func StoreMessagesForever(
 // newEventProc returns an xchain.EventLogsCallback that processes CCTP DepositForBurn & MessageSent events.
 func newEventProc(
 	db *db.DB,
-	chainVer xchain.ChainVersion,
+	chainID uint64,
+	isReceived isReceivedFunc,
 	getDepositForBurn getDepositForBurnFunc,
 	getMessageSent getMessageSentFunc,
 ) xchain.EventLogsCallback {
@@ -106,70 +126,84 @@ func newEventProc(
 				continue
 			}
 
-			msg := eventPairToMsg(chainVer.ID, burn, send)
+			msg := eventPairToMsg(chainID, burn, send)
 			msgs = append(msgs, msg)
 		}
 
-		if err := upsertMsgs(ctx, db, msgs); err != nil {
+		if err := upsertMsgs(ctx, db, msgs, isReceived); err != nil {
 			return errors.Wrap(err, "upsert msgs")
 		}
 
-		return db.SetCursor(ctx, chainVer.ID, header.Number.Uint64())
+		return db.SetCursor(ctx, chainID, header.Number.Uint64())
 	}
 }
 
 // upsertMsgs upserts a list of MsgSendUSDC by tx hash, if necessary.
-func upsertMsgs(ctx context.Context, db *db.DB, msgs []types.MsgSendUSDC) error {
-	for _, msg := range msgs {
-		curr, ok, err := db.GetMsg(ctx, msg.TxHash)
+func upsertMsgs(ctx context.Context, db *db.DB, msgs []types.MsgSendUSDC, isReceived isReceivedFunc) error {
+	var toInsert []types.MsgSendUSDC
+	var toUpdate []types.MsgSendUSDC
+
+	for _, streamed := range msgs {
+		stored, ok, err := db.GetMsg(ctx, streamed.TxHash)
 		if err != nil {
 			return errors.Wrap(err, "has msg")
 		}
 
 		// Message missed, insert.
 		if !ok {
-			if err := db.InsertMsg(ctx, withStatus(msg, types.MsgStatusSubmitted)); err != nil {
-				return errors.Wrap(err, "insert msg")
-			}
-
+			toInsert = append(toInsert, streamed)
 			continue
-		}
-
-		sanityCheck := func() error {
-			// Minted, but message hash changed
-			if curr.Status == types.MsgStatusMinted && curr.MessageHash != msg.MessageHash {
-				return errors.New("message hash changed post mint", "tx_hash", msg.TxHash, "old", curr.MessageHash, "new", msg.MessageHash)
-			}
-
-			// Same message hash, but different content
-			if curr.MessageHash == msg.MessageHash && !curr.Equals(msg) {
-				return errors.New("message same for different content", "tx_hash", msg.TxHash, "msg_hash", msg.MessageHash)
-			}
-
-			return nil
 		}
 
 		// Maybe warn.
-		if err := sanityCheck(); err != nil {
+		if err := sanityCheck(stored, streamed); err != nil {
 			log.Warn(ctx, "Failed sanity check [BUG]", err)
 		}
 
-		// Already minted, skip.
-		if curr.Status == types.MsgStatusMinted {
-			continue
+		status := stored.Status
+
+		// Confirm mint.
+		if status == types.MsgStatusMinted {
+			minted, err := isReceived(ctx, stored)
+			if err != nil {
+				return errors.Wrap(err, "is received")
+			}
+
+			// Message not received, re-mark as submitted.
+			if !minted {
+				status = types.MsgStatusSubmitted
+			}
 		}
 
-		// Already saved, skip (expected).
-		if curr.MessageHash == msg.MessageHash {
-			continue
+		// Mint confirmed, but message hash changed -> BUG. Block processing.
+		if status == types.MsgStatusMinted && stored.MessageHash != streamed.MessageHash {
+			err := errors.New("message hash changed post confirmed mint", "tx_hash", streamed.TxHash, "stored", stored.MessageHash, "streamed", streamed.MessageHash)
+			log.Error(ctx, "Unexpected confirmed mint", err)
+
+			return err
 		}
 
-		// Message hash changed, update.
-		if err := db.SetMsg(ctx, withStatus(msg, types.MsgStatusSubmitted)); err != nil {
+		correction := withStatus(streamed, status)
+
+		// Update if correction required.
+		if !stored.Equals(correction) {
+			log.Debug(ctx, "Correcting message", "tx_hash", streamed.TxHash, "diff", stored.Diff(correction))
+			toUpdate = append(toUpdate, correction)
+		}
+	}
+
+	// Insert
+	for _, msg := range toInsert {
+		if err := db.InsertMsg(ctx, msg); err != nil {
+			return errors.Wrap(err, "insert msg")
+		}
+	}
+
+	// Update
+	for _, msg := range toUpdate {
+		if err := db.SetMsg(ctx, msg); err != nil {
 			return errors.Wrap(err, "set msg")
 		}
-
-		continue
 	}
 
 	return nil
@@ -194,7 +228,7 @@ func eventPairToMsg(
 		Amount:       burn.Amount,
 		SrcChainID:   srcChainID,
 		DestChainID:  uint64(burn.DestinationDomain),
-		Status:       types.MsgStatusUnknown, // unknown, resolve in upsert
+		Status:       types.MsgStatusSubmitted, // we know it's at least submitted, because we a processing a finalized event
 	}
 }
 
@@ -248,4 +282,39 @@ func newMessageSentGetter(contract *MessageTransmitter, addr common.Address) get
 func withStatus(msg types.MsgSendUSDC, status types.MsgStatus) types.MsgSendUSDC {
 	msg.Status = status
 	return msg
+}
+
+// sanityCheck errors on unexpected stored vs. streamed msg state.
+func sanityCheck(stored, streamed types.MsgSendUSDC) error {
+	// Minted, but message hash changed
+	if stored.Status == types.MsgStatusMinted && stored.MessageHash != streamed.MessageHash {
+		return errors.New("message hash changed post marked mint", "tx_hash", stored.TxHash, "stored", stored.MessageHash, "streamed", stored.MessageHash)
+	}
+
+	// Same message hash, but different content
+	if stored.MessageHash == streamed.MessageHash && !stored.Equals(withStatus(streamed, stored.Status)) {
+		return errors.New("message same for different content", "tx_hash", stored.TxHash, "diff", stored.Diff(streamed))
+	}
+
+	// Source chain ID mismatch
+	if stored.SrcChainID != streamed.SrcChainID {
+		return errors.New("source chain ID mismatch", "tx_hash", stored.TxHash, "stored", stored.SrcChainID, "streamed", streamed.SrcChainID)
+	}
+
+	// Destination chain ID mismatch
+	if stored.DestChainID != streamed.DestChainID {
+		return errors.New("destination chain ID mismatch", "tx_hash", stored.TxHash, "stored", stored.DestChainID, "streamed", streamed.DestChainID)
+	}
+
+	// Amount mismatch
+	if stored.Amount.Cmp(streamed.Amount) != 0 {
+		return errors.New("amount mismatch", "tx_hash", stored.TxHash, "stored", stored.Amount, "streamed", streamed.Amount)
+	}
+
+	// Recipient mismatch
+	if stored.Recipient != streamed.Recipient {
+		return errors.New("recipient mismatch", "tx_hash", stored.TxHash, "stored", stored.Recipient, "streamed", streamed.Recipient)
+	}
+
+	return nil
 }

--- a/lib/cctp/types/types.go
+++ b/lib/cctp/types/types.go
@@ -1,6 +1,8 @@
 package types
 
 import (
+	"bytes"
+	"fmt"
 	"math/big"
 	"reflect"
 
@@ -45,53 +47,101 @@ type MsgSendUSDC struct {
 	Status       MsgStatus
 }
 
-func (msg MsgSendUSDC) Validate() error {
+func (m MsgSendUSDC) Validate() error {
 	emptyAddr := common.Address{}
 	emptyHash := common.Hash{}
 
-	if msg.Amount == nil {
+	if m.Amount == nil {
 		return errors.New("nil amount")
 	}
 
-	if msg.Amount.Sign() <= 0 {
+	if m.Amount.Sign() <= 0 {
 		return errors.New("non-positive amount")
 	}
 
-	if msg.SrcChainID == 0 {
+	if m.SrcChainID == 0 {
 		return errors.New("zero source chain ID")
 	}
 
-	if msg.DestChainID == 0 {
+	if m.DestChainID == 0 {
 		return errors.New("zero destination chain ID")
 	}
 
-	if msg.Recipient == emptyAddr {
+	if m.Recipient == emptyAddr {
 		return errors.New("empty recipient address")
 	}
 
-	if len(msg.MessageBytes) == 0 {
+	if len(m.MessageBytes) == 0 {
 		return errors.New("empty message bytes")
 	}
 
-	if msg.TxHash == emptyHash {
+	if m.TxHash == emptyHash {
 		return errors.New("empty transaction hash")
 	}
 
-	if msg.MessageHash == emptyHash {
+	if m.MessageHash == emptyHash {
 		return errors.New("empty message hash")
 	}
 
-	if msg.MessageHash != crypto.Keccak256Hash(msg.MessageBytes) {
+	if m.MessageHash != crypto.Keccak256Hash(m.MessageBytes) {
 		return errors.New("message hash != hash of message bytes")
 	}
 
-	if msg.BlockHeight == 0 {
+	if m.BlockHeight == 0 {
 		return errors.New("zero block height")
 	}
 
-	return msg.Status.Validate()
+	return m.Status.Validate()
 }
 
-func (msg MsgSendUSDC) Equals(other MsgSendUSDC) bool {
-	return reflect.DeepEqual(msg, other)
+func (m MsgSendUSDC) Equals(n MsgSendUSDC) bool {
+	return reflect.DeepEqual(m, n)
+}
+
+// abbrevBz returns a truncated hex representation of the bytes.
+// For bytes <= 8 bytes, returns the full hex string.
+// For longer bytes, returns "0x" + first 4 bytes + "..." + last 4 bytes.
+func abbrevBz(b []byte) string {
+	if len(b) <= 8 {
+		return "0x" + common.Bytes2Hex(b)
+	}
+
+	return "0x" + common.Bytes2Hex(b[:4]) + "..." + common.Bytes2Hex(b[len(b)-4:])
+}
+
+// Diff return json object describing the diff between two MsgSendUSDCs.
+// This should be used for logging / debugging purposes only.
+func (m MsgSendUSDC) Diff(n MsgSendUSDC) map[string]string {
+	diff := make(map[string]string)
+	notEq := func(a, b any) string { return fmt.Sprintf("%v != %v", a, b) }
+
+	if m.TxHash != n.TxHash {
+		diff["tx_hash"] = notEq(m.TxHash, n.TxHash)
+	}
+	if m.BlockHeight != n.BlockHeight {
+		diff["block_height"] = notEq(m.BlockHeight, n.BlockHeight)
+	}
+	if m.MessageHash != n.MessageHash {
+		diff["message_hash"] = notEq(m.MessageHash, n.MessageHash)
+	}
+	if m.SrcChainID != n.SrcChainID {
+		diff["src_chain_id"] = notEq(m.SrcChainID, n.SrcChainID)
+	}
+	if m.DestChainID != n.DestChainID {
+		diff["dest_chain_id"] = notEq(m.DestChainID, n.DestChainID)
+	}
+	if m.Amount.Cmp(n.Amount) != 0 {
+		diff["amount"] = notEq(m.Amount, n.Amount)
+	}
+	if m.Recipient != n.Recipient {
+		diff["recipient"] = notEq(m.Recipient, n.Recipient)
+	}
+	if m.Status != n.Status {
+		diff["status"] = notEq(m.Status, n.Status)
+	}
+	if !bytes.Equal(m.MessageBytes, n.MessageBytes) {
+		diff["message_bytes"] = notEq(abbrevBz(m.MessageBytes), abbrevBz(n.MessageBytes))
+	}
+
+	return diff
 }

--- a/lib/cctp/types/types_test.go
+++ b/lib/cctp/types/types_test.go
@@ -1,11 +1,15 @@
 package types_test
 
 import (
+	"fmt"
+	"math/big"
 	"testing"
 
 	"github.com/omni-network/omni/lib/cctp/db"
 	"github.com/omni-network/omni/lib/cctp/testutil"
 	"github.com/omni-network/omni/lib/cctp/types"
+
+	"github.com/ethereum/go-ethereum/common"
 
 	"github.com/stretchr/testify/require"
 )
@@ -29,4 +33,170 @@ func TestMsgEquals(t *testing.T) {
 
 	require.True(t, msg.Equals(same))
 	require.False(t, msg.Equals(diff))
+}
+
+func TestMsgDiff(t *testing.T) {
+	t.Parallel()
+
+	base := testutil.RandMsg()
+
+	tests := []struct {
+		name     string
+		modify   func(msg types.MsgSendUSDC) types.MsgSendUSDC
+		expected func(base, modified types.MsgSendUSDC) map[string]string
+	}{
+		{
+			name: "no differences",
+			modify: func(msg types.MsgSendUSDC) types.MsgSendUSDC {
+				return msg
+			},
+			expected: func(_, _ types.MsgSendUSDC) map[string]string {
+				return map[string]string{}
+			},
+		},
+		{
+			name: "different tx hash",
+			modify: func(msg types.MsgSendUSDC) types.MsgSendUSDC {
+				msg.TxHash = common.BytesToHash(testutil.RandBytes(32))
+				return msg
+			},
+			expected: func(base, modified types.MsgSendUSDC) map[string]string {
+				return map[string]string{
+					"tx_hash": fmt.Sprintf("%v != %v", base.TxHash, modified.TxHash),
+				}
+			},
+		},
+		{
+			name: "different block height",
+			modify: func(msg types.MsgSendUSDC) types.MsgSendUSDC {
+				msg.BlockHeight++
+				return msg
+			},
+			expected: func(base, modified types.MsgSendUSDC) map[string]string {
+				return map[string]string{
+					"block_height": fmt.Sprintf("%v != %v", base.BlockHeight, modified.BlockHeight),
+				}
+			},
+		},
+		{
+			name: "different message hash",
+			modify: func(msg types.MsgSendUSDC) types.MsgSendUSDC {
+				msg.MessageHash = common.BytesToHash(testutil.RandBytes(32))
+				return msg
+			},
+			expected: func(base, modified types.MsgSendUSDC) map[string]string {
+				return map[string]string{
+					"message_hash": fmt.Sprintf("%v != %v", base.MessageHash, modified.MessageHash),
+				}
+			},
+		},
+		{
+			name: "different source chain",
+			modify: func(msg types.MsgSendUSDC) types.MsgSendUSDC {
+				msg.SrcChainID++
+				return msg
+			},
+			expected: func(base, modified types.MsgSendUSDC) map[string]string {
+				return map[string]string{
+					"src_chain_id": fmt.Sprintf("%v != %v", base.SrcChainID, modified.SrcChainID),
+				}
+			},
+		},
+		{
+			name: "different destination chain",
+			modify: func(msg types.MsgSendUSDC) types.MsgSendUSDC {
+				msg.DestChainID++
+				return msg
+			},
+			expected: func(base, modified types.MsgSendUSDC) map[string]string {
+				return map[string]string{
+					"dest_chain_id": fmt.Sprintf("%v != %v", base.DestChainID, modified.DestChainID),
+				}
+			},
+		},
+		{
+			name: "different amount",
+			modify: func(msg types.MsgSendUSDC) types.MsgSendUSDC {
+				msg.Amount = big.NewInt(100)
+				return msg
+			},
+			expected: func(base, modified types.MsgSendUSDC) map[string]string {
+				return map[string]string{
+					"amount": fmt.Sprintf("%v != %v", base.Amount, modified.Amount),
+				}
+			},
+		},
+		{
+			name: "different recipient",
+			modify: func(msg types.MsgSendUSDC) types.MsgSendUSDC {
+				msg.Recipient = common.BytesToAddress(testutil.RandBytes(20))
+				return msg
+			},
+			expected: func(base, modified types.MsgSendUSDC) map[string]string {
+				return map[string]string{
+					"recipient": fmt.Sprintf("%v != %v", base.Recipient, modified.Recipient),
+				}
+			},
+		},
+		{
+			name: "different status",
+			modify: func(msg types.MsgSendUSDC) types.MsgSendUSDC {
+				msg.Status = types.MsgStatusMinted
+				return msg
+			},
+			expected: func(base, modified types.MsgSendUSDC) map[string]string {
+				return map[string]string{
+					"status": fmt.Sprintf("%v != %v", base.Status, modified.Status),
+				}
+			},
+		},
+		{
+			name: "different message bytes",
+			modify: func(msg types.MsgSendUSDC) types.MsgSendUSDC {
+				msg.MessageBytes = testutil.RandBytes(32)
+				return msg
+			},
+			expected: func(base, modified types.MsgSendUSDC) map[string]string {
+				return map[string]string{
+					"message_bytes": fmt.Sprintf("%v != %v", abbrevBz(base.MessageBytes), abbrevBz(modified.MessageBytes)),
+				}
+			},
+		},
+		{
+			name: "multiple differences",
+			modify: func(msg types.MsgSendUSDC) types.MsgSendUSDC {
+				msg.TxHash = common.BytesToHash(testutil.RandBytes(32))
+				msg.BlockHeight++
+				msg.Status = types.MsgStatusMinted
+
+				return msg
+			},
+			expected: func(base, modified types.MsgSendUSDC) map[string]string {
+				return map[string]string{
+					"tx_hash":      fmt.Sprintf("%v != %v", base.TxHash, modified.TxHash),
+					"block_height": fmt.Sprintf("%v != %v", base.BlockHeight, modified.BlockHeight),
+					"status":       fmt.Sprintf("%v != %v", base.Status, modified.Status),
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			modified := tt.modify(base)
+			diff := base.Diff(modified)
+			expected := tt.expected(base, modified)
+			require.Equal(t, expected, diff)
+		})
+	}
+}
+
+func abbrevBz(b []byte) string {
+	if len(b) <= 8 {
+		return "0x" + common.Bytes2Hex(b)
+	}
+
+	return "0x" + common.Bytes2Hex(b[:4]) + "..." + common.Bytes2Hex(b[len(b)-4:])
 }


### PR DESCRIPTION
Audite db with finalized messages

- rename StoreMessageForever to AuditForever (more appropriate)
- revert `minted` to `submitted` if mint not confirmed (will be retried by MintForever)
- refactor a bit
- correct any content mismatch. should only happen on reorg
   change in block height / message bytes / message hash
- log diff if corrections are required
- log [BUG] logs if unexpected fields changes

issue: none
