### PR TITLE
ci(e2e): disable all-e2e-tests in ci toml

### DIFF
--- a/e2e/manifests/ci.toml
+++ b/e2e/manifests/ci.toml
@@ -4,7 +4,7 @@ anvil_chains = ["mock_l2", "mock_l1"]
 multi_omni_evms = true
 pingpong_n = 5 # Increased ping pong to span validator updates
 evidence = 1 # Slash a validator for double signing
-all_e2e_tests = true
+# all_e2e_tests = true TODO(chrisitan): enable when failing test fixed
 
 [node.validator01]
 [node.validator02]


### PR DESCRIPTION
Disable `all_e2e_tests` in `ci.toml` since undelegations tests are failing

issue: #3729