### PR TITLE
ci(e2e/manifest): bump protected network off-chain services

### DIFF
--- a/e2e/manifests/mainnet.toml
+++ b/e2e/manifests/mainnet.toml
@@ -5,9 +5,9 @@ multi_omni_evms = true
 prometheus   = true
 
 pinned_halo_tag = "v0.14.1"
-pinned_relayer_tag = "5d3ffd7"
-pinned_monitor_tag = "5d3ffd7"
-pinned_solver_tag = "5d3ffd7"
+pinned_relayer_tag = "954f83a"
+pinned_monitor_tag = "954f83a"
+pinned_solver_tag = "954f83a"
 
 [node.validator01]
 [node.validator02]

--- a/e2e/manifests/omega.toml
+++ b/e2e/manifests/omega.toml
@@ -5,9 +5,9 @@ multi_omni_evms = true
 prometheus = true
 
 pinned_halo_tag = "v0.14.1"
-pinned_relayer_tag = "5d3ffd7"
-pinned_monitor_tag = "5d3ffd7"
-pinned_solver_tag = "5d3ffd7"
+pinned_relayer_tag = "954f83a"
+pinned_monitor_tag = "954f83a"
+pinned_solver_tag = "954f83a"
 
 [node.validator01]
 [node.validator02]


### PR DESCRIPTION
Bumps off-chain services to latest main (omega and mainnet). This enables swaps on omega and releases all other latest changes to "prod".

issue: none
