### PR TITLE
ci(e2e/manifest): bump protected network off-chain services

### DIFF
--- a/e2e/manifests/mainnet.toml
+++ b/e2e/manifests/mainnet.toml
@@ -5,9 +5,9 @@ multi_omni_evms = true
 prometheus   = true
 
 pinned_halo_tag = "v0.14.1"
-pinned_relayer_tag = "954f83a"
-pinned_monitor_tag = "954f83a"
-pinned_solver_tag = "954f83a"
+pinned_relayer_tag = "b64ab34"
+pinned_monitor_tag = "b64ab34"
+pinned_solver_tag = "b64ab34"
 
 [node.validator01]
 [node.validator02]

--- a/e2e/manifests/omega.toml
+++ b/e2e/manifests/omega.toml
@@ -5,9 +5,9 @@ multi_omni_evms = true
 prometheus = true
 
 pinned_halo_tag = "v0.14.1"
-pinned_relayer_tag = "954f83a"
-pinned_monitor_tag = "954f83a"
-pinned_solver_tag = "954f83a"
+pinned_relayer_tag = "b64ab34"
+pinned_monitor_tag = "b64ab34"
+pinned_solver_tag = "b64ab34"
 
 [node.validator01]
 [node.validator02]


### PR DESCRIPTION
Bump all protected network off-chain services. This is only fix a flowgen issue on omega, but aligning tags makes things simpler.

issue: none