### PR TITLE
ci(e2e/manifest): dump mainnet off-chain services

### DIFF
--- a/e2e/manifests/mainnet.toml
+++ b/e2e/manifests/mainnet.toml
@@ -5,9 +5,9 @@ multi_omni_evms = true
 prometheus   = true
 
 pinned_halo_tag = "v0.14.1"
-pinned_relayer_tag = "b64ab34"
-pinned_monitor_tag = "b64ab34"
-pinned_solver_tag = "b64ab34"
+pinned_relayer_tag = "74ecb74"
+pinned_monitor_tag = "74ecb74"
+pinned_solver_tag = "74ecb74"
 
 [node.validator01]
 [node.validator02]


### PR DESCRIPTION
Bumps mainnet off-chain services. This disables flowgen swaps on mainnet. Align all off-chain service tags for simplicity. 

issue: none