### PR TITLE
chore(lib/log): add test logger for e2e tests

### DIFF
--- a/e2e/test/e2e_test.go
+++ b/e2e/test/e2e_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/omni-network/omni/lib/ethclient/ethbackend"
 	"github.com/omni-network/omni/lib/evmchain"
 	"github.com/omni-network/omni/lib/feature"
+	"github.com/omni-network/omni/lib/log"
 	"github.com/omni-network/omni/lib/netconf"
 	"github.com/omni-network/omni/lib/xchain"
 
@@ -126,6 +127,7 @@ func test(t *testing.T, testFunc testFunc) {
 	}
 
 	ctx = feature.WithFlags(ctx, testnet.Manifest.FeatureFlags)
+	ctx = log.WithTestLogger(ctx, t)
 
 	if name := os.Getenv(app.EnvE2ENode); name != "" {
 		node := testnet.LookupNode(name)
@@ -167,10 +169,7 @@ func test(t *testing.T, testFunc testFunc) {
 	}
 
 	if testFunc.TestNetwork != nil {
-		t.Run("network", func(t *testing.T) {
-			t.Parallel()
-			testFunc.TestNetwork(ctx, t, deps)
-		})
+		testFunc.TestNetwork(ctx, t, deps)
 	}
 }
 

--- a/lib/log/log_test.go
+++ b/lib/log/log_test.go
@@ -59,9 +59,7 @@ func TestSimpleLogs(t *testing.T) {
 func AssertLogging(t *testing.T, testFunc func(*testing.T, context.Context)) {
 	t.Helper()
 
-	loggers := log.LoggersForT()
-
-	for name, initFunc := range loggers {
+	for name, initFunc := range log.LoggersForT() {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			var buf bytes.Buffer

--- a/lib/log/t.go
+++ b/lib/log/t.go
@@ -1,0 +1,17 @@
+package log
+
+import (
+	"strings"
+	"testing"
+)
+
+// testWriter is a simple io.Writer that logs to the testing.TB.
+// It is defined in t.go to mitigate t.Log noise which adds this filename to all logs.
+type testWriter struct {
+	t *testing.T
+}
+
+func (w testWriter) Write(b []byte) (int, error) {
+	w.t.Log(strings.TrimSpace(string(b)))
+	return len(b), nil
+}


### PR DESCRIPTION
Adds a `log.WihtTestLogger` function that tests can use to group test logs.

issue: none