### PR TITLE
chore(lib/netconf): support non-portal chains

### DIFF
--- a/e2e/app/definition.go
+++ b/e2e/app/definition.go
@@ -488,13 +488,15 @@ func networkFromDef(def Definition) netconf.Network {
 	newChain := func(chain types.EVMChain) netconf.Chain {
 		portal := def.Netman().Portals()[chain.ChainID]
 		return netconf.Chain{
-			ID:             chain.ChainID,
-			Name:           chain.Name,
-			BlockPeriod:    chain.BlockPeriod,
-			Shards:         chain.Shards,
-			AttestInterval: chain.AttestInterval(def.Testnet.Network),
-			PortalAddress:  portal.DeployInfo.PortalAddress,
-			DeployHeight:   portal.DeployInfo.DeployHeight,
+			ID:              chain.ChainID,
+			Name:            chain.Name,
+			BlockPeriod:     chain.BlockPeriod,
+			Shards:          chain.Shards,
+			AttestInterval:  chain.AttestInterval(def.Testnet.Network),
+			PortalAddress:   portal.DeployInfo.PortalAddress,
+			DeployHeight:    portal.DeployInfo.DeployHeight,
+			HasEmitPortal:   true,
+			HasSubmitPortal: true,
 		}
 	}
 

--- a/lib/netconf/provider.go
+++ b/lib/netconf/provider.go
@@ -163,13 +163,15 @@ func networkFromPortals(ctx context.Context, network ID, portals []bindings.Port
 		}
 
 		chains = append(chains, Chain{
-			ID:             portal.ChainId,
-			Name:           portal.Name,
-			PortalAddress:  portal.Addr,
-			DeployHeight:   portal.DeployHeight,
-			BlockPeriod:    period,
-			Shards:         toShardIDs(portal.Shards),
-			AttestInterval: portal.AttestInterval,
+			ID:              portal.ChainId,
+			Name:            portal.Name,
+			PortalAddress:   portal.Addr,
+			DeployHeight:    portal.DeployHeight,
+			BlockPeriod:     period,
+			Shards:          toShardIDs(portal.Shards),
+			AttestInterval:  portal.AttestInterval,
+			HasSubmitPortal: true,
+			HasEmitPortal:   true,
 		})
 	}
 

--- a/lib/netconf/static.go
+++ b/lib/netconf/static.go
@@ -70,6 +70,7 @@ func (s Static) OmniConsensusChain() Chain {
 		Shards:         []xchain.ShardID{xchain.ShardBroadcast0}, // Consensus chain only supports broadcast shard.
 		DeployHeight:   1,                                        // Emit portal blocks start at 1, not 0.
 		AttestInterval: 0,                                        // Emit portal blocks are never empty, so this isn't required.
+		HasEmitPortal:  true,
 	}
 }
 

--- a/lib/xchain/provider/fetch.go
+++ b/lib/xchain/provider/fetch.go
@@ -142,6 +142,8 @@ func (p *Provider) GetEmittedCursor(ctx context.Context, ref xchain.Ref, stream 
 	chain, rpcClient, err := p.getEVMChain(stream.SourceChainID)
 	if err != nil {
 		return xchain.EmitCursor{}, false, err
+	} else if !chain.HasEmitPortal {
+		return xchain.EmitCursor{}, false, errors.New("emit portal not available on source chain")
 	}
 
 	caller, err := bindings.NewOmniPortalCaller(chain.PortalAddress, rpcClient)
@@ -181,6 +183,8 @@ func (p *Provider) GetSubmittedCursor(
 	chain, rpcClient, err := p.getEVMChain(stream.DestChainID)
 	if err != nil {
 		return xchain.SubmitCursor{}, false, err
+	} else if !chain.HasSubmitPortal {
+		return xchain.SubmitCursor{}, false, errors.New("submit portal not available on destination chain")
 	}
 
 	caller, err := bindings.NewOmniPortalCaller(chain.PortalAddress, rpcClient)

--- a/relayer/app/worker_internal_test.go
+++ b/relayer/app/worker_internal_test.go
@@ -145,9 +145,9 @@ func TestWorker_Run(t *testing.T) {
 	}
 
 	network := netconf.Network{Chains: []netconf.Chain{
-		{ID: srcChain, Name: "source", Shards: []xchain.ShardID{xchain.ShardFinalized0, xchain.ShardLatest0}},
-		{ID: destChainA, Name: "mock_l1"},
-		{ID: destChainB, Name: "mock_l2"},
+		{ID: srcChain, Name: "source", Shards: []xchain.ShardID{xchain.ShardFinalized0, xchain.ShardLatest0}, HasEmitPortal: true},
+		{ID: destChainA, Name: "mock_l1", HasSubmitPortal: true},
+		{ID: destChainB, Name: "mock_l2", HasSubmitPortal: true},
 	}}
 
 	noAwait := func(context.Context, uint64) error { return nil }


### PR DESCRIPTION
Extend `netconf.Network` with support for non-portal (non-core) chains. This will be required in `solver` when adding non-core chain support.

The idea is:
 - load network from portal registry like we do now
 - then add a set of hardcoded external chains (for that network).
 
No additional changes should be required.

issue: none