### PR TITLE
fix(solver/app): retry on invalid transitions

### DIFF
--- a/e2e/app/eoa/fund.go
+++ b/e2e/app/eoa/fund.go
@@ -72,7 +72,7 @@ var (
 
 		// Needs enough to cover gas, and bridge eth between chains
 		RoleFlowgen: {
-			minEther:    0.1,
+			minEther:    0.01,
 			targetEther: 1,
 		},
 	}

--- a/e2e/app/eoa/testdata/threshold_reference.json
+++ b/e2e/app/eoa/testdata/threshold_reference.json
@@ -2,7 +2,7 @@
  "mainnet": {
   "ETH": {
    "cold": {
-    "min": "4.248 ETH",
+    "min": "4.067999999 ETH",
     "target": "16.48 ETH"
    },
    "create3-deployer": {
@@ -14,11 +14,11 @@
     "target": "0.01 ETH"
    },
    "flowgen": {
-    "min": "0.1 ETH",
+    "min": "0.01 ETH",
     "target": "1 ETH"
    },
    "hot": {
-    "min": "4.248 ETH",
+    "min": "4.067999999 ETH",
     "target": "16.48 ETH"
    },
    "manager": {
@@ -52,7 +52,7 @@
   },
   "OMNI": {
    "cold": {
-    "min": "2124 OMNI",
+    "min": "2033.9999995 OMNI",
     "target": "8240 OMNI"
    },
    "create3-deployer": {
@@ -64,11 +64,11 @@
     "target": "5 OMNI"
    },
    "flowgen": {
-    "min": "50 OMNI",
+    "min": "5 OMNI",
     "target": "500 OMNI"
    },
    "hot": {
-    "min": "2124 OMNI",
+    "min": "2033.999999999 OMNI",
     "target": "8240 OMNI"
    },
    "manager": {
@@ -104,7 +104,7 @@
  "omega": {
   "ETH": {
    "cold": {
-    "min": "24.248 ETH",
+    "min": "24.068 ETH",
     "target": "116.48 ETH"
    },
    "create3-deployer": {
@@ -116,11 +116,11 @@
     "target": "0.01 ETH"
    },
    "flowgen": {
-    "min": "0.1 ETH",
+    "min": "0.01 ETH",
     "target": "1 ETH"
    },
    "hot": {
-    "min": "24.248 ETH",
+    "min": "24.068 ETH",
     "target": "116.48 ETH"
    },
    "manager": {
@@ -154,7 +154,7 @@
   },
   "OMNI": {
    "cold": {
-    "min": "12124 OMNI",
+    "min": "12034 OMNI",
     "target": "58240 OMNI"
    },
    "create3-deployer": {
@@ -166,11 +166,11 @@
     "target": "5 OMNI"
    },
    "flowgen": {
-    "min": "50 OMNI",
+    "min": "5 OMNI",
     "target": "500 OMNI"
    },
    "hot": {
-    "min": "12124 OMNI",
+    "min": "12034 OMNI",
     "target": "58240 OMNI"
    },
    "manager": {
@@ -206,7 +206,7 @@
  "staging": {
   "ETH": {
    "cold": {
-    "min": "25.246 ETH",
+    "min": "25.066 ETH",
     "target": "120.46 ETH"
    },
    "create3-deployer": {
@@ -218,11 +218,11 @@
     "target": "2 ETH"
    },
    "flowgen": {
-    "min": "0.1 ETH",
+    "min": "0.01 ETH",
     "target": "1 ETH"
    },
    "hot": {
-    "min": "25.246 ETH",
+    "min": "25.066 ETH",
     "target": "120.46 ETH"
    },
    "manager": {
@@ -256,7 +256,7 @@
   },
   "OMNI": {
    "cold": {
-    "min": "12623 OMNI",
+    "min": "12533 OMNI",
     "target": "60230 OMNI"
    },
    "create3-deployer": {
@@ -268,11 +268,11 @@
     "target": "1000 OMNI"
    },
    "flowgen": {
-    "min": "50 OMNI",
+    "min": "5 OMNI",
     "target": "500 OMNI"
    },
    "hot": {
-    "min": "12623 OMNI",
+    "min": "12533 OMNI",
     "target": "60230 OMNI"
    },
    "manager": {

--- a/lib/contracts/solvernet/helpers.go
+++ b/lib/contracts/solvernet/helpers.go
@@ -1,0 +1,22 @@
+package solvernet
+
+var transitions = map[OrderStatus][]OrderStatus{
+	StatusPending: {StatusRejected, StatusClosed, StatusFilled},
+	StatusFilled:  {StatusClaimed},
+}
+
+// ValidTarget returns true if the target status can be reached from the current status.
+func (s OrderStatus) ValidTarget(target OrderStatus) bool {
+	current := s
+	if current == target {
+		return true
+	}
+
+	for _, next := range transitions[current] {
+		if next.ValidTarget(target) {
+			return true
+		}
+	}
+
+	return false
+}

--- a/lib/contracts/solvernet/helpers_internal_test.go
+++ b/lib/contracts/solvernet/helpers_internal_test.go
@@ -1,0 +1,38 @@
+package solvernet
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestStatus(t *testing.T) {
+	t.Parallel()
+
+	// All statuses can be reached from pending
+	require.True(t, StatusPending.ValidTarget(StatusPending))
+	require.True(t, StatusPending.ValidTarget(StatusRejected))
+	require.True(t, StatusPending.ValidTarget(StatusClosed))
+	require.True(t, StatusPending.ValidTarget(StatusFilled))
+	require.True(t, StatusPending.ValidTarget(StatusClaimed))
+
+	// Filled is followed by Claimed only
+	require.True(t, StatusFilled.ValidTarget(StatusFilled))
+	require.True(t, StatusFilled.ValidTarget(StatusClaimed))
+	require.False(t, StatusFilled.ValidTarget(StatusPending))
+	require.False(t, StatusFilled.ValidTarget(StatusRejected))
+	require.False(t, StatusFilled.ValidTarget(StatusClosed))
+
+	// Following states are all end states, they can only reach themselves
+	for _, s := range []OrderStatus{
+		StatusRejected,
+		StatusClosed,
+		StatusClaimed,
+	} {
+		require.False(t, s.ValidTarget(StatusPending))
+		require.False(t, s.ValidTarget(StatusFilled))
+		require.Equal(t, s == StatusRejected, s.ValidTarget(StatusRejected))
+		require.Equal(t, s == StatusClosed, s.ValidTarget(StatusClosed))
+		require.Equal(t, s == StatusClaimed, s.ValidTarget(StatusClaimed))
+	}
+}

--- a/lib/xchain/connect/connect.go
+++ b/lib/xchain/connect/connect.go
@@ -26,7 +26,9 @@ import (
 	rpcclient "github.com/cometbft/cometbft/rpc/client"
 	rpchttp "github.com/cometbft/cometbft/rpc/client/http"
 
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
+	ethtypes "github.com/ethereum/go-ethereum/core/types"
 )
 
 // Connector provides a simple abstraction to connect to the Omni network.
@@ -43,6 +45,25 @@ type Connector struct {
 // Backend returns an ethbackend for the given chainID.
 func (c Connector) Backend(chainID uint64) (*ethbackend.Backend, error) {
 	return c.Backends.Backend(chainID)
+}
+
+// BindOpts returns a new TransactOpts for interacting with bindings based contracts for the provided chain and account.
+func (c Connector) BindOpts(ctx context.Context, chainID uint64, from common.Address) (*bind.TransactOpts, error) {
+	backend, err := c.Backends.Backend(chainID)
+	if err != nil {
+		return nil, err
+	}
+
+	return backend.BindOpts(ctx, from)
+}
+
+func (c Connector) WaitMined(ctx context.Context, chainID uint64, tx *ethtypes.Transaction) (*ethclient.Receipt, error) {
+	backend, err := c.Backends.Backend(chainID)
+	if err != nil {
+		return nil, err
+	}
+
+	return backend.WaitMined(ctx, tx)
 }
 
 // Portal returns an OmniPortal contract.

--- a/solver/app/processor.go
+++ b/solver/app/processor.go
@@ -43,7 +43,10 @@ func newEventProcFunc(deps procDeps, chainID uint64) eventProcFunc {
 			"status", order.Status,
 		)
 
-		if event.Status != order.Status {
+		if !event.Status.ValidTarget(order.Status) {
+			// Invalid order transition can occur when RPCs return stale data, so just retry for now.
+			return errors.New("invalid order transition", "event_status", event.Status.String())
+		} else if event.Status != order.Status {
 			log.Debug(ctx, "Ignoring old order event (status already changed)", "event_status", event.Status.String())
 			return nil
 		}

--- a/solver/app/util_internal_test.go
+++ b/solver/app/util_internal_test.go
@@ -1,0 +1,93 @@
+package app
+
+import (
+	"flag"
+	"sync"
+	"testing"
+
+	"github.com/omni-network/omni/contracts/bindings"
+	"github.com/omni-network/omni/e2e/app/eoa"
+	"github.com/omni-network/omni/lib/contracts/solvernet"
+	"github.com/omni-network/omni/lib/evmchain"
+	"github.com/omni-network/omni/lib/netconf"
+	"github.com/omni-network/omni/lib/xchain/connect"
+
+	"github.com/ethereum/go-ethereum/common"
+
+	"github.com/stretchr/testify/require"
+)
+
+var (
+	integration = flag.Bool("integration", false, "enable integration tests")
+
+	claimNetwork = netconf.Omega
+	toClaim      = map[uint64][]OrderID{
+		evmchain.IDBaseSepolia: {
+			OrderID(common.HexToHash("0xf57063cbb9ae3149a61e2ab4b6680341b060a7a7ea6e089baab1cff6d54ea44c")),
+			OrderID(common.HexToHash("0xafb56f273df8e28757cab87880c4b8d0c8f526c0c35621e4686e7dc8fb6a1e1e")),
+			OrderID(common.HexToHash("0x3b88a49665cb86e305133ae71ab63b8f75ebffc187824f6e4055935041469548")),
+			OrderID(common.HexToHash("0x9d886375111a35c85f01d680e647aae8584afeadd903c6d8c24ff5ca037e6308")),
+		},
+	}
+)
+
+// TestManualClaim manually claims specific orders on a network.
+func TestManualClaim(t *testing.T) {
+	t.Parallel()
+	if !*integration {
+		t.Skip("integration tests not enabled")
+	}
+
+	ctx := t.Context()
+	conn, err := connect.New(ctx, claimNetwork, connect.WithInfuraENV("INFURA_SECRET"))
+	require.NoError(t, err)
+
+	var solverAddr common.Address
+	var once sync.Once
+
+	for chainID, orders := range toClaim {
+		t.Logf("Claiming orders for %s", evmchain.Name(chainID))
+
+		inbox, err := conn.SolverNetInbox(ctx, chainID)
+		require.NoError(t, err)
+
+		orderGetter := newOrderGetter(map[uint64]*bindings.SolverNetInbox{chainID: inbox})
+
+		for _, orderID := range orders {
+			order, ok, err := orderGetter(ctx, chainID, orderID)
+			require.NoError(t, err)
+			require.True(t, ok, "order not found")
+
+			if order.Status != solvernet.StatusFilled {
+				t.Logf("Skipping order no in filled state: %s=%s", orderID, order.Status)
+				continue
+			}
+
+			claimant, ok, err := getClaimant(claimNetwork, order)
+			require.NoError(t, err)
+			if !ok {
+				claimant = solverAddr
+			}
+
+			// When required, download the solver private key and add to backends.
+			once.Do(func() {
+				t.Log("Downloading solver private key")
+				solverPrivKey, err := eoa.PrivateKey(ctx, claimNetwork, eoa.RoleSolver)
+				require.NoError(t, err)
+				solverAddr, err = conn.Backends.AddAccount(solverPrivKey)
+				require.NoError(t, err)
+			})
+
+			txOpts, err := conn.BindOpts(ctx, chainID, solverAddr)
+			require.NoError(t, err)
+
+			tx, err := inbox.Claim(txOpts, order.ID, claimant)
+			require.NoError(t, err)
+
+			rec, err := conn.WaitMined(ctx, chainID, tx)
+			require.NoError(t, err)
+
+			t.Logf("Claimed order %s on %s: tx=%s (height=%s)", order.ID, evmchain.Name(chainID), tx.Hash(), rec.BlockNumber)
+		}
+	}
+}


### PR DESCRIPTION
Detect "invalid transitions" and retry, assuming that this is due to RPC providers providing stale data, so retries should fix it.

Also write a `TestManualClaim` utility to manually claim orders.

Also improve flowgen logging and decrease flowgen role min balance. 

issue: none