### PR TITLE
chore(lib/txmgr): over estimate gas limit

### DIFF
--- a/lib/txmgr/txmgr_internal_test.go
+++ b/lib/txmgr/txmgr_internal_test.go
@@ -495,7 +495,7 @@ func TestTxMgr_EstimateGas(t *testing.T) {
 	require.NotNil(t, tx)
 
 	// Check that the gas was estimated correctly.
-	require.Equal(t, gasEstimate, tx.Gas())
+	require.Equal(t, bumpGasLimit(gasEstimate), tx.Gas())
 }
 
 func TestTxMgr_EstimateGasFails(t *testing.T) {

--- a/monitor/xmonitor/indexer/indexer.go
+++ b/monitor/xmonitor/indexer/indexer.go
@@ -3,6 +3,7 @@ package indexer
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"strings"
 	"sync"
 	"time"
@@ -452,6 +453,7 @@ func (i *indexer) instrumentMsg(ctx context.Context, link *MsgLink) error {
 		"stream", s.Stream,
 		"offset", msg.StreamOffset,
 		"success", s.Success,
+		"gas_usage", fmt.Sprintf("%.1f%%", float64(receipt.GasUsed)/float64(msg.DestGasLimit)),
 		"latency", s.Latency,
 		"msg_tx", msg.TxHash,
 		"receipt_tx", receipt.TxHash,

--- a/solver/app/helpers.go
+++ b/solver/app/helpers.go
@@ -71,6 +71,17 @@ func maybeDebugRevert(ctx context.Context, cl ethclient.Client, from common.Addr
 		return false, nil
 	}
 
+	// Assume 95%+ gas usage was due to out of gas
+	if rec.GasUsed >= tx.Gas()*95/100 {
+		return true, errors.New("tx probably reverted due to out of gas",
+			"dest_chain", cl.Name(),
+			"tx", tx.Hash(),
+			"receipt_height", rec.BlockNumber,
+			"gas_used", rec.GasUsed,
+			"gas_limit", tx.Gas(),
+		)
+	}
+
 	// Try and get debug information of the reverted transaction
 	resp, err := cl.CallContract(ctx, callFromTx(from, tx), rec.BlockNumber)
 	if err == nil {


### PR DESCRIPTION
Increase gas limit by 100% in txmgr. This mitigates txs failing due to dynamic gas usage.

issue: none