### PR TITLE
ci(e2e/manifest): bump protected off-chain services to 2abbc90

### DIFF
--- a/e2e/manifests/mainnet.toml
+++ b/e2e/manifests/mainnet.toml
@@ -5,9 +5,9 @@ multi_omni_evms = true
 prometheus   = true
 
 pinned_halo_tag = "v0.14.1"
-pinned_relayer_tag = "74ecb74"
-pinned_monitor_tag = "74ecb74"
-pinned_solver_tag = "74ecb74"
+pinned_relayer_tag = "2abbc90"
+pinned_monitor_tag = "2abbc90"
+pinned_solver_tag = "2abbc90"
 
 [node.validator01]
 [node.validator02]

--- a/e2e/manifests/omega.toml
+++ b/e2e/manifests/omega.toml
@@ -5,9 +5,9 @@ multi_omni_evms = true
 prometheus = true
 
 pinned_halo_tag = "v0.14.1"
-pinned_relayer_tag = "16596aa"
-pinned_monitor_tag = "16596aa"
-pinned_solver_tag = "16596aa"
+pinned_relayer_tag = "2abbc90"
+pinned_monitor_tag = "2abbc90"
+pinned_solver_tag = "2abbc90"
 
 [node.validator01]
 [node.validator02]


### PR DESCRIPTION
Bump protected off-chain services to latest main `2abbc90`. 

This mainly includes a few solver fixes.

issue: none