### PR TITLE
ci(e2e/manifest): bump off-chain services to 531924c

### DIFF
--- a/e2e/manifests/mainnet.toml
+++ b/e2e/manifests/mainnet.toml
@@ -5,9 +5,9 @@ multi_omni_evms = true
 prometheus   = true
 
 pinned_halo_tag = "v0.14.1"
-pinned_relayer_tag = "2abbc90"
-pinned_monitor_tag = "2abbc90"
-pinned_solver_tag = "2abbc90"
+pinned_relayer_tag = "531924c"
+pinned_monitor_tag = "531924c"
+pinned_solver_tag = "531924c"
 
 [node.validator01]
 [node.validator02]

--- a/e2e/manifests/omega.toml
+++ b/e2e/manifests/omega.toml
@@ -5,9 +5,9 @@ multi_omni_evms = true
 prometheus = true
 
 pinned_halo_tag = "v0.14.1"
-pinned_relayer_tag = "2abbc90"
-pinned_monitor_tag = "2abbc90"
-pinned_solver_tag = "2abbc90"
+pinned_relayer_tag = "531924c"
+pinned_monitor_tag = "531924c"
+pinned_solver_tag = "531924c"
 
 [node.validator01]
 [node.validator02]


### PR DESCRIPTION
Bumps protected off-chain services to 531924c, this includes a fix for gas-limit-bumping.

issue: none