### PR TITLE
fix(lib/cctp): only parse attestation when complete

### DIFF
--- a/lib/cctp/client.go
+++ b/lib/cctp/client.go
@@ -48,6 +48,10 @@ func (c client) GetAttestation(ctx context.Context, messageHash common.Hash) ([]
 		return nil, "", err
 	}
 
+	if status == AttestationStatusPendingConfirmations {
+		return nil, status, nil
+	}
+
 	attestation, err := hexutil.Decode(res.Attestation)
 	if err != nil {
 		return nil, "", errors.Wrap(err, "decode attestation hex")


### PR DESCRIPTION
Only parse attestation when it is complete. Else it is not a hex string.

issue: none