### PR TITLE
chore(lib/cctp): require dest chain id is in-network

### DIFF
--- a/lib/cctp/audit_internal_test.go
+++ b/lib/cctp/audit_internal_test.go
@@ -349,7 +349,7 @@ func depositForBurnLog(addr common.Address, msg types.MsgSendUSDC) ethtypes.Log 
 		Data: mustPackData(
 			msg.Amount,                       // amount
 			cast.EthAddress32(msg.Recipient), // mintRecipient
-			domains[msg.DestChainID],         // destinationDomain
+			mainnetDomains[msg.DestChainID],  // destinationDomain
 			common.HexToHash("0x1"),          // destinationTokenMessenger (doesn't matter)
 			common.HexToHash("0x1"),          // destinationCaller (doesn't matter)
 		),

--- a/lib/cctp/domains.go
+++ b/lib/cctp/domains.go
@@ -21,10 +21,20 @@ var (
 		evmchain.IDArbSepolia:  3,
 		evmchain.IDBaseSepolia: 6,
 	}
-
-	// mainnet and testnet merged.
-	domains = mustMergeDomains(mainnetDomains, testnetDomains)
 )
+
+func domainIDForChain(networkID netconf.ID, chainID uint64) (uint32, bool) {
+	switch networkID {
+	case netconf.Mainnet:
+		d, ok := mainnetDomains[chainID]
+		return d, ok
+	case netconf.Omega, netconf.Staging:
+		d, ok := testnetDomains[chainID]
+		return d, ok
+	default:
+		return 0, false
+	}
+}
 
 func chainIDForDomain(networkID netconf.ID, domainID uint32) (uint64, bool) {
 	findIn := func(ds map[uint64]uint32) (uint64, bool) {
@@ -45,21 +55,4 @@ func chainIDForDomain(networkID netconf.ID, domainID uint32) (uint64, bool) {
 	default:
 		return 0, false
 	}
-}
-
-func mustMergeDomains(mainnet, testnet map[uint64]uint32) map[uint64]uint32 {
-	merged := make(map[uint64]uint32)
-	for k, v := range mainnet {
-		merged[k] = v
-	}
-
-	for k, v := range testnet {
-		if _, ok := merged[k]; ok {
-			panic("duplicate chain id")
-		}
-
-		merged[k] = v
-	}
-
-	return merged
 }

--- a/lib/cctp/integration_test.go
+++ b/lib/cctp/integration_test.go
@@ -173,7 +173,7 @@ func TestIntegration(t *testing.T) {
 			sendDB = wrongDB
 		}
 
-		msg, err := cctp.SendUSDC(ctx, sendDB, backend, cctp.SendUSDCArgs{
+		msg, err := cctp.SendUSDC(ctx, sendDB, netconf.Mainnet, backend, cctp.SendUSDCArgs{
 			Sender:      devAddr,
 			Recipient:   devAddr,
 			SrcChainID:  send.srcChainID,

--- a/lib/cctp/send.go
+++ b/lib/cctp/send.go
@@ -14,6 +14,7 @@ import (
 	"github.com/omni-network/omni/lib/ethclient/ethbackend"
 	"github.com/omni-network/omni/lib/evmchain"
 	"github.com/omni-network/omni/lib/log"
+	"github.com/omni-network/omni/lib/netconf"
 	"github.com/omni-network/omni/lib/tokens"
 	"github.com/omni-network/omni/lib/umath"
 
@@ -35,6 +36,7 @@ type SendUSDCArgs struct {
 func SendUSDC(
 	ctx context.Context,
 	db *db.DB,
+	networkID netconf.ID,
 	backend *ethbackend.Backend,
 	args SendUSDCArgs,
 ) (types.MsgSendUSDC, error) {
@@ -63,7 +65,7 @@ func SendUSDC(
 		return types.MsgSendUSDC{}, errors.Wrap(err, "bind opts")
 	}
 
-	domainID, ok := domains[args.DestChainID]
+	domainID, ok := domainIDForChain(networkID, args.DestChainID)
 	if !ok {
 		return types.MsgSendUSDC{}, errors.New("unknown domain ID", "dest_chain", dstChain)
 	}


### PR DESCRIPTION
Ensure dest chain ids is in-network.

CCTP uses same domains for testnet / mainnet. So it was possible to send a message to an in-network domain, but not in-network chain id. 

issue: none
