### PR TITLE
test(sdk): useOrder units react next pckg

### DIFF
--- a/sdk/packages/react-next/package.json
+++ b/sdk/packages/react-next/package.json
@@ -22,7 +22,8 @@
     "prepublishOnly": "pnpm build",
     "clean": "rm -rf dist tsconfig.tsbuildinfo",
     "test": "vitest run",
-    "coverage": "vitest run --coverage"
+    "coverage": "vitest run --coverage",
+    "check": "biome check --write"
   },
   "files": [
     "dist/**",

--- a/sdk/packages/react-next/src/hooks/useOrder.test-d.ts
+++ b/sdk/packages/react-next/src/hooks/useOrder.test-d.ts
@@ -1,4 +1,5 @@
 import type { OptionalAbis, Order } from '@omni-network/core'
+import type { UseMutateFunction } from '@tanstack/react-query'
 import type { Hex } from 'viem'
 import { expectTypeOf, test } from 'vitest'
 import type { Config, UseWaitForTransactionReceiptReturnType } from 'wagmi'
@@ -17,7 +18,7 @@ test('type: useOrder', () => {
   const result = useOrder(order)
 
   expectTypeOf(result).toMatchTypeOf<{
-    open: () => Promise<Hex>
+    open: UseMutateFunction<Hex, Error, void, unknown>
     orderId?: Hex
     validation?: UseValidateOrderResult
     txHash?: Hex
@@ -33,8 +34,9 @@ test('type: useOrder', () => {
     waitForTx: UseWaitForTransactionReceiptReturnType<Config, number>
   }>()
 
-  expectTypeOf(result.open).toBeFunction()
-  expectTypeOf(result.open).returns.toEqualTypeOf<Promise<Hex>>()
+  expectTypeOf(result.open).toMatchTypeOf<
+    UseMutateFunction<`0x${string}`, Error, void, unknown>
+  >()
 
   expectTypeOf(result.orderId).toEqualTypeOf<Hex | undefined>()
   expectTypeOf(result.txHash).toEqualTypeOf<Hex | undefined>()

--- a/sdk/packages/react-next/src/hooks/useOrder.test.ts
+++ b/sdk/packages/react-next/src/hooks/useOrder.test.ts
@@ -10,8 +10,6 @@ import {
 } from '../../test/index.js'
 import { useOrder } from './useOrder.js'
 
-// TODO no client error
-
 const {
   useValidateOrder,
   useGetOrderStatus,

--- a/sdk/packages/react-next/src/hooks/useOrder.test.ts
+++ b/sdk/packages/react-next/src/hooks/useOrder.test.ts
@@ -1,0 +1,412 @@
+import * as core from '@omni-network/core'
+import { waitFor } from '@testing-library/react'
+import { beforeEach, expect, test, vi } from 'vitest'
+import {
+  contracts,
+  createMockWaitForTransactionReceiptResult,
+  orderRequest,
+  renderHook,
+  resolvedOrder,
+} from '../../test/index.js'
+import { useOrder } from './useOrder.js'
+
+// TODO no client error
+
+const {
+  useValidateOrder,
+  useGetOrderStatus,
+  useOmniContracts,
+  useParseOpenEvent,
+  useWaitForTransactionReceipt,
+} = vi.hoisted(() => {
+  return {
+    useValidateOrder: vi.fn(),
+    useParseOpenEvent: vi.fn(),
+    useGetOrderStatus: vi.fn(),
+    useWaitForTransactionReceipt: vi.fn(),
+    useOmniContracts: vi.fn().mockImplementation(() => {
+      return {
+        data: {
+          ...contracts,
+        },
+      }
+    }),
+  }
+})
+
+vi.mock('wagmi', async () => {
+  const actual = await vi.importActual('wagmi')
+  return {
+    ...actual,
+    useWaitForTransactionReceipt,
+  }
+})
+
+vi.mock('./useValidateOrder.js', async () => {
+  return {
+    useValidateOrder: useValidateOrder,
+  }
+})
+
+vi.mock('./useOmniContracts.js', async () => {
+  return {
+    useOmniContracts: useOmniContracts,
+  }
+})
+
+vi.mock('./useGetOrderStatus.js', async () => {
+  return {
+    useGetOrderStatus: useGetOrderStatus,
+  }
+})
+
+vi.mock('./useParseOpenEvent.js', async () => {
+  return {
+    useParseOpenEvent: useParseOpenEvent,
+  }
+})
+
+beforeEach(() => {
+  vi.spyOn(core, 'openOrder').mockResolvedValue('0xTxHash')
+  useParseOpenEvent.mockReturnValue({
+    resolvedOrder,
+    error: null,
+  })
+  useGetOrderStatus.mockReturnValue({
+    status: 'not-found',
+  })
+  useValidateOrder.mockReturnValue({
+    status: 'pending',
+  })
+  useWaitForTransactionReceipt.mockReturnValue(
+    createMockWaitForTransactionReceiptResult({
+      isPending: true,
+      isSuccess: false,
+      data: undefined,
+      status: 'pending',
+    }),
+  )
+})
+
+const renderOrderHook = (
+  params: Parameters<typeof useOrder>[0],
+  options?: Parameters<typeof renderHook>[1],
+) => {
+  return renderHook(() => useOrder({ ...params }), {
+    mockContractsCall: true,
+    ...options,
+  })
+}
+
+test(`default: validates, opens, and transitions order through it's lifecycle`, async () => {
+  const { result, rerender } = renderHook(
+    ({ validateEnabled }: { validateEnabled: boolean }) =>
+      useOrder({ ...orderRequest, validateEnabled }),
+    { mockContractsCall: true, initialProps: { validateEnabled: true } },
+  )
+
+  await waitFor(() => {
+    expect(result.current.isReady).toBe(true)
+    expect(result.current.isValidated).toBe(false)
+    expect(result.current.isError).toBe(false)
+    expect(result.current.isTxPending).toBe(false)
+    expect(result.current.status).toBe('ready')
+    expect(result.current.validation?.status).toBe('pending')
+    expect(result.current.isTxSubmitted).toBe(false)
+    expect(result.current.txMutation.data).toBeUndefined()
+    expect(result.current.isOpen).toBe(false)
+    expect(result.current.txHash).toBeUndefined()
+    expect(result.current.error).toBeUndefined()
+  })
+
+  useValidateOrder.mockReturnValue({
+    status: 'accepted',
+  })
+
+  useWaitForTransactionReceipt.mockImplementation(() =>
+    createMockWaitForTransactionReceiptResult({
+      isPending: true,
+      isSuccess: false,
+      data: undefined,
+      status: 'pending',
+      fetchStatus: 'fetching',
+    }),
+  )
+
+  rerender({ validateEnabled: true })
+
+  await waitFor(() => {
+    expect(result.current.isValidated).toBe(true)
+    expect(result.current.validation?.status).toBe('accepted')
+  })
+
+  result.current.open()
+
+  await waitFor(() => {
+    expect(result.current.txHash).toBe('0xTxHash')
+    expect(result.current.isTxPending).toBe(false)
+    expect(result.current.isTxSubmitted).toBe(true)
+    expect(result.current.txMutation.data).toBe('0xTxHash')
+    expect(result.current.txMutation.isSuccess).toBe(true)
+    expect(result.current.status).toBe('opening')
+    expect(result.current.waitForTx.data).toBeUndefined()
+    expect(result.current.waitForTx.isSuccess).toBe(false)
+  })
+
+  useWaitForTransactionReceipt.mockImplementation(() =>
+    createMockWaitForTransactionReceiptResult(),
+  )
+
+  useGetOrderStatus.mockReturnValue({
+    status: 'open',
+  })
+
+  rerender({ validateEnabled: true })
+
+  await waitFor(() => {
+    expect(result.current.waitForTx.data).toBe('0xTxHash')
+    expect(result.current.waitForTx.isSuccess).toBe(true)
+    expect(result.current.isOpen).toBe(true)
+  })
+
+  useGetOrderStatus.mockReturnValue({
+    status: 'filled',
+  })
+
+  rerender({ validateEnabled: true })
+
+  await waitFor(() => expect(result.current.status).toBe('filled'))
+})
+
+test('behaviour: handles order rejection', async () => {
+  const { result, rerender } = renderOrderHook({
+    ...orderRequest,
+    validateEnabled: false,
+  })
+
+  useWaitForTransactionReceipt.mockImplementation(() =>
+    createMockWaitForTransactionReceiptResult(),
+  )
+
+  result.current.open()
+
+  useGetOrderStatus.mockReturnValue({
+    status: 'rejected',
+  })
+
+  rerender()
+
+  await waitFor(() => {
+    expect(result.current.status).toBe('rejected')
+    expect(result.current.isOpen).toBe(false)
+  })
+})
+
+test('behaviour: closed order is handled', async () => {
+  const { result, rerender } = renderOrderHook({
+    ...orderRequest,
+    validateEnabled: false,
+  })
+
+  useWaitForTransactionReceipt.mockImplementation(() =>
+    createMockWaitForTransactionReceiptResult(),
+  )
+
+  result.current.open()
+
+  useGetOrderStatus.mockReturnValue({
+    status: 'closed',
+  })
+
+  rerender()
+
+  await waitFor(() => {
+    expect(result.current.status).toBe('closed')
+    expect(result.current.isOpen).toBe(false)
+  })
+})
+
+test('behaviour: handles openOrder error', async () => {
+  vi.spyOn(core, 'openOrder').mockRejectedValue(new Error('Tx mutation error'))
+
+  const { result } = renderOrderHook({
+    ...orderRequest,
+    validateEnabled: false,
+  })
+
+  result.current.open()
+
+  await waitFor(() => {
+    expect(result.current.isError).toBe(true)
+    expect(result.current.error).toBeInstanceOf(core.OpenError)
+  })
+})
+
+test('behaviour: validate false/true: toggles validation behavior', async () => {
+  useValidateOrder.mockReturnValue({
+    status: 'pending',
+  })
+
+  const { result, rerender } = renderOrderHook({
+    ...orderRequest,
+    validateEnabled: false,
+  })
+
+  await waitFor(() => {
+    expect(result.current.isValidated).toBe(false)
+  })
+
+  useValidateOrder.mockReturnValue({
+    status: 'accepted',
+  })
+
+  rerender({ validateEnabled: true })
+
+  await waitFor(() => {
+    expect(result.current.isValidated).toBe(true)
+  })
+})
+
+test('behaviour:  handles validation error', async () => {
+  useValidateOrder.mockReturnValue({
+    status: 'error',
+    error: new Error('Validation failed'),
+  })
+
+  const { result } = renderOrderHook({ ...orderRequest, validateEnabled: true })
+
+  await waitFor(() => {
+    expect(result.current.isError).toBe(true)
+    expect(result.current.error).toBeInstanceOf(core.ValidateOrderError)
+  })
+})
+
+test('behaviour: handles transaction receipt error', async () => {
+  useWaitForTransactionReceipt.mockImplementation(() =>
+    createMockWaitForTransactionReceiptResult({
+      isError: true,
+      error: new Error('Receipt fetch failed'),
+      status: 'error',
+    }),
+  )
+
+  const { result } = renderOrderHook({
+    ...orderRequest,
+    validateEnabled: false,
+  })
+
+  await waitFor(() => {
+    expect(result.current.isError).toBe(true)
+    expect(result.current.error).toBeInstanceOf(core.TxReceiptError)
+    expect(result.current.status).toBe('error')
+  })
+})
+
+test('behaviour: handles parse open event error', async () => {
+  useParseOpenEvent.mockReturnValue({
+    status: 'error',
+    error: new core.ParseOpenEventError('Failed to parse open event'),
+  })
+
+  useWaitForTransactionReceipt.mockImplementation(() =>
+    createMockWaitForTransactionReceiptResult({
+      error: null,
+    }),
+  )
+
+  const { result } = renderOrderHook({
+    ...orderRequest,
+    validateEnabled: false,
+  })
+
+  await waitFor(() => {
+    expect(result.current.isError).toBe(true)
+    expect(result.current.error).toBeInstanceOf(core.ParseOpenEventError)
+  })
+})
+
+test('behaviour: handles order status error', async () => {
+  useGetOrderStatus.mockReturnValue({
+    status: 'error',
+    error: new core.DidFillError('Failed to get order status'),
+  })
+
+  useWaitForTransactionReceipt.mockImplementation(() =>
+    createMockWaitForTransactionReceiptResult({
+      isSuccess: true,
+      status: 'success',
+    }),
+  )
+
+  const { result } = renderOrderHook({
+    ...orderRequest,
+    validateEnabled: false,
+  })
+
+  await waitFor(() => {
+    expect(result.current.isError).toBe(true)
+    expect(result.current.error).toBeInstanceOf(core.DidFillError)
+  })
+})
+
+test('behaviour: handles wait success but order not found', async () => {
+  useWaitForTransactionReceipt.mockImplementation(() =>
+    createMockWaitForTransactionReceiptResult({
+      isSuccess: true,
+      status: 'success',
+    }),
+  )
+
+  const { result } = renderOrderHook({ ...orderRequest, validateEnabled: true })
+
+  await waitFor(() => {
+    expect(result.current.isError).toBe(true)
+    expect(result.current.error).toBeInstanceOf(core.GetOrderError)
+  })
+})
+
+test('behaviour: handles contracts load error', async () => {
+  useOmniContracts.mockImplementation(() => {
+    return {
+      data: {
+        inbox: undefined,
+      },
+      error: new Error('Failed to load contracts'),
+      isError: true,
+    }
+  })
+
+  const { result } = renderOrderHook(
+    { ...orderRequest, validateEnabled: true },
+    { mockContractsCallFailure: true },
+  )
+
+  await waitFor(() => {
+    expect(result.current.isError).toBe(true)
+    expect(result.current.error).toBeInstanceOf(core.LoadContractsError)
+    expect(result.current.status).toBe('error')
+  })
+})
+
+test('behaviour: open rejects when inbox contract not loaded', async () => {
+  const { result, rerender } = renderOrderHook(
+    { ...orderRequest, validateEnabled: false },
+    { mockContractsCall: false },
+  )
+
+  useOmniContracts.mockImplementation(() => {
+    return {
+      data: {
+        inbox: undefined,
+      },
+    }
+  })
+
+  rerender()
+
+  result.current.open()
+
+  await waitFor(() => {
+    expect(result.current.txMutation.isError).toBe(true)
+  })
+})

--- a/sdk/packages/react-next/src/hooks/useOrder.ts
+++ b/sdk/packages/react-next/src/hooks/useOrder.ts
@@ -14,7 +14,11 @@ import {
   ValidateOrderError,
   openOrder,
 } from '@omni-network/core'
-import { type UseMutationResult, useMutation } from '@tanstack/react-query'
+import {
+  type UseMutateFunction,
+  type UseMutationResult,
+  useMutation,
+} from '@tanstack/react-query'
 import type { Hex, WriteContractErrorType } from 'viem'
 import {
   type Config,
@@ -59,7 +63,7 @@ type UseOrderError =
   | undefined
 
 type UseOrderReturnType = {
-  open: () => Promise<Hex>
+  open: UseMutateFunction<`0x${string}`, MutationError, void, unknown>
   orderId?: Hex
   validation?: UseValidateOrderResult
   txHash?: Hex
@@ -145,7 +149,7 @@ export function useOrder<abis extends OptionalAbis>(
   })
 
   return {
-    open: txMutation.mutateAsync,
+    open: txMutation.mutate,
     orderId: resolvedOrder?.orderId,
     validation,
     txHash: txMutation.data,

--- a/sdk/packages/react-next/test/mocks.ts
+++ b/sdk/packages/react-next/test/mocks.ts
@@ -1,7 +1,16 @@
 import * as core from '@omni-network/core'
 import type { UseQueryResult } from '@tanstack/react-query'
 import { vi } from 'vitest'
+import type { useWaitForTransactionReceipt } from 'wagmi'
 import { contracts } from './shared.js'
+
+type UseWaitForTransactionReceiptReturn<Data> = Omit<
+  ReturnType<typeof useWaitForTransactionReceipt>,
+  'error' | 'data'
+> & {
+  error: Error | null
+  data: Data
+}
 
 export function mockContractsQuery(failure = false) {
   vi.spyOn(core, 'getContracts').mockImplementation(() => {
@@ -46,4 +55,40 @@ export function createMockQueryResult<TData = never>(
   }
 
   return result as UseQueryResult<TData>
+}
+
+export function createMockWaitForTransactionReceiptResult<
+  TResult extends ReturnType<typeof useWaitForTransactionReceipt> = never,
+>(
+  overrides?: Partial<UseWaitForTransactionReceiptReturn<TResult['data']>>,
+): UseWaitForTransactionReceiptReturn<TResult['data']> {
+  return {
+    isError: false,
+    isPending: false,
+    isSuccess: true,
+    isLoading: false,
+    isStale: false,
+    isLoadingError: false,
+    isRefetchError: false,
+    isPlaceholderData: false,
+    dataUpdatedAt: 0,
+    errorUpdatedAt: 0,
+    failureCount: 0,
+    failureReason: null,
+    errorUpdateCount: 0,
+    isFetched: true,
+    isFetchedAfterMount: true,
+    isFetching: false,
+    isInitialLoading: false,
+    isRefetching: false,
+    status: 'success',
+    data: '0xTxHash',
+    isPaused: false,
+    refetch: vi.fn(),
+    fetchStatus: 'idle' as const,
+    queryKey: [],
+    promise: Promise.resolve(),
+    error: null,
+    ...overrides,
+  }
 }


### PR DESCRIPTION
- use order units in react next pckg
- moved from `mutateAsync` to `mutate` for open method - happy to discuss this, but `mutateAsync` will reject the promise awaited by the consumer if there's an error, rather than relying on react query propagating state and preventing a throw
- there's benefits to both, but existing behaviour is to not allow the promise to reject when called
- that said, return type of `open` is not longer the `txHash`, and doesn't return a promise, consumers will need to get hash from the `txHash` return value

issue: none