### PR TITLE
chore(contracts/solvernet): support hyperlane chains

### DIFF
--- a/e2e/solve/deploy.go
+++ b/e2e/solve/deploy.go
@@ -3,6 +3,7 @@ package solve
 import (
 	"context"
 
+	"github.com/omni-network/omni/lib/contracts/solvernet"
 	"github.com/omni-network/omni/lib/contracts/solvernet/executor"
 	"github.com/omni-network/omni/lib/contracts/solvernet/inbox"
 	"github.com/omni-network/omni/lib/contracts/solvernet/middleman"
@@ -18,6 +19,8 @@ import (
 
 // Deploy deploys solve inbox / outbox / middleman contracts, and devnet app (if devnet).
 func Deploy(ctx context.Context, network netconf.Network, backends ethbackend.Backends) error {
+	network = solvernet.AddHLNetwork(network)
+
 	var eg1 errgroup.Group
 	eg1.Go(func() error { return deployBoxes(ctx, network, backends) })
 	eg1.Go(func() error { return maybeDeployMockTokens(ctx, network, backends) })

--- a/lib/contracts/solvernet/chains.go
+++ b/lib/contracts/solvernet/chains.go
@@ -1,0 +1,48 @@
+package solvernet
+
+import (
+	"github.com/omni-network/omni/lib/errors"
+	"github.com/omni-network/omni/lib/evmchain"
+	"github.com/omni-network/omni/lib/netconf"
+)
+
+// hlChains define solvernet chains secured by hyperlane.
+var hlChains = map[netconf.ID][]uint64{
+	// TODO(zodomo): add hyperlane chains here
+}
+
+// HLChains returns the list of hyperlane-secured chains for a given solvernet network.
+func HLChains(network netconf.ID) []netconf.Chain {
+	var resp []netconf.Chain
+	for _, chainID := range hlChains[network] {
+		chain, ok := evmchain.MetadataByID(chainID)
+		if !ok {
+			panic(errors.New("unknown chain", "chain_id", chainID))
+		}
+		resp = append(resp, netconf.Chain{
+			ID:          chain.ChainID,
+			Name:        chain.Name,
+			BlockPeriod: chain.BlockPeriod,
+		})
+	}
+
+	return resp
+}
+
+// IsHLChain returns true if the solvernet chain is secured by hyperlane.
+func IsHLChain(chainID uint64) bool {
+	for _, ids := range hlChains {
+		for _, id := range ids {
+			if id == chainID {
+				return true
+			}
+		}
+	}
+
+	return false
+}
+
+// AddHLNetwork returns a copy of the network with hyperlane-secured chains added.
+func AddHLNetwork(network netconf.Network) netconf.Network {
+	return network.AddChains(HLChains(network.ID)...)
+}

--- a/lib/contracts/solvernet/chains_test.go
+++ b/lib/contracts/solvernet/chains_test.go
@@ -1,0 +1,20 @@
+package solvernet_test
+
+import (
+	"testing"
+
+	"github.com/omni-network/omni/lib/contracts/solvernet"
+	"github.com/omni-network/omni/lib/netconf"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestHLChains(t *testing.T) {
+	t.Parallel()
+
+	require.NotPanics(t, func() {
+		for _, network := range netconf.All() {
+			_ = solvernet.HLChains(network)
+		}
+	})
+}

--- a/solver/app/app.go
+++ b/solver/app/app.go
@@ -70,6 +70,7 @@ func Run(ctx context.Context, cfg Config) error {
 	if err != nil {
 		return err
 	}
+	network = solvernet.AddHLNetwork(network)
 
 	if cfg.SolverPrivKey == "" {
 		return errors.New("private key not set")


### PR DESCRIPTION
Adds support for defining hyperlane-secured solvernet chains in `lib/contracts/solvernet`. 

issue: none