### PR TITLE
ci(e2e/manifest): bump protected solver to 39f21d4

### DIFF
--- a/e2e/manifests/mainnet.toml
+++ b/e2e/manifests/mainnet.toml
@@ -7,7 +7,7 @@ prometheus   = true
 pinned_halo_tag = "v0.14.1"
 pinned_relayer_tag = "07c4ac7"
 pinned_monitor_tag = "07c4ac7"
-pinned_solver_tag = "07c4ac7"
+pinned_solver_tag = "39f21d4"
 
 [node.validator01]
 [node.validator02]

--- a/e2e/manifests/omega.toml
+++ b/e2e/manifests/omega.toml
@@ -7,7 +7,7 @@ prometheus = true
 pinned_halo_tag = "v0.14.1"
 pinned_relayer_tag = "07c4ac7"
 pinned_monitor_tag = "07c4ac7"
-pinned_solver_tag = "07c4ac7"
+pinned_solver_tag = "39f21d4"
 
 [node.validator01]
 [node.validator02]


### PR DESCRIPTION
bump protected solver to 39f21d4. This includes price monitoring.

issue: none