### PR TITLE
chore(e2e/manifests): bump solver pin to 666757c

### DIFF
--- a/e2e/manifests/mainnet.toml
+++ b/e2e/manifests/mainnet.toml
@@ -7,7 +7,7 @@ prometheus   = true
 pinned_halo_tag = "v0.14.1"
 pinned_relayer_tag = "07c4ac7"
 pinned_monitor_tag = "07c4ac7"
-pinned_solver_tag = "c94587a"
+pinned_solver_tag = "666757c"
 
 [node.validator01]
 [node.validator02]

--- a/e2e/manifests/omega.toml
+++ b/e2e/manifests/omega.toml
@@ -7,7 +7,7 @@ prometheus = true
 pinned_halo_tag = "v0.14.1"
 pinned_relayer_tag = "07c4ac7"
 pinned_monitor_tag = "07c4ac7"
-pinned_solver_tag = "c94587a"
+pinned_solver_tag = "666757c"
 
 [node.validator01]
 [node.validator02]


### PR DESCRIPTION
Bump solver pin to 666757c, this includes increase in max native omni spend.

issue: none