### PR TITLE
chore(lib/cctp): reduce public interface

### DIFF
--- a/lib/cctp/audit.go
+++ b/lib/cctp/audit.go
@@ -24,13 +24,13 @@ type getMessageSentFunc func(logs []ethtypes.Log) (*MessageTransmitterMessageSen
 type getDepositForBurnFunc func(logs []ethtypes.Log) (*TokenMessengerDepositForBurn, bool, error)
 type isReceivedFunc func(ctx context.Context, msg types.MsgSendUSDC) (bool, error)
 
-// AuditForever streams finalized CCTP SendUSDC messages to `recipient`, and reconiles them db state.
+// auditForever streams finalized CCTP SendUSDC messages to `recipient`, and reconiles them db state.
 // It does this for all chains in `chains`.
 // - messages missed are inserted
 // - messages with incorrect fields are corrected
 // - messages marked as `minted` are cofirmed minted, else re-marked as `submitted`.
 // The audit process progresses db cursors.
-func AuditForever(
+func auditForever(
 	ctx context.Context,
 	db *db.DB,
 	networkID netconf.ID,

--- a/lib/cctp/cctp.go
+++ b/lib/cctp/cctp.go
@@ -1,0 +1,61 @@
+package cctp
+
+import (
+	"context"
+
+	"github.com/omni-network/omni/lib/cctp/db"
+	"github.com/omni-network/omni/lib/errors"
+	"github.com/omni-network/omni/lib/ethclient/ethbackend"
+	"github.com/omni-network/omni/lib/evmchain"
+	"github.com/omni-network/omni/lib/netconf"
+	xprovider "github.com/omni-network/omni/lib/xchain/provider"
+
+	"github.com/ethereum/go-ethereum/common"
+)
+
+// MintAuditForever forever mints, audits, and monitors all CCTP messages for
+// the given network / recipient, forever.
+func MintAuditForever(
+	ctx context.Context,
+	db *db.DB,
+	client Client,
+	network netconf.Network,
+	backends ethbackend.Backends,
+	recipient common.Address,
+	minter common.Address,
+	opts ...Option,
+) error {
+	clients := backends.Clients()
+	xprov := xprovider.New(network, clients, nil)
+
+	chains, err := getChains(network)
+	if err != nil {
+		return errors.Wrap(err, "get chains")
+	}
+
+	if err := auditForever(ctx, db, network.ID, xprov, clients, chains, recipient); err != nil {
+		return errors.Wrap(err, "audit forever")
+	}
+
+	if err := mintForever(ctx, db, client, backends, chains, minter, opts...); err != nil {
+		return errors.Wrap(err, "mint forever")
+	}
+
+	go monitorForever(ctx, db)
+
+	return nil
+}
+
+func getChains(network netconf.Network) ([]evmchain.Metadata, error) {
+	var chains []evmchain.Metadata
+	for _, c := range network.EVMChains() {
+		chain, ok := evmchain.MetadataByID(c.ID)
+		if !ok {
+			return nil, errors.New("unknown chain", "chain_id", c.ID)
+		}
+
+		chains = append(chains, chain)
+	}
+
+	return chains, nil
+}

--- a/lib/cctp/integration_test.go
+++ b/lib/cctp/integration_test.go
@@ -78,6 +78,8 @@ func TestIntegration(t *testing.T) {
 	}()
 
 	devPk, devAddr := testutil.NewAccount(t) // Test user
+	minter := devAddr
+	recipient := devAddr
 
 	backends, err := ethbackend.BackendsFromClients(clients, devPk)
 	require.NoError(t, err)
@@ -96,14 +98,8 @@ func TestIntegration(t *testing.T) {
 	db, err := cctpdb.New(memDB)
 	require.NoError(t, err)
 
-	// Mint forever
-	err = cctp.MintForever(ctx, db, cctpClient, backends, chains, devAddr,
-		cctp.WithMintInterval(1*time.Second),
-		cctp.WithPurgeInterval(10*time.Second))
-	require.NoError(t, err)
-
-	// Audit forever
-	err = cctp.AuditForever(ctx, db, netconf.Mainnet, xprov, clients, chains, devAddr)
+	// Mint / audit forever
+	err = cctp.MintAuditForever(ctx, db, cctpClient, network, backends, minter, recipient)
 	require.NoError(t, err)
 
 	// Track initial balances
@@ -273,7 +269,7 @@ func getChains(t *testing.T) []evmchain.Metadata {
 func makeNetwork(t *testing.T, chains []evmchain.Metadata) netconf.Network {
 	t.Helper()
 
-	network := netconf.Network{ID: netconf.Devnet}
+	network := netconf.Network{ID: netconf.Mainnet}
 	network.Chains = make([]netconf.Chain, len(chains))
 	for i, chain := range chains {
 		network.Chains[i] = netconf.Chain{

--- a/lib/cctp/mint.go
+++ b/lib/cctp/mint.go
@@ -21,46 +21,17 @@ import (
 	"github.com/ethereum/go-ethereum/crypto"
 )
 
-// MintForeverOption is a functional option for configuring MintForever.
-type MintForeverOption func(*mintForeverOpts)
-
-type mintForeverOpts struct {
-	mintInterval  time.Duration
-	purgeInterval time.Duration
-}
-
-// WithMintInterval sets the cadence for the mint loop.
-func WithMintInterval(interval time.Duration) MintForeverOption {
-	return func(c *mintForeverOpts) {
-		c.mintInterval = interval
-	}
-}
-
-// WithPurgeInterval sets the cadence for the purge loop.
-func WithPurgeInterval(interval time.Duration) MintForeverOption {
-	return func(c *mintForeverOpts) {
-		c.purgeInterval = interval
-	}
-}
-
-func defaultMintOpts() *mintForeverOpts {
-	return &mintForeverOpts{
-		mintInterval:  30 * time.Second,
-		purgeInterval: 20 * time.Minute,
-	}
-}
-
-// MintForever mints submitted CCTP MsgSendUSDC messages (from the db) on all chains.
-func MintForever(
+// mintForever mints submitted CCTP MsgSendUSDC messages (from the db) on all chains.
+func mintForever(
 	ctx context.Context,
 	db *cctpdb.DB,
 	client Client,
 	backends ethbackend.Backends,
 	chains []evmchain.Metadata,
 	minter common.Address,
-	opts ...MintForeverOption,
+	opts ...Option,
 ) error {
-	o := defaultMintOpts()
+	o := defaultOpts()
 	for _, opt := range opts {
 		opt(o)
 	}

--- a/lib/cctp/monitor.go
+++ b/lib/cctp/monitor.go
@@ -13,12 +13,7 @@ import (
 	"github.com/omni-network/omni/lib/log"
 )
 
-// MonitorForever monitors the CCTP messages in the database indefinitely.
-func MonitorForever(ctx context.Context, db *cctpdb.DB) {
-	go monitorForver(ctx, db)
-}
-
-func monitorForver(ctx context.Context, db *cctpdb.DB) {
+func monitorForever(ctx context.Context, db *cctpdb.DB) {
 	ticker := time.NewTicker(30 * time.Second)
 	defer ticker.Stop()
 

--- a/lib/cctp/options.go
+++ b/lib/cctp/options.go
@@ -1,0 +1,33 @@
+package cctp
+
+import (
+	"time"
+)
+
+type Option func(*options)
+
+type options struct {
+	mintInterval  time.Duration
+	purgeInterval time.Duration
+}
+
+// WithMintInterval sets the cadence for the mint loop.
+func WithMintInterval(interval time.Duration) Option {
+	return func(c *options) {
+		c.mintInterval = interval
+	}
+}
+
+// WithPurgeInterval sets the cadence for the purge loop.
+func WithPurgeInterval(interval time.Duration) Option {
+	return func(c *options) {
+		c.purgeInterval = interval
+	}
+}
+
+func defaultOpts() *options {
+	return &options{
+		mintInterval:  30 * time.Second,
+		purgeInterval: 20 * time.Minute,
+	}
+}


### PR DESCRIPTION
Reduce public interface of lib/cctp

Mint, audit, and monitor should always be called together.

issue: none