### PR TITLE
chore(e2e/manifests): bump solver pins

### DIFF
--- a/e2e/manifests/mainnet.toml
+++ b/e2e/manifests/mainnet.toml
@@ -7,7 +7,7 @@ prometheus   = true
 pinned_halo_tag = "v0.14.1"
 pinned_relayer_tag = "07c4ac7"
 pinned_monitor_tag = "07c4ac7"
-pinned_solver_tag = "666757c"
+pinned_solver_tag = "1216c4c"
 
 [node.validator01]
 [node.validator02]

--- a/e2e/manifests/omega.toml
+++ b/e2e/manifests/omega.toml
@@ -7,7 +7,7 @@ prometheus = true
 pinned_halo_tag = "v0.14.1"
 pinned_relayer_tag = "07c4ac7"
 pinned_monitor_tag = "07c4ac7"
-pinned_solver_tag = "666757c"
+pinned_solver_tag = "1216c4c"
 
 [node.validator01]
 [node.validator02]


### PR DESCRIPTION
Bump solver pin. This includes reducing OMNI max spend to 450k.

issue: none
