### PR TITLE
chore(contracts/solvernet): filter HL chains

### DIFF
--- a/e2e/solve/deploy.go
+++ b/e2e/solve/deploy.go
@@ -19,7 +19,7 @@ import (
 
 // Deploy deploys solve inbox / outbox / middleman contracts, and devnet app (if devnet).
 func Deploy(ctx context.Context, network netconf.Network, backends ethbackend.Backends) error {
-	network = solvernet.AddHLNetwork(network)
+	network = solvernet.AddHLNetwork(ctx, network, solvernet.FilterByBackends(backends))
 
 	var eg1 errgroup.Group
 	eg1.Go(func() error { return deployBoxes(ctx, network, backends) })

--- a/lib/contracts/solvernet/chains.go
+++ b/lib/contracts/solvernet/chains.go
@@ -1,9 +1,19 @@
 package solvernet
 
 import (
+	"context"
+
+	"github.com/omni-network/omni/contracts/bindings"
+	"github.com/omni-network/omni/lib/contracts"
 	"github.com/omni-network/omni/lib/errors"
+	"github.com/omni-network/omni/lib/ethclient"
+	"github.com/omni-network/omni/lib/ethclient/ethbackend"
 	"github.com/omni-network/omni/lib/evmchain"
+	"github.com/omni-network/omni/lib/log"
 	"github.com/omni-network/omni/lib/netconf"
+	"github.com/omni-network/omni/lib/xchain"
+
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 )
 
 // hlChains define solvernet chains secured by hyperlane.
@@ -42,7 +52,69 @@ func IsHLChain(chainID uint64) bool {
 	return false
 }
 
+// FilterByBackends returns an HL chain selector that excludes chains not in backends.
+// Useful when needing to deploy contracts to configured backends.
+func FilterByBackends(backends ethbackend.Backends) func(netconf.ID, netconf.Chain) bool {
+	return func(_ netconf.ID, chain netconf.Chain) bool {
+		_, err := backends.Backend(chain.ID)
+		return err == nil
+	}
+}
+
+// FilterByContracts returns an HL chain selector that excludes chains without inbox contracts deployed.
+// Note this also excludes chains without endpoints, or with any other error fetching inbox DeployedAt.
+func FilterByContracts(ctx context.Context, endpoints xchain.RPCEndpoints) func(netconf.ID, netconf.Chain) bool {
+	return func(network netconf.ID, chain netconf.Chain) bool {
+		endpoint, err := endpoints.ByNameOrID(chain.Name, chain.ID)
+		if err != nil {
+			return false
+		}
+
+		ethCl, err := ethclient.DialContext(ctx, chain.Name, endpoint)
+		if err != nil {
+			return false
+		}
+
+		addrs, err := contracts.GetAddresses(ctx, network)
+		if err != nil {
+			return false
+		}
+
+		contract, err := bindings.NewSolverNetInbox(addrs.SolverNetInbox, ethCl)
+		if err != nil {
+			return false
+		}
+
+		_, err = contract.DeployedAt(&bind.CallOpts{Context: ctx})
+
+		return err == nil
+	}
+}
+
 // AddHLNetwork returns a copy of the network with hyperlane-secured chains added.
-func AddHLNetwork(network netconf.Network) netconf.Network {
-	return network.AddChains(HLChains(network.ID)...)
+// Optional selector functions can be provided to filter the chains.
+func AddHLNetwork(ctx context.Context, network netconf.Network, selectors ...func(netconf.ID, netconf.Chain) bool) netconf.Network {
+	chains := HLChains(network.ID)
+
+	// Filter out chains using provided selectors
+	var included, excluded []string
+	for _, selector := range selectors {
+		var selected []netconf.Chain
+		for _, chain := range chains {
+			if selector(network.ID, chain) {
+				selected = append(selected, chain)
+			} else {
+				excluded = append(excluded, chain.Name)
+			}
+		}
+		chains = selected
+	}
+
+	for _, chain := range chains {
+		included = append(included, chain.Name)
+	}
+
+	log.Debug(ctx, "Adding hyperlane chains", "included", included, "excluded", excluded)
+
+	return network.AddChains(chains...)
 }

--- a/lib/contracts/solvernet/chains_test.go
+++ b/lib/contracts/solvernet/chains_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/omni-network/omni/lib/contracts/solvernet"
 	"github.com/omni-network/omni/lib/netconf"
+	"github.com/omni-network/omni/lib/xchain"
 
 	"github.com/stretchr/testify/require"
 )
@@ -17,4 +18,13 @@ func TestHLChains(t *testing.T) {
 			_ = solvernet.HLChains(network)
 		}
 	})
+}
+
+func TestFilterByContracts(t *testing.T) {
+	t.Parallel()
+	network := netconf.Network{ID: netconf.Mainnet}
+	endpoints := xchain.RPCEndpoints{"bsc": "https://foo.bar"}
+
+	network = solvernet.AddHLNetwork(t.Context(), network, solvernet.FilterByContracts(t.Context(), endpoints))
+	require.Empty(t, network.Chains)
 }

--- a/solver/app/app.go
+++ b/solver/app/app.go
@@ -70,7 +70,7 @@ func Run(ctx context.Context, cfg Config) error {
 	if err != nil {
 		return err
 	}
-	network = solvernet.AddHLNetwork(network)
+	network = solvernet.AddHLNetwork(ctx, network, solvernet.FilterByContracts(ctx, cfg.RPCEndpoints))
 
 	if cfg.SolverPrivKey == "" {
 		return errors.New("private key not set")


### PR DESCRIPTION
Support filtering HL chains by backends (for e2e deploy) and inbox contracts (for solver app).

issue: none