### PR TITLE
ci(e2e/manifest): bump mainnet monitor to 33faf3b

### DIFF
--- a/e2e/manifests/mainnet.toml
+++ b/e2e/manifests/mainnet.toml
@@ -7,7 +7,7 @@ prometheus   = true
 pinned_halo_tag = "v0.14.1"
 pinned_relayer_tag = "07c4ac7"
 pinned_monitor_tag = "07c4ac7"
-pinned_solver_tag = "1216c4c"
+pinned_solver_tag = "33faf3b"
 
 [node.validator01]
 [node.validator02]

--- a/e2e/manifests/mainnet.toml
+++ b/e2e/manifests/mainnet.toml
@@ -7,7 +7,7 @@ prometheus   = true
 pinned_halo_tag = "v0.14.1"
 pinned_relayer_tag = "07c4ac7"
 pinned_monitor_tag = "33faf3b"
-pinned_solver_tag = "07c4ac7"
+pinned_solver_tag = "1216c4c"
 
 [node.validator01]
 [node.validator02]

--- a/e2e/manifests/mainnet.toml
+++ b/e2e/manifests/mainnet.toml
@@ -6,8 +6,8 @@ prometheus   = true
 
 pinned_halo_tag = "v0.14.1"
 pinned_relayer_tag = "07c4ac7"
-pinned_monitor_tag = "07c4ac7"
-pinned_solver_tag = "33faf3b"
+pinned_monitor_tag = "33faf3b"
+pinned_solver_tag = "07c4ac7"
 
 [node.validator01]
 [node.validator02]


### PR DESCRIPTION
bump mainnet monitor to 33faf3b, this enables mainnet flowgen swaps.

issue: none