### PR TITLE
chore(e2e/manifests): bump monitor pin

### DIFF
--- a/e2e/manifests/mainnet.toml
+++ b/e2e/manifests/mainnet.toml
@@ -6,7 +6,7 @@ prometheus   = true
 
 pinned_halo_tag = "v0.14.1"
 pinned_relayer_tag = "07c4ac7"
-pinned_monitor_tag = "33faf3b"
+pinned_monitor_tag = "03452ee"
 pinned_solver_tag = "1216c4c"
 
 [node.validator01]

--- a/e2e/manifests/omega.toml
+++ b/e2e/manifests/omega.toml
@@ -6,7 +6,7 @@ prometheus = true
 
 pinned_halo_tag = "v0.14.1"
 pinned_relayer_tag = "07c4ac7"
-pinned_monitor_tag = "07c4ac7"
+pinned_monitor_tag = "03452ee"
 pinned_solver_tag = "1216c4c"
 
 [node.validator01]


### PR DESCRIPTION
Bump monitor pin. This includes cctpgen fixes and enabling it on mainnet.

issue: none
