### PR TITLE
chore(ci): skip rebalance tests if no secret access

### DIFF
--- a/.github/workflows/rebalance-test.yaml
+++ b/.github/workflows/rebalance-test.yaml
@@ -5,6 +5,7 @@ on:
 
 jobs:
   rebalance_test:
+    if: ${{ secrets.ETH_RPC  }} != ''  # Skip if no access to secrets
     runs-on: ubuntu-latest
     steps:
       - name: Check out the repo


### PR DESCRIPTION
Skip rebalance tests if it does not have access to secrets.

issue: none