### PR TITLE
chore(solver/rebalance): tweak thresholds

### DIFF
--- a/solver/rebalance/thresholds.go
+++ b/solver/rebalance/thresholds.go
@@ -93,14 +93,14 @@ var (
 		mustToken(evmchain.IDEthereum, tokens.USDC): {
 			min:     50_000,
 			target:  100_000,
-			surplus: 110_000,
+			surplus: 120_000,
 		},
 		mustToken(evmchain.IDBase, tokens.WSTETH): {
 			minSwap: 1,
 		},
 		mustToken(evmchain.IDBase, tokens.USDC): {
 			min:     20_000,
-			target:  50_000,
+			target:  40_000,
 			surplus: 50_000,
 		},
 	}


### PR DESCRIPTION
Tweak solver thresholds

- bump l1 usdc surplus (so that current balance isn't in surplus)
- reduce target base usdc (so that current balance isn't in deficit)

First is to reduce size of swaps when we first turn this one.
Second is general house cleaning to give us room between surplus and decific. Can increase target later if we have demand.

issue: none
