### PR TITLE
chore(e2e): remove sepolia from staging manifest

### DIFF
--- a/e2e/manifests/staging.toml
+++ b/e2e/manifests/staging.toml
@@ -1,5 +1,5 @@
 network = "staging"
-public_chains = ["holesky","sepolia","op_sepolia","base_sepolia","arb_sepolia"]
+public_chains = ["holesky","op_sepolia","base_sepolia","arb_sepolia"]
 multi_omni_evms = true
 prometheus = true
 


### PR DESCRIPTION
Removed Sepolia from staging manifest as we will treat it like a Hyperlane chain.

issue: none
