### PR TITLE
chore(sdk): use WalletClient type

### DIFF
--- a/sdk/packages/core/src/contracts/openOrder.test.ts
+++ b/sdk/packages/core/src/contracts/openOrder.test.ts
@@ -1,5 +1,5 @@
 import { mockL1Client, testOrder } from '@omni-network/test-utils'
-import { type Client, zeroAddress } from 'viem'
+import { type WalletClient, zeroAddress } from 'viem'
 import { expect, test, vi } from 'vitest'
 import { inboxABI } from '../constants/abis.js'
 import { typeHash } from '../constants/typehash.js'
@@ -43,7 +43,7 @@ test('default: opens order and returns the transaction hash', async () => {
 test('behaviour: throws an AccountRequiredError if the client does not have an associated account', async () => {
   await expect(
     openOrder({
-      client: {} as Client,
+      client: {} as WalletClient,
       inboxAddress: '0xaddress',
       order: testOrder,
     }),

--- a/sdk/packages/core/src/contracts/openOrder.ts
+++ b/sdk/packages/core/src/contracts/openOrder.ts
@@ -1,4 +1,4 @@
-import type { Address, Client } from 'viem'
+import type { Address, WalletClient } from 'viem'
 import { zeroAddress } from 'viem'
 import { type WriteContractReturnType, writeContract } from 'viem/actions'
 import { inboxABI } from '../constants/abis.js'
@@ -11,7 +11,7 @@ import { encodeOrderData } from '../utils/encodeOrderData.js'
 const defaultFillDeadline = () => Math.floor(Date.now() / 1000 + 86400)
 
 export type OpenOrderParams<abis extends OptionalAbis> = {
-  client: Client
+  client: WalletClient
   inboxAddress: Address
   order: Order<abis>
 }

--- a/sdk/packages/react/src/hooks/useOrder.ts
+++ b/sdk/packages/react/src/hooks/useOrder.ts
@@ -19,7 +19,7 @@ import {
   type UseMutationResult,
   useMutation,
 } from '@tanstack/react-query'
-import type { Hex, WriteContractErrorType } from 'viem'
+import type { Hex, WalletClient, WriteContractErrorType } from 'viem'
 import {
   type Config,
   type UseWaitForTransactionReceiptReturnType,
@@ -94,7 +94,7 @@ export function useOrder<abis extends OptionalAbis>(
 ): UseOrderReturnType {
   const { validateEnabled, ...order } = params
   const srcChainId = order.srcChainId ?? useChainId()
-  const client = useClient({ chainId: srcChainId })
+  const client = useClient({ chainId: srcChainId }) as WalletClient
   const contractsResult = useOmniContracts()
   const inboxAddress = contractsResult.data?.inbox
 


### PR DESCRIPTION
Use explicit `WalletClient` for sending order transaction

issue: none