### PR TITLE
chore(lib/cctp): reset in flight metrics

### DIFF
--- a/lib/cctp/cctp.go
+++ b/lib/cctp/cctp.go
@@ -41,7 +41,7 @@ func MintAuditForever(
 		return errors.Wrap(err, "mint forever")
 	}
 
-	go monitorForever(ctx, db)
+	go monitorForever(ctx, chains, db)
 
 	return nil
 }


### PR DESCRIPTION
Reset inflight metrics before setting them.

Else minted values stay "in-flight"

issue: none