### PR TITLE
chore(sdk): get wallet client for mutation

### DIFF
--- a/.pre-commit/run_sdk_checks.sh
+++ b/.pre-commit/run_sdk_checks.sh
@@ -22,6 +22,6 @@ echo "Installing deps via pnpm..."
 pnpm install
 
 # clean + build
-pnpm build
+pnpm run build
 
 pnpm run check

--- a/sdk/packages/react/src/hooks/useOrder.ts
+++ b/sdk/packages/react/src/hooks/useOrder.ts
@@ -25,10 +25,11 @@ import {
   type UseWaitForTransactionReceiptReturnType,
   type UseWriteContractReturnType,
   useChainId,
-  useClient,
+  useConfig,
   useWaitForTransactionReceipt,
 } from 'wagmi'
-import { NoClientError } from '../errors/index.js'
+import { getConnectorClient } from 'wagmi/actions'
+import type { NoClientError } from '../errors/index.js'
 import { useGetOrderStatus } from './useGetOrderStatus.js'
 import {
   type UseOmniContractsResult,
@@ -94,15 +95,15 @@ export function useOrder<abis extends OptionalAbis>(
 ): UseOrderReturnType {
   const { validateEnabled, ...order } = params
   const srcChainId = order.srcChainId ?? useChainId()
-  const client = useClient({ chainId: srcChainId })
+  const config = useConfig()
   const contractsResult = useOmniContracts()
   const inboxAddress = contractsResult.data?.inbox
 
   const txMutation = useMutation<SendOrderReturn, MutationError>({
     mutationFn: async () => {
-      if (client == null) {
-        throw new NoClientError('No client provided')
-      }
+      const client = await getConnectorClient(config, {
+        chainId: srcChainId,
+      })
       if (inboxAddress == null) {
         throw new LoadContractsError(
           'Inbox contract address needs to be loaded',


### PR DESCRIPTION
- useClient returns a public client but for mutations we need the wallet client
- `getConnectorClient` will give us the necessary wallet client to allow us to access mutations that require an account

issue: none