### PR TITLE
feat(e2e): use hlNetworkFromDef in fund action

### DIFF
--- a/e2e/app/chains.go
+++ b/e2e/app/chains.go
@@ -100,7 +100,7 @@ func hlNetworkFromDef(ctx context.Context, def Definition) (netconf.Network, err
 			Shards:          chain.Shards,
 			AttestInterval:  chain.AttestInterval(def.Testnet.Network),
 			PortalAddress:   portalAddress,
-			DeployHeight:    0, // TODO(zodomo): Can we retrieve the deploy height from the portal registry?
+			DeployHeight:    0, // Portal height isn't needed here as we aren't deploying OmniPortal contracts to Hyperlane networks
 			HasEmitPortal:   true,
 			HasSubmitPortal: true,
 		}

--- a/e2e/app/chains.go
+++ b/e2e/app/chains.go
@@ -13,8 +13,6 @@ import (
 	"github.com/omni-network/omni/lib/log"
 	"github.com/omni-network/omni/lib/netconf"
 	"github.com/omni-network/omni/lib/xchain"
-
-	"github.com/ethereum/go-ethereum/common"
 )
 
 // AddSolverEndpoints returns the RPC endpoints for the given solvernet network, including HL chains.
@@ -88,32 +86,23 @@ func hlNetworkFromDef(ctx context.Context, def Definition) (netconf.Network, err
 	}
 
 	newChain := func(chain types.EVMChain) netconf.Chain {
-		var portalAddress common.Address
-		if !solvernet.IsHLChain(chain.ChainID) {
-			portalAddress = addrs.Portal
-		}
-
-		var hasEmitPortal bool
-		var hasSubmitPortal bool
-		var shards []xchain.ShardID
-		var attestInterval uint64
-		if portalAddress != (common.Address{}) {
-			hasEmitPortal = true
-			hasSubmitPortal = true
-			shards = chain.Shards
-			attestInterval = chain.AttestInterval(def.Testnet.Network)
+		if solvernet.IsHLChain(chain.ChainID) {
+			return netconf.Chain{
+				ID:          chain.ChainID,
+				Name:        chain.Name,
+				BlockPeriod: chain.BlockPeriod,
+			}
 		}
 
 		return netconf.Chain{
 			ID:              chain.ChainID,
 			Name:            chain.Name,
 			BlockPeriod:     chain.BlockPeriod,
-			Shards:          shards,
-			AttestInterval:  attestInterval,
-			PortalAddress:   portalAddress,
-			DeployHeight:    0, // Portal height isn't needed here as we aren't deploying OmniPortal contracts to Hyperlane networks
-			HasEmitPortal:   hasEmitPortal,
-			HasSubmitPortal: hasSubmitPortal,
+			Shards:          chain.Shards,
+			AttestInterval:  chain.AttestInterval(def.Testnet.Network),
+			PortalAddress:   addrs.Portal,
+			HasEmitPortal:   true,
+			HasSubmitPortal: true,
 		}
 	}
 

--- a/e2e/app/chains.go
+++ b/e2e/app/chains.go
@@ -93,16 +93,27 @@ func hlNetworkFromDef(ctx context.Context, def Definition) (netconf.Network, err
 			portalAddress = addrs.Portal
 		}
 
+		var hasEmitPortal bool
+		var hasSubmitPortal bool
+		var shards []xchain.ShardID
+		var attestInterval uint64
+		if portalAddress != (common.Address{}) {
+			hasEmitPortal = true
+			hasSubmitPortal = true
+			shards = chain.Shards
+			attestInterval = chain.AttestInterval(def.Testnet.Network)
+		}
+
 		return netconf.Chain{
 			ID:              chain.ChainID,
 			Name:            chain.Name,
 			BlockPeriod:     chain.BlockPeriod,
-			Shards:          chain.Shards,
-			AttestInterval:  chain.AttestInterval(def.Testnet.Network),
+			Shards:          shards,
+			AttestInterval:  attestInterval,
 			PortalAddress:   portalAddress,
 			DeployHeight:    0, // Portal height isn't needed here as we aren't deploying OmniPortal contracts to Hyperlane networks
-			HasEmitPortal:   true,
-			HasSubmitPortal: true,
+			HasEmitPortal:   hasEmitPortal,
+			HasSubmitPortal: hasSubmitPortal,
 		}
 	}
 

--- a/e2e/app/fund.go
+++ b/e2e/app/fund.go
@@ -25,7 +25,10 @@ const saneMaxOmni = 60420 // Maximum amount of OMNI to fund (in ether OMNI).
 
 // FundAccounts funds the EOAs and contracts that need funding to their target balance.
 func FundAccounts(ctx context.Context, def Definition, hotOnly bool, dryRun bool) error {
-	network := networkFromDef(def)
+	network, err := hlNetworkFromDef(ctx, def)
+	if err != nil {
+		return errors.Wrap(err, "get hl network")
+	}
 
 	endpoints := ExternalEndpoints(def)
 


### PR DESCRIPTION
Can't use `app.networkFromDef` in `fund.go` due to `Portals` context not being present here. Decided to supplement the portal values in `hlNetworkFromDef`.

issue: none
