### PR TITLE
Fix reference of quote

### DIFF
--- a/docs/docs/pages/sdk/hooks/useQuote.md
+++ b/docs/docs/pages/sdk/hooks/useQuote.md
@@ -129,7 +129,7 @@ const quote = useQuote({
 })
 
 if (quote.isSuccess) {
-  console.log(`Depositing ${quote.data.deposit.amount} yields ${quote.data.expense.amount} on destination`);
+  console.log(`Depositing ${quote.deposit.amount} yields ${quote.expense.amount} on destination`);
 }
 ```
 


### PR DESCRIPTION
This pull request includes a minor change to the `useQuote` example in the `docs/docs/pages/sdk/hooks/useQuote.md` file. The change simplifies the code by removing unnecessary `.data` references when accessing `quote` properties.

* [`docs/docs/pages/sdk/hooks/useQuote.md`](diffhunk://#diff-2d4736623bcde6152d156dc6362d66a4606fc7291157aced7268314cf87b1e75L132-R132): Updated the `console.log` statement to directly access `quote.deposit` and `quote.expense` instead of using `quote.data.deposit` and `quote.data.expense`.