### PR TITLE
chore(sdk): bump pnpm version

### DIFF
--- a/sdk/package.json
+++ b/sdk/package.json
@@ -1,18 +1,18 @@
 {
-	"name": "omni-sdk",
-	"private": true,
-	"description": "Omni SDK workspace",
-	"version": "0.0.0",
-	"type": "module",
-	"packageManager": "pnpm@9.12.1",
-	"scripts": {
-		"build": "pnpm run --r --filter \"./packages/**\" build",
-		"check": "biome check --write",
-		"postinstall": "pnpm run build",
-		"test:unit": "pnpm run --filter '@omni-network/*' test",
-		"test:integration": "cd integration-tests && pnpm test"
-	},
-	"devDependencies": {
-		"@biomejs/biome": "^1.9.4"
-	}
+  "name": "omni-sdk",
+  "private": true,
+  "description": "Omni SDK workspace",
+  "version": "0.0.0",
+  "type": "module",
+  "packageManager": "pnpm@9.12.1",
+  "scripts": {
+    "build": "pnpm run --r --filter \"./packages/**\" build",
+    "check": "biome check --write",
+    "postinstall": "pnpm run build",
+    "test:unit": "pnpm run --filter '@omni-network/*' test",
+    "test:integration": "cd integration-tests && pnpm test"
+  },
+  "devDependencies": {
+    "@biomejs/biome": "^1.9.4"
+  }
 }

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -1,18 +1,18 @@
 {
-  "name": "omni-sdk",
-  "private": true,
-  "description": "Omni SDK workspace",
-  "version": "0.0.0",
-  "type": "module",
-  "packageManager": "pnpm@9.6.0",
-  "scripts": {
-    "build": "pnpm run --r --filter \"./packages/**\" build",
-    "check": "biome check --write",
-    "postinstall": "pnpm run build",
-    "test:unit": "pnpm run --filter '@omni-network/*' test",
-    "test:integration": "cd integration-tests && pnpm test"
-  },
-  "devDependencies": {
-    "@biomejs/biome": "^1.9.4"
-  }
+	"name": "omni-sdk",
+	"private": true,
+	"description": "Omni SDK workspace",
+	"version": "0.0.0",
+	"type": "module",
+	"packageManager": "pnpm@9.12.1",
+	"scripts": {
+		"build": "pnpm run --r --filter \"./packages/**\" build",
+		"check": "biome check --write",
+		"postinstall": "pnpm run build",
+		"test:unit": "pnpm run --filter '@omni-network/*' test",
+		"test:integration": "cd integration-tests && pnpm test"
+	},
+	"devDependencies": {
+		"@biomejs/biome": "^1.9.4"
+	}
 }

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -4,7 +4,7 @@
   "description": "Omni SDK workspace",
   "version": "0.0.0",
   "type": "module",
-  "packageManager": "pnpm@9.1.0",
+  "packageManager": "pnpm@9.6.0",
   "scripts": {
     "build": "pnpm run --r --filter \"./packages/**\" build",
     "check": "biome check --write",

--- a/sdk/packages/core/package.json
+++ b/sdk/packages/core/package.json
@@ -1,39 +1,39 @@
 {
-  "name": "@omni-network/core",
-  "description": "Core logic for interacting with Omni Solvernet",
-  "version": "0.1.0",
-  "type": "module",
-  "packageManager": "pnpm@9.6.0",
-  "sideEffects": false,
-  "main": "./dist/esm/index.js",
-  "module": "./dist/esm/index.js",
-  "types": "./dist/types/index.d.ts",
-  "exports": {
-    ".": {
-      "types": "./dist/types/index.d.ts",
-      "default": "./dist/esm/index.js"
-    },
-    "./package.json": "./package.json"
-  },
-  "scripts": {
-    "build": "pnpm clean && pnpm build:ts",
-    "build:ts": "tsc -p tsconfig.build.json",
-    "prepublishOnly": "pnpm build",
-    "clean": "rm -rf dist tsconfig.tsbuildinfo",
-    "test": "vitest run",
-    "coverage": "vitest run --coverage"
-  },
-  "files": ["dist/**", "src/**", "!dist/**/*.tsbuildinfo"],
-  "engines": {
-    "node": ">=22.x"
-  },
-  "dependencies": {
-    "viem": "catalog:"
-  },
-  "devDependencies": {
-    "@omni-network/test-utils": "workspace:^",
-    "typescript": "^5.7.2",
-    "vite": "^6.2.6",
-    "vitest": "^3.0.7"
-  }
+	"name": "@omni-network/core",
+	"description": "Core logic for interacting with Omni Solvernet",
+	"version": "0.1.0",
+	"type": "module",
+	"packageManager": "pnpm@9.12.1",
+	"sideEffects": false,
+	"main": "./dist/esm/index.js",
+	"module": "./dist/esm/index.js",
+	"types": "./dist/types/index.d.ts",
+	"exports": {
+		".": {
+			"types": "./dist/types/index.d.ts",
+			"default": "./dist/esm/index.js"
+		},
+		"./package.json": "./package.json"
+	},
+	"scripts": {
+		"build": "pnpm clean && pnpm build:ts",
+		"build:ts": "tsc -p tsconfig.build.json",
+		"prepublishOnly": "pnpm build",
+		"clean": "rm -rf dist tsconfig.tsbuildinfo",
+		"test": "vitest run",
+		"coverage": "vitest run --coverage"
+	},
+	"files": ["dist/**", "src/**", "!dist/**/*.tsbuildinfo"],
+	"engines": {
+		"node": ">=22.x"
+	},
+	"dependencies": {
+		"viem": "catalog:"
+	},
+	"devDependencies": {
+		"@omni-network/test-utils": "workspace:^",
+		"typescript": "^5.7.2",
+		"vite": "^6.2.6",
+		"vitest": "^3.0.7"
+	}
 }

--- a/sdk/packages/core/package.json
+++ b/sdk/packages/core/package.json
@@ -3,7 +3,7 @@
   "description": "Core logic for interacting with Omni Solvernet",
   "version": "0.1.0",
   "type": "module",
-  "packageManager": "pnpm@9.1.0",
+  "packageManager": "pnpm@9.6.0",
   "sideEffects": false,
   "main": "./dist/esm/index.js",
   "module": "./dist/esm/index.js",

--- a/sdk/packages/core/package.json
+++ b/sdk/packages/core/package.json
@@ -1,39 +1,39 @@
 {
-	"name": "@omni-network/core",
-	"description": "Core logic for interacting with Omni Solvernet",
-	"version": "0.1.0",
-	"type": "module",
-	"packageManager": "pnpm@9.12.1",
-	"sideEffects": false,
-	"main": "./dist/esm/index.js",
-	"module": "./dist/esm/index.js",
-	"types": "./dist/types/index.d.ts",
-	"exports": {
-		".": {
-			"types": "./dist/types/index.d.ts",
-			"default": "./dist/esm/index.js"
-		},
-		"./package.json": "./package.json"
-	},
-	"scripts": {
-		"build": "pnpm clean && pnpm build:ts",
-		"build:ts": "tsc -p tsconfig.build.json",
-		"prepublishOnly": "pnpm build",
-		"clean": "rm -rf dist tsconfig.tsbuildinfo",
-		"test": "vitest run",
-		"coverage": "vitest run --coverage"
-	},
-	"files": ["dist/**", "src/**", "!dist/**/*.tsbuildinfo"],
-	"engines": {
-		"node": ">=22.x"
-	},
-	"dependencies": {
-		"viem": "catalog:"
-	},
-	"devDependencies": {
-		"@omni-network/test-utils": "workspace:^",
-		"typescript": "^5.7.2",
-		"vite": "^6.2.6",
-		"vitest": "^3.0.7"
-	}
+  "name": "@omni-network/core",
+  "description": "Core logic for interacting with Omni Solvernet",
+  "version": "0.1.0",
+  "type": "module",
+  "packageManager": "pnpm@9.12.1",
+  "sideEffects": false,
+  "main": "./dist/esm/index.js",
+  "module": "./dist/esm/index.js",
+  "types": "./dist/types/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/types/index.d.ts",
+      "default": "./dist/esm/index.js"
+    },
+    "./package.json": "./package.json"
+  },
+  "scripts": {
+    "build": "pnpm clean && pnpm build:ts",
+    "build:ts": "tsc -p tsconfig.build.json",
+    "prepublishOnly": "pnpm build",
+    "clean": "rm -rf dist tsconfig.tsbuildinfo",
+    "test": "vitest run",
+    "coverage": "vitest run --coverage"
+  },
+  "files": ["dist/**", "src/**", "!dist/**/*.tsbuildinfo"],
+  "engines": {
+    "node": ">=22.x"
+  },
+  "dependencies": {
+    "viem": "catalog:"
+  },
+  "devDependencies": {
+    "@omni-network/test-utils": "workspace:^",
+    "typescript": "^5.7.2",
+    "vite": "^6.2.6",
+    "vitest": "^3.0.7"
+  }
 }

--- a/sdk/packages/react/package.json
+++ b/sdk/packages/react/package.json
@@ -1,69 +1,69 @@
 {
-	"name": "@omni-network/react",
-	"description": "React hooks for Omni Solvernet",
-	"version": "0.1.0",
-	"type": "module",
-	"license": "MIT",
-	"packageManager": "pnpm@9.12.1",
-	"sideEffects": false,
-	"main": "./dist/esm/index.js",
-	"module": "./dist/esm/index.js",
-	"types": "./dist/types/index.d.ts",
-	"exports": {
-		".": {
-			"types": "./dist/types/index.d.ts",
-			"default": "./dist/esm/index.js"
-		},
-		"./package.json": "./package.json"
-	},
-	"scripts": {
-		"build": "pnpm clean && pnpm build:ts",
-		"build:ts": "tsc -p tsconfig.build.json",
-		"prepublishOnly": "pnpm build",
-		"clean": "rm -rf dist tsconfig.tsbuildinfo",
-		"test": "vitest run",
-		"coverage": "vitest run --coverage",
-		"check": "biome check --write"
-	},
-	"files": [
-		"dist/**",
-		"src/**",
-		"!dist/**/*.tsbuildinfo",
-		"!src/**/*.test.ts",
-		"!src/**/*.test-d.ts"
-	],
-	"engines": {
-		"node": ">=22.x"
-	},
-	"peerDependencies": {
-		"@tanstack/react-query": "^5.64.2",
-		"react": ">=18",
-		"viem": "2.x",
-		"wagmi": "2.x"
-	},
-	"devDependencies": {
-		"@omni-network/test-utils": "workspace:^",
-		"@testing-library/dom": "catalog:",
-		"@testing-library/react": "catalog:",
-		"@types/react": "catalog:",
-		"@types/react-dom": "catalog:",
-		"@vitest/coverage-v8": "^3.0.7",
-		"happy-dom": "^17.4.4",
-		"typescript": "^5.7.2",
-		"vite": "^6.2.6",
-		"vitest": "^3.0.7",
-		"react": "catalog:",
-		"react-dom": "catalog:"
-	},
-	"repository": {
-		"type": "git",
-		"url": "git+https://github.com/omni-network/omni.git",
-		"directory": "sdk/packages/react"
-	},
-	"keywords": ["typescript", "web3", "ethereum", "omni"],
-	"author": "Omni Network",
-	"homepage": "https://omni.network/",
-	"dependencies": {
-		"@omni-network/core": "workspace:^"
-	}
+  "name": "@omni-network/react",
+  "description": "React hooks for Omni Solvernet",
+  "version": "0.1.0",
+  "type": "module",
+  "license": "MIT",
+  "packageManager": "pnpm@9.12.1",
+  "sideEffects": false,
+  "main": "./dist/esm/index.js",
+  "module": "./dist/esm/index.js",
+  "types": "./dist/types/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/types/index.d.ts",
+      "default": "./dist/esm/index.js"
+    },
+    "./package.json": "./package.json"
+  },
+  "scripts": {
+    "build": "pnpm clean && pnpm build:ts",
+    "build:ts": "tsc -p tsconfig.build.json",
+    "prepublishOnly": "pnpm build",
+    "clean": "rm -rf dist tsconfig.tsbuildinfo",
+    "test": "vitest run",
+    "coverage": "vitest run --coverage",
+    "check": "biome check --write"
+  },
+  "files": [
+    "dist/**",
+    "src/**",
+    "!dist/**/*.tsbuildinfo",
+    "!src/**/*.test.ts",
+    "!src/**/*.test-d.ts"
+  ],
+  "engines": {
+    "node": ">=22.x"
+  },
+  "peerDependencies": {
+    "@tanstack/react-query": "^5.64.2",
+    "react": ">=18",
+    "viem": "2.x",
+    "wagmi": "2.x"
+  },
+  "devDependencies": {
+    "@omni-network/test-utils": "workspace:^",
+    "@testing-library/dom": "catalog:",
+    "@testing-library/react": "catalog:",
+    "@types/react": "catalog:",
+    "@types/react-dom": "catalog:",
+    "@vitest/coverage-v8": "^3.0.7",
+    "happy-dom": "^17.4.4",
+    "typescript": "^5.7.2",
+    "vite": "^6.2.6",
+    "vitest": "^3.0.7",
+    "react": "catalog:",
+    "react-dom": "catalog:"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/omni-network/omni.git",
+    "directory": "sdk/packages/react"
+  },
+  "keywords": ["typescript", "web3", "ethereum", "omni"],
+  "author": "Omni Network",
+  "homepage": "https://omni.network/",
+  "dependencies": {
+    "@omni-network/core": "workspace:^"
+  }
 }

--- a/sdk/packages/react/package.json
+++ b/sdk/packages/react/package.json
@@ -4,7 +4,7 @@
   "version": "0.1.0",
   "type": "module",
   "license": "MIT",
-  "packageManager": "pnpm@9.1.0",
+  "packageManager": "pnpm@9.6.0",
   "sideEffects": false,
   "main": "./dist/esm/index.js",
   "module": "./dist/esm/index.js",

--- a/sdk/packages/react/package.json
+++ b/sdk/packages/react/package.json
@@ -1,69 +1,69 @@
 {
-  "name": "@omni-network/react",
-  "description": "React hooks for Omni Solvernet",
-  "version": "0.1.0",
-  "type": "module",
-  "license": "MIT",
-  "packageManager": "pnpm@9.6.0",
-  "sideEffects": false,
-  "main": "./dist/esm/index.js",
-  "module": "./dist/esm/index.js",
-  "types": "./dist/types/index.d.ts",
-  "exports": {
-    ".": {
-      "types": "./dist/types/index.d.ts",
-      "default": "./dist/esm/index.js"
-    },
-    "./package.json": "./package.json"
-  },
-  "scripts": {
-    "build": "pnpm clean && pnpm build:ts",
-    "build:ts": "tsc -p tsconfig.build.json",
-    "prepublishOnly": "pnpm build",
-    "clean": "rm -rf dist tsconfig.tsbuildinfo",
-    "test": "vitest run",
-    "coverage": "vitest run --coverage",
-    "check": "biome check --write"
-  },
-  "files": [
-    "dist/**",
-    "src/**",
-    "!dist/**/*.tsbuildinfo",
-    "!src/**/*.test.ts",
-    "!src/**/*.test-d.ts"
-  ],
-  "engines": {
-    "node": ">=22.x"
-  },
-  "peerDependencies": {
-    "@tanstack/react-query": "^5.64.2",
-    "react": ">=18",
-    "viem": "2.x",
-    "wagmi": "2.x"
-  },
-  "devDependencies": {
-    "@omni-network/test-utils": "workspace:^",
-    "@testing-library/dom": "catalog:",
-    "@testing-library/react": "catalog:",
-    "@types/react": "catalog:",
-    "@types/react-dom": "catalog:",
-    "@vitest/coverage-v8": "^3.0.7",
-    "happy-dom": "^17.4.4",
-    "typescript": "^5.7.2",
-    "vite": "^6.2.6",
-    "vitest": "^3.0.7",
-    "react": "catalog:",
-    "react-dom": "catalog:"
-  },
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/omni-network/omni.git",
-    "directory": "sdk/packages/react"
-  },
-  "keywords": ["typescript", "web3", "ethereum", "omni"],
-  "author": "Omni Network",
-  "homepage": "https://omni.network/",
-  "dependencies": {
-    "@omni-network/core": "workspace:^"
-  }
+	"name": "@omni-network/react",
+	"description": "React hooks for Omni Solvernet",
+	"version": "0.1.0",
+	"type": "module",
+	"license": "MIT",
+	"packageManager": "pnpm@9.12.1",
+	"sideEffects": false,
+	"main": "./dist/esm/index.js",
+	"module": "./dist/esm/index.js",
+	"types": "./dist/types/index.d.ts",
+	"exports": {
+		".": {
+			"types": "./dist/types/index.d.ts",
+			"default": "./dist/esm/index.js"
+		},
+		"./package.json": "./package.json"
+	},
+	"scripts": {
+		"build": "pnpm clean && pnpm build:ts",
+		"build:ts": "tsc -p tsconfig.build.json",
+		"prepublishOnly": "pnpm build",
+		"clean": "rm -rf dist tsconfig.tsbuildinfo",
+		"test": "vitest run",
+		"coverage": "vitest run --coverage",
+		"check": "biome check --write"
+	},
+	"files": [
+		"dist/**",
+		"src/**",
+		"!dist/**/*.tsbuildinfo",
+		"!src/**/*.test.ts",
+		"!src/**/*.test-d.ts"
+	],
+	"engines": {
+		"node": ">=22.x"
+	},
+	"peerDependencies": {
+		"@tanstack/react-query": "^5.64.2",
+		"react": ">=18",
+		"viem": "2.x",
+		"wagmi": "2.x"
+	},
+	"devDependencies": {
+		"@omni-network/test-utils": "workspace:^",
+		"@testing-library/dom": "catalog:",
+		"@testing-library/react": "catalog:",
+		"@types/react": "catalog:",
+		"@types/react-dom": "catalog:",
+		"@vitest/coverage-v8": "^3.0.7",
+		"happy-dom": "^17.4.4",
+		"typescript": "^5.7.2",
+		"vite": "^6.2.6",
+		"vitest": "^3.0.7",
+		"react": "catalog:",
+		"react-dom": "catalog:"
+	},
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/omni-network/omni.git",
+		"directory": "sdk/packages/react"
+	},
+	"keywords": ["typescript", "web3", "ethereum", "omni"],
+	"author": "Omni Network",
+	"homepage": "https://omni.network/",
+	"dependencies": {
+		"@omni-network/core": "workspace:^"
+	}
 }

--- a/sdk/packages/test-utils/package.json
+++ b/sdk/packages/test-utils/package.json
@@ -1,35 +1,35 @@
 {
-  "name": "@omni-network/test-utils",
-  "private": true,
-  "description": "Shared test utilities for SDK packages",
-  "version": "0.0.0",
-  "type": "module",
-  "packageManager": "pnpm@9.6.0",
-  "sideEffects": false,
-  "main": "./dist/esm/index.js",
-  "module": "./dist/esm/index.js",
-  "types": "./dist/types/index.d.ts",
-  "exports": {
-    ".": {
-      "types": "./dist/types/index.d.ts",
-      "default": "./dist/esm/index.js"
-    },
-    "./package.json": "./package.json"
-  },
-  "scripts": {
-    "build": "pnpm clean && pnpm build:ts",
-    "build:ts": "tsc -p tsconfig.json",
-    "clean": "rm -rf dist tsconfig.tsbuildinfo"
-  },
-  "files": ["dist/**", "src/**", "!dist/**/*.tsbuildinfo"],
-  "engines": {
-    "node": ">=22.x"
-  },
-  "dependencies": {
-    "viem": "catalog:"
-  },
-  "devDependencies": {
-    "@types/node": "^22.13.10",
-    "typescript": "^5.7.2"
-  }
+	"name": "@omni-network/test-utils",
+	"private": true,
+	"description": "Shared test utilities for SDK packages",
+	"version": "0.0.0",
+	"type": "module",
+	"packageManager": "pnpm@9.12.1",
+	"sideEffects": false,
+	"main": "./dist/esm/index.js",
+	"module": "./dist/esm/index.js",
+	"types": "./dist/types/index.d.ts",
+	"exports": {
+		".": {
+			"types": "./dist/types/index.d.ts",
+			"default": "./dist/esm/index.js"
+		},
+		"./package.json": "./package.json"
+	},
+	"scripts": {
+		"build": "pnpm clean && pnpm build:ts",
+		"build:ts": "tsc -p tsconfig.json",
+		"clean": "rm -rf dist tsconfig.tsbuildinfo"
+	},
+	"files": ["dist/**", "src/**", "!dist/**/*.tsbuildinfo"],
+	"engines": {
+		"node": ">=22.x"
+	},
+	"dependencies": {
+		"viem": "catalog:"
+	},
+	"devDependencies": {
+		"@types/node": "^22.13.10",
+		"typescript": "^5.7.2"
+	}
 }

--- a/sdk/packages/test-utils/package.json
+++ b/sdk/packages/test-utils/package.json
@@ -4,7 +4,7 @@
   "description": "Shared test utilities for SDK packages",
   "version": "0.0.0",
   "type": "module",
-  "packageManager": "pnpm@9.1.0",
+  "packageManager": "pnpm@9.6.0",
   "sideEffects": false,
   "main": "./dist/esm/index.js",
   "module": "./dist/esm/index.js",

--- a/sdk/packages/test-utils/package.json
+++ b/sdk/packages/test-utils/package.json
@@ -1,35 +1,35 @@
 {
-	"name": "@omni-network/test-utils",
-	"private": true,
-	"description": "Shared test utilities for SDK packages",
-	"version": "0.0.0",
-	"type": "module",
-	"packageManager": "pnpm@9.12.1",
-	"sideEffects": false,
-	"main": "./dist/esm/index.js",
-	"module": "./dist/esm/index.js",
-	"types": "./dist/types/index.d.ts",
-	"exports": {
-		".": {
-			"types": "./dist/types/index.d.ts",
-			"default": "./dist/esm/index.js"
-		},
-		"./package.json": "./package.json"
-	},
-	"scripts": {
-		"build": "pnpm clean && pnpm build:ts",
-		"build:ts": "tsc -p tsconfig.json",
-		"clean": "rm -rf dist tsconfig.tsbuildinfo"
-	},
-	"files": ["dist/**", "src/**", "!dist/**/*.tsbuildinfo"],
-	"engines": {
-		"node": ">=22.x"
-	},
-	"dependencies": {
-		"viem": "catalog:"
-	},
-	"devDependencies": {
-		"@types/node": "^22.13.10",
-		"typescript": "^5.7.2"
-	}
+  "name": "@omni-network/test-utils",
+  "private": true,
+  "description": "Shared test utilities for SDK packages",
+  "version": "0.0.0",
+  "type": "module",
+  "packageManager": "pnpm@9.12.1",
+  "sideEffects": false,
+  "main": "./dist/esm/index.js",
+  "module": "./dist/esm/index.js",
+  "types": "./dist/types/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/types/index.d.ts",
+      "default": "./dist/esm/index.js"
+    },
+    "./package.json": "./package.json"
+  },
+  "scripts": {
+    "build": "pnpm clean && pnpm build:ts",
+    "build:ts": "tsc -p tsconfig.json",
+    "clean": "rm -rf dist tsconfig.tsbuildinfo"
+  },
+  "files": ["dist/**", "src/**", "!dist/**/*.tsbuildinfo"],
+  "engines": {
+    "node": ">=22.x"
+  },
+  "dependencies": {
+    "viem": "catalog:"
+  },
+  "devDependencies": {
+    "@types/node": "^22.13.10",
+    "typescript": "^5.7.2"
+  }
 }


### PR DESCRIPTION
- need to bump to 9.12.1 as it introduced a fix to allow scoped packages to be used in workspace catalog

issue: none