### PR TITLE
fix(e2e): skip omni consensus chain

### DIFF
--- a/e2e/app/admin/common.go
+++ b/e2e/app/admin/common.go
@@ -221,11 +221,7 @@ func (s shared) runHL(ctx context.Context, def app.Definition, fn func(context.C
 	}
 	network = solvernet.AddHLNetwork(ctx, network, solvernet.FilterByEndpoints(_s.endpoints))
 
-	for _, _chain := range network.Chains {
-		if netconf.IsOmniConsensus(_s.testnet.Network, _chain.ID) {
-			continue
-		}
-
+	for _, _chain := range network.EVMChains() {
 		c, err := setupChainHL(ctx, _s, _chain)
 		if err != nil {
 			return errors.Wrap(err, "setup chain hl", "chain", _chain.Name)

--- a/e2e/app/admin/common.go
+++ b/e2e/app/admin/common.go
@@ -222,6 +222,10 @@ func (s shared) runHL(ctx context.Context, def app.Definition, fn func(context.C
 	network = solvernet.AddHLNetwork(ctx, network, solvernet.FilterByEndpoints(_s.endpoints))
 
 	for _, _chain := range network.Chains {
+		if netconf.IsOmniConsensus(_s.testnet.Network, _chain.ID) {
+			continue
+		}
+
 		c, err := setupChainHL(ctx, _s, _chain)
 		if err != nil {
 			return errors.Wrap(err, "setup chain hl", "chain", _chain.Name)


### PR DESCRIPTION
The Omni consensus chain needs to be skipped within the expanded network when using the HL-specific upgrade functions.

issue: #3925