### PR TITLE
chore(solver/rebalance): add new tokens and thresholds

### DIFF
--- a/solver/rebalance/integration_test.go
+++ b/solver/rebalance/integration_test.go
@@ -5,8 +5,10 @@ import (
 	"flag"
 	"log/slog"
 	"math/big"
+	"math/rand"
 	"os"
 	"os/signal"
+	"slices"
 	"syscall"
 	"testing"
 	"time"
@@ -23,7 +25,6 @@ import (
 	"github.com/omni-network/omni/lib/tokenpricer"
 	"github.com/omni-network/omni/lib/tokenpricer/coingecko"
 	"github.com/omni-network/omni/lib/tokens"
-	"github.com/omni-network/omni/lib/tokens/tokenutil"
 	"github.com/omni-network/omni/lib/tutil"
 	"github.com/omni-network/omni/lib/xchain"
 	xprovider "github.com/omni-network/omni/lib/xchain/provider"
@@ -63,6 +64,7 @@ func TestIntegration(t *testing.T) {
 	rpcs := getRPCs(t)
 	chains := getChains(t)
 	network := makeNetwork(t, chains)
+	pricer := newPricer(ctx)
 
 	clients, stop := testutil.StartAnvilForks(t, ctx, rpcs, chains)
 	defer stop()
@@ -74,7 +76,6 @@ func TestIntegration(t *testing.T) {
 	}()
 
 	solverPk, solver := testutil.NewAccount(t)
-	fundETH(t, ctx, clients, solver)
 
 	backends, err := ethbackend.BackendsFromClients(clients, solverPk)
 	tutil.RequireNoError(t, err)
@@ -83,89 +84,187 @@ func TestIntegration(t *testing.T) {
 	// Start attesting CCTP messages
 	cctpClient := cctp.StartTestClient(ctx, t, xprov, chains, clients)
 
-	l1USDC := mustToken(t, evmchain.IDEthereum, tokens.USDC)
-	l1WSTETH := mustToken(t, evmchain.IDEthereum, tokens.WSTETH)
-	baseWSTETH := mustToken(t, evmchain.IDBase, tokens.WSTETH)
-	baseUSDC := mustToken(t, evmchain.IDBase, tokens.USDC)
+	// Unbalance solver
+	fundUnbalanced(t, ctx, pricer, clients, solver)
 
-	// Fund L1 USDC at suprlus threshold, so we have some to swap after briding from base
-	err = anvil.FundUSDC(ctx, clients[evmchain.IDEthereum], l1USDC.Address, rebalance.GetFundThreshold(l1USDC).Surplus(), solver)
-	tutil.RequireNoError(t, err)
+	// sumDeficits returns the token deficits in
+	sumDeficits := func() *big.Int {
+		sum := bi.Zero()
 
-	// Fund 10 base wstETH above surplus
-	err = anvil.FundERC20(ctx, clients[evmchain.IDBase], baseWSTETH.Address,
-		bi.Add(rebalance.GetFundThreshold(baseWSTETH).Surplus(), bi.Ether(10)),
-		solver,
-		anvil.WithSlotIdx(1))
-	tutil.RequireNoError(t, err)
+		for _, tkn := range rebalance.Tokens() {
+			d, err := rebalance.GetUSDDeficit(ctx, clients[tkn.ChainID], pricer, tkn, solver)
+			tutil.RequireNoError(t, err)
+			sum = bi.Add(sum, d)
+		}
 
-	// Fund L1 wstETH at 8 below target
-	// We use a deficit < base surplus, because not all surplus will be moved (due to min / max swap limits)
-	err = anvil.FundERC20(ctx, clients[evmchain.IDEthereum], l1WSTETH.Address,
-		bi.Sub(rebalance.GetFundThreshold(l1WSTETH).Target(), bi.Ether(8)),
-		solver)
-	tutil.RequireNoError(t, err)
+		return sum
+	}
 
-	// Fund base USDC at surplus threshold, so we can send some after swapping wstETH
-	err = anvil.FundUSDC(ctx, clients[evmchain.IDBase], baseUSDC.Address, rebalance.GetFundThreshold(baseUSDC).Surplus(), solver)
-	tutil.RequireNoError(t, err)
+	// Confirm unbalance
+	deficit := sumDeficits()
+	log.Info(ctx, "Starting deficit", "deficit", formatUSD(deficit))
+	tutil.RequireGT(t, deficit, bi.Dec6(50_000)) // Require at least 50k deficit
 
 	// Start rebalancing
-	interval := 5 * time.Second // fast interval for testing
-	dbDir := ""                 // use in-mem db
-	err = rebalance.Start(ctx, network, cctpClient, newPricer(ctx), backends, solver, dbDir, rebalance.WithInterval(interval))
+	interval := 5 * time.Second // Fast interval for testing
+	dbDir := ""                 // Use in-memory db
+	err = rebalance.Start(ctx, network, cctpClient, pricer, backends, solver, dbDir, rebalance.WithInterval(interval))
 	tutil.RequireNoError(t, err)
-
-	must := func(amt *big.Int, err error) *big.Int {
-		tutil.RequireNoError(t, err)
-		return amt
-	}
-
-	balance := func(chainID uint64, token tokens.Token) string {
-		return token.FormatAmt(must(tokenutil.BalanceOf(ctx, clients[chainID], token, solver)))
-	}
 
 	// Wait for rebalance
 	tutil.RequireEventually(t, ctx, func() bool {
-		// Surplus base WSTETH should < min swap
-		if bi.LT(
-			must(rebalance.GetSurplus(ctx, clients[evmchain.IDBase], baseWSTETH, solver)),
-			rebalance.GetFundThreshold(baseWSTETH).MinSwap(),
-		) {
+		deficit := sumDeficits()
+
+		// Consider < 10k deficit as "rebalanced"
+		// Wiggle room accounts for min swaps & sends
+		if bi.GT(deficit, bi.Dec6(10000)) {
+			log.Info(ctx, "Rebalance not complete", "deficit", formatUSD(deficit))
 			return false
 		}
 
-		// L1 wsteth deficit should be filled (mostly)
-		// "Mostly" because of min / max swap limits, and differences between live and pool prices
-		deficit := must(rebalance.GetDeficit(ctx, clients[evmchain.IDEthereum], l1WSTETH, solver))
-		if !bi.LT(deficit, bi.Ether(0.1)) {
-			log.Info(ctx, "L1 wstETH deficit",
-				"deficit", l1WSTETH.FormatAmt(deficit),
-				"balance", balance(evmchain.IDEthereum, l1WSTETH))
-
-			return false
-		}
-
-		// Log results
-		log.Info(ctx, "Rebalance complete",
-			"base_wsteth", balance(evmchain.IDBase, baseWSTETH),
-			"l1_usdc", balance(evmchain.IDEthereum, l1USDC),
-			"l1_usdc", balance(evmchain.IDEthereum, l1WSTETH))
+		log.Info(ctx, "Rebalance complete", "deficit", formatUSD(deficit))
 
 		return true
 	}, 2*time.Minute, 5*time.Second)
 }
 
-func fundETH(t *testing.T, ctx context.Context, clients map[uint64]ethclient.Client, account common.Address) {
+// fundUnbalanced funds the solver w/ unbalanced tokens (based on threshold values).
+func fundUnbalanced(t *testing.T, ctx context.Context, pricer tokenpricer.Pricer, clients map[uint64]ethclient.Client, solver common.Address) {
 	t.Helper()
 
-	// Fund ETH
-	for chainID, client := range clients {
-		amount := bi.Ether(1) // 1 ETH
-		err := anvil.FundAccounts(ctx, client, amount, account)
-		require.NoError(t, err)
-		log.Info(ctx, "Funded ETH", "chain", chainID, "amount", amount, "account", account)
+	// Make sure we have enough ETH for gas on all chains
+	for _, client := range clients {
+		err := anvil.FundAccounts(ctx, client, bi.Ether(1), solver)
+		tutil.RequireNoError(t, err)
 	}
+
+	// return list of tokens to defict and surplus
+	toDeficit, toSurplus := func() ([]tokens.Token, []tokens.Token) {
+		for { // retry until we can return
+			var toDeficit []tokens.Token
+			var toSurplus []tokens.Token
+
+			for i, token := range shuffle(rebalance.Tokens()) {
+				if i%2 == 0 {
+					toDeficit = append(toDeficit, token)
+				}
+				if i%2 == 1 {
+					toSurplus = append(toSurplus, token)
+				}
+			}
+
+			// filter out tokens we can never surplus
+			toSurplus = filter(toSurplus, func(t tokens.Token) bool {
+				return !rebalance.GetFundThreshold(t).NeverSurplus()
+			})
+
+			// retry, should generally not happen
+			// Need at least one token to surplus
+			if len(toSurplus) == 0 {
+				continue
+			}
+
+			return toDeficit, toSurplus
+		}
+	}()
+
+	// Goal total deficit / surplus (should match, so we can rebalance)
+	// NOTE: target thresholds may prever us from matching defict target
+	totalDeficitUSD := float64(100_000)
+	totalSurplusUSD := float64(100_000)
+
+	// Fund deficit tokens
+	for _, token := range toDeficit {
+		toDeficitUSD := totalDeficitUSD / float64(len(toDeficit))
+
+		price, err := pricer.USDPrice(ctx, token.Asset)
+		tutil.RequireNoError(t, err)
+
+		thresh := rebalance.GetFundThreshold(token)
+		toDeficit := bi.MulF64(oneOf(token), toDeficitUSD/price)
+		toFund := bi.Sub(thresh.Target(), toDeficit)
+
+		// Target threshold < desired deficit - don't fund and move on
+		if bi.LTE(toFund, bi.Zero()) {
+			continue
+		}
+
+		fundToken(t, ctx, clients[token.ChainID], token, solver, toFund)
+
+		log.Info(ctx, "Funded deficit",
+			"chain", evmchain.Name(token.ChainID),
+			"token", token.Asset,
+			"amount", token.FormatAmt(toFund),
+			"thresh_target", token.FormatAmt(thresh.Target()),
+			"deficit", token.FormatAmt(toDeficit))
+	}
+
+	// Fund surplus tokens
+	for _, token := range toSurplus {
+		thresh := rebalance.GetFundThreshold(token)
+		require.False(t, thresh.NeverSurplus())
+
+		toSurplusUSD := totalSurplusUSD / float64(len(toSurplus))
+
+		price, err := pricer.USDPrice(ctx, token.Asset)
+		tutil.RequireNoError(t, err)
+
+		toSurplus := bi.MulF64(oneOf(token), toSurplusUSD/price)
+		toFund := bi.Add(thresh.Surplus(), toSurplus)
+
+		fundToken(t, ctx, clients[token.ChainID], token, solver, toFund)
+
+		log.Info(ctx, "Funded surplus",
+			"chain", evmchain.Name(token.ChainID),
+			"token", token.Asset,
+			"amount", token.FormatAmt(toFund),
+			"thresh_surplus", token.FormatAmt(thresh.Surplus()),
+			"surplus", token.FormatAmt(toSurplus))
+	}
+}
+
+// fundToken funds the solver with a specific token.
+func fundToken(t *testing.T, ctx context.Context, client ethclient.Client, token tokens.Token, account common.Address, amt *big.Int) {
+	t.Helper()
+
+	if token.Is(tokens.ETH) {
+		err := anvil.FundAccounts(ctx, client, amt, account)
+		tutil.RequireNoError(t, err)
+
+		return
+	}
+
+	if token.Is(tokens.USDC) {
+		err := anvil.FundUSDC(ctx, client, token.Address, amt, account)
+		tutil.RequireNoError(t, err)
+
+		return
+	}
+
+	// L1 WSTETH has _balance map at slot
+	if token.Is(tokens.WSTETH) && token.ChainID == evmchain.IDEthereum {
+		err := anvil.FundERC20(ctx, client, token.Address, amt, account, anvil.WithSlotIdx(0))
+		tutil.RequireNoError(t, err)
+
+		return
+	}
+
+	// Bridged WSTETH has _balance map at slot
+	if token.Is(tokens.WSTETH) {
+		err := anvil.FundERC20(ctx, client, token.Address, amt, account, anvil.WithSlotIdx(1))
+		tutil.RequireNoError(t, err)
+
+		return
+	}
+
+	if token.Is(tokens.USDT) {
+		err := anvil.FundUSDT(ctx, client, token.Address, amt, account)
+		tutil.RequireNoError(t, err)
+
+		return
+	}
+
+	t.Fatalf("unsupported token %s", token)
 }
 
 // getRPCs returns mainnet rpcs urls from env vars.
@@ -193,6 +292,8 @@ func getChains(t *testing.T) []evmchain.Metadata {
 	return []evmchain.Metadata{
 		mustMeta(t, evmchain.IDEthereum),
 		mustMeta(t, evmchain.IDBase),
+		mustMeta(t, evmchain.IDArbitrumOne),
+		mustMeta(t, evmchain.IDOptimism),
 	}
 }
 
@@ -223,14 +324,6 @@ func mustMeta(t *testing.T, chainID uint64) evmchain.Metadata {
 	return meta
 }
 
-func mustToken(t *testing.T, chainID uint64, asset tokens.Asset) tokens.Token {
-	t.Helper()
-	token, ok := tokens.ByAsset(chainID, asset)
-	require.True(t, ok)
-
-	return token
-}
-
 func newPricer(ctx context.Context) tokenpricer.Pricer {
 	apiKey := os.Getenv("COINGECKO_API_KEY")
 	pricer := tokenpricer.NewCached(coingecko.New(coingecko.WithAPIKey(apiKey)))
@@ -240,4 +333,33 @@ func newPricer(ctx context.Context) tokenpricer.Pricer {
 	go pricer.ClearCacheForever(ctx, priceCacheEvictInterval)
 
 	return pricer
+}
+
+func shuffle[T any](xs []T) []T {
+	clone := slices.Clone(xs)
+
+	rand.Shuffle(len(clone), func(i, j int) {
+		clone[i], clone[j] = clone[j], clone[i]
+	})
+
+	return clone
+}
+
+func filter[T any](xs []T, f func(T) bool) []T {
+	var out []T
+	for _, x := range xs {
+		if f(x) {
+			out = append(out, x)
+		}
+	}
+
+	return out
+}
+
+func oneOf(t tokens.Token) *big.Int {
+	if t.Decimals == 6 {
+		return bi.Dec6(1)
+	}
+
+	return bi.Ether(1)
 }

--- a/solver/rebalance/rebalance.go
+++ b/solver/rebalance/rebalance.go
@@ -21,10 +21,10 @@ import (
 
 var (
 	// minSend is the minimum amount of surplus USDC to send to other chains.
-	minSend = bi.Dec6(1000) // 1000 USDC
+	minSend = bi.Dec6(1000) // 1k USDC
 
 	// maxSend is the maximum amount of USDC allowed in a single send.
-	maxSend = bi.Dec6(5000) // 5000 USDC
+	maxSend = bi.Dec6(10000) // 10k USDC
 )
 
 // rebalanceForever starts rebalancing loops for each chain in the network.
@@ -115,7 +115,7 @@ func sendSurplusOnce(
 		return nil
 	}
 
-	deficits, err := GetUSDDeficitsDescending(ctx, db, network, backends.Clients(), pricer, solver)
+	deficits, err := GetUSDChainDeficits(ctx, db, network, backends.Clients(), pricer, solver)
 	if err != nil {
 		return errors.Wrap(err, "get deficits")
 	}

--- a/solver/rebalance/thresholds.go
+++ b/solver/rebalance/thresholds.go
@@ -101,26 +101,100 @@ func GetFundThreshold(token tokens.Token) FundThreshold {
 
 var (
 	thresholds = map[tokens.Token]FundThreshold{
-		mustToken(evmchain.IDEthereum, tokens.WSTETH): {
-			min:     10,
+		// ETH
+		mustToken(evmchain.IDEthereum, tokens.ETH): {
+			min:     20,
 			target:  50,
-			surplus: inf,
+			surplus: 60,
+			minSwap: 1,
+			maxSwap: 5,
 		},
+		mustToken(evmchain.IDBase, tokens.ETH): {
+			min:     1,
+			target:  3,
+			surplus: 5,
+			minSwap: 1,
+			maxSwap: 5,
+		},
+		mustToken(evmchain.IDArbitrumOne, tokens.ETH): {
+			min:     1,
+			target:  6,
+			surplus: 8,
+			minSwap: 1,
+			maxSwap: 5,
+		},
+		mustToken(evmchain.IDOptimism, tokens.ETH): {
+			min:     1,
+			target:  6,
+			surplus: 8,
+			minSwap: 1,
+			maxSwap: 5,
+		},
+
+		// USDC
 		mustToken(evmchain.IDEthereum, tokens.USDC): {
-			min:     50_000,
-			target:  100_000,
-			surplus: 120_000,
+			min:     50000,
+			target:  100000,
+			surplus: 120000,
 			minSwap: 1000,
-			maxSwap: 5000,
+			maxSwap: 10000,
+		},
+		mustToken(evmchain.IDBase, tokens.USDC): {
+			min:     20000,
+			target:  40000,
+			surplus: 50000,
+			minSwap: 1000,
+			maxSwap: 10000,
+		},
+		mustToken(evmchain.IDArbitrumOne, tokens.USDC): {
+			min:     5000,
+			target:  15000,
+			surplus: 20000,
+			minSwap: 1000,
+			maxSwap: 10000,
+		},
+		mustToken(evmchain.IDOptimism, tokens.USDC): {
+			min:     5000,
+			target:  15000,
+			surplus: 20000,
+			minSwap: 1000,
+			maxSwap: 10000,
+		},
+
+		// USDT
+		mustToken(evmchain.IDEthereum, tokens.USDT): {
+			min:     1000,
+			target:  5000,
+			surplus: 10000,
+			minSwap: 1000,
+			maxSwap: 10000,
+		},
+		mustToken(evmchain.IDOptimism, tokens.USDT): {
+			min:     5000,
+			target:  10000,
+			surplus: 12000,
+			minSwap: 1000,
+			maxSwap: 10000,
+		},
+		mustToken(evmchain.IDArbitrumOne, tokens.USDT): {
+			min:     5000,
+			target:  10000,
+			surplus: 12000,
+			minSwap: 1000,
+			maxSwap: 10000,
+		},
+
+		// WSTETH
+		mustToken(evmchain.IDEthereum, tokens.WSTETH): {
+			min:     20,
+			target:  50,
+			surplus: 55,
+			minSwap: 1,
+			maxSwap: 5,
 		},
 		mustToken(evmchain.IDBase, tokens.WSTETH): {
 			minSwap: 1,
-			maxSwap: 3,
-		},
-		mustToken(evmchain.IDBase, tokens.USDC): {
-			min:     20_000,
-			target:  40_000,
-			surplus: 50_000,
+			maxSwap: 5,
 		},
 	}
 )

--- a/solver/rebalance/tokens.go
+++ b/solver/rebalance/tokens.go
@@ -10,6 +10,19 @@ var rebalanceTokens = []tokens.Token{
 	// USDC
 	mustToken(evmchain.IDEthereum, tokens.USDC),
 	mustToken(evmchain.IDBase, tokens.USDC),
+	mustToken(evmchain.IDArbitrumOne, tokens.USDC),
+	mustToken(evmchain.IDOptimism, tokens.USDC),
+
+	// USDT
+	mustToken(evmchain.IDEthereum, tokens.USDT),
+	mustToken(evmchain.IDArbitrumOne, tokens.USDT),
+	mustToken(evmchain.IDOptimism, tokens.USDT),
+
+	// ETH
+	mustToken(evmchain.IDEthereum, tokens.ETH),
+	mustToken(evmchain.IDBase, tokens.ETH),
+	mustToken(evmchain.IDArbitrumOne, tokens.ETH),
+	mustToken(evmchain.IDOptimism, tokens.ETH),
 
 	// WSETH
 	mustToken(evmchain.IDEthereum, tokens.WSTETH),


### PR DESCRIPTION
Enable new tokens and thresholds.

Most of changes here are updating tests
- updating snapshot tests to show total chain deficits (in USD)
- and most importantly, updating integration tests to rebalance more tokens

Integration tests now work as follows
- put some tokens in deficit
- put others in surplus
- wait for deficit to decrease to acceptable amount

issue: none