### PR TITLE
fix(solver/rebalance): do not send usdc lt minSend

### DIFF
--- a/solver/rebalance/rebalance.go
+++ b/solver/rebalance/rebalance.go
@@ -157,12 +157,12 @@ func sendSurplusOnce(
 			continue
 		}
 
-		if bi.LT(surplus, minSend) { // No surplus left to send.
-			log.Debug(ctx, "No surplus left to send")
+		toSend := d.Amount
+
+		if bi.LT(toSend, minSend) { // Not enough worth sending.
+			log.Debug(ctx, "Surplus < minSend, skipping send")
 			break
 		}
-
-		toSend := d.Amount
 
 		if bi.GT(toSend, surplus) { // Cap send to available surplus.
 			log.Debug(ctx, "Deficit > surplus, capping send")


### PR DESCRIPTION
Do not send less than minSend.

This prevents repetitive low value sends to chains it low deficit, 
that isn't filled due to minSwap caps.

issue: none
