### PR TITLE
chore(e2e): update solver pin to 55f8dba

### DIFF
--- a/e2e/manifests/mainnet.toml
+++ b/e2e/manifests/mainnet.toml
@@ -7,7 +7,7 @@ prometheus   = true
 pinned_halo_tag = "v0.14.1"
 pinned_relayer_tag = "07c4ac7"
 pinned_monitor_tag = "03452ee"
-pinned_solver_tag = "08b2b8d"
+pinned_solver_tag = "55f8dba"
 
 [node.validator01]
 [node.validator02]

--- a/e2e/manifests/omega.toml
+++ b/e2e/manifests/omega.toml
@@ -7,7 +7,7 @@ prometheus = true
 pinned_halo_tag = "v0.14.1"
 pinned_relayer_tag = "07c4ac7"
 pinned_monitor_tag = "03452ee"
-pinned_solver_tag = "08b2b8d"
+pinned_solver_tag = "55f8dba"
 
 [node.validator01]
 [node.validator02]


### PR DESCRIPTION
Bump solver pin to 55f8dba.

This includes a minSend fix.

issue: none
