### PR TITLE
chore(sdk): bump versions

### DIFF
--- a/sdk/packages/core/README.md
+++ b/sdk/packages/core/README.md
@@ -1,7 +1,5 @@
 # Omni SDK core
 
-## Note - The SDK is in alpha so expect breaking changes
-
 ## Overview
 
 The Omni SDK contains APIs for interfacing with Omni SolverNet, your gateway to any transaction, on any chain.

--- a/sdk/packages/core/package.json
+++ b/sdk/packages/core/package.json
@@ -22,7 +22,7 @@
     "clean": "rm -rf dist tsconfig.tsbuildinfo",
     "coverage": "vitest run --coverage",
     "prepublishOnly": "pnpm build",
-    "publish": "pnpm publish --access public",
+    "publish": "pnpm publish",
     "test": "vitest run"
   },
   "files": ["dist/**", "src/**", "!dist/**/*.tsbuildinfo"],

--- a/sdk/packages/core/package.json
+++ b/sdk/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@omni-network/core",
   "description": "Core logic for interacting with Omni Solvernet",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "type": "module",
   "license": "MIT",
   "packageManager": "pnpm@9.12.1",

--- a/sdk/packages/core/package.json
+++ b/sdk/packages/core/package.json
@@ -19,10 +19,11 @@
   "scripts": {
     "build": "pnpm clean && pnpm build:ts",
     "build:ts": "tsc -p tsconfig.build.json",
-    "prepublishOnly": "pnpm build",
     "clean": "rm -rf dist tsconfig.tsbuildinfo",
-    "test": "vitest run",
-    "coverage": "vitest run --coverage"
+    "coverage": "vitest run --coverage",
+    "prepublishOnly": "pnpm build",
+    "publish": "pnpm publish --access public",
+    "test": "vitest run"
   },
   "files": ["dist/**", "src/**", "!dist/**/*.tsbuildinfo"],
   "engines": {

--- a/sdk/packages/core/src/version.ts
+++ b/sdk/packages/core/src/version.ts
@@ -1,1 +1,1 @@
-export const version = '0.1.1'
+export const version = '0.1.2'

--- a/sdk/packages/react/package.json
+++ b/sdk/packages/react/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@omni-network/react",
   "description": "React hooks for Omni Solvernet",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "type": "module",
   "license": "MIT",
   "packageManager": "pnpm@9.12.1",
@@ -19,11 +19,11 @@
   "scripts": {
     "build": "pnpm clean && pnpm build:ts",
     "build:ts": "tsc -p tsconfig.build.json",
-    "prepublishOnly": "pnpm build",
     "clean": "rm -rf dist tsconfig.tsbuildinfo",
-    "test": "vitest run",
     "coverage": "vitest run --coverage",
-    "check": "biome check --write"
+    "prepublishOnly": "pnpm build",
+    "publish": "pnpm publish --access public",
+    "test": "vitest run"
   },
   "files": [
     "dist/**",

--- a/sdk/packages/react/package.json
+++ b/sdk/packages/react/package.json
@@ -22,7 +22,7 @@
     "clean": "rm -rf dist tsconfig.tsbuildinfo",
     "coverage": "vitest run --coverage",
     "prepublishOnly": "pnpm build",
-    "publish": "pnpm publish --access public",
+    "publish": "pnpm publish",
     "test": "vitest run"
   },
   "files": [

--- a/sdk/packages/react/src/version.ts
+++ b/sdk/packages/react/src/version.ts
@@ -1,1 +1,1 @@
-export const version = '0.1.1'
+export const version = '0.1.2'


### PR DESCRIPTION
- bump versions since publish didn't strip `catalog:` from package.json
-  remove alpha comments 
- update scripts

issue: none