### PR TITLE
feat(solver): enable RPC overrides in solver

### DIFF
--- a/solver/app/chains.go
+++ b/solver/app/chains.go
@@ -1,0 +1,38 @@
+package app
+
+import (
+	"context"
+
+	"github.com/omni-network/omni/e2e/types"
+	"github.com/omni-network/omni/lib/contracts/solvernet"
+	"github.com/omni-network/omni/lib/errors"
+	"github.com/omni-network/omni/lib/evmchain"
+	"github.com/omni-network/omni/lib/log"
+	"github.com/omni-network/omni/lib/netconf"
+	"github.com/omni-network/omni/lib/xchain"
+)
+
+// AddSolverEndpoints returns the RPC endpoints for the given solvernet network, including HL chains.
+func AddSolverEndpoints(ctx context.Context, networkID netconf.ID, endpoints xchain.RPCEndpoints, rpcOverrides map[string]string) (xchain.RPCEndpoints, error) {
+	log.Debug(ctx, "Adding solver endpoints", "network", networkID, "endpoints", endpoints, "rpc_overrides", rpcOverrides)
+
+	// extend endpoints w/ hl chains
+	for _, chain := range solvernet.HLChains(networkID) {
+		meta, ok := evmchain.MetadataByID(chain.ID)
+		if !ok {
+			return xchain.RPCEndpoints{}, errors.New("unknown chain", "chain_id", chain.ID)
+		}
+
+		rpc, ok := rpcOverrides[meta.Name]
+		if !ok {
+			rpc = types.PublicRPCByName(meta.Name)
+			if rpc == "" {
+				return xchain.RPCEndpoints{}, errors.New("missing rpc override", "chain", meta.Name)
+			}
+		}
+
+		endpoints[meta.Name] = rpc
+	}
+
+	return endpoints, nil
+}

--- a/solver/app/config.go
+++ b/solver/app/config.go
@@ -25,6 +25,7 @@ type Config struct {
 	DBDir           string
 	Tracer          tracer.Config
 	CoinGeckoAPIKey string
+	RPCOverrides    map[string]string
 }
 
 func DefaultConfig() Config {

--- a/solver/cmd/flags.go
+++ b/solver/cmd/flags.go
@@ -18,4 +18,5 @@ func bindRunFlags(flags *pflag.FlagSet, cfg *solver.Config) {
 	flags.StringVar(&cfg.APIAddr, "api-addr", cfg.APIAddr, "The address to bind the API server")
 	flags.StringVar(&cfg.DBDir, "db-dir", cfg.DBDir, "The path to the database directory")
 	flags.StringVar(&cfg.CoinGeckoAPIKey, "coingecko-apikey", cfg.CoinGeckoAPIKey, "The CoinGecko API key to use for fetching token prices")
+	flags.StringToStringVar(&cfg.RPCOverrides, "rpc-overrides", cfg.RPCOverrides, "Public chain rpc overrides: '<chain1>=<url1>,<url2>'")
 }


### PR DESCRIPTION
Solver app itself was not retrieving the RPC overrides, so the Hyperlane network did not include any Hyperlane chains due to missing endpoints. I've attempted to bind these RPC overrides to the solver config. This PR doesn't functionally change the solver as the hyperlane extended network is not used after creating it, as I want to see if this works first.

issue: none
