### PR TITLE
feat(lib): support Sepolia ETH in solver

### DIFF
--- a/lib/tokens/tokens.json
+++ b/lib/tokens/tokens.json
@@ -54,6 +54,16 @@
   "Name": "Ether",
   "Decimals": 18,
   "CoingeckoID": "ethereum",
+  "ChainID": 11155111,
+  "ChainClass": "testnet",
+  "Address": "0x0000000000000000000000000000000000000000",
+  "IsMock": false
+ },
+ {
+  "Symbol": "ETH",
+  "Name": "Ether",
+  "Decimals": 18,
+  "CoingeckoID": "ethereum",
   "ChainID": 421614,
   "ChainClass": "testnet",
   "Address": "0x0000000000000000000000000000000000000000",

--- a/lib/tokens/tokens_test.go
+++ b/lib/tokens/tokens_test.go
@@ -42,6 +42,7 @@ func TestGenTokens(t *testing.T) {
 
 		// Native ETH (testnet)
 		nativeETH(evmchain.IDHolesky),
+		nativeETH(evmchain.IDSepolia),
 		nativeETH(evmchain.IDArbSepolia),
 		nativeETH(evmchain.IDBaseSepolia),
 		nativeETH(evmchain.IDOpSepolia),

--- a/solver/app/testdata/TestClaimants.golden
+++ b/solver/app/testdata/TestClaimants.golden
@@ -1,7 +1,0 @@
-{
- "wstETH": {
-  "mainnet": "0x79ef4d1224a055ad4ee5e2226d0cb3720d929ae7",
-  "omega": "0x521786be8a0f455700c25fb25f94a4b626e460ec",
-  "staging": "0x521786be8a0f455700c25fb25f94a4b626e460ec"
- }
-}

--- a/solver/app/testdata/TestTokens.golden
+++ b/solver/app/testdata/TestTokens.golden
@@ -51,6 +51,16 @@
  },
  {
   "address": "0x0000000000000000000000000000000000000000",
+  "chainId": 11155111,
+  "coingeckoId": "ethereum",
+  "isMock": false,
+  "maxSpend": "3 ETH",
+  "minSpend": "0.001 ETH",
+  "name": "Ether",
+  "symbol": "ETH"
+ },
+ {
+  "address": "0x0000000000000000000000000000000000000000",
   "chainId": 421614,
   "coingeckoId": "ethereum",
   "isMock": false,


### PR DESCRIPTION
Hyperlane backends appear to be functioning, however my orders got rejected due to Sepolia ETH not being in the solver's token list. Added Sepolia ETH.

issue: none