### PR TITLE
feat(e2e/solve): filter out applied routes

### DIFF
--- a/e2e/solve/routing.go
+++ b/e2e/solve/routing.go
@@ -20,9 +20,9 @@ import (
 
 // Route represents a SolverNet route from a source chain to a destination chain.
 type Route struct {
-	ChainID     uint64
-	Outbox      common.Address
-	InboxConfig bindings.ISolverNetOutboxInboxConfig
+	ChainID      uint64
+	InboxConfig  common.Address
+	OutboxConfig bindings.ISolverNetOutboxInboxConfig
 }
 
 // SetSolverNetRoutes sets the SolverNet routes for all chains in a given network.
@@ -96,9 +96,9 @@ func getRoutes(src netconf.Chain, network netconf.Network, inboxAddr common.Addr
 		}
 
 		routes = append(routes, Route{
-			ChainID:     dest.ID,
-			Outbox:      outboxAddr,
-			InboxConfig: bindings.ISolverNetOutboxInboxConfig{Inbox: inboxAddr, Provider: provider},
+			ChainID:      dest.ID,
+			InboxConfig:  outboxAddr,
+			OutboxConfig: bindings.ISolverNetOutboxInboxConfig{Inbox: inboxAddr, Provider: provider},
 		})
 	}
 
@@ -132,9 +132,9 @@ func filterRoutes(ctx context.Context, src netconf.Chain, network netconf.Networ
 		}
 
 		currentRoutes = append(currentRoutes, Route{
-			ChainID:     dest.ID,
-			Outbox:      inboxConfig,
-			InboxConfig: outboxConfig,
+			ChainID:      dest.ID,
+			InboxConfig:  inboxConfig,
+			OutboxConfig: outboxConfig,
 		})
 	}
 
@@ -228,7 +228,7 @@ func chainIDs(routes []Route) []uint64 {
 func outboxes(routes []Route) []common.Address {
 	outboxes := make([]common.Address, 0, len(routes))
 	for _, route := range routes {
-		outboxes = append(outboxes, route.Outbox)
+		outboxes = append(outboxes, route.InboxConfig)
 	}
 
 	return outboxes
@@ -238,7 +238,7 @@ func outboxes(routes []Route) []common.Address {
 func inboxConfigs(routes []Route) []bindings.ISolverNetOutboxInboxConfig {
 	inboxConfigs := make([]bindings.ISolverNetOutboxInboxConfig, 0, len(routes))
 	for _, route := range routes {
-		inboxConfigs = append(inboxConfigs, route.InboxConfig)
+		inboxConfigs = append(inboxConfigs, route.OutboxConfig)
 	}
 
 	return inboxConfigs

--- a/e2e/solve/routing_internal_test.go
+++ b/e2e/solve/routing_internal_test.go
@@ -72,25 +72,25 @@ func makeRoutes() []TestRoute {
 		outboxAddr:  dummyOutboxAddr,
 		expectedRoutes: []Route{
 			{
-				ChainID: omniStaging.ID,
-				Outbox:  dummyOutboxAddr,
-				InboxConfig: bindings.ISolverNetOutboxInboxConfig{
+				ChainID:     omniStaging.ID,
+				InboxConfig: dummyOutboxAddr,
+				OutboxConfig: bindings.ISolverNetOutboxInboxConfig{
 					Inbox:    dummyInboxAddr,
 					Provider: solvernet.ProviderNone,
 				},
 			},
 			{
-				ChainID: opSepolia.ID,
-				Outbox:  dummyOutboxAddr,
-				InboxConfig: bindings.ISolverNetOutboxInboxConfig{
+				ChainID:     opSepolia.ID,
+				InboxConfig: dummyOutboxAddr,
+				OutboxConfig: bindings.ISolverNetOutboxInboxConfig{
 					Inbox:    dummyInboxAddr,
 					Provider: solvernet.ProviderCore,
 				},
 			},
 			{
-				ChainID: arbSepolia.ID,
-				Outbox:  dummyOutboxAddr,
-				InboxConfig: bindings.ISolverNetOutboxInboxConfig{
+				ChainID:     arbSepolia.ID,
+				InboxConfig: dummyOutboxAddr,
+				OutboxConfig: bindings.ISolverNetOutboxInboxConfig{
 					Inbox:    dummyInboxAddr,
 					Provider: solvernet.ProviderCore,
 				},
@@ -108,25 +108,25 @@ func makeRoutes() []TestRoute {
 		expectedRoutes: []Route{
 			// Omni EVM (Core) should be skipped
 			{
-				ChainID: opSepolia.ID,
-				Outbox:  dummyOutboxAddr,
-				InboxConfig: bindings.ISolverNetOutboxInboxConfig{
+				ChainID:     opSepolia.ID,
+				InboxConfig: dummyOutboxAddr,
+				OutboxConfig: bindings.ISolverNetOutboxInboxConfig{
 					Inbox:    dummyInboxAddr,
 					Provider: solvernet.ProviderHL,
 				},
 			},
 			{
-				ChainID: arbSepolia.ID,
-				Outbox:  dummyOutboxAddr,
-				InboxConfig: bindings.ISolverNetOutboxInboxConfig{
+				ChainID:     arbSepolia.ID,
+				InboxConfig: dummyOutboxAddr,
+				OutboxConfig: bindings.ISolverNetOutboxInboxConfig{
 					Inbox:    dummyInboxAddr,
 					Provider: solvernet.ProviderHL,
 				},
 			},
 			{
-				ChainID: sepoliaChain.ID,
-				Outbox:  dummyOutboxAddr,
-				InboxConfig: bindings.ISolverNetOutboxInboxConfig{
+				ChainID:     sepoliaChain.ID,
+				InboxConfig: dummyOutboxAddr,
+				OutboxConfig: bindings.ISolverNetOutboxInboxConfig{
 					Inbox:    dummyInboxAddr,
 					Provider: solvernet.ProviderNone,
 				},
@@ -142,33 +142,33 @@ func makeRoutes() []TestRoute {
 		outboxAddr:  dummyOutboxAddr,
 		expectedRoutes: []Route{
 			{
-				ChainID: omniStaging.ID,
-				Outbox:  dummyOutboxAddr,
-				InboxConfig: bindings.ISolverNetOutboxInboxConfig{
+				ChainID:     omniStaging.ID,
+				InboxConfig: dummyOutboxAddr,
+				OutboxConfig: bindings.ISolverNetOutboxInboxConfig{
 					Inbox:    dummyInboxAddr,
 					Provider: solvernet.ProviderCore,
 				},
 			},
 			{
-				ChainID: opSepolia.ID,
-				Outbox:  dummyOutboxAddr,
-				InboxConfig: bindings.ISolverNetOutboxInboxConfig{
+				ChainID:     opSepolia.ID,
+				InboxConfig: dummyOutboxAddr,
+				OutboxConfig: bindings.ISolverNetOutboxInboxConfig{
 					Inbox:    dummyInboxAddr,
 					Provider: solvernet.ProviderNone,
 				},
 			},
 			{
-				ChainID: arbSepolia.ID,
-				Outbox:  dummyOutboxAddr,
-				InboxConfig: bindings.ISolverNetOutboxInboxConfig{
+				ChainID:     arbSepolia.ID,
+				InboxConfig: dummyOutboxAddr,
+				OutboxConfig: bindings.ISolverNetOutboxInboxConfig{
 					Inbox:    dummyInboxAddr,
 					Provider: solvernet.ProviderCore,
 				},
 			},
 			{
-				ChainID: sepoliaChain.ID,
-				Outbox:  dummyOutboxAddr,
-				InboxConfig: bindings.ISolverNetOutboxInboxConfig{
+				ChainID:     sepoliaChain.ID,
+				InboxConfig: dummyOutboxAddr,
+				OutboxConfig: bindings.ISolverNetOutboxInboxConfig{
 					Inbox:    dummyInboxAddr,
 					Provider: solvernet.ProviderHL,
 				},


### PR DESCRIPTION
All valid routes are currently being written when routes are set. This change filters out routes that are already applied, saving gas.

issue: none