### PR TITLE
fix(e2e): fix post upgrade executor test

### DIFF
--- a/e2e/app/admin/upgrade.go
+++ b/e2e/app/admin/upgrade.go
@@ -493,6 +493,12 @@ func upgradeSolverNetExecutor(ctx context.Context, s shared, network netconf.Net
 
 	var chainIDs []uint64
 	for _, dest := range network.EVMChains() {
+		// Use solvernet.Provider to determine if the route is valid, chainIds are used in post-upgrade tests
+		_, ok := solvernet.Provider(c.ChainID, dest.ID)
+		if !ok {
+			continue
+		}
+
 		chainIDs = append(chainIDs, dest.ID)
 	}
 


### PR DESCRIPTION
Post-upgrade tests for the Executor included the Omni EVM chain ID in all runs, when not all routes support it. This change validates routes prior to testing, so we don't trigger reverts from invalid routes.

ref https://linear.app/omni-network/issue/OMNI-262