### PR TITLE
feat(sdk): changeset canary publishing workflow

### DIFF
--- a/.github/workflows/changeset-snapshot.yml
+++ b/.github/workflows/changeset-snapshot.yml
@@ -1,0 +1,45 @@
+# this workflow is used to manually dispatch canary versions of the SDK
+name: SDK Snapshot
+on:
+  workflow_dispatch:
+
+jobs:
+  snapshot:
+    name: Release snapshot version
+    permissions:
+      contents: write
+      id-token: write
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9
+
+      - name: Setup node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Install deps
+        working-directory: sdk
+        run: pnpm install
+
+      - name: Publish
+        working-directory: sdk
+        continue-on-error: true
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          snapshot=$(git branch --show-current | tr -cs '[:alnum:]-' '-' | tr '[:upper:]' '[:lower:]' | sed 's/-$//')
+          npm config set "//registry.npmjs.org/:_authToken" "$NPM_TOKEN"
+          pnpm clean
+          pnpm changeset version --no-git-tag --snapshot $snapshot
+          pnpm changeset:prepublish
+          pnpm changeset publish --no-git-tag --snapshot $snapshot --tag $snapshot


### PR DESCRIPTION
- manual dispatch workflow to trigger canary publishing to npm
- branch will need to be selected, so ideally we can select the changeset PR branch that gets created

issue: ref https://linear.app/omni-network/issue/OMNI-162