### PR TITLE
chore(sdk): drop bad workflow cmd and use absolute path

### DIFF
--- a/.github/workflows/changeset.yaml
+++ b/.github/workflows/changeset.yaml
@@ -87,6 +87,7 @@ jobs:
         # if: steps.sdk_changes.outputs.any_changed == 'true'
         uses: changesets/action@v1
         with:
+          cwd: ${{ github.workspace }}/sdk
           commit: "chore(sdk): bump versions"
           title: "chore(sdk): bump versions"
           version: "pnpm changeset:version"

--- a/.github/workflows/changeset.yaml
+++ b/.github/workflows/changeset.yaml
@@ -86,7 +86,6 @@ jobs:
       - name: Bump versions
         # if: steps.sdk_changes.outputs.any_changed == 'true'
         uses: changesets/action@v1
-        working-directory: sdk
         with:
           commit: "chore(sdk): bump versions"
           title: "chore(sdk): bump versions"


### PR DESCRIPTION
- drop bad cmd causing ci to bomb

issue: none