### PR TITLE
chore(e2e): bump solver monitor pins to e704542

### DIFF
--- a/e2e/manifests/mainnet.toml
+++ b/e2e/manifests/mainnet.toml
@@ -6,8 +6,8 @@ prometheus   = true
 
 pinned_halo_tag = "v0.14.1"
 pinned_relayer_tag = "07c4ac7"
-pinned_monitor_tag = "03452ee"
-pinned_solver_tag = "210db56"
+pinned_monitor_tag = "e704542"
+pinned_solver_tag = "e704542"
 
 [node.validator01]
 [node.validator02]

--- a/e2e/manifests/omega.toml
+++ b/e2e/manifests/omega.toml
@@ -6,8 +6,8 @@ prometheus = true
 
 pinned_halo_tag = "v0.14.1"
 pinned_relayer_tag = "07c4ac7"
-pinned_monitor_tag = "03452ee"
-pinned_solver_tag = "210db56"
+pinned_monitor_tag = "e704542"
+pinned_solver_tag = "e704542"
 
 [node.validator01]
 [node.validator02]


### PR DESCRIPTION
Bump solver and monitor to e704542.

Includes solver min threshold updates.
And cctp mint / purge improvements.

issue: none