### PR TITLE
chore(sdk): resolve conflicts when publishing

### DIFF
--- a/sdk/integration-tests/package.json
+++ b/sdk/integration-tests/package.json
@@ -1,6 +1,7 @@
 {
   "name": "integration-tests",
   "type": "module",
+  "private": true,
   "scripts": {
     "test": "vitest run"
   },

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -7,7 +7,7 @@
   "packageManager": "pnpm@9.12.1",
   "scripts": {
     "build": "pnpm run --r --filter \"./packages/**\" build",
-    "changeset:prepublish": "pnpm build",
+    "changeset:prepublish": "pnpm clean && pnpm build",
     "changeset:publish": "pnpm changeset:prepublish && changeset publish",
     "changeset:version": "changeset version && pnpm version:bump && pnpm check",
     "check": "biome check --write",

--- a/sdk/packages/core/package.json
+++ b/sdk/packages/core/package.json
@@ -21,8 +21,6 @@
     "build:ts": "tsc -p tsconfig.build.json",
     "clean": "rm -rf dist tsconfig.tsbuildinfo",
     "coverage": "vitest run --coverage",
-    "prepublishOnly": "pnpm build",
-    "publish": "pnpm publish",
     "test": "vitest run"
   },
   "files": ["dist/**", "src/**", "!dist/**/*.tsbuildinfo"],

--- a/sdk/packages/react/package.json
+++ b/sdk/packages/react/package.json
@@ -21,8 +21,6 @@
     "build:ts": "tsc -p tsconfig.build.json",
     "clean": "rm -rf dist tsconfig.tsbuildinfo",
     "coverage": "vitest run --coverage",
-    "prepublishOnly": "pnpm build",
-    "publish": "pnpm publish",
     "test": "vitest run"
   },
   "files": [


### PR DESCRIPTION
- integrations need to be set as private
- prepublish and publish scripts in packages were causing issues with running `changeset:publish` and we should only be publishing via changeset now anyway

issue: none