### PR TITLE
feat(e2e): enable sepolia on omega

### DIFF
--- a/lib/contracts/solvernet/chains.go
+++ b/lib/contracts/solvernet/chains.go
@@ -35,7 +35,7 @@ var hlChains = map[netconf.ID][]uint64{
 		// evmchain.IDHyperEVMTestnet,
 		// evmchain.IDPolygonAmoy,
 		// evmchain.IDPlumeTestnet,
-		// evmchain.IDSepolia,
+		evmchain.IDSepolia,
 	},
 
 	// Staging


### PR DESCRIPTION
Enable Sepolia in the Omega Hyperlane network, and validate all routes are correct.

ref https://linear.app/omni-network/issue/OMNI-244