### PR TITLE
feat(sdk): add queryOpts support to useOmniContracts

### DIFF
--- a/sdk/packages/react/src/hooks/useOmniContracts.test.ts
+++ b/sdk/packages/react/src/hooks/useOmniContracts.test.ts
@@ -1,7 +1,23 @@
+import type { useQuery } from '@tanstack/react-query'
 import { waitFor } from '@testing-library/react'
-import { expect, test } from 'vitest'
+import { expect, test, vi } from 'vitest'
 import { contracts, renderHook } from '../../test/index.js'
 import { useOmniContracts } from './useOmniContracts.js'
+
+const { useQueryMock } = vi.hoisted(() => {
+  return { useQueryMock: vi.fn() }
+})
+
+vi.mock('@tanstack/react-query', async () => {
+  const actual = await vi.importActual('@tanstack/react-query')
+  const actualUseQuery = actual.useQuery as typeof useQuery
+  return {
+    ...actual,
+    useQuery: useQueryMock.mockImplementation((params) => {
+      return actualUseQuery(params)
+    }),
+  }
+})
 
 test('default: returns contracts when API call succeeds', async () => {
   const { result } = renderHook(() => useOmniContracts(), {
@@ -14,6 +30,15 @@ test('default: returns contracts when API call succeeds', async () => {
 
   expect(result.current.isSuccess).toBe(true)
   expect(result.current.data).toEqual(contracts)
+})
+
+test('parameters: passes through queryOpts to useQuery', async () => {
+  const queryOpts = {
+    refetchInterval: 5000,
+    staleTime: 10000,
+  }
+  renderHook(() => useOmniContracts({ queryOpts }), { mockContractsCall: true })
+  expect(useQueryMock).toHaveBeenCalledWith(expect.objectContaining(queryOpts))
 })
 
 test('behaviour: handles API error gracefully', async () => {

--- a/sdk/packages/react/src/hooks/useOmniContracts.ts
+++ b/sdk/packages/react/src/hooks/useOmniContracts.ts
@@ -1,11 +1,27 @@
 import type { OmniContracts } from '@omni-network/core'
-import { type UseQueryResult, useQuery } from '@tanstack/react-query'
+import {
+  type UseQueryOptions,
+  type UseQueryResult,
+  useQuery,
+} from '@tanstack/react-query'
 import { useOmniContext } from '../context/omni.js'
 import { getOmniContractsQueryOptions } from '../utils/getContracts.js'
 
+export type UseOmniContractsParameters = {
+  queryOpts?: Omit<
+    UseQueryOptions<OmniContracts>,
+    'queryKey' | 'queryFn' | 'enabled'
+  >
+}
+
 export type UseOmniContractsResult = UseQueryResult<OmniContracts>
 
-export function useOmniContracts(): UseOmniContractsResult {
+export function useOmniContracts({
+  queryOpts,
+}: UseOmniContractsParameters = {}): UseOmniContractsResult {
   const config = useOmniContext()
-  return useQuery(getOmniContractsQueryOptions(config))
+  return useQuery({
+    ...getOmniContractsQueryOptions(config),
+    ...queryOpts,
+  })
 }


### PR DESCRIPTION
Continuing adding support for queryOpts to hooks

issue: none