### PR TITLE
chore(sdk): remove is native flag

### DIFF
--- a/sdk/.changeset/slick-mirrors-add.md
+++ b/sdk/.changeset/slick-mirrors-add.md
@@ -1,0 +1,8 @@
+---
+"@omni-network/react": minor
+"@omni-network/core": minor
+---
+
+Removed isNative flag from the quote inputs, deposit.token and expense.token are always optional now. By default we assume native when token is not provided, but we also support tokens in which case you need to provide the address.
+
+This cleans up the interface for consumers as the isNative flag was proving awkward.

--- a/sdk/examples/core/src/run.ts
+++ b/sdk/examples/core/src/run.ts
@@ -81,8 +81,8 @@ console.log(
 const quote = await getQuote({
   srcChainId: baseSepolia.id,
   destChainId: holesky.id,
-  deposit: { amount: depositAmount, isNative: true },
-  expense: { isNative: true },
+  deposit: { amount: depositAmount },
+  expense: {},
   mode: 'expense',
   environment,
 })

--- a/sdk/examples/core/src/run.ts
+++ b/sdk/examples/core/src/run.ts
@@ -82,7 +82,6 @@ const quote = await getQuote({
   srcChainId: baseSepolia.id,
   destChainId: holesky.id,
   deposit: { amount: depositAmount },
-  expense: {},
   mode: 'expense',
   environment,
 })

--- a/sdk/examples/react/src/App.tsx
+++ b/sdk/examples/react/src/App.tsx
@@ -59,7 +59,6 @@ function Quote() {
     srcChainId: baseSepolia.id,
     destChainId: holesky.id,
     deposit: { amount: parseEther('0.1') },
-    expense: {},
     mode: 'expense',
     enabled: true,
   })

--- a/sdk/examples/react/src/App.tsx
+++ b/sdk/examples/react/src/App.tsx
@@ -58,8 +58,8 @@ function Quote() {
   const quote = useQuote({
     srcChainId: baseSepolia.id,
     destChainId: holesky.id,
-    deposit: { amount: parseEther('0.1'), isNative: true },
-    expense: { isNative: true },
+    deposit: { amount: parseEther('0.1') },
+    expense: {},
     mode: 'expense',
     enabled: true,
   })

--- a/sdk/integration-tests/suites/flows.tsx
+++ b/sdk/integration-tests/suites/flows.tsx
@@ -151,11 +151,6 @@ describe.concurrent('ETH transfer orders', () => {
         destChainId: mockL2Id,
         deposit: {
           amount: parseEther('2'),
-          token: zeroAddress,
-        },
-        expense: {
-          amount: parseEther('1'),
-          token: zeroAddress,
         },
       } as const
 

--- a/sdk/integration-tests/suites/flows.tsx
+++ b/sdk/integration-tests/suites/flows.tsx
@@ -151,11 +151,11 @@ describe.concurrent('ETH transfer orders', () => {
         destChainId: mockL2Id,
         deposit: {
           amount: parseEther('2'),
-          isNative: true,
+          token: zeroAddress,
         },
         expense: {
           amount: parseEther('1'),
-          isNative: true,
+          token: zeroAddress,
         },
       } as const
 
@@ -453,10 +453,10 @@ describe.concurrent('ETH transfer orders', () => {
         destChainId: mockL2Id,
         deposit: {
           amount,
-          isNative: true,
+          token: zeroAddress,
         },
         expense: {
-          isNative: true,
+          token: zeroAddress,
         },
       } as const
 

--- a/sdk/integration-tests/suites/react-hooks.tsx
+++ b/sdk/integration-tests/suites/react-hooks.tsx
@@ -75,11 +75,10 @@ describe.concurrent('useQuote()', () => {
           destChainId: mockL2Id,
           deposit: {
             amount: 1n,
-            isNative: true,
+            token: zeroAddress,
           },
           expense: {
-            amount: 1n,
-            isNative: true,
+            token: zeroAddress,
           },
         })
       },
@@ -106,12 +105,11 @@ describe.concurrent('useQuote()', () => {
           srcChainId: mockL1Id,
           destChainId: mockL2Id,
           deposit: {
-            amount: 1n,
-            isNative: true,
+            token: zeroAddress,
           },
           expense: {
             amount: 1n,
-            isNative: true,
+            token: zeroAddress,
           },
         })
       },
@@ -138,8 +136,8 @@ describe.concurrent('useQuote()', () => {
           mode: 'expense',
           srcChainId: 1,
           destChainId: 17000,
-          deposit: { isNative: true, amount: parseEther('1') },
-          expense: { isNative: true },
+          deposit: { token: zeroAddress, amount: parseEther('1') },
+          expense: { token: zeroAddress },
         })
       },
       { wrapper: ContextProvider },
@@ -166,8 +164,8 @@ describe.concurrent('useQuote()', () => {
           mode: 'expense',
           srcChainId: 1,
           destChainId: 42161,
-          deposit: { isNative: true },
-          expense: { isNative: true },
+          deposit: { token: zeroAddress, amount: 0n },
+          expense: { token: zeroAddress },
         })
       },
       { wrapper: ContextProvider },

--- a/sdk/packages/core/src/api/getQuote.test.ts
+++ b/sdk/packages/core/src/api/getQuote.test.ts
@@ -21,7 +21,6 @@ const params: GetQuoteParameters = {
   destChainId: 2,
   mode: 'expense',
   deposit: { amount: 100n },
-  expense: {},
 }
 
 test('default: fetches a quote', async () => {

--- a/sdk/packages/core/src/api/getQuote.ts
+++ b/sdk/packages/core/src/api/getQuote.ts
@@ -2,25 +2,28 @@ import { type Address, type Hex, fromHex, zeroAddress } from 'viem'
 import { fetchJSON } from '../internal/api.js'
 import type { Environment } from '../types/config.js'
 import type { Quote, Quoteable } from '../types/quote.js'
+import type { Prettify } from '../types/utils.js'
 import { getApiUrl } from '../utils/getApiUrl.js'
 import { toJSON } from '../utils/toJSON.js'
 
-export type GetQuoteParameters = {
-  srcChainId?: number
-  destChainId: number
-  environment?: Environment | string
-} & (
-  | {
-      mode: 'deposit'
-      deposit: Omit<Quoteable, 'amount'>
-      expense: Omit<Quoteable, 'amount'> & { amount: bigint }
-    }
-  | {
-      mode: 'expense'
-      deposit: Omit<Quoteable, 'amount'> & { amount: bigint }
-      expense: Omit<Quoteable, 'amount'>
-    }
-)
+export type GetQuoteParameters = Prettify<
+  {
+    srcChainId?: number
+    destChainId: number
+    environment?: Environment | string
+  } & (
+    | {
+        mode: 'deposit'
+        deposit: Omit<Quoteable, 'amount'>
+        expense: Omit<Quoteable, 'amount'> & { amount: bigint }
+      }
+    | {
+        mode: 'expense'
+        deposit: Omit<Quoteable, 'amount'> & { amount: bigint }
+        expense: Omit<Quoteable, 'amount'>
+      }
+  )
+>
 
 // the response from /quote endpoint (amounts are hex encoded bigints)
 type QuoteResponse = {

--- a/sdk/packages/core/src/api/getQuote.ts
+++ b/sdk/packages/core/src/api/getQuote.ts
@@ -8,11 +8,19 @@ import { toJSON } from '../utils/toJSON.js'
 export type GetQuoteParameters = {
   srcChainId?: number
   destChainId: number
-  mode: 'expense' | 'deposit'
-  deposit: Quoteable
-  expense: Quoteable
   environment?: Environment | string
-}
+} & (
+  | {
+      mode: 'deposit'
+      deposit: Omit<Quoteable, 'amount'>
+      expense: Omit<Quoteable, 'amount'> & { amount: bigint }
+    }
+  | {
+      mode: 'expense'
+      deposit: Omit<Quoteable, 'amount'> & { amount: bigint }
+      expense: Omit<Quoteable, 'amount'>
+    }
+)
 
 // the response from /quote endpoint (amounts are hex encoded bigints)
 type QuoteResponse = {
@@ -57,7 +65,7 @@ export async function getQuote(quote: GetQuoteParameters): Promise<Quote> {
 // trim params to create obj expected by /quote endpoint
 export const toQuoteUnit = (q: Quoteable, omitAmount: boolean) => ({
   amount: omitAmount ? undefined : q.amount,
-  token: q.isNative ? zeroAddress : q.token,
+  token: q.token ?? zeroAddress,
 })
 
 // asserts a json response is QuoteResponse

--- a/sdk/packages/core/src/api/getQuote.ts
+++ b/sdk/packages/core/src/api/getQuote.ts
@@ -14,13 +14,13 @@ export type GetQuoteParameters = Prettify<
   } & (
     | {
         mode: 'deposit'
-        deposit: Prettify<Omit<Quoteable, 'amount'>>
+        deposit?: Prettify<Omit<Quoteable, 'amount'>>
         expense: Prettify<Omit<Quoteable, 'amount'> & { amount: bigint }>
       }
     | {
         mode: 'expense'
         deposit: Prettify<Omit<Quoteable, 'amount'> & { amount: bigint }>
-        expense: Prettify<Omit<Quoteable, 'amount'>>
+        expense?: Prettify<Omit<Quoteable, 'amount'>>
       }
   )
 >
@@ -48,8 +48,12 @@ export async function getQuote(quote: GetQuoteParameters): Promise<Quote> {
     body: toJSON({
       sourceChainId: srcChainId,
       destChainId: destChainId,
-      deposit: toQuoteUnit(depositInput, mode === 'deposit'),
-      expense: toQuoteUnit(expenseInput, mode === 'expense'),
+      deposit: depositInput
+        ? toQuoteUnit(depositInput, mode === 'deposit')
+        : {},
+      expense: expenseInput
+        ? toQuoteUnit(expenseInput, mode === 'expense')
+        : {},
     }),
   })
 

--- a/sdk/packages/core/src/api/getQuote.ts
+++ b/sdk/packages/core/src/api/getQuote.ts
@@ -14,13 +14,13 @@ export type GetQuoteParameters = Prettify<
   } & (
     | {
         mode: 'deposit'
-        deposit: Omit<Quoteable, 'amount'>
-        expense: Omit<Quoteable, 'amount'> & { amount: bigint }
+        deposit: Prettify<Omit<Quoteable, 'amount'>>
+        expense: Prettify<Omit<Quoteable, 'amount'> & { amount: bigint }>
       }
     | {
         mode: 'expense'
-        deposit: Omit<Quoteable, 'amount'> & { amount: bigint }
-        expense: Omit<Quoteable, 'amount'>
+        deposit: Prettify<Omit<Quoteable, 'amount'> & { amount: bigint }>
+        expense: Prettify<Omit<Quoteable, 'amount'>>
       }
   )
 >

--- a/sdk/packages/core/src/contracts/sendOrder.test.ts
+++ b/sdk/packages/core/src/contracts/sendOrder.test.ts
@@ -1,5 +1,5 @@
 import { mockL1Client, testOrder } from '@omni-network/test-utils'
-import { type Client, zeroAddress } from 'viem'
+import type { Client } from 'viem'
 import { expect, test, vi } from 'vitest'
 import { inboxABI } from '../constants/abis.js'
 import { typeHash } from '../constants/typehash.js'
@@ -86,7 +86,7 @@ test('behaviour: sets the order value when the deposit token address is zero', a
     sendOrder({
       client: mockL1Client,
       inboxAddress: '0xaddress',
-      order: { ...testOrder, deposit: { token: zeroAddress, amount: 3n } },
+      order: { ...testOrder, deposit: { amount: 3n } },
     }),
   ).resolves.toEqual('0xtxHash')
   expect(writeContract).toHaveBeenLastCalledWith(mockL1Client, {

--- a/sdk/packages/core/src/types/quote.ts
+++ b/sdk/packages/core/src/types/quote.ts
@@ -1,9 +1,6 @@
 import type { Address } from 'viem'
 
-// TODO add complex type to enforce one of the amounts is defined
-export type Quoteable =
-  | { isNative: true; token?: never; amount?: bigint }
-  | { isNative: false; token: Address; amount?: bigint }
+export type Quoteable = { token?: Address; amount?: bigint }
 
 export type Quote = {
   deposit: { token: Address; amount: bigint }

--- a/sdk/packages/core/src/types/utils.ts
+++ b/sdk/packages/core/src/types/utils.ts
@@ -1,0 +1,14 @@
+/**
+ * @description Create partial of T, but w/ required keys K
+ *
+ * @example
+ * PartialBy<{ foo: string, bar: number }, 'foo'>
+ * => { foo?: string, bar: number }
+ *
+ */
+export type PartialBy<T, K extends keyof T> = Omit<T, K> &
+  ExactPartial<Pick<T, K>>
+
+export type ExactPartial<type> = {
+  [key in keyof type]?: type[key] | undefined
+}

--- a/sdk/packages/core/src/types/utils.ts
+++ b/sdk/packages/core/src/types/utils.ts
@@ -1,14 +1,11 @@
 /**
- * @description Create partial of T, but w/ required keys K
+ * @description combine members of intersections into readable types
  *
+ * @see {@link https://twitter.com/mattpocockuk/status/1622730173446557697?s=20&t=NdpAcmEFXY01xkqU3KO0Mg}
  * @example
- * PartialBy<{ foo: string, bar: number }, 'foo'>
- * => { foo?: string, bar: number }
- *
+ * Prettify<{ a: string } & { b: string } & { c: number, d: bigint }>
+ * => { a: string, b: string, c: number, d: bigint }
  */
-export type PartialBy<T, K extends keyof T> = Omit<T, K> &
-  ExactPartial<Pick<T, K>>
-
-export type ExactPartial<type> = {
-  [key in keyof type]?: type[key] | undefined
-}
+export type Prettify<T> = {
+  [K in keyof T]: T[K]
+} & {}

--- a/sdk/packages/react/src/hooks/useQuote.test-d.ts
+++ b/sdk/packages/react/src/hooks/useQuote.test-d.ts
@@ -7,8 +7,8 @@ test('type: useQuote', () => {
   const result = useQuote({
     destChainId: 2,
     mode: 'expense',
-    deposit: { isNative: true },
-    expense: { isNative: true },
+    deposit: { amount: 0n, token: '0x00' },
+    expense: { token: '0x00' },
     enabled: true,
   })
 

--- a/sdk/packages/react/src/hooks/useQuote.test-d.ts
+++ b/sdk/packages/react/src/hooks/useQuote.test-d.ts
@@ -1,7 +1,7 @@
-import type { FetchJSONError, Quote, Quoteable } from '@omni-network/core'
+import type { FetchJSONError, Quote } from '@omni-network/core'
 import type { UseQueryResult } from '@tanstack/react-query'
 import { expectTypeOf, test } from 'vitest'
-import { useQuote } from './useQuote.js'
+import { type UseQuoteParams, useQuote } from './useQuote.js'
 
 test('type: useQuote', () => {
   const result = useQuote({
@@ -10,16 +10,13 @@ test('type: useQuote', () => {
     deposit: { amount: 0n, token: '0x00' },
     expense: { token: '0x00' },
     enabled: true,
+    environment: 'devnet',
+    queryOpts: {
+      refetchInterval: 100,
+    },
   })
 
-  expectTypeOf(useQuote).parameter(0).toMatchTypeOf<{
-    srcChainId?: number
-    destChainId: number
-    mode: 'expense' | 'deposit'
-    deposit: Quoteable
-    expense: Quoteable
-    enabled: boolean
-  }>()
+  expectTypeOf(useQuote).parameter(0).toMatchTypeOf<UseQuoteParams>()
 
   expectTypeOf(result.isError).toBeBoolean()
   expectTypeOf(result.isPending).toBeBoolean()

--- a/sdk/packages/react/src/hooks/useQuote.test.ts
+++ b/sdk/packages/react/src/hooks/useQuote.test.ts
@@ -3,18 +3,17 @@ import { waitFor } from '@testing-library/react'
 import { zeroAddress } from 'viem'
 import { beforeEach, expect, test, vi } from 'vitest'
 import { quote, renderHook } from '../../test/index.js'
-import { useQuote } from './useQuote.js'
+import { type UseQuoteParams, useQuote } from './useQuote.js'
 
 beforeEach(() => {
   vi.spyOn(core, 'getQuote').mockResolvedValue(quote)
 })
 
-const params: Parameters<typeof useQuote>[0] = {
+const params: UseQuoteParams = {
   srcChainId: 1,
   destChainId: 2,
   mode: 'expense',
   deposit: { amount: 100n },
-  expense: {},
   enabled: true,
 } as const
 
@@ -91,7 +90,6 @@ test('parameters: mode', () => {
   rerender({
     ...params,
     mode: 'deposit',
-    deposit: {},
     expense: { token: zeroAddress, amount: 100n },
   })
 

--- a/sdk/packages/react/src/hooks/useQuote.ts
+++ b/sdk/packages/react/src/hooks/useQuote.ts
@@ -13,7 +13,7 @@ import { useMemo } from 'react'
 import { useOmniContext } from '../context/omni.js'
 import { hashFn } from '../utils/query.js'
 
-type UseQuoteParams = GetQuoteParameters & {
+export type UseQuoteParams = GetQuoteParameters & {
   enabled: boolean
   queryOpts?: Omit<
     UseQueryOptions<Quote, QuoteError>,


### PR DESCRIPTION
- remove isNative flag from quote
- it creates an awkward experience as a consumer due to the never type, instead we can just make token optional, and infer native when that's the case

issue: none