### PR TITLE
chore(e2e): readd initializers for mainnet upgrade

### DIFF
--- a/e2e/app/admin/upgrade.go
+++ b/e2e/app/admin/upgrade.go
@@ -383,15 +383,12 @@ func upgradeSolverNetInbox(ctx context.Context, s shared, _ netconf.Network, c c
 		return errors.Wrap(err, "get addrs")
 	}
 
-	// var inboxABI = mustGetABI(bindings.SolverNetInboxMetaData)
+	var inboxABI = mustGetABI(bindings.SolverNetInboxMetaData)
 	// TODO: replace if re-initialization is required
-	/*
-		initializer, err := inboxABI.Pack("initializeV2", addrs.SolverNetOutbox)
-		if err != nil {
-			return errors.Wrap(err, "pack initializer")
-		}
-	*/
-	initializer := []byte{}
+	initializer, err := inboxABI.Pack("initializeV2", addrs.SolverNetOutbox)
+	if err != nil {
+		return errors.Wrap(err, "pack initializer")
+	}
 
 	mailbox, _ := solvernet.HyperlaneMailbox(c.ChainID)
 
@@ -437,15 +434,12 @@ func upgradeSolverNetOutbox(ctx context.Context, s shared, network netconf.Netwo
 		})
 	}
 
-	// var outboxABI = mustGetABI(bindings.SolverNetOutboxMetaData)
+	var outboxABI = mustGetABI(bindings.SolverNetOutboxMetaData)
 	// TODO: replace if re-initialization is required
-	/*
-		initializer, err := outboxABI.Pack("initializeV2", chainIDs, inboxes)
-		if err != nil {
-			return errors.Wrap(err, "pack initializer")
-		}
-	*/
-	initializer := []byte{}
+	initializer, err := outboxABI.Pack("initializeV2", chainIDs, inboxes)
+	if err != nil {
+		return errors.Wrap(err, "pack initializer")
+	}
 
 	mailbox, _ := solvernet.HyperlaneMailbox(c.ChainID)
 


### PR DESCRIPTION
Mainnet still needs the V2 initializers, they were removed for additional upgrades on staging and omega.

Do not merge until we are ready for mainnet upgrade.

ref https://linear.app/omni-network/issue/OMNI-262