### PR TITLE
fix(e2e): fix solvernet admin script cfg

### DIFF
--- a/e2e/app/admin/pausebridge.go
+++ b/e2e/app/admin/pausebridge.go
@@ -18,7 +18,7 @@ func pauseBridge(ctx context.Context, s shared, c chain, addr common.Address, ac
 		return errors.Wrap(err, "pack calldata", "chain", c.Name)
 	}
 
-	out, err := s.runForge(ctx, c.RPCEndpoint, calldata, s.manager)
+	out, err := s.runForge(ctx, coreForgeCfg(c.RPCEndpoint, s.manager), calldata)
 	if err != nil {
 		return errors.Wrap(err, "run forge", "out", out, "chain", c.Name)
 	}
@@ -37,7 +37,7 @@ func unpauseBridge(ctx context.Context, s shared, c chain, addr common.Address, 
 		return errors.Wrap(err, "pack calldata", "chain", c.Name)
 	}
 
-	out, err := s.runForge(ctx, c.RPCEndpoint, calldata, s.manager)
+	out, err := s.runForge(ctx, coreForgeCfg(c.RPCEndpoint, s.manager), calldata)
 	if err != nil {
 		return errors.Wrap(err, "run forge", "out", out, "chain", c.Name)
 	}

--- a/e2e/app/admin/pauseportal.go
+++ b/e2e/app/admin/pauseportal.go
@@ -16,7 +16,7 @@ func pausePortal(ctx context.Context, s shared, c chain) error {
 		return errors.Wrap(err, "pack calldata", "chain", c.Name)
 	}
 
-	out, err := s.runForge(ctx, c.RPCEndpoint, calldata, s.manager)
+	out, err := s.runForge(ctx, coreForgeCfg(c.RPCEndpoint, s.manager), calldata)
 	if err != nil {
 		return errors.Wrap(err, "run forge", "out", out, "chain", c.Name)
 	}
@@ -35,7 +35,7 @@ func unpausePortal(ctx context.Context, s shared, c chain) error {
 		return errors.Wrap(err, "pack calldata", "chain", c.Name)
 	}
 
-	out, err := s.runForge(ctx, c.RPCEndpoint, calldata, s.manager)
+	out, err := s.runForge(ctx, coreForgeCfg(c.RPCEndpoint, s.manager), calldata)
 	if err != nil {
 		return errors.Wrap(err, "run forge", "out", out, "chain", c.Name)
 	}

--- a/e2e/app/admin/pausesolvernet.go
+++ b/e2e/app/admin/pausesolvernet.go
@@ -20,7 +20,7 @@ func pauseSolverNetAll(ctx context.Context, s shared, c chain, addr common.Addre
 		return errors.Wrap(err, "pack calldata", "chain", c.Name)
 	}
 
-	out, err := s.runForge(ctx, c.RPCEndpoint, calldata, s.manager)
+	out, err := s.runForge(ctx, coreForgeCfg(c.RPCEndpoint, s.manager), calldata)
 	if err != nil {
 		return errors.Wrap(err, "run forge", "out", out, "chain", c.Name)
 	}
@@ -41,7 +41,7 @@ func pauseSolverNetOpen(ctx context.Context, s shared, c chain, addr common.Addr
 		return errors.Wrap(err, "pack calldata", "chain", c.Name)
 	}
 
-	out, err := s.runForge(ctx, c.RPCEndpoint, calldata, s.manager)
+	out, err := s.runForge(ctx, coreForgeCfg(c.RPCEndpoint, s.manager), calldata)
 	if err != nil {
 		return errors.Wrap(err, "run forge", "out", out, "chain", c.Name)
 	}
@@ -62,7 +62,7 @@ func pauseSolverNetClose(ctx context.Context, s shared, c chain, addr common.Add
 		return errors.Wrap(err, "pack calldata", "chain", c.Name)
 	}
 
-	out, err := s.runForge(ctx, c.RPCEndpoint, calldata, s.manager)
+	out, err := s.runForge(ctx, coreForgeCfg(c.RPCEndpoint, s.manager), calldata)
 	if err != nil {
 		return errors.Wrap(err, "run forge", "out", out, "chain", c.Name)
 	}

--- a/e2e/app/admin/pausexcall.go
+++ b/e2e/app/admin/pausexcall.go
@@ -17,7 +17,7 @@ func pauseXCall(ctx context.Context, s shared, c chain) error {
 		return errors.Wrap(err, "pack calldata", "chain", c.Name)
 	}
 
-	out, err := s.runForge(ctx, c.RPCEndpoint, calldata, s.manager)
+	out, err := s.runForge(ctx, coreForgeCfg(c.RPCEndpoint, s.manager), calldata)
 	if err != nil {
 		return errors.Wrap(err, "run forge", "out", out, "chain", c.Name)
 	}
@@ -41,7 +41,7 @@ func pauseXCallTo(ctx context.Context, s shared, c chain, toID uint64) error {
 		return errors.Wrap(err, "pack calldata", "chain", c.Name)
 	}
 
-	out, err := s.runForge(ctx, c.RPCEndpoint, calldata, s.manager)
+	out, err := s.runForge(ctx, coreForgeCfg(c.RPCEndpoint, s.manager), calldata)
 	if err != nil {
 		return errors.Wrap(err, "run forge", "out", out, "chain", c.Name)
 	}
@@ -60,7 +60,7 @@ func unpauseXCall(ctx context.Context, s shared, c chain) error {
 		return errors.Wrap(err, "pack calldata", "chain", c.Name)
 	}
 
-	out, err := s.runForge(ctx, c.RPCEndpoint, calldata, s.manager)
+	out, err := s.runForge(ctx, coreForgeCfg(c.RPCEndpoint, s.manager), calldata)
 	if err != nil {
 		return errors.Wrap(err, "run forge", "out", out, "chain", c.Name)
 	}
@@ -84,7 +84,7 @@ func unpauseXCallTo(ctx context.Context, s shared, c chain, toID uint64) error {
 		return errors.Wrap(err, "pack calldata", "chain", c.Name)
 	}
 
-	out, err := s.runForge(ctx, c.RPCEndpoint, calldata, s.manager)
+	out, err := s.runForge(ctx, coreForgeCfg(c.RPCEndpoint, s.manager), calldata)
 	if err != nil {
 		return errors.Wrap(err, "run forge", "out", out, "chain", c.Name)
 	}

--- a/e2e/app/admin/pausexsubmit.go
+++ b/e2e/app/admin/pausexsubmit.go
@@ -17,7 +17,7 @@ func pauseXSubmit(ctx context.Context, s shared, c chain) error {
 		return errors.Wrap(err, "pack calldata", "chain", c.Name)
 	}
 
-	out, err := s.runForge(ctx, c.RPCEndpoint, calldata, s.manager)
+	out, err := s.runForge(ctx, coreForgeCfg(c.RPCEndpoint, s.manager), calldata)
 	if err != nil {
 		return errors.Wrap(err, "run forge", "out", out, "chain", c.Name)
 	}
@@ -41,7 +41,7 @@ func pauseXSubmitFrom(ctx context.Context, s shared, c chain, fromID uint64) err
 		return errors.Wrap(err, "pack calldata", "chain", c.Name)
 	}
 
-	out, err := s.runForge(ctx, c.RPCEndpoint, calldata, s.manager)
+	out, err := s.runForge(ctx, coreForgeCfg(c.RPCEndpoint, s.manager), calldata)
 	if err != nil {
 		return errors.Wrap(err, "run forge", "out", out, "chain", c.Name)
 	}
@@ -60,7 +60,7 @@ func unpauseXSubmit(ctx context.Context, s shared, c chain) error {
 		return errors.Wrap(err, "pack calldata", "chain", c.Name)
 	}
 
-	out, err := s.runForge(ctx, c.RPCEndpoint, calldata, s.manager)
+	out, err := s.runForge(ctx, coreForgeCfg(c.RPCEndpoint, s.manager), calldata)
 	if err != nil {
 		return errors.Wrap(err, "run forge", "out", out, "chain", c.Name)
 	}
@@ -84,7 +84,7 @@ func unpauseXSubmitFrom(ctx context.Context, s shared, c chain, fromID uint64) e
 		return errors.Wrap(err, "pack calldata", "chain", c.Name)
 	}
 
-	out, err := s.runForge(ctx, c.RPCEndpoint, calldata, s.manager)
+	out, err := s.runForge(ctx, coreForgeCfg(c.RPCEndpoint, s.manager), calldata)
 	if err != nil {
 		return errors.Wrap(err, "run forge", "out", out, "chain", c.Name)
 	}

--- a/e2e/app/admin/upgrade.go
+++ b/e2e/app/admin/upgrade.go
@@ -154,7 +154,7 @@ func upgradePortal(ctx context.Context, s shared, c chain) error {
 		return errors.Wrap(err, "pack calldata")
 	}
 
-	out, err := s.runForge(ctx, c.RPCEndpoint, calldata, s.upgrader, s.deployer)
+	out, err := s.runForge(ctx, coreForgeCfg(c.RPCEndpoint, s.upgrader, s.deployer), calldata)
 	if err != nil {
 		return errors.Wrap(err, "run forge", "out", out)
 	}
@@ -191,7 +191,7 @@ func upgradeFeeOracleV1(ctx context.Context, s shared, c chain) error {
 		return errors.Wrap(err, "pack calldata")
 	}
 
-	out, err := s.runForge(ctx, c.RPCEndpoint, calldata, s.upgrader, s.deployer)
+	out, err := s.runForge(ctx, coreForgeCfg(c.RPCEndpoint, s.upgrader, s.deployer), calldata)
 	if err != nil {
 		return errors.Wrap(err, "run forge", "out", out)
 	}
@@ -215,7 +215,7 @@ func upgradeGasStation(ctx context.Context, s shared, c chain) error {
 		return errors.Wrap(err, "pack calldata")
 	}
 
-	out, err := s.runForge(ctx, c.RPCEndpoint, calldata, s.upgrader, s.deployer)
+	out, err := s.runForge(ctx, coreForgeCfg(c.RPCEndpoint, s.upgrader, s.deployer), calldata)
 	if err != nil {
 		return errors.Wrap(err, "run forge", "out", out)
 	}
@@ -239,7 +239,7 @@ func upgradeGasPump(ctx context.Context, s shared, c chain) error {
 		return errors.Wrap(err, "pack calldata")
 	}
 
-	out, err := s.runForge(ctx, c.RPCEndpoint, calldata, s.upgrader, s.deployer)
+	out, err := s.runForge(ctx, coreForgeCfg(c.RPCEndpoint, s.upgrader, s.deployer), calldata)
 	if err != nil {
 		return errors.Wrap(err, "run forge", "out", out)
 	}
@@ -258,7 +258,7 @@ func ugpradeSlashing(ctx context.Context, s shared, c chain) error {
 		return errors.Wrap(err, "pack calldata")
 	}
 
-	out, err := s.runForge(ctx, c.RPCEndpoint, calldata, s.upgrader, s.deployer)
+	out, err := s.runForge(ctx, coreForgeCfg(c.RPCEndpoint, s.upgrader, s.deployer), calldata)
 	if err != nil {
 		return errors.Wrap(err, "run forge", "out", out)
 	}
@@ -277,7 +277,7 @@ func ugpradeDistribution(ctx context.Context, s shared, c chain) error {
 		return errors.Wrap(err, "pack calldata")
 	}
 
-	out, err := s.runForge(ctx, c.RPCEndpoint, calldata, s.upgrader, s.deployer)
+	out, err := s.runForge(ctx, coreForgeCfg(c.RPCEndpoint, s.upgrader, s.deployer), calldata)
 	if err != nil {
 		return errors.Wrap(err, "run forge", "out", out)
 	}
@@ -305,7 +305,7 @@ func upgradeStaking(ctx context.Context, s shared, c chain) error {
 		return errors.Wrap(err, "pack calldata")
 	}
 
-	out, err := s.runForge(ctx, c.RPCEndpoint, calldata, s.upgrader, s.deployer)
+	out, err := s.runForge(ctx, coreForgeCfg(c.RPCEndpoint, s.upgrader, s.deployer), calldata)
 	if err != nil {
 		return errors.Wrap(err, "run forge", "out", out)
 	}
@@ -324,7 +324,7 @@ func upgradeBridgeNative(ctx context.Context, s shared, c chain) error {
 		return errors.Wrap(err, "pack calldata")
 	}
 
-	out, err := s.runForge(ctx, c.RPCEndpoint, calldata, s.upgrader, s.deployer)
+	out, err := s.runForge(ctx, coreForgeCfg(c.RPCEndpoint, s.upgrader, s.deployer), calldata)
 	if err != nil {
 		return errors.Wrap(err, "run forge", "out", out)
 	}
@@ -348,7 +348,7 @@ func upgradeBridgeL1(ctx context.Context, s shared, c chain) error {
 		return errors.Wrap(err, "pack calldata")
 	}
 
-	out, err := s.runForge(ctx, c.RPCEndpoint, calldata, s.upgrader, s.deployer)
+	out, err := s.runForge(ctx, coreForgeCfg(c.RPCEndpoint, s.upgrader, s.deployer), calldata)
 	if err != nil {
 		return errors.Wrap(err, "run forge", "out", out)
 	}
@@ -367,7 +367,7 @@ func upgradePortalRegistry(ctx context.Context, s shared, c chain) error {
 		return errors.Wrap(err, "pack calldata")
 	}
 
-	out, err := s.runForge(ctx, c.RPCEndpoint, calldata, s.upgrader, s.deployer)
+	out, err := s.runForge(ctx, coreForgeCfg(c.RPCEndpoint, s.upgrader, s.deployer), calldata)
 	if err != nil {
 		return errors.Wrap(err, "run forge", "out", out)
 	}
@@ -405,7 +405,7 @@ func upgradeSolverNetInbox(ctx context.Context, s shared, _ netconf.Network, c c
 		return errors.Wrap(err, "pack calldata")
 	}
 
-	out, err := s.runForge(ctx, c.RPCEndpoint, calldata, s.upgrader, s.deployer)
+	out, err := s.runForge(ctx, solveForgeCfg(c.RPCEndpoint, s.upgrader, s.deployer), calldata)
 	if err != nil {
 		return errors.Wrap(err, "run forge", "out", out)
 	}
@@ -459,7 +459,7 @@ func upgradeSolverNetOutbox(ctx context.Context, s shared, network netconf.Netwo
 		return errors.Wrap(err, "pack calldata")
 	}
 
-	out, err := s.runForge(ctx, c.RPCEndpoint, calldata, s.upgrader, s.deployer)
+	out, err := s.runForge(ctx, solveForgeCfg(c.RPCEndpoint, s.upgrader, s.deployer), calldata)
 	if err != nil {
 		return errors.Wrap(err, "run forge", "out", out)
 	}
@@ -484,7 +484,7 @@ func upgradeSolverNetMiddleman(ctx context.Context, s shared, _ netconf.Network,
 		return errors.Wrap(err, "pack calldata")
 	}
 
-	out, err := s.runForge(ctx, c.RPCEndpoint, calldata, s.upgrader, s.deployer)
+	out, err := s.runForge(ctx, solveForgeCfg(c.RPCEndpoint, s.upgrader, s.deployer), calldata)
 	if err != nil {
 		return errors.Wrap(err, "run forge", "out", out)
 	}
@@ -520,7 +520,7 @@ func upgradeSolverNetExecutor(ctx context.Context, s shared, network netconf.Net
 		return errors.Wrap(err, "pack calldata")
 	}
 
-	out, err := s.runForge(ctx, c.RPCEndpoint, calldata, s.upgrader, s.deployer)
+	out, err := s.runForge(ctx, solveForgeCfg(c.RPCEndpoint, s.upgrader, s.deployer), calldata)
 	if err != nil {
 		return errors.Wrap(err, "run forge", "out", out)
 	}
@@ -541,7 +541,7 @@ func setPortalFeeOracleV2(ctx context.Context, s shared, c chain) error {
 		return errors.Wrap(err, "pack calldata")
 	}
 
-	out, err := s.runForge(ctx, c.RPCEndpoint, calldata, s.manager)
+	out, err := s.runForge(ctx, coreForgeCfg(c.RPCEndpoint, s.manager), calldata)
 	if err != nil {
 		return errors.Wrap(err, "run forge", "out", out)
 	}


### PR DESCRIPTION
Fix solvernet admin script config.

Requires different root dir and script name than.

issue: none