### PR TITLE
fix(lib): fix portal assignment in deploy

### DIFF
--- a/lib/contracts/solvernet/inbox/deploy.go
+++ b/lib/contracts/solvernet/inbox/deploy.go
@@ -127,6 +127,15 @@ func deploy(ctx context.Context, cfg DeploymentConfig, network netconf.Network, 
 		return common.Address{}, nil, errors.New("unexpected address", "expected", cfg.ExpectedAddr, "actual", addr)
 	}
 
+	chainID, err := backend.ChainID(ctx)
+	if err != nil {
+		return common.Address{}, nil, errors.Wrap(err, "get chain id")
+	}
+
+	if solvernet.IsHLOnly(chainID.Uint64()) {
+		cfg.Portal = common.Address{}
+	}
+
 	impl, tx, _, err := bindings.DeploySolverNetInbox(txOpts, backend, cfg.Portal, cfg.Mailbox)
 	if err != nil {
 		return common.Address{}, nil, errors.Wrap(err, "deploy impl")
@@ -150,11 +159,6 @@ func deploy(ctx context.Context, cfg DeploymentConfig, network netconf.Network, 
 	receipt, err := backend.WaitMined(ctx, tx)
 	if err != nil {
 		return common.Address{}, nil, errors.Wrap(err, "wait mined proxy")
-	}
-
-	chainID, err := backend.ChainID(ctx)
-	if err != nil {
-		return common.Address{}, nil, errors.Wrap(err, "get chain id")
 	}
 
 	// setOutboxes

--- a/lib/contracts/solvernet/outbox/deploy.go
+++ b/lib/contracts/solvernet/outbox/deploy.go
@@ -132,6 +132,15 @@ func deploy(ctx context.Context, cfg DeploymentConfig, network netconf.Network, 
 		return common.Address{}, nil, errors.New("unexpected address", "expected", cfg.ExpectedAddr, "actual", addr)
 	}
 
+	chainID, err := backend.ChainID(ctx)
+	if err != nil {
+		return common.Address{}, nil, errors.Wrap(err, "get chain id")
+	}
+
+	if solvernet.IsHLOnly(chainID.Uint64()) {
+		cfg.Portal = common.Address{}
+	}
+
 	impl, tx, _, err := bindings.DeploySolverNetOutbox(txOpts, backend, cfg.Executor, cfg.Portal, cfg.Mailbox)
 	if err != nil {
 		return common.Address{}, nil, errors.Wrap(err, "deploy impl")
@@ -157,17 +166,11 @@ func deploy(ctx context.Context, cfg DeploymentConfig, network netconf.Network, 
 		return common.Address{}, nil, errors.Wrap(err, "wait mined proxy")
 	}
 
-	chainID, err := backend.ChainID(ctx)
-	if err != nil {
-		return common.Address{}, nil, errors.Wrap(err, "get chain id")
-	}
-	srcChainID := chainID.Uint64()
-
 	// setInboxes
 	var chainIDs []uint64
 	var inboxes []bindings.ISolverNetOutboxInboxConfig
 	for _, dest := range network.EVMChains() {
-		provider, ok := solvernet.Provider(srcChainID, dest.ID)
+		provider, ok := solvernet.Provider(chainID.Uint64(), dest.ID)
 		if !ok {
 			continue
 		}


### PR DESCRIPTION
Portal address needs to be the zero address on hyperlane-only chains when deployed.

ref https://linear.app/omni-network/issue/OMNI-244