### PR TITLE
feat(e2e): add upgrade all command

### DIFF
--- a/e2e/app/admin/upgrade.go
+++ b/e2e/app/admin/upgrade.go
@@ -140,6 +140,11 @@ func UpgradeSolverNetExecutor(ctx context.Context, def app.Definition, cfg Confi
 	return setup(def, cfg).runHL(ctx, def, upgradeSolverNetExecutor)
 }
 
+// UpgradeSolverNetAll upgrades all of the SolverNet contracts.
+func UpgradeSolverNetAll(ctx context.Context, def app.Definition, cfg Config) error {
+	return setup(def, cfg).runHL(ctx, def, upgradeSolverNetAll)
+}
+
 // SetPortalFeeOracleV2 upgrades the OmniPortal's FeeOracle to the FeeOracleV2 contract.
 func SetPortalFeeOracleV2(ctx context.Context, def app.Definition, cfg Config) error {
 	return setup(def, cfg).run(ctx, setPortalFeeOracleV2)
@@ -526,6 +531,25 @@ func upgradeSolverNetExecutor(ctx context.Context, s shared, network netconf.Net
 	}
 
 	log.Info(ctx, "SolverNetExecutor upgraded ✅", "chain", c.Name, "addr", addrs.SolverNetExecutor, "out", out)
+
+	return nil
+}
+
+func upgradeSolverNetAll(ctx context.Context, s shared, network netconf.Network, c chain) error {
+	err := upgradeSolverNetInbox(ctx, s, network, c)
+	if err != nil {
+		return errors.Wrap(err, "upgradeSolverNetInbox")
+	}
+
+	err = upgradeSolverNetOutbox(ctx, s, network, c)
+	if err != nil {
+		return errors.Wrap(err, "upgradeSolverNetOutbox")
+	}
+
+	err = upgradeSolverNetExecutor(ctx, s, network, c)
+	if err != nil {
+		return errors.Wrap(err, "upgradeSolverNetExecutor")
+	}
 
 	return nil
 }

--- a/e2e/cmd/admin.go
+++ b/e2e/cmd/admin.go
@@ -38,6 +38,7 @@ func newAdminCmd(def *app.Definition) *cobra.Command {
 		newUpgradeSolverNetOutboxCmd(def, &cfg),
 		newUpgradeSolverNetMiddlemanCmd(def, &cfg), // TODO(zodomo): Deprecate
 		newUpgradeSolverNetExecutorCmd(def, &cfg),
+		newUpgradeSolverNetAllCmd(def, &cfg),
 		newSetPortalFeeOracleV2Cmd(def, &cfg),
 		newAllowValidatorsCmd(def, &cfg),
 		newPlanUpgradeCmd(def, &cfg),
@@ -283,6 +284,18 @@ func newUpgradeSolverNetExecutorCmd(def *app.Definition, cfg *admin.Config) *cob
 		Short: "Upgrade the SolverNetExecutor contract.",
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			return admin.UpgradeSolverNetExecutor(cmd.Context(), *def, *cfg)
+		},
+	}
+
+	return cmd
+}
+
+func newUpgradeSolverNetAllCmd(def *app.Definition, cfg *admin.Config) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "upgrade-solvernet-all",
+		Short: "Upgrade all of the SolverNet contracts.",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return admin.UpgradeSolverNetAll(cmd.Context(), *def, *cfg)
 		},
 	}
 


### PR DESCRIPTION
Added a command to upgrade all SolverNet contract at once. This is primarily so we can run comprehensive dry runs of upgrading everything. We currently can't run them concurrently whenever there are situations where one command is dependent on another contract being upgraded prior. This allows us to simulate and run everything.

ref https://linear.app/omni-network/issue/OMNI-262