### PR TITLE
chore(e2e): new solver and monitor pins

### DIFF
--- a/e2e/manifests/mainnet.toml
+++ b/e2e/manifests/mainnet.toml
@@ -6,8 +6,8 @@ prometheus   = true
 
 pinned_halo_tag = "v0.14.1"
 pinned_relayer_tag = "07c4ac7"
-pinned_monitor_tag = "e704542"
-pinned_solver_tag = "e00e25c"
+pinned_monitor_tag = "6d1cdee"
+pinned_solver_tag = "6d1cdee"
 
 [node.validator01]
 [node.validator02]

--- a/e2e/manifests/omega.toml
+++ b/e2e/manifests/omega.toml
@@ -6,8 +6,8 @@ prometheus = true
 
 pinned_halo_tag = "v0.14.1"
 pinned_relayer_tag = "07c4ac7"
-pinned_monitor_tag = "b571d0c"
-pinned_solver_tag = "b571d0c"
+pinned_monitor_tag = "6d1cdee"
+pinned_solver_tag = "6d1cdee"
 
 [node.validator01]
 [node.validator02]


### PR DESCRIPTION
Updating pins for solver and monitor on omega and mainnet.

ref https://linear.app/omni-network/issue/OMNI-262