### PR TITLE
chore(e2e): pins for mantle inclusion

### DIFF
--- a/e2e/manifests/mainnet.toml
+++ b/e2e/manifests/mainnet.toml
@@ -6,8 +6,8 @@ prometheus   = true
 
 pinned_halo_tag = "v0.14.1"
 pinned_relayer_tag = "07c4ac7"
-pinned_monitor_tag = "6d1cdee"
-pinned_solver_tag = "6d1cdee"
+pinned_monitor_tag = "97880d5"
+pinned_solver_tag = "97880d5"
 
 [node.validator01]
 [node.validator02]

--- a/e2e/manifests/omega.toml
+++ b/e2e/manifests/omega.toml
@@ -6,8 +6,8 @@ prometheus = true
 
 pinned_halo_tag = "v0.14.1"
 pinned_relayer_tag = "07c4ac7"
-pinned_monitor_tag = "6d1cdee"
-pinned_solver_tag = "6d1cdee"
+pinned_monitor_tag = "97880d5"
+pinned_solver_tag = "97880d5"
 
 [node.validator01]
 [node.validator02]


### PR DESCRIPTION
Need to update monitor/solver to include mantle in the HL network.

ref https://linear.app/omni-network/issue/OMNI-262