### PR TITLE
chore(e2e/manifest): bump protected to v0-15-0

### DIFF
--- a/e2e/manifests/mainnet.toml
+++ b/e2e/manifests/mainnet.toml
@@ -4,7 +4,7 @@ public_chains = ["ethereum","arbitrum_one","base","optimism"]
 multi_omni_evms = true
 prometheus   = true
 
-pinned_halo_tag = "v0.14.1"
+pinned_halo_tag = "v0.15.0"
 pinned_relayer_tag = "07c4ac7"
 pinned_monitor_tag = "97880d5"
 pinned_solver_tag = "97880d5"

--- a/e2e/manifests/omega.toml
+++ b/e2e/manifests/omega.toml
@@ -4,7 +4,7 @@ public_chains = ["holesky","op_sepolia", "base_sepolia","arb_sepolia"]
 multi_omni_evms = true
 prometheus = true
 
-pinned_halo_tag = "v0.14.1"
+pinned_halo_tag = "v0.15.0"
 pinned_relayer_tag = "07c4ac7"
 pinned_monitor_tag = "97880d5"
 pinned_solver_tag = "97880d5"


### PR DESCRIPTION
Bump protected network halo to v0.15.0, in preparation for `3_drake` upgrade`.

issue: none