### PR TITLE
chore(docs): remove middleman update withExecAndTransfer

### DIFF
--- a/docs/docs/pages/guides/contracts-without-onbehalfof.mdx
+++ b/docs/docs/pages/guides/contracts-without-onbehalfof.mdx
@@ -107,7 +107,3 @@ const order = useOrder({
 </Callout>
 
 For tokenized positions with uknown, variable mint amounts, you can use the [`withExecAndTransfer`](/sdk/utils/withExecAndTransfer.mdx) utility.
-
-<Callout type="info">
-    Currently, `withExecAndTransfer` utility only supports native token deposits. Work on ERC20 support, and general UX improvements is ongoing.
-</Callout>

--- a/docs/docs/pages/sdk/faq.mdx
+++ b/docs/docs/pages/sdk/faq.mdx
@@ -18,9 +18,7 @@ Additionally, solvers have the ability to `reject` an order for various reasons 
 
 ### Are any changes necessary to my contracts?
 
-**No changes are required to your existing smart contracts.** The Omni system interacts *with* your contracts as they are deployed. Solvers simply call the functions you've already exposed on the destination chain, facilitated by the `SolverNetOutbox` and / or `SolverNetMiddleman`.
-
-Even smart contracts that don't expose `onBehalfOf` methods (which would enable the solver to deposit "on behalf of" a user) are compatible, because you can configure the `SolverNetMiddleman` to receive tokens and transfer them to the user afterwards. See the `withExecAndTransfer` hook for details.
+**No changes are required to your existing smart contracts.** The Omni system interacts *with* your contracts as they are deployed. Solvers simply call the functions you've already exposed on the destination chain, facilitated by the `SolverNetOutbox` and `SolverNetExecutor`.
 
 ### What is the flow at a smart contract level?
 

--- a/docs/docs/pages/sdk/utils/withExecAndTransfer.mdx
+++ b/docs/docs/pages/sdk/utils/withExecAndTransfer.mdx
@@ -3,23 +3,15 @@ sidebar_position: 1
 title: withExecAndTransfer
 ---
 
-import { Callout } from 'vocs/components'
-
 
 # `withExecAndTransfer`
 
-Use the `withExecAndTransfer` utility for interacting with destination contracts that accept native token deposits, and return dynamic tokenized positions.
+Use the `withExecAndTransfer` utility for interacting with destination contracts that accept token deposits, and return dynamic tokenized positions.
 
 For example:
 
 - Alice deposits 1 ETH into a contract
 - Alice receives some dynamic amount of vTokens (value tokens) in return
-
-
-<Callout type="info">
-    This utility only supports native token deposits.
-    Work is in progress to support ERC20 token deposits.
-</Callout>
 
 
 


### PR DESCRIPTION
Small docs fixes

- remove middleman references from faq
- remove caveat that withExecAndTransfer only works for native deposits (it supports erc20 deposits now)

issue: none
