### PR TITLE
refactor(core): apply zod validation

### DIFF
--- a/sdk/examples/react/src/App.tsx
+++ b/sdk/examples/react/src/App.tsx
@@ -104,7 +104,7 @@ function Order() {
     destChainId: holesky.id,
     deposit: { amount: parseEther('0.1') },
     expense: {
-      amount: parseEther('0.199'),
+      amount: parseEther('0.099'),
       spender: zeroAddress,
     },
     calls: [{ target: account.address ?? '0x', value: parseEther('0.099') }],

--- a/sdk/examples/react/src/App.tsx
+++ b/sdk/examples/react/src/App.tsx
@@ -80,11 +80,11 @@ function Quote() {
           </div>
           <div>
             quote.deposit.amount:{' '}
-            {quote.isSuccess ? `${formatEther(quote.deposit.amount)} ETH` : ""}
+            {quote.isSuccess ? `${formatEther(quote.deposit.amount)} ETH` : ''}
           </div>
           <div>
             quote.expense.amount:{' '}
-            {quote.isSuccess ? `${formatEther(quote.expense.amount)} ETH` : ""}
+            {quote.isSuccess ? `${formatEther(quote.expense.amount)} ETH` : ''}
           </div>
         </>
       ) : (
@@ -141,27 +141,36 @@ function Order() {
                 target="_blank"
                 rel="noopener noreferrer"
                 href={`https://sepolia.basescan.org/tx/${encodeURIComponent(
-                  order.txHash
+                  order.txHash,
                 )}`}
               >
                 <code>{order.txHash}</code>
               </a>
             )}
           </div>
-          <div>isError: <code>{JSON.stringify(order.isError)}</code></div>
-          <div>error: <pre>{order.error?.message}</pre></div>
-          <div>orderId: <code>{order.orderId}</code></div>
-          <div>destTxHash: {order.destTxHash && (
+          <div>
+            isError: <code>{JSON.stringify(order.isError)}</code>
+          </div>
+          <div>
+            error: <pre>{order.error?.message}</pre>
+          </div>
+          <div>
+            orderId: <code>{order.orderId}</code>
+          </div>
+          <div>
+            destTxHash:{' '}
+            {order.destTxHash && (
               <a
                 target="_blank"
                 rel="noopener noreferrer"
                 href={`https://holesky.etherscan.io/tx/${encodeURIComponent(
-                  order.destTxHash
+                  order.destTxHash,
                 )}`}
               >
                 <code>{order.destTxHash}</code>
               </a>
-            )}</div>
+            )}
+          </div>
           <button
             onClick={() => order.open()}
             disabled={

--- a/sdk/examples/react/src/App.tsx
+++ b/sdk/examples/react/src/App.tsx
@@ -104,7 +104,7 @@ function Order() {
     destChainId: holesky.id,
     deposit: { amount: parseEther('0.1') },
     expense: {
-      amount: parseEther('0.099'),
+      amount: parseEther('0.199'),
       spender: zeroAddress,
     },
     calls: [{ target: account.address ?? '0x', value: parseEther('0.099') }],

--- a/sdk/packages/core/package.json
+++ b/sdk/packages/core/package.json
@@ -28,7 +28,8 @@
     "node": ">=22.x"
   },
   "dependencies": {
-    "viem": "catalog:"
+    "viem": "catalog:",
+    "zod": "^3.25.7"
   },
   "devDependencies": {
     "typescript": "^5.7.2",

--- a/sdk/packages/core/src/api/getQuote.ts
+++ b/sdk/packages/core/src/api/getQuote.ts
@@ -1,4 +1,4 @@
-import { string, z } from 'zod'
+import { string, z } from 'zod/v4-mini'
 import { fromHex, Hex, zeroAddress } from 'viem'
 import { fetchJSON } from '../internal/api.js'
 import type { Environment } from '../types/config.js'

--- a/sdk/packages/core/src/api/getQuote.ts
+++ b/sdk/packages/core/src/api/getQuote.ts
@@ -1,5 +1,5 @@
-import { z } from 'zod'
-import { fromHex, zeroAddress } from 'viem'
+import { string, z } from 'zod'
+import { fromHex, Hex, zeroAddress } from 'viem'
 import { fetchJSON } from '../internal/api.js'
 import type { Environment } from '../types/config.js'
 import type { Quote, Quoteable } from '../types/quote.js'
@@ -11,11 +11,11 @@ import { address, hex } from '../schema/types.js'
 export const quoteResponseSchema = z.object({
   deposit: z.object({
     token: address(),
-    amount: hex(),
+    amount: z.union([hex(), string()]),
   }),
   expense: z.object({
     token: address(),
-    amount: hex(),
+    amount: z.union([hex(), string()]),
   }),
 })
 
@@ -74,8 +74,8 @@ export async function getQuote(quote: GetQuoteParameters): Promise<Quote> {
   const { deposit, expense } = json
 
   return {
-    deposit: { ...deposit, amount: fromHex(deposit.amount, 'bigint') },
-    expense: { ...expense, amount: fromHex(expense.amount, 'bigint') },
+    deposit: { ...deposit, amount: fromHex(deposit.amount as Hex, 'bigint') },
+    expense: { ...expense, amount: fromHex(expense.amount as Hex, 'bigint') },
   } satisfies Quote
 }
 

--- a/sdk/packages/core/src/api/getQuote.ts
+++ b/sdk/packages/core/src/api/getQuote.ts
@@ -1,12 +1,12 @@
+import { type Hex, fromHex, zeroAddress } from 'viem'
 import { string, z } from 'zod/v4-mini'
-import { fromHex, Hex, zeroAddress } from 'viem'
 import { fetchJSON } from '../internal/api.js'
+import { address, hex } from '../schema/types.js'
 import type { Environment } from '../types/config.js'
 import type { Quote, Quoteable } from '../types/quote.js'
 import type { Prettify } from '../types/utils.js'
 import { getApiUrl } from '../utils/getApiUrl.js'
 import { toJSON } from '../utils/toJSON.js'
-import { address, hex } from '../schema/types.js'
 
 export const quoteResponseSchema = z.object({
   deposit: z.object({

--- a/sdk/packages/core/src/api/validateOrder.ts
+++ b/sdk/packages/core/src/api/validateOrder.ts
@@ -119,24 +119,43 @@ const isValidateRes = (json: unknown): json is ValidationResponse => {
   )
 }
 
+// asserts a json response is AcceptedResult
+export function isAcceptedRes(json: unknown): json is AcceptedResult {
+  return acceptedResponseSchema.safeParse(json).success
+}
+
+// asserts a json response is RejectedResult
+export function isRejectedRes(
+  json: unknown,
+): json is z.infer<typeof rejectedResponseSchema> {
+  return rejectedResponseSchema.safeParse(json).success
+}
+
+// asserts a json response is ErrorResult
+export function isErrorRes(
+  json: unknown,
+): json is z.infer<typeof errorResponseSchema> {
+  return errorResponseSchema.safeParse(json).success
+}
+
 export type AcceptedResult = z.infer<typeof acceptedResponseSchema>
 
 export function assertAcceptedResult(
   res: ValidationResponse,
 ): asserts res is AcceptedResult {
   // if the response is accepted
-  if (acceptedResponseSchema.safeParse(res).success) {
+  if (isAcceptedRes(res)) {
     return
   }
 
   // if the response is an error
-  if (errorResponseSchema.safeParse(res).success) {
+  if (isErrorRes(res)) {
     const { error } = errorResponseSchema.parse(res)
     throw new ValidateOrderError(error.message, `Code ${error.code}`)
   }
 
   // if the response is rejected
-  if (rejectedResponseSchema.safeParse(res).success) {
+  if (isRejectedRes(res)) {
     const { rejectDescription, rejectReason } =
       rejectedResponseSchema.parse(res)
     throw new ValidateOrderError(

--- a/sdk/packages/core/src/api/validateOrder.ts
+++ b/sdk/packages/core/src/api/validateOrder.ts
@@ -1,5 +1,5 @@
-import { z } from 'zod/v4-mini'
 import { encodeFunctionData, zeroAddress } from 'viem'
+import { z } from 'zod/v4-mini'
 import { ValidateOrderError } from '../errors/base.js'
 import { fetchJSON } from '../internal/api.js'
 import type { OptionalAbis } from '../types/abi.js'
@@ -22,7 +22,7 @@ const rejectedResponseSchema = z.object({
   rejected: z.literal(true),
   rejectReason: z.string(),
   rejectDescription: z.string(),
-}) 
+})
 
 const errorResponseSchema = z.object({
   error: z.object({
@@ -35,7 +35,7 @@ export type ValidateOrderParameters<abis extends OptionalAbis> = Order<abis> & {
   environment?: Environment | string
 }
 
-export type ValidationResponse = 
+export type ValidationResponse =
   | z.infer<typeof acceptedResponseSchema>
   | z.infer<typeof rejectedResponseSchema>
   | z.infer<typeof errorResponseSchema>
@@ -124,24 +124,21 @@ export type AcceptedResult = z.infer<typeof acceptedResponseSchema>
 export function assertAcceptedResult(
   res: ValidationResponse,
 ): asserts res is AcceptedResult {
-
   // if the response is accepted
-  if(acceptedResponseSchema.safeParse(res).success) {
-    return;
+  if (acceptedResponseSchema.safeParse(res).success) {
+    return
   }
 
   // if the response is an error
   if (errorResponseSchema.safeParse(res).success) {
-    const { error } = errorResponseSchema.parse(res);
-    throw new ValidateOrderError(
-      error.message,
-      `Code ${error.code}`,
-    )
+    const { error } = errorResponseSchema.parse(res)
+    throw new ValidateOrderError(error.message, `Code ${error.code}`)
   }
 
   // if the response is rejected
   if (rejectedResponseSchema.safeParse(res).success) {
-    const { rejectDescription, rejectReason } = rejectedResponseSchema.parse(res);
+    const { rejectDescription, rejectReason } =
+      rejectedResponseSchema.parse(res)
     throw new ValidateOrderError(
       rejectDescription ?? 'Server rejected order',
       rejectReason,
@@ -152,5 +149,5 @@ export function assertAcceptedResult(
   throw new ValidateOrderError(
     'Unexpected response from server',
     'Unknown error',
-  );
+  )
 }

--- a/sdk/packages/core/src/api/validateOrder.ts
+++ b/sdk/packages/core/src/api/validateOrder.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod'
+import { z } from 'zod/v4-mini'
 import { encodeFunctionData, zeroAddress } from 'viem'
 import { ValidateOrderError } from '../errors/base.js'
 import { fetchJSON } from '../internal/api.js'
@@ -10,15 +10,15 @@ import { toJSON } from '../utils/toJSON.js'
 
 const acceptedResponseSchema = z.object({
   accepted: z.literal(true),
-  rejectCode: z.literal(0).optional(),
-  rejected: z.literal(false).optional(),
-  rejectReason: z.literal("").optional(),
-  rejectDescription: z.literal("").optional(),
+  rejectCode: z.optional(z.literal(0)),
+  rejected: z.optional(z.literal(false)),
+  rejectReason: z.optional(z.literal('')),
+  rejectDescription: z.optional(z.literal('')),
 })
 
 const rejectedResponseSchema = z.object({
-  accepted: z.literal(false).optional(),
-  rejectCode: z.number().optional(),
+  accepted: z.optional(z.literal(false)),
+  rejectCode: z.optional(z.number()),
   rejected: z.literal(true),
   rejectReason: z.string(),
   rejectDescription: z.string(),

--- a/sdk/packages/core/src/api/validateOrder.ts
+++ b/sdk/packages/core/src/api/validateOrder.ts
@@ -14,26 +14,22 @@ const acceptedResponseSchema = z.object({
   rejected: z.literal(false).optional(),
   rejectReason: z.literal("").optional(),
   rejectDescription: z.literal("").optional(),
-}).strict()
+})
 
-const rejectedResponseSchema = z
-  .object({
-    accepted: z.literal(false).optional(),
-    rejectCode: z.number().optional(),
-    rejected: z.literal(true),
-    rejectReason: z.string(),
-    rejectDescription: z.string(),
-  })
-  .strict()
+const rejectedResponseSchema = z.object({
+  accepted: z.literal(false).optional(),
+  rejectCode: z.number().optional(),
+  rejected: z.literal(true),
+  rejectReason: z.string(),
+  rejectDescription: z.string(),
+}) 
 
-const errorResponseSchema = z
-  .object({
-    error: z.object({
-      code: z.number(),
-      message: z.string(),
-    }),
-  })
-  .strict()
+const errorResponseSchema = z.object({
+  error: z.object({
+    code: z.number(),
+    message: z.string(),
+  }),
+})
 
 export type ValidateOrderParameters<abis extends OptionalAbis> = Order<abis> & {
   environment?: Environment | string

--- a/sdk/packages/core/src/api/validateOrder.ts
+++ b/sdk/packages/core/src/api/validateOrder.ts
@@ -147,5 +147,10 @@ export function assertAcceptedResult(
       rejectReason,
     )
   }
-  
+
+  // fallback: no matching schema
+  throw new ValidateOrderError(
+    'Unexpected response from server',
+    'Unknown error',
+  );
 }

--- a/sdk/packages/core/src/internal/api.ts
+++ b/sdk/packages/core/src/internal/api.ts
@@ -1,5 +1,5 @@
-import { version } from '../version.js'
 import { z } from 'zod/v4-mini'
+import { version } from '../version.js'
 
 const jsonErrorSchema = z.object({
   code: z.number(),

--- a/sdk/packages/core/src/internal/api.ts
+++ b/sdk/packages/core/src/internal/api.ts
@@ -1,11 +1,14 @@
 import { version } from '../version.js'
+import { z } from 'zod'
+
+const jsonErrorSchema = z.object({
+  code: z.number(),
+  status: z.string(),
+  message: z.string(),
+})
 
 // JSONError is a json error response from the solver api
-export type JSONError = {
-  code: number
-  status: string
-  message: string
-}
+export type JSONError = z.infer<typeof jsonErrorSchema>
 
 // FetchJSONError is a JSONError or a generic Error (e.g. network error)
 export type FetchJSONError = JSONError | Error
@@ -22,20 +25,15 @@ export async function fetchJSON(
   const json = await res.json()
 
   if (!res.ok) {
-    if (!isJSONError(json.error)) new Error(`${res.status} ${res.statusText}`)
+    if (!isJSONError(json.error)) {
+      throw new Error(`${res.status} ${res.statusText}`)
+    }
     throw json.error
   }
 
   return json
 }
 
-// TODO: use zod
 function isJSONError(error: unknown): error is JSONError {
-  const err = error as JSONError
-  return (
-    err != null &&
-    typeof err.code === 'number' &&
-    typeof err.status === 'string' &&
-    typeof err.message === 'string'
-  )
+  return jsonErrorSchema.safeParse(error).success
 }

--- a/sdk/packages/core/src/internal/api.ts
+++ b/sdk/packages/core/src/internal/api.ts
@@ -1,5 +1,5 @@
 import { version } from '../version.js'
-import { z } from 'zod'
+import { z } from 'zod/v4-mini'
 
 const jsonErrorSchema = z.object({
   code: z.number(),

--- a/sdk/packages/core/src/schema/types.ts
+++ b/sdk/packages/core/src/schema/types.ts
@@ -1,0 +1,16 @@
+import type { Address, Hex } from 'viem'
+import { z, ZodType } from 'zod'
+
+export const hex = (): ZodType<Hex> =>
+  z
+  .string()
+  .refine((val): val is Hex => /^0x[0-9a-fA-F]+$/.test(val), {
+    message: 'Invalid hex string: must start with 0x and contain only hex characters',
+  }) as unknown as ZodType<Hex>
+
+export const address = (): ZodType<Address> =>
+  z
+  .string()
+  .refine((val): val is Address => /^0x[0-9a-fA-F]{40}$/.test(val), {
+    message: 'Invalid address: must start with 0x and be 20 bytes long',
+  }) as unknown as ZodType<Address>

--- a/sdk/packages/core/src/schema/types.ts
+++ b/sdk/packages/core/src/schema/types.ts
@@ -1,15 +1,16 @@
-import { z } from 'zod/v4-mini';
-import type { Address, Hex } from 'viem';
+import type { Address, Hex } from 'viem'
+import { z } from 'zod/v4-mini'
 export const hex = () =>
   z.string().check(
     z.regex(/^0x[0-9a-fA-F]+$/, {
-      message: 'Invalid hex string: must start with 0x and contain only hex characters',
-    })
-  ) as z.ZodMiniType<Hex>;
+      message:
+        'Invalid hex string: must start with 0x and contain only hex characters',
+    }),
+  ) as z.ZodMiniType<Hex>
 
 export const address = () =>
   z.string().check(
     z.regex(/^0x[0-9a-fA-F]{40}$/, {
       message: 'Invalid address: must start with 0x and be 20 bytes long',
-    })
-  ) as z.ZodMiniType<Address>;
+    }),
+  ) as z.ZodMiniType<Address>

--- a/sdk/packages/core/src/schema/types.ts
+++ b/sdk/packages/core/src/schema/types.ts
@@ -1,16 +1,15 @@
-import type { Address, Hex } from 'viem'
-import { z, ZodType } from 'zod'
+import { z } from 'zod/v4-mini';
+import type { Address, Hex } from 'viem';
+export const hex = () =>
+  z.string().check(
+    z.regex(/^0x[0-9a-fA-F]+$/, {
+      message: 'Invalid hex string: must start with 0x and contain only hex characters',
+    })
+  ) as z.ZodMiniType<Hex>;
 
-export const hex = (): ZodType<Hex> =>
-  z
-  .string()
-  .refine((val): val is Hex => /^0x[0-9a-fA-F]+$/.test(val), {
-    message: 'Invalid hex string: must start with 0x and contain only hex characters',
-  }) as unknown as ZodType<Hex>
-
-export const address = (): ZodType<Address> =>
-  z
-  .string()
-  .refine((val): val is Address => /^0x[0-9a-fA-F]{40}$/.test(val), {
-    message: 'Invalid address: must start with 0x and be 20 bytes long',
-  }) as unknown as ZodType<Address>
+export const address = () =>
+  z.string().check(
+    z.regex(/^0x[0-9a-fA-F]{40}$/, {
+      message: 'Invalid address: must start with 0x and be 20 bytes long',
+    })
+  ) as z.ZodMiniType<Address>;

--- a/sdk/packages/react/src/hooks/useValidateOrder.ts
+++ b/sdk/packages/react/src/hooks/useValidateOrder.ts
@@ -4,7 +4,7 @@ import type {
   Order,
   ValidationResponse,
 } from '@omni-network/core'
-import { validateOrder } from '@omni-network/core'
+import { isAcceptedRes, isRejectedRes, validateOrder } from '@omni-network/core'
 import { type UseQueryResult, useQuery } from '@tanstack/react-query'
 import { useMemo } from 'react'
 import { useOmniContext } from '../context/omni.js'
@@ -75,9 +75,8 @@ const useResult = (
   useMemo(() => {
     if (q.isError) return { status: 'error', error: q.error }
     if (q.isPending) return { status: 'pending' }
-    if (q.data.accepted) return { status: 'accepted' }
-
-    if (q.data.rejected) {
+    if (isAcceptedRes(q.data)) return { status: 'accepted' }
+    if (isRejectedRes(q.data)) {
       return {
         status: 'rejected',
         // TODO validation on rejections

--- a/sdk/pnpm-lock.yaml
+++ b/sdk/pnpm-lock.yaml
@@ -58,7 +58,7 @@ importers:
         version: link:../../packages/core
       viem:
         specifier: 'catalog:'
-        version: 2.28.1(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.22.4)
+        version: 2.28.1(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.25.7)
     devDependencies:
       typescript:
         specifier: ~5.7.2
@@ -83,10 +83,10 @@ importers:
         version: 18.3.1(react@18.3.1)
       viem:
         specifier: 'catalog:'
-        version: 2.28.1(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.22.4)
+        version: 2.28.1(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.25.7)
       wagmi:
         specifier: 'catalog:'
-        version: 2.15.1(@tanstack/query-core@5.75.0)(@tanstack/react-query@5.75.0(react@18.3.1))(@types/react@18.3.20)(bufferutil@4.0.9)(react@18.3.1)(typescript@5.7.3)(utf-8-validate@5.0.10)(viem@2.28.1(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.22.4))(zod@3.22.4)
+        version: 2.15.1(@tanstack/query-core@5.75.0)(@tanstack/react-query@5.75.0(react@18.3.1))(@types/react@18.3.20)(bufferutil@4.0.9)(react@18.3.1)(typescript@5.7.3)(utf-8-validate@5.0.10)(viem@2.28.1(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.25.7))(zod@3.25.7)
     devDependencies:
       '@types/react':
         specifier: 'catalog:'
@@ -129,10 +129,10 @@ importers:
         version: 18.3.1(react@18.3.1)
       viem:
         specifier: 'catalog:'
-        version: 2.28.1(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.22.4)
+        version: 2.28.1(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.25.7)
       wagmi:
         specifier: 'catalog:'
-        version: 2.15.1(@tanstack/query-core@5.75.0)(@tanstack/react-query@5.75.0(react@18.3.1))(@types/react@18.3.20)(bufferutil@4.0.9)(react@18.3.1)(typescript@5.7.3)(utf-8-validate@5.0.10)(viem@2.28.1(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.22.4))(zod@3.22.4)
+        version: 2.15.1(@tanstack/query-core@5.75.0)(@tanstack/react-query@5.75.0(react@18.3.1))(@types/react@18.3.20)(bufferutil@4.0.9)(react@18.3.1)(typescript@5.7.3)(utf-8-validate@5.0.10)(viem@2.28.1(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.25.7))(zod@3.25.7)
     devDependencies:
       '@omni-network/test-utils':
         specifier: workspace:*
@@ -169,7 +169,10 @@ importers:
     dependencies:
       viem:
         specifier: 'catalog:'
-        version: 2.28.1(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.22.4)
+        version: 2.28.1(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.25.7)
+      zod:
+        specifier: ^3.25.7
+        version: 3.25.7
     devDependencies:
       typescript:
         specifier: ^5.7.2
@@ -191,10 +194,10 @@ importers:
         version: 5.75.0(react@18.3.1)
       viem:
         specifier: 2.x
-        version: 2.28.1(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.22.4)
+        version: 2.28.1(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.25.7)
       wagmi:
         specifier: 2.x
-        version: 2.15.1(@tanstack/query-core@5.75.0)(@tanstack/react-query@5.75.0(react@18.3.1))(@types/react@18.3.20)(bufferutil@4.0.9)(react@18.3.1)(typescript@5.7.3)(utf-8-validate@5.0.10)(viem@2.28.1(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.22.4))(zod@3.22.4)
+        version: 2.15.1(@tanstack/query-core@5.75.0)(@tanstack/react-query@5.75.0(react@18.3.1))(@types/react@18.3.20)(bufferutil@4.0.9)(react@18.3.1)(typescript@5.7.3)(utf-8-validate@5.0.10)(viem@2.28.1(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.25.7))(zod@3.25.7)
     devDependencies:
       '@testing-library/dom':
         specifier: 'catalog:'
@@ -234,7 +237,7 @@ importers:
     dependencies:
       viem:
         specifier: 'catalog:'
-        version: 2.28.1(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.22.4)
+        version: 2.28.1(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.25.7)
     devDependencies:
       '@types/node':
         specifier: ^22.13.10
@@ -2765,6 +2768,9 @@ packages:
   zod@3.22.4:
     resolution: {integrity: sha512-iC+8Io04lddc+mVqQ9AZ7OQ2MrUKGN+oIQyq1vemgt46jwCwLfhq7/pwnBnNXXXZb8VTVLKwp9EDkx+ryxIWmg==}
 
+  zod@3.25.7:
+    resolution: {integrity: sha512-YGdT1cVRmKkOg6Sq7vY7IkxdphySKnXhaUmFI4r4FcuFVNgpCb9tZfNwXbT6BPjD5oz0nubFsoo9pIqKrDcCvg==}
+
   zustand@5.0.0:
     resolution: {integrity: sha512-LE+VcmbartOPM+auOjCCLQOsQ05zUTp8RkgwRzefUk+2jISdMMFnxvyTjA4YNWr5ZGXYbVsEMZosttuxUBkojQ==}
     engines: {node: '>=12.20.0'}
@@ -3479,13 +3485,24 @@ snapshots:
       - utf-8-validate
       - zod
 
-  '@reown/appkit-controllers@1.7.3(@types/react@18.3.20)(bufferutil@4.0.9)(react@18.3.1)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.22.4)':
+  '@reown/appkit-common@1.7.3(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.25.7)':
     dependencies:
-      '@reown/appkit-common': 1.7.3(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.22.4)
+      big.js: 6.2.2
+      dayjs: 1.11.13
+      viem: 2.28.1(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.25.7)
+    transitivePeerDependencies:
+      - bufferutil
+      - typescript
+      - utf-8-validate
+      - zod
+
+  '@reown/appkit-controllers@1.7.3(@types/react@18.3.20)(bufferutil@4.0.9)(react@18.3.1)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.25.7)':
+    dependencies:
+      '@reown/appkit-common': 1.7.3(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.25.7)
       '@reown/appkit-wallet': 1.7.3(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)
-      '@walletconnect/universal-provider': 2.19.2(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.22.4)
+      '@walletconnect/universal-provider': 2.19.2(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.25.7)
       valtio: 1.13.2(@types/react@18.3.20)(react@18.3.1)
-      viem: 2.28.1(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.22.4)
+      viem: 2.28.1(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.25.7)
     transitivePeerDependencies:
       - '@azure/app-configuration'
       - '@azure/cosmos'
@@ -3517,12 +3534,12 @@ snapshots:
     dependencies:
       buffer: 6.0.3
 
-  '@reown/appkit-scaffold-ui@1.7.3(@types/react@18.3.20)(bufferutil@4.0.9)(react@18.3.1)(typescript@5.7.3)(utf-8-validate@5.0.10)(valtio@1.13.2(@types/react@18.3.20)(react@18.3.1))(zod@3.22.4)':
+  '@reown/appkit-scaffold-ui@1.7.3(@types/react@18.3.20)(bufferutil@4.0.9)(react@18.3.1)(typescript@5.7.3)(utf-8-validate@5.0.10)(valtio@1.13.2(@types/react@18.3.20)(react@18.3.1))(zod@3.25.7)':
     dependencies:
-      '@reown/appkit-common': 1.7.3(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.22.4)
-      '@reown/appkit-controllers': 1.7.3(@types/react@18.3.20)(bufferutil@4.0.9)(react@18.3.1)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.22.4)
-      '@reown/appkit-ui': 1.7.3(@types/react@18.3.20)(bufferutil@4.0.9)(react@18.3.1)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.22.4)
-      '@reown/appkit-utils': 1.7.3(@types/react@18.3.20)(bufferutil@4.0.9)(react@18.3.1)(typescript@5.7.3)(utf-8-validate@5.0.10)(valtio@1.13.2(@types/react@18.3.20)(react@18.3.1))(zod@3.22.4)
+      '@reown/appkit-common': 1.7.3(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.25.7)
+      '@reown/appkit-controllers': 1.7.3(@types/react@18.3.20)(bufferutil@4.0.9)(react@18.3.1)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.25.7)
+      '@reown/appkit-ui': 1.7.3(@types/react@18.3.20)(bufferutil@4.0.9)(react@18.3.1)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.25.7)
+      '@reown/appkit-utils': 1.7.3(@types/react@18.3.20)(bufferutil@4.0.9)(react@18.3.1)(typescript@5.7.3)(utf-8-validate@5.0.10)(valtio@1.13.2(@types/react@18.3.20)(react@18.3.1))(zod@3.25.7)
       '@reown/appkit-wallet': 1.7.3(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)
       lit: 3.1.0
     transitivePeerDependencies:
@@ -3553,10 +3570,10 @@ snapshots:
       - valtio
       - zod
 
-  '@reown/appkit-ui@1.7.3(@types/react@18.3.20)(bufferutil@4.0.9)(react@18.3.1)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.22.4)':
+  '@reown/appkit-ui@1.7.3(@types/react@18.3.20)(bufferutil@4.0.9)(react@18.3.1)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.25.7)':
     dependencies:
-      '@reown/appkit-common': 1.7.3(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.22.4)
-      '@reown/appkit-controllers': 1.7.3(@types/react@18.3.20)(bufferutil@4.0.9)(react@18.3.1)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.22.4)
+      '@reown/appkit-common': 1.7.3(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.25.7)
+      '@reown/appkit-controllers': 1.7.3(@types/react@18.3.20)(bufferutil@4.0.9)(react@18.3.1)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.25.7)
       '@reown/appkit-wallet': 1.7.3(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)
       lit: 3.1.0
       qrcode: 1.5.3
@@ -3587,16 +3604,16 @@ snapshots:
       - utf-8-validate
       - zod
 
-  '@reown/appkit-utils@1.7.3(@types/react@18.3.20)(bufferutil@4.0.9)(react@18.3.1)(typescript@5.7.3)(utf-8-validate@5.0.10)(valtio@1.13.2(@types/react@18.3.20)(react@18.3.1))(zod@3.22.4)':
+  '@reown/appkit-utils@1.7.3(@types/react@18.3.20)(bufferutil@4.0.9)(react@18.3.1)(typescript@5.7.3)(utf-8-validate@5.0.10)(valtio@1.13.2(@types/react@18.3.20)(react@18.3.1))(zod@3.25.7)':
     dependencies:
-      '@reown/appkit-common': 1.7.3(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.22.4)
-      '@reown/appkit-controllers': 1.7.3(@types/react@18.3.20)(bufferutil@4.0.9)(react@18.3.1)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.22.4)
+      '@reown/appkit-common': 1.7.3(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.25.7)
+      '@reown/appkit-controllers': 1.7.3(@types/react@18.3.20)(bufferutil@4.0.9)(react@18.3.1)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.25.7)
       '@reown/appkit-polyfills': 1.7.3
       '@reown/appkit-wallet': 1.7.3(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)
       '@walletconnect/logger': 2.1.2
-      '@walletconnect/universal-provider': 2.19.2(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.22.4)
+      '@walletconnect/universal-provider': 2.19.2(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.25.7)
       valtio: 1.13.2(@types/react@18.3.20)(react@18.3.1)
-      viem: 2.28.1(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.22.4)
+      viem: 2.28.1(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.25.7)
     transitivePeerDependencies:
       - '@azure/app-configuration'
       - '@azure/cosmos'
@@ -3635,20 +3652,20 @@ snapshots:
       - typescript
       - utf-8-validate
 
-  '@reown/appkit@1.7.3(@types/react@18.3.20)(bufferutil@4.0.9)(react@18.3.1)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.22.4)':
+  '@reown/appkit@1.7.3(@types/react@18.3.20)(bufferutil@4.0.9)(react@18.3.1)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.25.7)':
     dependencies:
-      '@reown/appkit-common': 1.7.3(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.22.4)
-      '@reown/appkit-controllers': 1.7.3(@types/react@18.3.20)(bufferutil@4.0.9)(react@18.3.1)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.22.4)
+      '@reown/appkit-common': 1.7.3(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.25.7)
+      '@reown/appkit-controllers': 1.7.3(@types/react@18.3.20)(bufferutil@4.0.9)(react@18.3.1)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.25.7)
       '@reown/appkit-polyfills': 1.7.3
-      '@reown/appkit-scaffold-ui': 1.7.3(@types/react@18.3.20)(bufferutil@4.0.9)(react@18.3.1)(typescript@5.7.3)(utf-8-validate@5.0.10)(valtio@1.13.2(@types/react@18.3.20)(react@18.3.1))(zod@3.22.4)
-      '@reown/appkit-ui': 1.7.3(@types/react@18.3.20)(bufferutil@4.0.9)(react@18.3.1)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.22.4)
-      '@reown/appkit-utils': 1.7.3(@types/react@18.3.20)(bufferutil@4.0.9)(react@18.3.1)(typescript@5.7.3)(utf-8-validate@5.0.10)(valtio@1.13.2(@types/react@18.3.20)(react@18.3.1))(zod@3.22.4)
+      '@reown/appkit-scaffold-ui': 1.7.3(@types/react@18.3.20)(bufferutil@4.0.9)(react@18.3.1)(typescript@5.7.3)(utf-8-validate@5.0.10)(valtio@1.13.2(@types/react@18.3.20)(react@18.3.1))(zod@3.25.7)
+      '@reown/appkit-ui': 1.7.3(@types/react@18.3.20)(bufferutil@4.0.9)(react@18.3.1)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.25.7)
+      '@reown/appkit-utils': 1.7.3(@types/react@18.3.20)(bufferutil@4.0.9)(react@18.3.1)(typescript@5.7.3)(utf-8-validate@5.0.10)(valtio@1.13.2(@types/react@18.3.20)(react@18.3.1))(zod@3.25.7)
       '@reown/appkit-wallet': 1.7.3(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)
       '@walletconnect/types': 2.19.2
-      '@walletconnect/universal-provider': 2.19.2(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.22.4)
+      '@walletconnect/universal-provider': 2.19.2(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.25.7)
       bs58: 6.0.0
       valtio: 1.13.2(@types/react@18.3.20)(react@18.3.1)
-      viem: 2.28.1(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.22.4)
+      viem: 2.28.1(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.25.7)
     transitivePeerDependencies:
       - '@azure/app-configuration'
       - '@azure/cosmos'
@@ -3736,9 +3753,9 @@ snapshots:
   '@rollup/rollup-win32-x64-msvc@4.40.1':
     optional: true
 
-  '@safe-global/safe-apps-provider@0.18.6(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.22.4)':
+  '@safe-global/safe-apps-provider@0.18.6(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.25.7)':
     dependencies:
-      '@safe-global/safe-apps-sdk': 9.1.0(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.22.4)
+      '@safe-global/safe-apps-sdk': 9.1.0(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.25.7)
       events: 3.3.0
     transitivePeerDependencies:
       - bufferutil
@@ -3746,10 +3763,10 @@ snapshots:
       - utf-8-validate
       - zod
 
-  '@safe-global/safe-apps-sdk@9.1.0(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.22.4)':
+  '@safe-global/safe-apps-sdk@9.1.0(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.25.7)':
     dependencies:
       '@safe-global/safe-gateway-typescript-sdk': 3.23.1
-      viem: 2.28.1(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.22.4)
+      viem: 2.28.1(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.25.7)
     transitivePeerDependencies:
       - bufferutil
       - typescript
@@ -3941,16 +3958,16 @@ snapshots:
       loupe: 3.1.3
       tinyrainbow: 2.0.0
 
-  '@wagmi/connectors@5.8.0(@types/react@18.3.20)(@wagmi/core@2.17.0(@tanstack/query-core@5.75.0)(@types/react@18.3.20)(react@18.3.1)(typescript@5.7.3)(use-sync-external-store@1.4.0(react@18.3.1))(viem@2.28.1(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.22.4)))(bufferutil@4.0.9)(react@18.3.1)(typescript@5.7.3)(utf-8-validate@5.0.10)(viem@2.28.1(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.22.4))(zod@3.22.4)':
+  '@wagmi/connectors@5.8.0(@types/react@18.3.20)(@wagmi/core@2.17.0(@tanstack/query-core@5.75.0)(@types/react@18.3.20)(react@18.3.1)(typescript@5.7.3)(use-sync-external-store@1.4.0(react@18.3.1))(viem@2.28.1(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.25.7)))(bufferutil@4.0.9)(react@18.3.1)(typescript@5.7.3)(utf-8-validate@5.0.10)(viem@2.28.1(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.25.7))(zod@3.25.7)':
     dependencies:
       '@coinbase/wallet-sdk': 4.3.0
       '@metamask/sdk': 0.32.0(bufferutil@4.0.9)(utf-8-validate@5.0.10)
-      '@safe-global/safe-apps-provider': 0.18.6(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.22.4)
-      '@safe-global/safe-apps-sdk': 9.1.0(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.22.4)
-      '@wagmi/core': 2.17.0(@tanstack/query-core@5.75.0)(@types/react@18.3.20)(react@18.3.1)(typescript@5.7.3)(use-sync-external-store@1.4.0(react@18.3.1))(viem@2.28.1(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.22.4))
-      '@walletconnect/ethereum-provider': 2.20.0(@types/react@18.3.20)(bufferutil@4.0.9)(react@18.3.1)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.22.4)
+      '@safe-global/safe-apps-provider': 0.18.6(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.25.7)
+      '@safe-global/safe-apps-sdk': 9.1.0(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.25.7)
+      '@wagmi/core': 2.17.0(@tanstack/query-core@5.75.0)(@types/react@18.3.20)(react@18.3.1)(typescript@5.7.3)(use-sync-external-store@1.4.0(react@18.3.1))(viem@2.28.1(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.25.7))
+      '@walletconnect/ethereum-provider': 2.20.0(@types/react@18.3.20)(bufferutil@4.0.9)(react@18.3.1)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.25.7)
       cbw-sdk: '@coinbase/wallet-sdk@3.9.3'
-      viem: 2.28.1(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.22.4)
+      viem: 2.28.1(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.25.7)
     optionalDependencies:
       typescript: 5.7.3
     transitivePeerDependencies:
@@ -3980,11 +3997,11 @@ snapshots:
       - utf-8-validate
       - zod
 
-  '@wagmi/core@2.17.0(@tanstack/query-core@5.75.0)(@types/react@18.3.20)(react@18.3.1)(typescript@5.7.3)(use-sync-external-store@1.4.0(react@18.3.1))(viem@2.28.1(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.22.4))':
+  '@wagmi/core@2.17.0(@tanstack/query-core@5.75.0)(@types/react@18.3.20)(react@18.3.1)(typescript@5.7.3)(use-sync-external-store@1.4.0(react@18.3.1))(viem@2.28.1(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.25.7))':
     dependencies:
       eventemitter3: 5.0.1
       mipd: 0.0.7(typescript@5.7.3)
-      viem: 2.28.1(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.22.4)
+      viem: 2.28.1(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.25.7)
       zustand: 5.0.0(@types/react@18.3.20)(react@18.3.1)(use-sync-external-store@1.4.0(react@18.3.1))
     optionalDependencies:
       '@tanstack/query-core': 5.75.0
@@ -3995,7 +4012,7 @@ snapshots:
       - react
       - use-sync-external-store
 
-  '@walletconnect/core@2.19.2(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.22.4)':
+  '@walletconnect/core@2.19.2(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.25.7)':
     dependencies:
       '@walletconnect/heartbeat': 1.2.2
       '@walletconnect/jsonrpc-provider': 1.0.14
@@ -4009,7 +4026,7 @@ snapshots:
       '@walletconnect/safe-json': 1.0.2
       '@walletconnect/time': 1.0.2
       '@walletconnect/types': 2.19.2
-      '@walletconnect/utils': 2.19.2(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.22.4)
+      '@walletconnect/utils': 2.19.2(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.25.7)
       '@walletconnect/window-getters': 1.0.1
       es-toolkit: 1.33.0
       events: 3.3.0
@@ -4038,7 +4055,7 @@ snapshots:
       - utf-8-validate
       - zod
 
-  '@walletconnect/core@2.20.0(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.22.4)':
+  '@walletconnect/core@2.20.0(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.25.7)':
     dependencies:
       '@walletconnect/heartbeat': 1.2.2
       '@walletconnect/jsonrpc-provider': 1.0.14
@@ -4052,7 +4069,7 @@ snapshots:
       '@walletconnect/safe-json': 1.0.2
       '@walletconnect/time': 1.0.2
       '@walletconnect/types': 2.20.0
-      '@walletconnect/utils': 2.20.0(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.22.4)
+      '@walletconnect/utils': 2.20.0(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.25.7)
       '@walletconnect/window-getters': 1.0.1
       es-toolkit: 1.33.0
       events: 3.3.0
@@ -4085,18 +4102,18 @@ snapshots:
     dependencies:
       tslib: 1.14.1
 
-  '@walletconnect/ethereum-provider@2.20.0(@types/react@18.3.20)(bufferutil@4.0.9)(react@18.3.1)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.22.4)':
+  '@walletconnect/ethereum-provider@2.20.0(@types/react@18.3.20)(bufferutil@4.0.9)(react@18.3.1)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.25.7)':
     dependencies:
-      '@reown/appkit': 1.7.3(@types/react@18.3.20)(bufferutil@4.0.9)(react@18.3.1)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.22.4)
+      '@reown/appkit': 1.7.3(@types/react@18.3.20)(bufferutil@4.0.9)(react@18.3.1)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.25.7)
       '@walletconnect/jsonrpc-http-connection': 1.0.8
       '@walletconnect/jsonrpc-provider': 1.0.14
       '@walletconnect/jsonrpc-types': 1.0.4
       '@walletconnect/jsonrpc-utils': 1.0.8
       '@walletconnect/keyvaluestorage': 1.1.1
-      '@walletconnect/sign-client': 2.20.0(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.22.4)
+      '@walletconnect/sign-client': 2.20.0(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.25.7)
       '@walletconnect/types': 2.20.0
-      '@walletconnect/universal-provider': 2.20.0(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.22.4)
-      '@walletconnect/utils': 2.20.0(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.22.4)
+      '@walletconnect/universal-provider': 2.20.0(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.25.7)
+      '@walletconnect/utils': 2.20.0(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.25.7)
       events: 3.3.0
     transitivePeerDependencies:
       - '@azure/app-configuration'
@@ -4217,16 +4234,16 @@ snapshots:
     dependencies:
       tslib: 1.14.1
 
-  '@walletconnect/sign-client@2.19.2(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.22.4)':
+  '@walletconnect/sign-client@2.19.2(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.25.7)':
     dependencies:
-      '@walletconnect/core': 2.19.2(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.22.4)
+      '@walletconnect/core': 2.19.2(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.25.7)
       '@walletconnect/events': 1.0.1
       '@walletconnect/heartbeat': 1.2.2
       '@walletconnect/jsonrpc-utils': 1.0.8
       '@walletconnect/logger': 2.1.2
       '@walletconnect/time': 1.0.2
       '@walletconnect/types': 2.19.2
-      '@walletconnect/utils': 2.19.2(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.22.4)
+      '@walletconnect/utils': 2.19.2(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.25.7)
       events: 3.3.0
     transitivePeerDependencies:
       - '@azure/app-configuration'
@@ -4252,16 +4269,16 @@ snapshots:
       - utf-8-validate
       - zod
 
-  '@walletconnect/sign-client@2.20.0(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.22.4)':
+  '@walletconnect/sign-client@2.20.0(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.25.7)':
     dependencies:
-      '@walletconnect/core': 2.20.0(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.22.4)
+      '@walletconnect/core': 2.20.0(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.25.7)
       '@walletconnect/events': 1.0.1
       '@walletconnect/heartbeat': 1.2.2
       '@walletconnect/jsonrpc-utils': 1.0.8
       '@walletconnect/logger': 2.1.2
       '@walletconnect/time': 1.0.2
       '@walletconnect/types': 2.20.0
-      '@walletconnect/utils': 2.20.0(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.22.4)
+      '@walletconnect/utils': 2.20.0(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.25.7)
       events: 3.3.0
     transitivePeerDependencies:
       - '@azure/app-configuration'
@@ -4347,7 +4364,7 @@ snapshots:
       - ioredis
       - uploadthing
 
-  '@walletconnect/universal-provider@2.19.2(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.22.4)':
+  '@walletconnect/universal-provider@2.19.2(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.25.7)':
     dependencies:
       '@walletconnect/events': 1.0.1
       '@walletconnect/jsonrpc-http-connection': 1.0.8
@@ -4356,9 +4373,9 @@ snapshots:
       '@walletconnect/jsonrpc-utils': 1.0.8
       '@walletconnect/keyvaluestorage': 1.1.1
       '@walletconnect/logger': 2.1.2
-      '@walletconnect/sign-client': 2.19.2(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.22.4)
+      '@walletconnect/sign-client': 2.19.2(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.25.7)
       '@walletconnect/types': 2.19.2
-      '@walletconnect/utils': 2.19.2(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.22.4)
+      '@walletconnect/utils': 2.19.2(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.25.7)
       es-toolkit: 1.33.0
       events: 3.3.0
     transitivePeerDependencies:
@@ -4386,7 +4403,7 @@ snapshots:
       - utf-8-validate
       - zod
 
-  '@walletconnect/universal-provider@2.20.0(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.22.4)':
+  '@walletconnect/universal-provider@2.20.0(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.25.7)':
     dependencies:
       '@walletconnect/events': 1.0.1
       '@walletconnect/jsonrpc-http-connection': 1.0.8
@@ -4395,9 +4412,9 @@ snapshots:
       '@walletconnect/jsonrpc-utils': 1.0.8
       '@walletconnect/keyvaluestorage': 1.1.1
       '@walletconnect/logger': 2.1.2
-      '@walletconnect/sign-client': 2.20.0(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.22.4)
+      '@walletconnect/sign-client': 2.20.0(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.25.7)
       '@walletconnect/types': 2.20.0
-      '@walletconnect/utils': 2.20.0(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.22.4)
+      '@walletconnect/utils': 2.20.0(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.25.7)
       es-toolkit: 1.33.0
       events: 3.3.0
     transitivePeerDependencies:
@@ -4425,7 +4442,7 @@ snapshots:
       - utf-8-validate
       - zod
 
-  '@walletconnect/utils@2.19.2(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.22.4)':
+  '@walletconnect/utils@2.19.2(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.25.7)':
     dependencies:
       '@noble/ciphers': 1.2.1
       '@noble/curves': 1.8.1
@@ -4443,7 +4460,7 @@ snapshots:
       detect-browser: 5.3.0
       query-string: 7.1.3
       uint8arrays: 3.1.0
-      viem: 2.23.2(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.22.4)
+      viem: 2.23.2(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.25.7)
     transitivePeerDependencies:
       - '@azure/app-configuration'
       - '@azure/cosmos'
@@ -4468,7 +4485,7 @@ snapshots:
       - utf-8-validate
       - zod
 
-  '@walletconnect/utils@2.20.0(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.22.4)':
+  '@walletconnect/utils@2.20.0(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.25.7)':
     dependencies:
       '@noble/ciphers': 1.2.1
       '@noble/curves': 1.8.1
@@ -4486,7 +4503,7 @@ snapshots:
       detect-browser: 5.3.0
       query-string: 7.1.3
       uint8arrays: 3.1.0
-      viem: 2.23.2(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.22.4)
+      viem: 2.23.2(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.25.7)
     transitivePeerDependencies:
       - '@azure/app-configuration'
       - '@azure/cosmos'
@@ -4524,6 +4541,11 @@ snapshots:
     optionalDependencies:
       typescript: 5.7.3
       zod: 3.22.4
+
+  abitype@1.0.8(typescript@5.7.3)(zod@3.25.7):
+    optionalDependencies:
+      typescript: 5.7.3
+      zod: 3.25.7
 
   aes-js@4.0.0-beta.5: {}
 
@@ -5317,14 +5339,14 @@ snapshots:
 
   outdent@0.5.0: {}
 
-  ox@0.6.7(typescript@5.7.3)(zod@3.22.4):
+  ox@0.6.7(typescript@5.7.3)(zod@3.25.7):
     dependencies:
       '@adraffy/ens-normalize': 1.11.0
       '@noble/curves': 1.9.0
       '@noble/hashes': 1.8.0
       '@scure/bip32': 1.6.2
       '@scure/bip39': 1.5.4
-      abitype: 1.0.8(typescript@5.7.3)(zod@3.22.4)
+      abitype: 1.0.8(typescript@5.7.3)(zod@3.25.7)
       eventemitter3: 5.0.1
     optionalDependencies:
       typescript: 5.7.3
@@ -5339,6 +5361,20 @@ snapshots:
       '@scure/bip32': 1.6.2
       '@scure/bip39': 1.5.4
       abitype: 1.0.8(typescript@5.7.3)(zod@3.22.4)
+      eventemitter3: 5.0.1
+    optionalDependencies:
+      typescript: 5.7.3
+    transitivePeerDependencies:
+      - zod
+
+  ox@0.6.9(typescript@5.7.3)(zod@3.25.7):
+    dependencies:
+      '@adraffy/ens-normalize': 1.11.0
+      '@noble/curves': 1.9.0
+      '@noble/hashes': 1.8.0
+      '@scure/bip32': 1.6.2
+      '@scure/bip39': 1.5.4
+      abitype: 1.0.8(typescript@5.7.3)(zod@3.25.7)
       eventemitter3: 5.0.1
     optionalDependencies:
       typescript: 5.7.3
@@ -5802,15 +5838,15 @@ snapshots:
       '@types/react': 18.3.20
       react: 18.3.1
 
-  viem@2.23.2(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.22.4):
+  viem@2.23.2(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.25.7):
     dependencies:
       '@noble/curves': 1.8.1
       '@noble/hashes': 1.7.1
       '@scure/bip32': 1.6.2
       '@scure/bip39': 1.5.4
-      abitype: 1.0.8(typescript@5.7.3)(zod@3.22.4)
+      abitype: 1.0.8(typescript@5.7.3)(zod@3.25.7)
       isows: 1.0.6(ws@8.18.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))
-      ox: 0.6.7(typescript@5.7.3)(zod@3.22.4)
+      ox: 0.6.7(typescript@5.7.3)(zod@3.25.7)
       ws: 8.18.0(bufferutil@4.0.9)(utf-8-validate@5.0.10)
     optionalDependencies:
       typescript: 5.7.3
@@ -5828,6 +5864,23 @@ snapshots:
       abitype: 1.0.8(typescript@5.7.3)(zod@3.22.4)
       isows: 1.0.6(ws@8.18.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))
       ox: 0.6.9(typescript@5.7.3)(zod@3.22.4)
+      ws: 8.18.1(bufferutil@4.0.9)(utf-8-validate@5.0.10)
+    optionalDependencies:
+      typescript: 5.7.3
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+      - zod
+
+  viem@2.28.1(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.25.7):
+    dependencies:
+      '@noble/curves': 1.8.2
+      '@noble/hashes': 1.7.2
+      '@scure/bip32': 1.6.2
+      '@scure/bip39': 1.5.4
+      abitype: 1.0.8(typescript@5.7.3)(zod@3.25.7)
+      isows: 1.0.6(ws@8.18.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))
+      ox: 0.6.9(typescript@5.7.3)(zod@3.25.7)
       ws: 8.18.1(bufferutil@4.0.9)(utf-8-validate@5.0.10)
     optionalDependencies:
       typescript: 5.7.3
@@ -5911,14 +5964,14 @@ snapshots:
       - tsx
       - yaml
 
-  wagmi@2.15.1(@tanstack/query-core@5.75.0)(@tanstack/react-query@5.75.0(react@18.3.1))(@types/react@18.3.20)(bufferutil@4.0.9)(react@18.3.1)(typescript@5.7.3)(utf-8-validate@5.0.10)(viem@2.28.1(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.22.4))(zod@3.22.4):
+  wagmi@2.15.1(@tanstack/query-core@5.75.0)(@tanstack/react-query@5.75.0(react@18.3.1))(@types/react@18.3.20)(bufferutil@4.0.9)(react@18.3.1)(typescript@5.7.3)(utf-8-validate@5.0.10)(viem@2.28.1(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.25.7))(zod@3.25.7):
     dependencies:
       '@tanstack/react-query': 5.75.0(react@18.3.1)
-      '@wagmi/connectors': 5.8.0(@types/react@18.3.20)(@wagmi/core@2.17.0(@tanstack/query-core@5.75.0)(@types/react@18.3.20)(react@18.3.1)(typescript@5.7.3)(use-sync-external-store@1.4.0(react@18.3.1))(viem@2.28.1(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.22.4)))(bufferutil@4.0.9)(react@18.3.1)(typescript@5.7.3)(utf-8-validate@5.0.10)(viem@2.28.1(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.22.4))(zod@3.22.4)
-      '@wagmi/core': 2.17.0(@tanstack/query-core@5.75.0)(@types/react@18.3.20)(react@18.3.1)(typescript@5.7.3)(use-sync-external-store@1.4.0(react@18.3.1))(viem@2.28.1(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.22.4))
+      '@wagmi/connectors': 5.8.0(@types/react@18.3.20)(@wagmi/core@2.17.0(@tanstack/query-core@5.75.0)(@types/react@18.3.20)(react@18.3.1)(typescript@5.7.3)(use-sync-external-store@1.4.0(react@18.3.1))(viem@2.28.1(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.25.7)))(bufferutil@4.0.9)(react@18.3.1)(typescript@5.7.3)(utf-8-validate@5.0.10)(viem@2.28.1(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.25.7))(zod@3.25.7)
+      '@wagmi/core': 2.17.0(@tanstack/query-core@5.75.0)(@types/react@18.3.20)(react@18.3.1)(typescript@5.7.3)(use-sync-external-store@1.4.0(react@18.3.1))(viem@2.28.1(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.25.7))
       react: 18.3.1
       use-sync-external-store: 1.4.0(react@18.3.1)
-      viem: 2.28.1(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.22.4)
+      viem: 2.28.1(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.25.7)
     optionalDependencies:
       typescript: 5.7.3
     transitivePeerDependencies:
@@ -6051,6 +6104,8 @@ snapshots:
       yargs-parser: 18.1.3
 
   zod@3.22.4: {}
+
+  zod@3.25.7: {}
 
   zustand@5.0.0(@types/react@18.3.20)(react@18.3.1)(use-sync-external-store@1.4.0(react@18.3.1)):
     optionalDependencies:


### PR DESCRIPTION
This pull request introduces schema validation using `zod` for API responses and updates the dependency versions accordingly. The key changes include replacing manual type checks with `zod` schemas, adding reusable schema definitions for `Hex` and `Address`, and updating the `zod` dependency to version `3.25.7`.

### Schema Validation Improvements
* Introduced `zod` schemas for API response validation, replacing manual type checks:
  - Added `quoteResponseSchema` in `getQuote.ts` for validating `/quote` endpoint responses. [[1]](diffhunk://#diff-101f182783d724265f180469bd06c3b45c5e6b3859a72b370542240fc823a94dL1-R20) [[2]](diffhunk://#diff-101f182783d724265f180469bd06c3b45c5e6b3859a72b370542240fc823a94dL29-R42) [[3]](diffhunk://#diff-101f182783d724265f180469bd06c3b45c5e6b3859a72b370542240fc823a94dL80-R90)
  - Added `validationResponseSchema` in `validateOrder.ts` for validating `/check` endpoint responses. [[1]](diffhunk://#diff-96750a7e0625b36220d40fa76be2a87d6b9cd84be331cb86d743593fe9480e0eR1) [[2]](diffhunk://#diff-96750a7e0625b36220d40fa76be2a87d6b9cd84be331cb86d743593fe9480e0eR11-R28) [[3]](diffhunk://#diff-96750a7e0625b36220d40fa76be2a87d6b9cd84be331cb86d743593fe9480e0eL97-R102)
  - Added `jsonErrorSchema` in `api.ts` for validating JSON error responses. [[1]](diffhunk://#diff-b9b961350498806cf7efe0ed76491c61cbd3fb1cb90d380d8333edf9dd4d8f6eR2-R11) [[2]](diffhunk://#diff-b9b961350498806cf7efe0ed76491c61cbd3fb1cb90d380d8333edf9dd4d8f6eL25-R38)

* Defined reusable `zod` schemas for `Hex` and `Address` types in `types.ts`. These ensure consistent validation for hexadecimal strings and Ethereum addresses.

### Dependency Updates
* Added `zod` as a dependency

issue: none