### PR TITLE
chore(e2e): bump solver monitor pins to 0502c1f

### DIFF
--- a/e2e/manifests/mainnet.toml
+++ b/e2e/manifests/mainnet.toml
@@ -6,8 +6,8 @@ prometheus   = true
 
 pinned_halo_tag = "v0.15.0"
 pinned_relayer_tag = "07c4ac7"
-pinned_monitor_tag = "97880d5"
-pinned_solver_tag = "97880d5"
+pinned_monitor_tag = "0502c1f"
+pinned_solver_tag = "0502c1f"
 
 [node.validator01]
 [node.validator02]

--- a/e2e/manifests/omega.toml
+++ b/e2e/manifests/omega.toml
@@ -6,8 +6,8 @@ prometheus = true
 
 pinned_halo_tag = "v0.15.0"
 pinned_relayer_tag = "07c4ac7"
-pinned_monitor_tag = "97880d5"
-pinned_solver_tag = "97880d5"
+pinned_monitor_tag = "0502c1f"
+pinned_solver_tag = "0502c1f"
 
 [node.validator01]
 [node.validator02]


### PR DESCRIPTION
Bump solver manifests pins.

This includes adding Mantle USDC support &  rebalancing. 

issue: none
