### PR TITLE
chore(e2e): bump solver monitor pins to 19d83ba

### DIFF
--- a/e2e/manifests/mainnet.toml
+++ b/e2e/manifests/mainnet.toml
@@ -6,8 +6,8 @@ prometheus   = true
 
 pinned_halo_tag = "v0.15.0"
 pinned_relayer_tag = "07c4ac7"
-pinned_monitor_tag = "a060acc"
-pinned_solver_tag = "a060acc"
+pinned_monitor_tag = "19d83ba"
+pinned_solver_tag = "19d83ba"
 
 [node.validator01]
 [node.validator02]

--- a/e2e/manifests/omega.toml
+++ b/e2e/manifests/omega.toml
@@ -6,8 +6,8 @@ prometheus = true
 
 pinned_halo_tag = "v0.15.0"
 pinned_relayer_tag = "07c4ac7"
-pinned_monitor_tag = "a060acc"
-pinned_solver_tag = "a060acc"
+pinned_monitor_tag = "19d83ba"
+pinned_solver_tag = "19d83ba"
 
 [node.validator01]
 [node.validator02]


### PR DESCRIPTION
Bump solver pints 19d83ba

Includes mantle fund threshold updates.

issue: none
