### PR TITLE
chore(docs): remove network name from assets table

### DIFF
--- a/docs/docs/pages/sdk/assets/mainnet.mdx
+++ b/docs/docs/pages/sdk/assets/mainnet.mdx
@@ -1,17 +1,17 @@
-| Network | Chain | Chain ID | Asset | Contract Address |
-| ------- | ----- | -------- | ----- | ---------------- |
-| Mainnet | Arbitrum One | 42161 | ETH | Native |
-| Mainnet | Arbitrum One | 42161 | USDC | 0xaf88d065e77c8cC2239327C5EDb3A432268e5831 |
-| Mainnet | Arbitrum One | 42161 | USDT | 0xFd086bC7CD5C481DCC9C85ebE478A1C0b69FCbb9 |
-| Mainnet | Base | 8453 | ETH | Native |
-| Mainnet | Base | 8453 | USDC | 0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913 |
-| Mainnet | Base | 8453 | wstETH | 0xc1CBa3fCea344f92D9239c08C0568f6F2F0ee452 |
-| Mainnet | Ethereum | 1 | ETH | Native |
-| Mainnet | Ethereum | 1 | OMNI | 0x36E66fbBce51e4cD5bd3C62B637Eb411b18949D4 |
-| Mainnet | Ethereum | 1 | USDC | 0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48 |
-| Mainnet | Ethereum | 1 | USDT | 0xdAC17F958D2ee523a2206206994597C13D831ec7 |
-| Mainnet | Ethereum | 1 | wstETH | 0x7f39C581F595B53c5cb19bD0b3f8dA6c935E2Ca0 |
-| Mainnet | Mantle | 5000 | USDC | 0x09Bc4E0D864854c6aFB6eB9A9cdF58aC190D0dF9 |
-| Mainnet | Optimism | 10 | ETH | Native |
-| Mainnet | Optimism | 10 | USDC | 0x0b2C639c533813f4Aa9D7837CAf62653d097Ff85 |
-| Mainnet | Optimism | 10 | USDT | 0x94b008aA00579c1307B0EF2c499aD98a8ce58e58 |
+| Chain | Chain ID | Asset | Contract Address |
+| ----- | -------- | ----- | ---------------- |
+| Arbitrum One | 42161 | ETH | Native |
+| Arbitrum One | 42161 | USDC | 0xaf88d065e77c8cC2239327C5EDb3A432268e5831 |
+| Arbitrum One | 42161 | USDT | 0xFd086bC7CD5C481DCC9C85ebE478A1C0b69FCbb9 |
+| Base | 8453 | ETH | Native |
+| Base | 8453 | USDC | 0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913 |
+| Base | 8453 | wstETH | 0xc1CBa3fCea344f92D9239c08C0568f6F2F0ee452 |
+| Ethereum | 1 | ETH | Native |
+| Ethereum | 1 | OMNI | 0x36E66fbBce51e4cD5bd3C62B637Eb411b18949D4 |
+| Ethereum | 1 | USDC | 0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48 |
+| Ethereum | 1 | USDT | 0xdAC17F958D2ee523a2206206994597C13D831ec7 |
+| Ethereum | 1 | wstETH | 0x7f39C581F595B53c5cb19bD0b3f8dA6c935E2Ca0 |
+| Mantle | 5000 | USDC | 0x09Bc4E0D864854c6aFB6eB9A9cdF58aC190D0dF9 |
+| Optimism | 10 | ETH | Native |
+| Optimism | 10 | USDC | 0x0b2C639c533813f4Aa9D7837CAf62653d097Ff85 |
+| Optimism | 10 | USDT | 0x94b008aA00579c1307B0EF2c499aD98a8ce58e58 |

--- a/docs/docs/pages/sdk/assets/testnet.mdx
+++ b/docs/docs/pages/sdk/assets/testnet.mdx
@@ -1,14 +1,14 @@
-| Network | Chain | Chain ID | Asset | Contract Address |
-| ------- | ----- | -------- | ----- | ---------------- |
-| Testnet | Arb Sepolia | 421614 | ETH | Native |
-| Testnet | Arb Sepolia | 421614 | USDC | 0x75faf114eafb1BDbe2F0316DF893fd58CE46AA4d |
-| Testnet | Base Sepolia | 84532 | ETH | Native |
-| Testnet | Base Sepolia | 84532 | USDC | 0x036CbD53842c5426634e7929541eC2318f3dCF7e |
-| Testnet | Holesky | 17000 | ETH | Native |
-| Testnet | Holesky | 17000 | OMNI | 0xD036C60f46FF51dd7Fbf6a819b5B171c8A076b07 |
-| Testnet | Holesky | 17000 | wstETH | 0x8d09a4502Cc8Cf1547aD300E066060D043f6982D |
-| Testnet | OP Sepolia | 11155420 | ETH | Native |
-| Testnet | OP Sepolia | 11155420 | USDC | 0x5fd84259d66Cd46123540766Be93DFE6D43130D7 |
-| Testnet | Sepolia | 11155111 | ETH | Native |
-| Testnet | Sepolia | 11155111 | USDC | 0x1c7D4B196Cb0C7B01d743Fbc6116a902379C7238 |
-| Testnet | Sepolia | 11155111 | wstETH | 0xB82381A3fBD3FaFA77B3a7bE693342618240067b |
+| Chain | Chain ID | Asset | Contract Address |
+| ----- | -------- | ----- | ---------------- |
+| Arb Sepolia | 421614 | ETH | Native |
+| Arb Sepolia | 421614 | USDC | 0x75faf114eafb1BDbe2F0316DF893fd58CE46AA4d |
+| Base Sepolia | 84532 | ETH | Native |
+| Base Sepolia | 84532 | USDC | 0x036CbD53842c5426634e7929541eC2318f3dCF7e |
+| Holesky | 17000 | ETH | Native |
+| Holesky | 17000 | OMNI | 0xD036C60f46FF51dd7Fbf6a819b5B171c8A076b07 |
+| Holesky | 17000 | wstETH | 0x8d09a4502Cc8Cf1547aD300E066060D043f6982D |
+| OP Sepolia | 11155420 | ETH | Native |
+| OP Sepolia | 11155420 | USDC | 0x5fd84259d66Cd46123540766Be93DFE6D43130D7 |
+| Sepolia | 11155111 | ETH | Native |
+| Sepolia | 11155111 | USDC | 0x1c7D4B196Cb0C7B01d743Fbc6116a902379C7238 |
+| Sepolia | 11155111 | wstETH | 0xB82381A3fBD3FaFA77B3a7bE693342618240067b |

--- a/solver/app/tokens_internal_test.go
+++ b/solver/app/tokens_internal_test.go
@@ -21,11 +21,11 @@ import (
 // TestGenSupportTokensDoc generates the supported tokens docs.
 func TestGenSupportTokensDoc(t *testing.T) {
 	t.Parallel()
-	genSupportedTokens(t, netconf.Omega, "Testnet", "../../../docs/docs/pages/sdk/assets/testnet.mdx")
-	genSupportedTokens(t, netconf.Mainnet, "Mainnet", "../../../docs/docs/pages/sdk/assets/mainnet.mdx")
+	genSupportedTokens(t, netconf.Omega, "../../../docs/docs/pages/sdk/assets/testnet.mdx")
+	genSupportedTokens(t, netconf.Mainnet, "../../../docs/docs/pages/sdk/assets/mainnet.mdx")
 }
 
-func genSupportedTokens(t *testing.T, network netconf.ID, networkName string, fileName string) {
+func genSupportedTokens(t *testing.T, network netconf.ID, fileName string) {
 	t.Helper()
 	m, err := manifests.Manifest(network)
 	require.NoError(t, err)
@@ -57,15 +57,15 @@ func genSupportedTokens(t *testing.T, network netconf.ID, networkName string, fi
 				addr = "Native"
 			}
 
-			lines = append(lines, fmt.Sprintf("| %s | %s | %d | %s | %s |", networkName, meta.PrettyName, meta.ChainID, token.Symbol, addr))
+			lines = append(lines, fmt.Sprintf("| %s | %d | %s | %s |", meta.PrettyName, meta.ChainID, token.Symbol, addr))
 		}
 	}
 
 	sort.Strings(lines)
 
 	var b bytes.Buffer
-	b.WriteString("| Network | Chain | Chain ID | Asset | Contract Address |\n")
-	b.WriteString("| ------- | ----- | -------- | ----- | ---------------- |\n")
+	b.WriteString("| Chain | Chain ID | Asset | Contract Address |\n")
+	b.WriteString("| ----- | -------- | ----- | ---------------- |\n")
 
 	for _, line := range lines {
 		b.WriteString(line + "\n")


### PR DESCRIPTION
Remove network name from asset table.

We have headers for "Testnet" and "Mainnet" in docs
The network name in each table row was the same.

issue: none
