### PR TITLE
docs: fix link to supported Assets

### DIFF
--- a/docs/docs/pages/sdk/faq.mdx
+++ b/docs/docs/pages/sdk/faq.mdx
@@ -41,7 +41,7 @@ This is now live on both testnet and mainnet.
 
 ### Is there a way to determine what tokens are supported?
 
-Yes, the [Supported Assets](./supported-assets.mdx) page lists the currently supported assets and their associated limits.
+Yes, the [Supported Assets](/sdk/supported-assets.mdx) page lists the currently supported assets and their associated limits.
 
 You can also fetch this information programmatically via the API: `https://solver.mainnet.omni.network/api/v1/tokens`.
 


### PR DESCRIPTION
this link was on [this page](https://docs.omni.network/sdk/faq). now it fixed and works properly. 