### PR TITLE
chore(e2e): bump solver monitor pins to cdbfa4b

### DIFF
--- a/e2e/manifests/mainnet.toml
+++ b/e2e/manifests/mainnet.toml
@@ -6,8 +6,8 @@ prometheus   = true
 
 pinned_halo_tag = "v0.15.0"
 pinned_relayer_tag = "07c4ac7"
-pinned_monitor_tag = "d3552d9"
-pinned_solver_tag = "d3552d9"
+pinned_monitor_tag = "cdbfa4b"
+pinned_solver_tag = "cdbfa4b"
 
 [node.validator01]
 [node.validator02]

--- a/e2e/manifests/omega.toml
+++ b/e2e/manifests/omega.toml
@@ -6,8 +6,8 @@ prometheus = true
 
 pinned_halo_tag = "v0.15.0"
 pinned_relayer_tag = "07c4ac7"
-pinned_monitor_tag = "d3552d9"
-pinned_solver_tag = "d3552d9"
+pinned_monitor_tag = "cdbfa4b"
+pinned_solver_tag = "cdbfa4b"
 
 [node.validator01]
 [node.validator02]


### PR DESCRIPTION
Bump solver monitor pins to cdbfa4b.

Includes cctp sanity check log removal.

issue: none