### PR TITLE
chore(solver): better reject unsupported dest

### DIFF
--- a/solver/app/check.go
+++ b/solver/app/check.go
@@ -28,6 +28,11 @@ func newChecker(backends unibackend.Backends, isAllowedCall callAllowFunc, price
 			return newRejection(types.RejectUnsupportedSrcChain, errors.New("unsupported source chain", "chain_id", req.SourceChainID))
 		}
 
+		_, ok := solvernet.Provider(req.SourceChainID, req.DestinationChainID)
+		if !ok {
+			return newRejection(types.RejectUnsupportedDestChain, errors.New("unsupported destination chain", "chain_id", req.DestinationChainID))
+		}
+
 		dstBackend, err := backends.Backend(req.DestinationChainID)
 		if err != nil {
 			return newRejection(types.RejectUnsupportedDestChain, errors.New("unsupported destination chain", "chain_id", req.DestinationChainID))

--- a/solver/app/reject.go
+++ b/solver/app/reject.go
@@ -72,6 +72,11 @@ func newShouldRejector(
 
 		// Internal logic just return errors (convert them to rejections below)
 		err = func(ctx context.Context, order Order) error {
+			_, ok := solvernet.Provider(order.SourceChainID, pendingData.DestinationChainID)
+			if !ok {
+				return newRejection(types.RejectUnsupportedDestChain, errors.New("unsupported destination chain", "chain_id", pendingData.DestinationChainID))
+			}
+
 			backend, err := backends.Backend(pendingData.DestinationChainID)
 			if err != nil {
 				return newRejection(types.RejectUnsupportedDestChain, err)

--- a/solver/app/testutils_internal_test.go
+++ b/solver/app/testutils_internal_test.go
@@ -415,6 +415,15 @@ func orderTestCases(t *testing.T, solver common.Address) []orderTestCase {
 			},
 		},
 		{
+			name:   "unsupported dest chain - no route",
+			reason: types.RejectUnsupportedDestChain,
+			reject: true,
+			order: testOrder{
+				srcChainID: evmchain.IDSepolia,   // Hyperlane only chain
+				dstChainID: evmchain.IDOmniOmega, // Core only
+			},
+		},
+		{
 			name:   "invalid deposit (native token mismatch)",
 			reason: types.RejectInvalidDeposit,
 			reject: true,


### PR DESCRIPTION
Reject with UnsupportedDestChain for routes with no settle route between them.

These would previously be rejected with DestCallReverts

issue: none