### PR TITLE
chore(e2e): update solver monitor pins to f770313

### DIFF
--- a/e2e/manifests/mainnet.toml
+++ b/e2e/manifests/mainnet.toml
@@ -6,8 +6,8 @@ prometheus   = true
 
 pinned_halo_tag = "v0.15.0"
 pinned_relayer_tag = "07c4ac7"
-pinned_monitor_tag = "cdbfa4b"
-pinned_solver_tag = "cdbfa4b"
+pinned_monitor_tag = "f770313"
+pinned_solver_tag = "f770313"
 
 [node.validator01]
 [node.validator02]

--- a/e2e/manifests/omega.toml
+++ b/e2e/manifests/omega.toml
@@ -6,8 +6,8 @@ prometheus = true
 
 pinned_halo_tag = "v0.15.0"
 pinned_relayer_tag = "07c4ac7"
-pinned_monitor_tag = "cdbfa4b"
-pinned_solver_tag = "cdbfa4b"
+pinned_monitor_tag = "f770313"
+pinned_solver_tag = "f770313"
 
 [node.validator01]
 [node.validator02]


### PR DESCRIPTION
Update solver monitor pins to f770313.

This includes

- addtional mantle tokens support
- better rejects for unsupported routes

issue: none