### PR TITLE
chore(e2e): bump sovler monitor pins to a5b598b

### DIFF
--- a/e2e/manifests/mainnet.toml
+++ b/e2e/manifests/mainnet.toml
@@ -6,8 +6,8 @@ prometheus   = true
 
 pinned_halo_tag = "v0.15.0"
 pinned_relayer_tag = "07c4ac7"
-pinned_monitor_tag = "f770313"
-pinned_solver_tag = "f770313"
+pinned_monitor_tag = "a5b598b"
+pinned_solver_tag = "a5b598b"
 
 [node.validator01]
 [node.validator02]

--- a/e2e/manifests/omega.toml
+++ b/e2e/manifests/omega.toml
@@ -6,8 +6,8 @@ prometheus = true
 
 pinned_halo_tag = "v0.15.0"
 pinned_relayer_tag = "07c4ac7"
-pinned_monitor_tag = "f770313"
-pinned_solver_tag = "f770313"
+pinned_monitor_tag = "a5b598b"
+pinned_solver_tag = "a5b598b"
 
 [node.validator01]
 [node.validator02]


### PR DESCRIPTION
Bump solver monitor pins to a5b598b.

This includes fix to /check trace request.

issue: none