### PR TITLE
docs(sdk): more details about debug flag

### DIFF
--- a/docs/docs/pages/guides/debugging-destination-calls.mdx
+++ b/docs/docs/pages/guides/debugging-destination-calls.mdx
@@ -1,0 +1,42 @@
+---
+sidebar_position: 4
+title: Debugging destination calls
+description: How to debug destination calls reverting.
+---
+
+# Debugging destination calls
+
+When validating orders using the Omni SDK, the SolverNet API may reject orders by returning a `DestCallReverts` rejection reason, indicating a call fails to execute on the destination chain.
+
+:::code-group
+
+```ts [Core]
+import { type Order, validateOrder } from '@omni-network/core'
+
+const order: Order = {...} // Order parameters with invalid call
+
+const validation = await validateOrder(order)
+if (validation.rejected && validation.rejectReason === 'DestCallReverts') {
+  const debugValidation = await validateOrder({...order, debug: true})
+  console.log('debug trace', debugValidation.trace)
+}
+```
+
+```tsx [React]
+import { useOrder } from '@omni-network/react'
+
+function MyComponent() {
+  const orderResult = useOrder({
+    // ... Order parameters with invalid call
+    validateEnabled: true, // enable validation
+    debugValidation: true, // enable debug trace
+  })
+  if (orderResult.validation?.status === 'rejected' && orderResult.validation?.rejectReason === 'DestCallReverts') {
+    console.log('debug trace', orderResult.validation.trace)
+  }
+}
+```
+
+:::
+
+The `trace` object returned by the validation will be the result of calling [the `debug_traceCall` RPC method](https://geth.ethereum.org/docs/interacting-with-geth/rpc/ns-debug#debugtracecall), providing more details about the error that caused the call to revert.

--- a/docs/docs/pages/sdk/core/openOrder.md
+++ b/docs/docs/pages/sdk/core/openOrder.md
@@ -2,9 +2,9 @@
 
 The `openOrder` function implements a common flow to open an order on a SolverNet inbox contract, by combining single-purpose functions:
 
-1. Validating the order, using [`validateOrder`](/sdk/core/validateOrder.md)
-2. Sending the order transaction, using [`sendOrder`](/sdk/core/sendOrder.mdx)
-3. Waiting for the order to be open on the blockchain, using [`waitForOrderOpen`](/sdk/core/waitForOrderOpen.md)
+1. Validating the order, using [`validateOrder`](/sdk/core/validateOrder)
+2. Sending the order transaction, using [`sendOrder`](/sdk/core/sendOrder)
+3. Waiting for the order to be open on the blockchain, using [`waitForOrderOpen`](/sdk/core/waitForOrderOpen)
 
 ## Usage
 

--- a/docs/docs/pages/sdk/core/validateOrder.mdx
+++ b/docs/docs/pages/sdk/core/validateOrder.mdx
@@ -1,3 +1,5 @@
+import { Callout } from 'vocs/components'
+
 # `validateOrder`
 
 The `validateOrder` function validates order parameters with the SolverNet server to check if an order could be handled by SolverNet.
@@ -126,6 +128,10 @@ if (validation.rejected) {
   console.error(`Validation rejected order with reason: ${validation.rejectReason} - ${validation.rejectDescription}`)
 }
 ```
+
+<Callout type="tip" title="Debug trace">
+You can use the `debug` parameter to receive a `trace` object as part of the validation response. This trace can notably be useful to [debug destination calls reverting](/guides/debugging-destination-calls/).
+</Callout>
 
 ### Server error
 

--- a/docs/docs/pages/sdk/hooks/useOrder.mdx
+++ b/docs/docs/pages/sdk/hooks/useOrder.mdx
@@ -3,6 +3,8 @@ sidebar_position: 2
 title: useOrder
 ---
 
+import { Callout } from 'vocs/components'
+
 ## Usage
 
 `import { useOrder } from '@omni-network/react'`
@@ -109,6 +111,10 @@ The result of the pre-validation check if `validateEnabled` is true.
   rejectDescription?: string
 }
 `
+
+<Callout type="tip" title="Debug trace">
+You can use the `debugValidation` parameter to receive a `trace` object as part of the validation response. This trace can notably be useful to [debug destination calls reverting](/guides/debugging-destination-calls/).
+</Callout>
 
 ### error
 `Error | undefined`

--- a/docs/vocs.config.tsx
+++ b/docs/vocs.config.tsx
@@ -83,6 +83,10 @@ export default defineConfig({
               link: '/sdk/core/getQuote',
             },
             {
+              text: 'validateOrder',
+              link: '/sdk/core/validateOrder',
+            },
+            {
               text: 'openOrder',
               link: '/sdk/core/openOrder',
             },
@@ -121,6 +125,7 @@ export default defineConfig({
             { text: 'Cross Chain Transfers', link: '/guides/transfers' },
             { text: 'Multi-Step Deposit', link: '/guides/multistep-deposit' },
             { text: 'Contracts without onBehalfOf', link: '/guides/contracts-without-onbehalfof' },
+            { text: 'Debugging destination calls', link: '/guides/debugging-destination-calls' },
             { text: 'Symbiotic', link: '/guides/examples/symbiotic' },
             { text: 'Rocketpool', link: '/guides/examples/rocketpool' },
           ],

--- a/sdk/integration-tests/suites/react-hooks.tsx
+++ b/sdk/integration-tests/suites/react-hooks.tsx
@@ -294,7 +294,10 @@ describe('useOrder()', () => {
       validateEnabled: true,
       debugValidation: true,
     }
-    const result = await executeTestOrderUsingReact({ order, rejectReason: 'DestCallReverts' })
+    const result = await executeTestOrderUsingReact({
+      order,
+      rejectReason: 'DestCallReverts',
+    })
     if (result?.validation?.status !== 'rejected')
       throw new Error('Validation status should be rejected')
     expect(result?.validation?.trace).toBeInstanceOf(Object)

--- a/sdk/integration-tests/suites/react-hooks.tsx
+++ b/sdk/integration-tests/suites/react-hooks.tsx
@@ -8,6 +8,7 @@ import {
 } from '@omni-network/react'
 import {
   createAnvilClient,
+  inbox,
   invalidChainId,
   invalidTokenAddress,
   mockL1Chain,
@@ -265,7 +266,7 @@ describe('useOrder()', () => {
     await executeTestOrderUsingReact({ order })
   })
 
-  test('parameters: returns the trace when the debugValidation flag is enabled', async () => {
+  test('parameters: returns the trace when the debugValidation flag is enabled and the validation is successful', async () => {
     const amount = parseEther('1') / 2n
     const order = {
       srcChainId: mockL1Id,
@@ -279,6 +280,23 @@ describe('useOrder()', () => {
     const result = await executeTestOrderUsingReact({ order })
     if (result?.validation?.status !== 'accepted')
       throw new Error('Validation status should be accepted')
+    expect(result?.validation?.trace).toBeInstanceOf(Object)
+  })
+
+  test('parameters: returns the trace when the debugValidation flag is enabled and the validation is rejected', async () => {
+    const amount = parseEther('1') / 2n
+    const order = {
+      srcChainId: mockL1Id,
+      destChainId: mockL2Id,
+      expense: { token: zeroAddress, amount },
+      deposit: { token: zeroAddress, amount: parseEther('1') },
+      calls: [{ target: inbox, value: amount, data: new Uint8Array(4) }],
+      validateEnabled: true,
+      debugValidation: true,
+    }
+    const result = await executeTestOrderUsingReact({ order, rejectReason: 'DestCallReverts' })
+    if (result?.validation?.status !== 'rejected')
+      throw new Error('Validation status should be rejected')
     expect(result?.validation?.trace).toBeInstanceOf(Object)
   })
 

--- a/sdk/integration-tests/test-utils.tsx
+++ b/sdk/integration-tests/test-utils.tsx
@@ -264,7 +264,7 @@ type ExecuteTestOrderUsingReactParams = {
 
 export async function executeTestOrderUsingReact(
   params: ExecuteTestOrderUsingReactParams,
-): Promise<ReturnType<typeof useOrder> | null> {
+): Promise<ReturnType<typeof useOrder>> {
   const { account, order, rejectReason } = params
   const orderRef = useOrderRef(order, account)
 
@@ -282,7 +282,7 @@ export async function executeTestOrderUsingReact(
       throw new Error('Rejection expected')
     expect(orderRef.current?.validation?.status).toBe('rejected')
     expect(orderRef.current?.validation?.rejectReason).toBe(rejectReason)
-    return null
+    return orderRef.current
   }
 
   expect(orderRef.current?.validation?.status).toBe('accepted')


### PR DESCRIPTION
Adds a dedicated guide page to the docs about using the `debug` flag and links in the relevant pages

issue: none