### PR TITLE
chore(e2e/manifests): update solver pin to 7112442

### DIFF
--- a/e2e/manifests/mainnet.toml
+++ b/e2e/manifests/mainnet.toml
@@ -6,8 +6,8 @@ prometheus   = true
 
 pinned_halo_tag = "v0.15.0"
 pinned_relayer_tag = "07c4ac7"
-pinned_monitor_tag = "a5b598b"
-pinned_solver_tag = "a5b598b"
+pinned_monitor_tag = "7112442"
+pinned_solver_tag = "7112442"
 
 [node.validator01]
 [node.validator02]

--- a/e2e/manifests/omega.toml
+++ b/e2e/manifests/omega.toml
@@ -6,8 +6,8 @@ prometheus = true
 
 pinned_halo_tag = "v0.15.0"
 pinned_relayer_tag = "07c4ac7"
-pinned_monitor_tag = "a5b598b"
-pinned_solver_tag = "a5b598b"
+pinned_monitor_tag = "7112442"
+pinned_solver_tag = "7112442"
 
 [node.validator01]
 [node.validator02]


### PR DESCRIPTION
Update solver pin to 7112442.

This includes:
- same check /check fixes
- hyper evm rebalancing

issue: none