### PR TITLE
Fix EthHash return type and clean up docs

### DIFF
--- a/lib/bi/big.go
+++ b/lib/bi/big.go
@@ -2,7 +2,7 @@
 // since the native API is clunky and error-prone (since it is mutable).
 //
 // Note that it doesn't do nil-checks, that should be done by the application
-// when data enters the system as nil values aare invalid.
+// when data enters the system as nil values are invalid.
 package bi
 
 import (

--- a/lib/cast/cast.go
+++ b/lib/cast/cast.go
@@ -1,4 +1,4 @@
-// Package cast provides save casting functions for converting between types without panicking.
+// Package cast provides safe casting functions for converting between types without panicking.
 package cast
 
 import (
@@ -52,7 +52,8 @@ func EthHash(b []byte) (common.Hash, error) {
 		return common.Hash{}, errors.New("invalid hash length", "len", len(b))
 	}
 
-	return resp, nil
+	// Convert the byte array to common.Hash explicitly.
+	return common.BytesToHash(resp[:]), nil
 }
 
 // Array32 casts a slice to an array of length 32.
@@ -91,7 +92,7 @@ func MustEthAddress(b []byte) common.Address {
 	return addr
 }
 
-// Array20 casts a slice to an array of length 32.
+// Array20 casts a slice to an array of length 20.
 func Array20[A any](slice []A) ([20]A, error) {
 	if len(slice) == 20 {
 		return [20]A(slice), nil

--- a/lib/umath/umath.go
+++ b/lib/umath/umath.go
@@ -1,6 +1,6 @@
 // Package umath provides some useful unsigned math functions to prevent underflows.
 // It also provides some type conversion functions to convert between different
-// integer types to prevent underflows and overflows or overflows.
+// integer types to prevent underflows and overflows.
 package umath
 
 import (

--- a/lib/xchain/connect/connect.go
+++ b/lib/xchain/connect/connect.go
@@ -114,7 +114,7 @@ type options struct {
 type option func(*options) error
 
 // WithPublicRPCs returns an option using well known public free RPCs for all xchains.
-// This is used be default if no other option is provided.
+// This is used by default if no other option is provided.
 func WithPublicRPCs() option {
 	return func(o *options) error {
 		for name, rpc := range o.Endpoints {


### PR DESCRIPTION
## Summary
- fix EthHash return type conversion
- update comments in cast, umath, bi and connect packages

## Testing
- `gofmt -w lib/cast/cast.go lib/bi/big.go lib/umath/umath.go lib/xchain/connect/connect.go`


------
https://chatgpt.com/codex/tasks/task_e_6827aaffd0ac832bae7ee02fd5dedbfb