### PR TITLE
chore(e2e): bump solver monitor pin to 99562dc

### DIFF
--- a/e2e/manifests/mainnet.toml
+++ b/e2e/manifests/mainnet.toml
@@ -6,8 +6,8 @@ prometheus   = true
 
 pinned_halo_tag = "v0.15.0"
 pinned_relayer_tag = "07c4ac7"
-pinned_monitor_tag = "7112442"
-pinned_solver_tag = "7112442"
+pinned_monitor_tag = "99562dc"
+pinned_solver_tag = "99562dc"
 
 [node.validator01]
 [node.validator02]

--- a/e2e/manifests/omega.toml
+++ b/e2e/manifests/omega.toml
@@ -6,8 +6,8 @@ prometheus = true
 
 pinned_halo_tag = "v0.15.0"
 pinned_relayer_tag = "07c4ac7"
-pinned_monitor_tag = "7112442"
-pinned_solver_tag = "7112442"
+pinned_monitor_tag = "99562dc"
+pinned_solver_tag = "99562dc"
 
 [node.validator01]
 [node.validator02]


### PR DESCRIPTION
Bump solver monitor pin to 99562dc.

Includes:
- rebalance mutex fix
- solvernet contract binding updates (backwards compatible)

issue: none
