### PR TITLE
chore(solver): bump solver monitor pins to 1fb2571

### DIFF
--- a/e2e/manifests/mainnet.toml
+++ b/e2e/manifests/mainnet.toml
@@ -6,8 +6,8 @@ prometheus   = true
 
 pinned_halo_tag = "v0.15.0"
 pinned_relayer_tag = "07c4ac7"
-pinned_monitor_tag = "2144f65"
-pinned_solver_tag = "2144f65"
+pinned_monitor_tag = "1fb2571"
+pinned_solver_tag = "1fb2571"
 
 [node.validator01]
 [node.validator02]

--- a/e2e/manifests/omega.toml
+++ b/e2e/manifests/omega.toml
@@ -6,8 +6,8 @@ prometheus = true
 
 pinned_halo_tag = "v0.15.0"
 pinned_relayer_tag = "07c4ac7"
-pinned_monitor_tag = "2144f65"
-pinned_solver_tag = "2144f65"
+pinned_monitor_tag = "1fb2571"
+pinned_solver_tag = "1fb2571"
 
 [node.validator01]
 [node.validator02]


### PR DESCRIPTION
Bump solver monitor pins to 1fb2571.

This includes enabling HYPE and USDT0.

issue: none