### PR TITLE
chore(e2e): remove unneeded initializers

### DIFF
--- a/e2e/app/admin/common.go
+++ b/e2e/app/admin/common.go
@@ -412,26 +412,16 @@ func dedup(strs []string) []string {
 	return res
 }
 
-func solverNetInboxInitializer(outbox common.Address) ([]byte, error) {
-	var inboxABI = mustGetABI(bindings.SolverNetInboxMetaData)
+func solverNetInboxInitializer() ([]byte, error) {
+	// var inboxABI = mustGetABI(bindings.SolverNetInboxMetaData)
 	// TODO: replace if re-initialization is required
-	initializer, err := inboxABI.Pack("initializeV2", outbox)
-	if err != nil {
-		return nil, errors.Wrap(err, "pack initializer")
-	}
-
-	return initializer, nil
+	return []byte{}, nil
 }
 
-func solverNetOutboxInitializer(chainIDs []uint64, configs []bindings.ISolverNetOutboxInboxConfig) ([]byte, error) {
-	var outboxABI = mustGetABI(bindings.SolverNetOutboxMetaData)
+func solverNetOutboxInitializer() ([]byte, error) {
+	// var outboxABI = mustGetABI(bindings.SolverNetOutboxMetaData)
 	// TODO: replace if re-initialization is required
-	initializer, err := outboxABI.Pack("initializeV2", chainIDs, configs)
-	if err != nil {
-		return nil, errors.Wrap(err, "pack initializer")
-	}
-
-	return initializer, nil
+	return []byte{}, nil
 }
 
 func solverNetExecutorInitializer() ([]byte, error) {

--- a/e2e/app/admin/upgrade.go
+++ b/e2e/app/admin/upgrade.go
@@ -383,7 +383,7 @@ func upgradeSolverNetInbox(ctx context.Context, s shared, _ netconf.Network, c c
 		return errors.Wrap(err, "get addrs")
 	}
 
-	initializer, err := solverNetInboxInitializer(addrs.SolverNetOutbox)
+	initializer, err := solverNetInboxInitializer()
 	if err != nil {
 		return errors.Wrap(err, "pack initializer")
 	}
@@ -432,7 +432,7 @@ func upgradeSolverNetOutbox(ctx context.Context, s shared, network netconf.Netwo
 		})
 	}
 
-	initializer, err := solverNetOutboxInitializer(chainIDs, inboxes)
+	initializer, err := solverNetOutboxInitializer()
 	if err != nil {
 		return errors.Wrap(err, "pack initializer")
 	}
@@ -524,12 +524,12 @@ func upgradeSolverNetAll(ctx context.Context, s shared, network netconf.Network,
 		portal = common.Address{}
 	}
 
-	inboxInitializer, err := solverNetInboxInitializer(addrs.SolverNetOutbox)
+	inboxInitializer, err := solverNetInboxInitializer()
 	if err != nil {
 		return errors.Wrap(err, "pack inbox initializer")
 	}
 
-	outboxInitializer, err := solverNetOutboxInitializer(chainIDs, inboxes)
+	outboxInitializer, err := solverNetOutboxInitializer()
 	if err != nil {
 		return errors.Wrap(err, "pack outbox initializer")
 	}


### PR DESCRIPTION
Upgrading `SolverNetOutbox` and need to remove initializers that are no longer necessary.

ref none
