### PR TITLE
chore(sdk): set svm package to private

### DIFF
--- a/sdk/packages/svm/package.json
+++ b/sdk/packages/svm/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@omni-network/svm",
+  "private": true,
   "description": "SVM support for Omni Solvernet",
   "version": "0.0.1",
   "type": "module",


### PR DESCRIPTION
- changeset publish command sees the changelog in the SVM package and tries to publish
- as a result simply adding the package to the ignore doesn't suffice
- we can either - delete the changelog + add to the ignore list, or simply set to private for now

issue: none