### PR TITLE
Fix typos in metrics and contract monitoring logs

### DIFF
--- a/monitor/app/metrics.go
+++ b/monitor/app/metrics.go
@@ -41,7 +41,7 @@ var (
 		Namespace: "monitor",
 		Subsystem: "public_rpc",
 		Name:      "sync_diff",
-		Help:      "Sync difference (highest blocks) betweent public RPC and omni node",
+		Help:      "Sync difference (highest blocks) between public RPC and omni node",
 	})
 
 	gasTipCap = promauto.NewGauge(prometheus.GaugeOpts{

--- a/monitor/contract/monitor.go
+++ b/monitor/contract/monitor.go
@@ -38,7 +38,7 @@ func StartMonitoring(ctx context.Context, network netconf.Network, endpoints xch
 
 	allContracts, err := contracts.ToMonitor(ctx, network.ID)
 	if err != nil {
-		log.Error(ctx, "Failed to get contract addreses to monitor - skipping monitoring", err)
+		log.Error(ctx, "Failed to get contract addresses to monitor - skipping monitoring", err)
 		return nil
 	}
 


### PR DESCRIPTION


Description:  
This pull request corrects two typos in the codebase:
- In `monitor/app/metrics.go`, the word "betweent" is corrected to "between" in the Prometheus metric help text.
- In `monitor/contract/monitor.go`, the word "addresses" is corrected in the error log message.

These changes improve the clarity and professionalism of log and metric messages. No functional code changes are introduced.
