### PR TITLE
chore(solver/app): e2e test svm orders

### DIFF
--- a/e2e/app/definition.go
+++ b/e2e/app/definition.go
@@ -570,6 +570,15 @@ func networkFromDef(def Definition) netconf.Network {
 		chains = append(chains, newChain(anvil.Chain))
 	}
 
+	// Add SVM chains
+	for _, svm := range def.Testnet.SVMChains {
+		chains = append(chains, netconf.Chain{
+			ID:          svm.ChainID,
+			Name:        svm.Name,
+			BlockPeriod: svm.BlockPeriod,
+		})
+	}
+
 	return netconf.Network{
 		ID:     def.Testnet.Network,
 		Chains: chains,

--- a/e2e/app/monitor.go
+++ b/e2e/app/monitor.go
@@ -109,7 +109,7 @@ func StartMonitoringReceipts(ctx context.Context, def Definition) func() error {
 			})
 	}
 
-	results, cancel := forkjoin.NewWithInputs(ctx, streamReceipts, network.Chains)
+	results, cancel := forkjoin.NewWithInputs(ctx, streamReceipts, network.CoreChains())
 
 	return func() error {
 		log.Debug(ctx, "Checking receipts")

--- a/e2e/app/svm.go
+++ b/e2e/app/svm.go
@@ -2,11 +2,14 @@ package app
 
 import (
 	"context"
+	"encoding/json"
+	"os"
 	"path/filepath"
 	"time"
 
 	"github.com/omni-network/omni/anchor/anchorinbox"
 	"github.com/omni-network/omni/e2e/app/eoa"
+	"github.com/omni-network/omni/lib/anvil"
 	"github.com/omni-network/omni/lib/contracts/solvernet"
 	"github.com/omni-network/omni/lib/errors"
 	"github.com/omni-network/omni/lib/log"
@@ -51,6 +54,16 @@ func svmInit(ctx context.Context, def Definition) error {
 		roleAccounts = append(roleAccounts, key.PublicKey())
 	}
 
+	const exCount = 5
+	var exKeys []solana.PrivateKey
+	for _, key := range anvil.ExternalAccounts {
+		exKeys = append(exKeys, svmutil.MapEVMKey(key))
+		roleAccounts = append(roleAccounts, svmutil.MapEVMKey(key).PublicKey())
+		if len(exKeys) >= exCount {
+			break
+		}
+	}
+
 	log.Debug(ctx, "SVM: Requesting role airdrops")
 	// Fund all roles with SOL
 	fundAmount := solana.LAMPORTS_PER_SOL * 1e6 // 1M SOL in lamports
@@ -85,6 +98,10 @@ func svmInit(ctx context.Context, def Definition) error {
 		return err
 	}
 
+	if err := dumpSVMConfig(ctx, svmDir, svmChain.ExternalRPC, exKeys, mintResp, anchorinbox.Program()); err != nil {
+		return err
+	}
+
 	log.Info(ctx, "SVM initialized", "usdc_mint", mintResp.MintAccount, "anchor_inbox", anchorinbox.ProgramID)
 
 	return nil
@@ -110,4 +127,58 @@ func svmRoleKeys(ctx context.Context, network netconf.ID, chainID uint64) (map[e
 	}
 
 	return keys, nil
+}
+
+func dumpSVMConfig(
+	ctx context.Context,
+	dir string,
+	addr string,
+	wallets []solana.PrivateKey,
+	mint svmutil.CreateMintResp,
+	program svmutil.Program) error {
+	type mintConfig struct {
+		Symbol    string `json:"symbol"`
+		Mint      string `json:"account"`
+		Authority string `json:"authority_key"`
+	}
+	type programConfig struct {
+		Name    string `json:"name"`
+		Account string `json:"account"`
+	}
+
+	var wl []string
+	for _, w := range wallets {
+		wl = append(wl, w.String())
+	}
+
+	config := struct {
+		RPCAddress string          `json:"rpc_address"`
+		Mints      []mintConfig    `json:"mints"`
+		Programs   []programConfig `json:"programs"`
+		Wallets    []string        `json:"wallet_keys"`
+	}{
+		RPCAddress: addr,
+		Wallets:    wl,
+		Mints: []mintConfig{{
+			Symbol:    "USDC",
+			Mint:      mint.MintAccount.String(),
+			Authority: mint.Authority.String(),
+		}},
+		Programs: []programConfig{{
+			Name:    program.Name,
+			Account: program.MustPublicKey().String(),
+		}},
+	}
+	content, err := json.MarshalIndent(config, "", "  ")
+	if err != nil {
+		return errors.Wrap(err, "marshal config")
+	}
+	configFile := filepath.Join(dir, "config.json")
+	if err := os.WriteFile(configFile, content, 0644); err != nil {
+		return errors.Wrap(err, "write config file")
+	}
+
+	log.Info(ctx, "Dumped SVM config file", "file", configFile)
+
+	return nil
 }

--- a/e2e/app/svm.go
+++ b/e2e/app/svm.go
@@ -75,7 +75,7 @@ func svmInit(ctx context.Context, def Definition) error {
 	}
 
 	log.Debug(ctx, "SVM: Initializing anchorinbox program")
-	const closeBuffer = time.Second * 0 // Allow immediate closing in devnet
+	const closeBuffer = time.Second * 60 // Allow 60s for fills on devnet
 	init, err := anchorinbox.NewInit(svmChain.ChainID, closeBuffer, roleKeys[eoa.RoleSolver].PublicKey())
 	if err != nil {
 		return errors.Wrap(err, "create anchorinbox init instruction")

--- a/e2e/docker/compose.yaml.tmpl
+++ b/e2e/docker/compose.yaml.tmpl
@@ -172,10 +172,11 @@ services:
         hard: 1000000
     ports:
       - 8899:8899
+      - 8900:8900
     volumes:
       - ./svm:/root/.config/solana/
     logging:
-          driver: local
+      driver: local
     networks:
       {{ $.NetworkName }}:
         {{ if $.Network }}ipv4_address: 10.186.73.204{{ end }}

--- a/e2e/docker/testdata/TestComposeTemplate_commit.golden
+++ b/e2e/docker/testdata/TestComposeTemplate_commit.golden
@@ -173,10 +173,11 @@ services:
         hard: 1000000
     ports:
       - 8899:8899
+      - 8900:8900
     volumes:
       - ./svm:/root/.config/solana/
     logging:
-          driver: local
+      driver: local
     networks:
       test:
         ipv4_address: 10.186.73.204

--- a/e2e/docker/testdata/TestComposeTemplate_empheral_network.golden
+++ b/e2e/docker/testdata/TestComposeTemplate_empheral_network.golden
@@ -173,10 +173,11 @@ services:
         hard: 1000000
     ports:
       - 8899:8899
+      - 8900:8900
     volumes:
       - ./svm:/root/.config/solana/
     logging:
-          driver: local
+      driver: local
     networks:
       test:
         ipv4_address: 10.186.73.204

--- a/e2e/docker/testdata/TestComposeTemplate_empheral_network_upgrade.golden
+++ b/e2e/docker/testdata/TestComposeTemplate_empheral_network_upgrade.golden
@@ -173,10 +173,11 @@ services:
         hard: 1000000
     ports:
       - 8899:8899
+      - 8900:8900
     volumes:
       - ./svm:/root/.config/solana/
     logging:
-          driver: local
+      driver: local
     networks:
       test:
         ipv4_address: 10.186.73.204

--- a/e2e/solve/fund.go
+++ b/e2e/solve/fund.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"math/big"
 
+	"github.com/omni-network/omni/contracts/bindings"
 	"github.com/omni-network/omni/e2e/app/eoa"
 	"github.com/omni-network/omni/lib/anvil"
 	"github.com/omni-network/omni/lib/bi"
@@ -31,35 +32,52 @@ func maybeFundERC20Solver(ctx context.Context, network netconf.ID, backends ethb
 	if err != nil {
 		return err
 	}
+	usdcOnMockL1, err := Find(evmchain.IDMockL1, tokens.USDC.Symbol)
+	if err != nil {
+		return err
+	}
+	usdcOnMockL2, err := Find(evmchain.IDMockL2, tokens.USDC.Symbol)
+	if err != nil {
+		return err
+	}
 
 	// erc20 tokens to fund solver with on devnet. useful for solvernet development when forking public networks
 	toFund := []struct {
 		chainID uint64
 		addr    common.Address
 	}{
-		// holesky wstETH
-		{chainID: evmchain.IDMockL1, addr: common.HexToAddress("0x8d09a4502cc8cf1547ad300e066060d043f6982d")},
-		// holesky stETH
-		{chainID: evmchain.IDMockL1, addr: common.HexToAddress("0x3f1c547b21f65e10480de3ad8e19faac46c95034")},
 		// devnet wstETH
 		{chainID: evmchain.IDMockL1, addr: wstETHOnMockL1},
 		{chainID: evmchain.IDMockL2, addr: wstETHOnMockL2},
+		// devnet USDC
+		{chainID: evmchain.IDMockL1, addr: usdcOnMockL1},
+		{chainID: evmchain.IDMockL2, addr: usdcOnMockL2},
 	}
 
 	solver := eoa.MustAddress(netconf.Devnet, eoa.RoleSolver)
 	eth1m := bi.Ether(1_000_000)
 
 	for _, tkn := range toFund {
-		ethCl, ok := backends.Clients()[tkn.chainID]
-		if !ok {
-			continue
+		backend, err := backends.Backend(tkn.chainID)
+		if err != nil {
+			return err
 		}
 
-		// if devnet is not forking the public chain tkn is deployed on, this sets
-		// storage on an unused address, which is fine
-		err := anvil.FundERC20(ctx, ethCl, tkn.addr, eth1m, solver)
+		merc20, err := bindings.NewMockERC20(tkn.addr, backend)
 		if err != nil {
-			return errors.Wrap(err, "fund tkn failed", "chain_id", tkn.chainID, "addr", tkn.addr)
+			return errors.Wrap(err, "new mock erc20")
+		}
+
+		txOpts, err := backend.BindOpts(ctx, solver)
+		if err != nil {
+			return err
+		}
+
+		tx, err := merc20.Mint(txOpts, solver, eth1m)
+		if err != nil {
+			return errors.Wrap(err, "mint token")
+		} else if _, err := backend.WaitMined(ctx, tx); err != nil {
+			return errors.Wrap(err, "wait for mint tx")
 		}
 	}
 
@@ -88,14 +106,26 @@ func maybeFundERC20Flowgen(ctx context.Context, network netconf.ID, backends eth
 	eth1m := bi.Ether(1_000_000)
 
 	for _, tkn := range toFund {
-		ethCl, ok := backends.Clients()[tkn.chainID]
-		if !ok {
-			continue
+		backend, err := backends.Backend(tkn.chainID)
+		if err != nil {
+			return err
 		}
 
-		err := anvil.FundERC20(ctx, ethCl, tkn.addr, eth1m, flowgen)
+		merc20, err := bindings.NewMockERC20(tkn.addr, backend)
 		if err != nil {
-			return errors.Wrap(err, "fund tkn failed", "chain_id", tkn.chainID, "addr", tkn.addr)
+			return errors.Wrap(err, "new mock erc20")
+		}
+
+		txOpts, err := backend.BindOpts(ctx, flowgen)
+		if err != nil {
+			return err
+		}
+
+		tx, err := merc20.Mint(txOpts, flowgen, eth1m)
+		if err != nil {
+			return errors.Wrap(err, "mint token")
+		} else if _, err := backend.WaitMined(ctx, tx); err != nil {
+			return errors.Wrap(err, "wait for mint tx")
 		}
 
 		log.Debug(ctx, "Funded flowgen", "chain", tkn.chainID, "address", flowgen, "token_address", tkn.addr)

--- a/e2e/solve/svmtest.go
+++ b/e2e/solve/svmtest.go
@@ -1,0 +1,199 @@
+//nolint:contextcheck // Not critical for testing
+package solve
+
+import (
+	"context"
+	"time"
+
+	"github.com/omni-network/omni/anchor/anchorinbox"
+	"github.com/omni-network/omni/e2e/app/eoa"
+	"github.com/omni-network/omni/e2e/types"
+	"github.com/omni-network/omni/lib/bi"
+	"github.com/omni-network/omni/lib/contracts/solvernet"
+	"github.com/omni-network/omni/lib/errors"
+	"github.com/omni-network/omni/lib/evmchain"
+	"github.com/omni-network/omni/lib/log"
+	"github.com/omni-network/omni/lib/netconf"
+	"github.com/omni-network/omni/lib/svmutil"
+	"github.com/omni-network/omni/lib/tokens"
+
+	"github.com/ethereum/go-ethereum/common"
+
+	"github.com/gagliardetto/solana-go"
+	"github.com/gagliardetto/solana-go/rpc"
+)
+
+func TestSVM(ctx context.Context, testnet types.Testnet) error {
+	if len(testnet.SVMChains) == 0 {
+		return nil
+	} else if len(testnet.SVMChains) > 1 {
+		return errors.New("multiple SVM chains")
+	} else if testnet.Network != netconf.Devnet {
+		return errors.New("not devnet")
+	}
+
+	svmChain := testnet.SVMChains[0]
+	cl := rpc.New(svmChain.ExternalRPC)
+
+	for i, svmOrder := range makeSVMOrders(ctx, testnet.Network) {
+		txResp, err := svmutil.SendSimple(ctx, cl, svmOrder.PrivateKey, svmOrder.Build())
+		if err != nil {
+			return err
+		}
+
+		_, err = svmutil.AwaitConfirmedTransaction(ctx, cl, txResp)
+		if err != nil {
+			return err
+		}
+
+		for {
+			state, _, err := anchorinbox.GetOrderState(ctx, cl, svmOrder.OpenOrder.ID)
+			if err != nil {
+				return err
+			}
+
+			if state.Status == anchorinbox.StatusRejected {
+				return errors.New("svm order rejected", "index", i, "order_id", svmOrder.ID(), "status", state.Status, "reason", state.RejectReason)
+			} else if state.Status != anchorinbox.StatusClaimed {
+				log.Debug(ctx, "SVM order status", "index", i, "order_id", svmOrder.ID(), "status", state.Status)
+				time.Sleep(time.Second) // Wait before checking again
+
+				continue
+			}
+
+			break
+		}
+	}
+
+	return nil
+}
+
+type svmOrder struct {
+	anchorinbox.OpenOrder
+	PrivateKey solana.PrivateKey
+}
+
+func (o svmOrder) ID() solvernet.OrderID {
+	return solvernet.OrderID(o.OpenOrder.ID)
+}
+
+func makeSVMOrders(ctx context.Context, network netconf.ID) []svmOrder {
+	var keys []solana.PrivateKey
+	for _, role := range []eoa.Role{eoa.RoleFlowgen, eoa.RoleHot} {
+		pk, err := eoa.PrivateKey(ctx, network, role)
+		if err != nil {
+			panic(errors.Wrap(err, "get private key for role", "role", role, "network", network))
+		}
+		keys = append(keys, svmutil.MapEVMKey(pk))
+	}
+
+	return []svmOrder{
+		// Create order 1: svm USDC -> mockL1 USDC
+		mustSVMOrder(
+			keys[0],
+			mustToken(evmchain.IDSolanaLocal, tokens.USDC),
+			mustToken(evmchain.IDMockL1, tokens.USDC),
+			10, // 10 USDC
+		),
+		// Create order 2: svm USDC -> mockL2 ETH
+		mustSVMOrder(
+			keys[1],
+			mustToken(evmchain.IDSolanaLocal, tokens.USDC),
+			mustToken(evmchain.IDMockL2, tokens.WSTETH),
+			0.01, // 0.01 WSTETH
+		),
+	}
+}
+
+func mustSVMOrder(owner solana.PrivateKey, src, dst tokens.Token, expenseF64 float64) svmOrder {
+	params, err := svmTokenParams(src, dst, expenseF64)
+	if err != nil {
+		panic(errors.Wrap(err, "create SVM order params"))
+	}
+
+	openOrder, err := anchorinbox.NewOpenOrder(params, owner.PublicKey(), src.SVMAddress)
+	if err != nil {
+		panic(errors.Wrap(err, "create SVM open order"))
+	}
+
+	return svmOrder{
+		OpenOrder:  openOrder,
+		PrivateKey: owner,
+	}
+}
+
+func mustToken(chainID uint64, asset tokens.Asset) tokens.Token {
+	token, ok := tokens.ByAsset(chainID, asset)
+	if !ok {
+		panic(errors.New("get token by asset", "chain_id", chainID, "asset", asset))
+	}
+
+	return token
+}
+
+func svmTokenParams(src, dst tokens.Token, expenseF64 float64) (anchorinbox.OpenParams, error) {
+	expenseAmount := dst.F64ToAmt(expenseF64)
+	depositAmount := mustDepositAmount(expenseAmount, src, dst)
+
+	expenses, calls := expenseAndCall(expenseAmount, dst, common.Address{}) // Send to zero address for now
+
+	svmCall, err := toSVMCall(calls)
+	if err != nil {
+		return anchorinbox.OpenParams{}, err
+	}
+
+	svmExpense, err := toSVMExpense(expenses)
+	if err != nil {
+		return anchorinbox.OpenParams{}, err
+	}
+
+	return anchorinbox.OpenParams{
+		DepositAmount: depositAmount.Uint64(),
+		DestChainId:   dst.ChainID,
+		Call:          svmCall,
+		Expense:       svmExpense,
+	}, nil
+}
+
+func toSVMExpense(expenses []solvernet.Expense) (anchorinbox.EVMTokenExpense, error) {
+	if len(expenses) != 1 {
+		return anchorinbox.EVMTokenExpense{}, errors.New("expected exactly one expense")
+	}
+	expense := expenses[0]
+
+	if expense.Amount == nil {
+		expense.Amount = bi.Zero()
+	}
+	amount, err := svmutil.U128(expense.Amount)
+	if err != nil {
+		return anchorinbox.EVMTokenExpense{}, err
+	}
+
+	return anchorinbox.EVMTokenExpense{
+		Spender: expense.Spender,
+		Token:   expense.Token,
+		Amount:  amount,
+	}, nil
+}
+
+func toSVMCall(calls []solvernet.Call) (anchorinbox.EVMCall, error) {
+	if len(calls) != 1 {
+		return anchorinbox.EVMCall{}, errors.New("expected exactly one call")
+	}
+	call := calls[0].ToBinding()
+
+	if call.Value == nil {
+		call.Value = bi.Zero()
+	}
+	value, err := svmutil.U128(call.Value)
+	if err != nil {
+		return anchorinbox.EVMCall{}, err
+	}
+
+	return anchorinbox.EVMCall{
+		Target:   call.Target,
+		Selector: call.Selector,
+		Value:    value,
+		Params:   call.Params,
+	}, nil
+}

--- a/e2e/test/app_test.go
+++ b/e2e/test/app_test.go
@@ -31,10 +31,7 @@ func TestApp_Hash(t *testing.T) {
 
 		require.Eventually(t, func() bool {
 			status, err := client.Status(ctx)
-			require.NoError(t, err)
-			require.NotZero(t, status.SyncInfo.LatestBlockHeight)
-
-			return status.SyncInfo.LatestBlockHeight >= requestedHeight
+			return err == nil && status.SyncInfo.LatestBlockHeight >= requestedHeight
 		}, 5*time.Second, 500*time.Millisecond)
 
 		block, err := client.Block(ctx, &requestedHeight)

--- a/e2e/test/solve_test.go
+++ b/e2e/test/solve_test.go
@@ -42,6 +42,19 @@ func TestSolver(t *testing.T) {
 	})
 }
 
+func TestSolverSVM(t *testing.T) {
+	t.Parallel()
+	skipFunc := func(manifest types.Manifest) bool {
+		return !manifest.AllE2ETests
+	}
+	maybeTestNetwork(t, skipFunc, func(ctx context.Context, t *testing.T, deps NetworkDeps) {
+		t.Helper()
+
+		err := solve.TestSVM(ctx, deps.Testnet)
+		tutil.RequireNoError(t, err)
+	})
+}
+
 func testContractsAPI(ctx context.Context, t *testing.T, solverAddr string) {
 	t.Helper()
 

--- a/lib/contracts/solvernet/config.go
+++ b/lib/contracts/solvernet/config.go
@@ -154,10 +154,8 @@ func Provider(srcChainID, destChainID uint64) (uint8, bool) {
 		return ProviderNone, false
 	}
 
-	if IsTrusted(destChainID) {
+	if IsTrusted(srcChainID) || IsTrusted(destChainID) {
 		return ProviderTrusted, true
-	} else if IsTrusted(srcChainID) {
-		return ProviderNone, false // Trusted chains are only destinations for now.
 	}
 
 	if srcChainID == destChainID {

--- a/lib/contracts/solvernet/outbox/deploy.go
+++ b/lib/contracts/solvernet/outbox/deploy.go
@@ -181,6 +181,18 @@ func deploy(ctx context.Context, cfg DeploymentConfig, network netconf.Network, 
 			Provider: provider,
 		})
 	}
+	for _, dest := range network.SVMChains() {
+		provider, ok := solvernet.Provider(chainID.Uint64(), dest.ID)
+		if !ok {
+			continue
+		}
+
+		chainIDs = append(chainIDs, dest.ID)
+		inboxes = append(inboxes, bindings.ISolverNetOutboxInboxConfig{
+			Inbox:    cfg.Inbox,
+			Provider: provider,
+		})
+	}
 
 	txOpts, err = backend.BindOpts(ctx, cfg.Owner)
 	if err != nil {

--- a/lib/netconf/netconf.go
+++ b/lib/netconf/netconf.go
@@ -336,6 +336,20 @@ func (n Network) StreamsBetween(srcChainID uint64, dstChainID uint64) []xchain.S
 	return resp
 }
 
+func (n Network) CoreChains() []Chain {
+	var resp []Chain
+	for _, chain := range n.Chains {
+		if evmchain.IsSVM(chain.ID) {
+			continue // Skip non-core chains.
+		}
+		// TODO(corver): Also exclude HL chains
+
+		resp = append(resp, chain)
+	}
+
+	return resp
+}
+
 // Chain defines the configuration of an execution chain that supports
 // the Omni cross chain protocol. This is most supported Rollup EVMs, but
 // also the Omni EVM, and the Omni Consensus chain.

--- a/lib/svmutil/compose_test.go
+++ b/lib/svmutil/compose_test.go
@@ -252,7 +252,7 @@ func TestInbox(t *testing.T) {
 		p.DepositAmount = depositAmount
 		p.Call.Params = tutil.RandomBytes(4)
 
-		openOrder, err = anchorinbox.NewOpenOrder(p, owner, mintResp.MintAccount, mintResp.AuthATA())
+		openOrder, err = anchorinbox.NewOpenOrder(p, owner, mintResp.MintAccount)
 		require.NoError(t, err)
 
 		// Send Open instruction
@@ -373,7 +373,7 @@ func TestInbox(t *testing.T) {
 
 	// Prep Open instruction
 	t.Run("open and close", func(t *testing.T) {
-		openOrder, err := anchorinbox.NewOpenOrder(anchorinbox.OpenParams{DepositAmount: depositAmount}, owner, mintResp.MintAccount, mintResp.AuthATA())
+		openOrder, err := anchorinbox.NewOpenOrder(anchorinbox.OpenParams{DepositAmount: depositAmount}, owner, mintResp.MintAccount)
 		require.NoError(t, err)
 		closeOrder := anchorinbox.NewCloseInstruction(
 			openOrder.ID,
@@ -421,7 +421,7 @@ func TestInbox(t *testing.T) {
 
 	t.Run("open and reject", func(t *testing.T) {
 		const reason uint8 = 99
-		openOrder, err := anchorinbox.NewOpenOrder(anchorinbox.OpenParams{DepositAmount: depositAmount}, owner, mintResp.MintAccount, mintResp.AuthATA())
+		openOrder, err := anchorinbox.NewOpenOrder(anchorinbox.OpenParams{DepositAmount: depositAmount}, owner, mintResp.MintAccount)
 		require.NoError(t, err)
 
 		// Send open instructions

--- a/lib/svmutil/helpers.go
+++ b/lib/svmutil/helpers.go
@@ -162,3 +162,22 @@ func FilterDataLogs(logs []string, program solana.PublicKey) ([]string, bool, er
 
 	return filtered, len(stack) == 0, nil
 }
+
+// GetBlock is a convenience function returning the block for the given slot,
+// or false if no block found for the slot,
+// or and error.
+func GetBlock(ctx context.Context, cl *rpc.Client, slot uint64, details rpc.TransactionDetailsType) (*rpc.GetBlockResult, bool, error) {
+	block, err := cl.GetBlockWithOpts(ctx, slot, &rpc.GetBlockOpts{
+		TransactionDetails:             details,
+		Rewards:                        ptr(false),
+		Commitment:                     rpc.CommitmentConfirmed,
+		MaxSupportedTransactionVersion: ptr(rpc.MaxSupportedTransactionVersion0),
+	})
+	if errors.Is(err, rpc.ErrNotConfirmed) {
+		return nil, false, nil
+	} else if err != nil {
+		return nil, false, WrapRPCError(err, "getBlock")
+	}
+
+	return block, true, nil
+}

--- a/lib/svmutil/localsvm/main.go
+++ b/lib/svmutil/localsvm/main.go
@@ -68,7 +68,7 @@ func run(ctx context.Context, dir string) error {
 	}
 
 	log.Info(ctx, "Initializing anchor inbox program...")
-	const closeBuffer = time.Second * 0 // Allow immediate closing in devnet
+	const closeBuffer = time.Minute // Allow 1min for devent fills
 	init, err := anchorinbox.NewInit(evmchain.IDSolanaLocal, closeBuffer, privkey.PublicKey())
 	if err != nil {
 		return errors.Wrap(err, "create anchor inbox init instruction")

--- a/lib/svmutil/stream.go
+++ b/lib/svmutil/stream.go
@@ -60,7 +60,7 @@ func Stream(ctx context.Context, cl *rpc.Client, req StreamReq, callback StreamC
 			}
 			prev = sig
 
-			ctx := log.WithCtx(ctx, "slot", sig.Slot, log.Hex7("sig", sig.Signature[:]))
+			ctx := log.WithCtx(ctx, "slot", sig.Slot, "sig", sig.Signature.String()[:7])
 
 			err := callback(ctx, sig)
 			if ctx.Err() != nil {

--- a/lib/tokens/tokens.go
+++ b/lib/tokens/tokens.go
@@ -106,9 +106,15 @@ func ByAsset(chainID uint64, asset Asset) (Token, bool) {
 	return Token{}, false
 }
 
-// Native is an alias for ByAddress with the native token address.
+// Native is an alias for ByUniAddress with the native/zero token address.
 func Native(chainID uint64) (Token, bool) {
-	return ByAddress(chainID, NativeAddr)
+	for _, t := range tokens {
+		if t.ChainID == chainID && t.UniAddress().IsZero() {
+			return t, true
+		}
+	}
+
+	return Token{}, false
 }
 
 // ByAddress returns the token with the given address and chain ID.

--- a/lib/tokens/tokens.json
+++ b/lib/tokens/tokens.json
@@ -550,6 +550,17 @@
   "IsMock": false
  },
  {
+  "Symbol": "USDC",
+  "Name": "USD Coin",
+  "Decimals": 6,
+  "CoingeckoID": "usd-coin",
+  "ChainID": 352,
+  "ChainClass": "devnet",
+  "Address": "0x0000000000000000000000000000000000000000",
+  "SVMAddress": "6AfTP38VbvM3gxMRy8ubvb7NbhzhjVB8VGMy2uBby1pY",
+  "IsMock": true
+ },
+ {
   "Symbol": "wstETH",
   "Name": "Wrapped Staked Ether",
   "Decimals": 18,

--- a/lib/tokens/tokens_test.go
+++ b/lib/tokens/tokens_test.go
@@ -13,11 +13,13 @@ import (
 	"github.com/omni-network/omni/lib/errors"
 	"github.com/omni-network/omni/lib/evmchain"
 	"github.com/omni-network/omni/lib/netconf"
+	"github.com/omni-network/omni/lib/svmutil"
 	"github.com/omni-network/omni/lib/tokens"
 	"github.com/omni-network/omni/lib/tutil"
 
 	"github.com/ethereum/go-ethereum/common"
 
+	"github.com/gagliardetto/solana-go"
 	"github.com/stretchr/testify/require"
 )
 
@@ -118,6 +120,9 @@ func TestGenTokens(t *testing.T) {
 			ChainID:    evmchain.IDHyperEVM,
 			ChainClass: tokens.ClassMainnet,
 		},
+
+		// SVM mints/tokens
+		svm(evmchain.IDSolanaLocal, tokens.USDC, svmutil.DevnetUSDCMint.PublicKey()),
 	)
 
 	for _, mock := range e2e.MockTokens() {
@@ -224,6 +229,20 @@ func omniERC20(network netconf.ID) tokens.Token {
 		ChainID:    chainID,
 		ChainClass: mustChainClass(chainID),
 		Address:    contracts.TokenAddr(network),
+	}
+}
+
+func svm(chainID uint64, asset tokens.Asset, address solana.PublicKey) tokens.Token {
+	return tokens.Token{
+		Asset:   asset,
+		ChainID: chainID,
+		ChainClass: map[uint64]tokens.ChainClass{
+			evmchain.IDSolanaLocal: tokens.ClassDevent,
+			evmchain.IDSolanaTest:  tokens.ClassTestnet,
+			evmchain.IDSolana:      tokens.ClassMainnet,
+		}[chainID],
+		SVMAddress: address,
+		IsMock:     chainID == evmchain.IDSolanaLocal,
 	}
 }
 

--- a/lib/uniswap/swap_test.go
+++ b/lib/uniswap/swap_test.go
@@ -63,7 +63,7 @@ func TestSwapToFromUSDC(t *testing.T) {
 	eth1k := bi.Ether(1_000)
 	tutil.RequireNoError(t, anvil.FundAccounts(ctx, ethCl, eth1k, swapper))
 	tutil.RequireNoError(t, anvil.FundERC20(ctx, ethCl, wstETH.Address, eth1k, swapper))
-	tutil.RequireNoError(t, anvil.FundL1USDT(ctx, ethCl, usdt.Address, bi.Dec6(1000), swapper))
+	tutil.RequireNoError(t, anvil.FundERC20(ctx, ethCl, usdt.Address, bi.Dec6(1000), swapper))
 
 	tests := []struct {
 		name     string

--- a/lib/xchain/provider/fetch.go
+++ b/lib/xchain/provider/fetch.go
@@ -10,6 +10,7 @@ import (
 	"github.com/omni-network/omni/lib/cchain"
 	"github.com/omni-network/omni/lib/errors"
 	"github.com/omni-network/omni/lib/ethclient"
+	"github.com/omni-network/omni/lib/evmchain"
 	"github.com/omni-network/omni/lib/tracer"
 	"github.com/omni-network/omni/lib/umath"
 	"github.com/omni-network/omni/lib/xchain"
@@ -225,6 +226,10 @@ func (p *Provider) GetSubmittedCursor(
 func (p *Provider) GetBlock(ctx context.Context, req xchain.ProviderRequest) (xchain.Block, bool, error) {
 	ctx, span := tracer.Start(ctx, spanName("get_block"))
 	defer span.End()
+
+	if evmchain.IsSVM(req.ChainID) {
+		return xchain.Block{}, false, errors.New("svm chains are not supported")
+	}
 
 	//nolint:nestif // Not so bad
 	if req.ChainID == p.cChainID {

--- a/lib/xchain/provider/provider.go
+++ b/lib/xchain/provider/provider.go
@@ -13,6 +13,7 @@ import (
 	"github.com/omni-network/omni/lib/cchain"
 	"github.com/omni-network/omni/lib/errors"
 	"github.com/omni-network/omni/lib/ethclient"
+	"github.com/omni-network/omni/lib/evmchain"
 	"github.com/omni-network/omni/lib/expbackoff"
 	"github.com/omni-network/omni/lib/log"
 	"github.com/omni-network/omni/lib/netconf"
@@ -136,6 +137,8 @@ func (p *Provider) stream(
 	chain, ok := p.network.Chain(req.ChainID)
 	if !ok {
 		return errors.New("unknown chain ID")
+	} else if evmchain.IsSVM(chain.ID) {
+		return errors.New("svm chains are not supported")
 	}
 
 	chainVersionName := p.network.ChainVersionName(xchain.ChainVersion{ID: req.ChainID, ConfLevel: req.ConfLevel})
@@ -223,6 +226,8 @@ func (p *Provider) stream(
 func (p *Provider) getEVMChain(chainID uint64) (netconf.Chain, ethclient.Client, error) {
 	if chainID == p.cChainID {
 		return netconf.Chain{}, nil, errors.New("consensus chain not supported")
+	} else if evmchain.IsSVM(chainID) {
+		return netconf.Chain{}, nil, errors.New("svm chains are not supported")
 	}
 
 	chain, ok := p.network.Chain(chainID)

--- a/solver/app/app.go
+++ b/solver/app/app.go
@@ -356,7 +356,7 @@ func startProcessingEvents(
 
 	callAllower := newCallAllower(network.ID, addrs.SolverNetExecutor)
 
-	ageCache := newAgeCache(ethBackends)
+	ageCache := newAgeCache(backends)
 	go monitorAgeCacheForever(ctx, network, ageCache)
 
 	filledPnL := newFilledPnlFunc(pricer, targetName, network.ChainName, ageCache.InstrumentDestFilled)

--- a/solver/app/pricer.go
+++ b/solver/app/pricer.go
@@ -7,6 +7,7 @@ import (
 	"math/big"
 	"time"
 
+	"github.com/omni-network/omni/lib/bi"
 	"github.com/omni-network/omni/lib/errors"
 	"github.com/omni-network/omni/lib/evmchain"
 	"github.com/omni-network/omni/lib/log"
@@ -100,12 +101,20 @@ func debugOrderPrice(ctx context.Context, priceFunc priceFunc, order Order) {
 	}
 
 	depositAmt := pendingData.MinReceived[0].Amount
+	if bi.IsZero(depositAmt) {
+		return
+	}
+
 	depositTkn, ok := tokenByAddr32(order.SourceChainID, pendingData.MinReceived[0].Token)
 	if !ok {
 		return
 	}
 
 	expenseAmt := pendingData.MaxSpent[0].Amount
+	if bi.IsZero(expenseAmt) {
+		return
+	}
+
 	expenseTkn, ok := tokenByAddr32(pendingData.DestinationChainID, pendingData.MaxSpent[0].Token)
 	if !ok {
 		return

--- a/solver/app/procdeps.go
+++ b/solver/app/procdeps.go
@@ -169,7 +169,7 @@ func newFiller(
 		// xcall fee
 		fee, err := outbox.FillFee(callOpts, pendingData.FillOriginData)
 		if err != nil {
-			return errors.Wrap(err, "get fulfill fee")
+			return errors.Wrap(err, "get fulfill fee", "custom", solvernet.DetectCustomError(err))
 		}
 
 		txOpts.Value = bi.Add(nativeValue, fee)

--- a/solver/app/processor.go
+++ b/solver/app/processor.go
@@ -53,11 +53,11 @@ func newEventProcFunc(deps procDeps, chainID uint64) eventProcFunc {
 		// maybeReject rejects orders if necessary, logging and counting them, returning true if rejected.
 		maybeReject := func() (bool, error) {
 			reason, reject, err := deps.ShouldReject(ctx, order)
-			if err != nil {
+			if !reject && err != nil {
 				return false, errors.Wrap(err, "should reject")
-			} else if !reject {
+			} else if !reject /* && err == nil */ {
 				return false, nil
-			}
+			} /* else reject && err != nil */
 
 			log.InfoErr(ctx, "Rejecting order", err, "reason", reason)
 

--- a/solver/app/reject_internal_test.go
+++ b/solver/app/reject_internal_test.go
@@ -70,7 +70,11 @@ func TestShouldReject(t *testing.T) {
 			}
 
 			reason, reject, err := shouldReject(t.Context(), tt.order)
-			require.NoError(t, err)
+			if tt.reject {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
 			require.Equal(t, tt.reason, reason, "expected reject reason %s, got %s", tt.reason, reason)
 			require.Equal(t, tt.reject, reject, "expected reject %s, got %s", tt.reject, reject)
 

--- a/solver/app/svmproc.go
+++ b/solver/app/svmproc.go
@@ -155,7 +155,7 @@ func newSVMStreamCallback(
 			}
 		}
 
-		log.Debug(ctx, "SVM: Processed events", "sig", sig.Signature, "slot", sig.Slot, "events", len(events))
+		log.Debug(ctx, "SVM: Processed events", "events", len(events))
 
 		if err := cursors.SetTxSig(ctx, chainVer, sig.Signature); err != nil {
 			return errors.Wrap(err, "update cursor")

--- a/solver/app/testdata/TestCheck/insufficient_native_balance/resp_body.json
+++ b/solver/app/testdata/TestCheck/insufficient_native_balance/resp_body.json
@@ -3,6 +3,6 @@
   "rejected": true,
   "rejectCode": 5,
   "rejectReason": "InsufficientInventory",
-  "rejectDescription": "insufficient balance [balance=0 ETH, expense=1 ETH]",
+  "rejectDescription": "insufficient solver balance [balance=0 ETH, chain=base_sepolia, expense=1 ETH]",
   "trace": null
 }

--- a/solver/app/testdata/TestTokens.golden
+++ b/solver/app/testdata/TestTokens.golden
@@ -480,6 +480,16 @@
   "symbol": "HYPE"
  },
  {
+  "address": "6AfTP38VbvM3gxMRy8ubvb7NbhzhjVB8VGMy2uBby1pY",
+  "chainId": 352,
+  "coingeckoId": "usd-coin",
+  "isMock": true,
+  "maxSpend": "10 USDC",
+  "minSpend": "0.1 USDC",
+  "name": "USD Coin",
+  "symbol": "USDC"
+ },
+ {
   "address": "0x6319df7c227e34B967C1903A08a698A3cC43492B",
   "chainId": 84532,
   "coingeckoId": "wrapped-steth",

--- a/solver/app/tokens_internal_test.go
+++ b/solver/app/tokens_internal_test.go
@@ -101,7 +101,7 @@ func TestTokens(t *testing.T) {
 		golden = append(golden, map[string]any{
 			"name":        tkn.Name,
 			"symbol":      tkn.Symbol,
-			"address":     tkn.Address.Hex(),
+			"address":     tkn.UniAddress().String(),
 			"maxSpend":    tkn.FormatAmt(bounds.MaxSpend),
 			"minSpend":    tkn.FormatAmt(bounds.MinSpend),
 			"chainId":     tkn.ChainID,


### PR DESCRIPTION
- Submit a few orders in  `e2e/solve.TestSVM`, ensure they get claimed.
- Fix funding of mock tokens in anvil
- Set SVMChain solver provider routes
- Add SVM devnet USDC token
- support svm in age cache
- better reject error logging 

issue: none