### PR TITLE
chore(solver/client): optional fees in price endpoint

### DIFF
--- a/monitor/flowgen/bridging/bridging.go
+++ b/monitor/flowgen/bridging/bridging.go
@@ -265,6 +265,7 @@ func swapPrice(ctx context.Context, scl sclient.Client, srcToken, dstToken token
 		DestinationChainID: dstToken.ChainID,
 		DepositToken:       srcToken.UniAddress(),
 		ExpenseToken:       dstToken.UniAddress(),
+		IncludeFees:        true,
 	}
 
 	return scl.Price(ctx, priceReq)

--- a/solver/app/pricer.go
+++ b/solver/app/pricer.go
@@ -85,7 +85,11 @@ func wrapPriceHandlerFunc(priceFunc priceFunc) priceHandlerFunc {
 			return types.Price{}, errors.Wrap(err, "price")
 		}
 
-		return price.WithFeeBips(feeBips(srcToken.Asset, dstToken.Asset)), nil // Add fee to the price.
+		if req.IncludeFees { // Add fee to the price.
+			price = price.WithFeeBips(feeBips(srcToken.Asset, dstToken.Asset))
+		}
+
+		return price, nil
 	}
 }
 

--- a/solver/app/testdata/TestPrice/0-OMNI-OMNI/req_body.json
+++ b/solver/app/testdata/TestPrice/0-OMNI-OMNI/req_body.json
@@ -1,0 +1,7 @@
+{
+ "sourceChainId": 1652,
+ "destChainId": 1651,
+ "depositToken": "0x73cc960fb6705e9a6a3d9eaf4de94a828cfa6d2a",
+ "expenseToken": "0x0000000000000000000000000000000000000000",
+ "includeFees": true
+}

--- a/solver/app/testdata/TestPrice/0-OMNI-OMNI/resp_body.json
+++ b/solver/app/testdata/TestPrice/0-OMNI-OMNI/resp_body.json
@@ -1,0 +1,7 @@
+{
+ "numerator": "0x1",
+ "denominator": "0x1",
+ "imprecise_rate": 1,
+ "deposit": "OMNI",
+ "expense": "OMNI"
+}

--- a/solver/app/testdata/TestPrice/1-ETH-OMNI/req_body.json
+++ b/solver/app/testdata/TestPrice/1-ETH-OMNI/req_body.json
@@ -1,0 +1,7 @@
+{
+ "sourceChainId": 1652,
+ "destChainId": 1651,
+ "depositToken": "0x0000000000000000000000000000000000000000",
+ "expenseToken": "0x0000000000000000000000000000000000000000",
+ "includeFees": true
+}

--- a/solver/app/testdata/TestPrice/1-ETH-OMNI/resp_body.json
+++ b/solver/app/testdata/TestPrice/1-ETH-OMNI/resp_body.json
@@ -1,0 +1,7 @@
+{
+ "numerator": "0x927c0",
+ "denominator": "0x3eb",
+ "imprecise_rate": 598.2053838484546,
+ "deposit": "ETH",
+ "expense": "OMNI"
+}

--- a/solver/app/testdata/TestPrice/2-wstETH-wstETH/req_body.json
+++ b/solver/app/testdata/TestPrice/2-wstETH-wstETH/req_body.json
@@ -1,0 +1,7 @@
+{
+ "sourceChainId": 1654,
+ "destChainId": 1652,
+ "depositToken": "0x86156a9225dce4781005d8cdc48106e308a0f338",
+ "expenseToken": "0x86156a9225dce4781005d8cdc48106e308a0f338",
+ "includeFees": true
+}

--- a/solver/app/testdata/TestPrice/2-wstETH-wstETH/resp_body.json
+++ b/solver/app/testdata/TestPrice/2-wstETH-wstETH/resp_body.json
@@ -1,0 +1,7 @@
+{
+ "numerator": "0x3e8",
+ "denominator": "0x3eb",
+ "imprecise_rate": 0.9970089730807578,
+ "deposit": "wstETH",
+ "expense": "wstETH"
+}

--- a/solver/app/testdata/TestPrice/3-wstETH-ETH/req_body.json
+++ b/solver/app/testdata/TestPrice/3-wstETH-ETH/req_body.json
@@ -1,0 +1,7 @@
+{
+ "sourceChainId": 1652,
+ "destChainId": 1654,
+ "depositToken": "0x86156a9225dce4781005d8cdc48106e308a0f338",
+ "expenseToken": "0x0000000000000000000000000000000000000000",
+ "includeFees": true
+}

--- a/solver/app/testdata/TestPrice/3-wstETH-ETH/resp_body.json
+++ b/solver/app/testdata/TestPrice/3-wstETH-ETH/resp_body.json
@@ -1,0 +1,7 @@
+{
+ "numerator": "0xfa0",
+ "denominator": "0xbc1",
+ "imprecise_rate": 1.3293452974410103,
+ "deposit": "wstETH",
+ "expense": "ETH"
+}

--- a/solver/app/testdata/TestPrice/4-USDC-ETH/req_body.json
+++ b/solver/app/testdata/TestPrice/4-USDC-ETH/req_body.json
@@ -1,0 +1,7 @@
+{
+ "sourceChainId": 1652,
+ "destChainId": 1654,
+ "depositToken": "0xfac41d3e0777e7f5611bceddd827a05c0cea985f",
+ "expenseToken": "0x0000000000000000000000000000000000000000",
+ "includeFees": true
+}

--- a/solver/app/testdata/TestPrice/4-USDC-ETH/resp_body.json
+++ b/solver/app/testdata/TestPrice/4-USDC-ETH/resp_body.json
@@ -1,0 +1,7 @@
+{
+ "numerator": "0x1",
+ "denominator": "0xbc1",
+ "imprecise_rate": 0.00033233632436025255,
+ "deposit": "USDC",
+ "expense": "ETH"
+}

--- a/solver/app/testutils_internal_test.go
+++ b/solver/app/testutils_internal_test.go
@@ -1031,6 +1031,7 @@ func depositFor(t *testing.T, expense *big.Int) *big.Int {
 		types.PriceRequest{
 			SourceChainID:      evmchain.IDMockL2,
 			DestinationChainID: evmchain.IDMockL1,
+			IncludeFees:        true,
 		})
 	tutil.RequireNoError(t, err)
 
@@ -1046,6 +1047,7 @@ func expenseFor(t *testing.T, deposit *big.Int) *big.Int {
 		types.PriceRequest{
 			SourceChainID:      evmchain.IDMockL2,
 			DestinationChainID: evmchain.IDMockL1,
+			IncludeFees:        true,
 		})
 	require.NoError(t, err)
 

--- a/solver/types/api.go
+++ b/solver/types/api.go
@@ -71,6 +71,7 @@ type PriceRequest struct {
 	DestinationChainID uint64      `json:"destChainId"`
 	DepositToken       uni.Address `json:"depositToken"`
 	ExpenseToken       uni.Address `json:"expenseToken"`
+	IncludeFees        bool        `json:"includeFees"` // If true, include fees in the price calculation
 }
 
 type TokensResponse struct {


### PR DESCRIPTION
Add `includeFees` field to `/price` endpoint and make it optional and default to `false`. 

issue: none