### PR TITLE
chore(e2e/manifest): bump mainnet solver

### DIFF
--- a/e2e/manifests/mainnet.toml
+++ b/e2e/manifests/mainnet.toml
@@ -7,7 +7,7 @@ prometheus   = true
 pinned_halo_tag = "v0.15.0"
 pinned_relayer_tag = "07c4ac7"
 pinned_monitor_tag = "e7c1bd8"
-pinned_solver_tag = "e7c1bd8"
+pinned_solver_tag = "855e393"
 
 [node.validator01]
 [node.validator02]


### PR DESCRIPTION
Bumps mainnet solver to skip past hyperevm outage.

issue: none