### PR TITLE
chore(e2e/vmcompose): enable geth debug logs

### DIFF
--- a/e2e/vmcompose/provider.go
+++ b/e2e/vmcompose/provider.go
@@ -93,7 +93,7 @@ func (p *Provider) Setup() error {
 			}
 		}
 
-		gethVerbosity := 3 // Info level
+		gethVerbosity := 4 // Debug level
 
 		def := docker.ComposeDef{
 			UpgradeVersion: p.Testnet.UpgradeVersion,

--- a/e2e/vmcompose/testdata/TestSetup_127-0-0-1-compose.yaml.golden
+++ b/e2e/vmcompose/testdata/TestSetup_127-0-0-1-compose.yaml.golden
@@ -44,7 +44,7 @@ services:
       - --pprof.addr=0.0.0.0
       - --metrics
       - --graphql
-      - --verbosity=3 # Log level (1=error,2=warn,3=info,4=debug)
+      - --verbosity=4 # Log level (1=error,2=warn,3=info,4=debug)
       
     ports:
       - 8551:8551 # Auth RPC

--- a/e2e/vmcompose/testdata/TestSetup_127-0-0-2-compose.yaml.golden
+++ b/e2e/vmcompose/testdata/TestSetup_127-0-0-2-compose.yaml.golden
@@ -44,7 +44,7 @@ services:
       - --pprof.addr=0.0.0.0
       - --metrics
       - --graphql
-      - --verbosity=3 # Log level (1=error,2=warn,3=info,4=debug)
+      - --verbosity=4 # Log level (1=error,2=warn,3=info,4=debug)
       
     ports:
       - 8551:8551 # Auth RPC

--- a/e2e/vmcompose/testdata/TestSetup_127-0-0-4-compose.yaml.golden
+++ b/e2e/vmcompose/testdata/TestSetup_127-0-0-4-compose.yaml.golden
@@ -44,7 +44,7 @@ services:
       - --pprof.addr=0.0.0.0
       - --metrics
       - --graphql
-      - --verbosity=3 # Log level (1=error,2=warn,3=info,4=debug)
+      - --verbosity=4 # Log level (1=error,2=warn,3=info,4=debug)
       
     ports:
       - 8551:8551 # Auth RPC

--- a/e2e/vmcompose/testdata/TestSetup_127-0-0-5-compose.yaml.golden
+++ b/e2e/vmcompose/testdata/TestSetup_127-0-0-5-compose.yaml.golden
@@ -44,7 +44,7 @@ services:
       - --pprof.addr=0.0.0.0
       - --metrics
       - --graphql
-      - --verbosity=3 # Log level (1=error,2=warn,3=info,4=debug)
+      - --verbosity=4 # Log level (1=error,2=warn,3=info,4=debug)
       
     ports:
       - 8551:8551 # Auth RPC


### PR DESCRIPTION
Increase geth logs to debug so we can see which rpc are called.

issue: none