### PR TITLE
Remove ds-test usage

### DIFF
--- a/contracts/avs/foundry.toml
+++ b/contracts/avs/foundry.toml
@@ -5,7 +5,6 @@ libs = ["node_modules"]
 
 remappings = [
   "forge-std/=node_modules/forge-std/src",
-  "ds-test/=node_modules/ds-test/src",
   "src/=src",
   "core-test/=../core/test",
   "core/=../core/src",

--- a/contracts/avs/package.json
+++ b/contracts/avs/package.json
@@ -13,7 +13,6 @@
     "test": "forge test"
   },
   "devDependencies": {
-    "ds-test": "github:dapphub/ds-test",
     "forge-std": "github:foundry-rs/forge-std"
   },
   "dependencies": {

--- a/contracts/avs/pnpm-lock.yaml
+++ b/contracts/avs/pnpm-lock.yaml
@@ -27,9 +27,6 @@ importers:
         specifier: ^6.2.0
         version: 6.2.0
     devDependencies:
-      ds-test:
-        specifier: github:dapphub/ds-test
-        version: https://codeload.github.com/dapphub/ds-test/tar.gz/e282159d5170298eb2455a6c05280ab5a73a4ef0
       forge-std:
         specifier: github:foundry-rs/forge-std
         version: https://codeload.github.com/foundry-rs/forge-std/tar.gz/8ba9031ffcbe25aa0d1224d3ca263a995026e477
@@ -475,9 +472,6 @@ packages:
     resolution: {integrity: sha512-uIFDxqpRZGZ6ThOk84hEfqWoHx2devRFvpTZcTHur85vImfaxUbTW9Ryh4CpCuDnToOP1CEtXKIgytHBPVff5A==}
     engines: {node: '>=0.3.1'}
 
-  ds-test@https://codeload.github.com/dapphub/ds-test/tar.gz/e282159d5170298eb2455a6c05280ab5a73a4ef0:
-    resolution: {tarball: https://codeload.github.com/dapphub/ds-test/tar.gz/e282159d5170298eb2455a6c05280ab5a73a4ef0}
-    version: 1.0.0
 
   eigenlayer-contracts@https://codeload.github.com/Layr-Labs/eigenlayer-contracts/tar.gz/b6a3a91e1c0c126981de409b00b5fba178503447:
     resolution: {tarball: https://codeload.github.com/Layr-Labs/eigenlayer-contracts/tar.gz/b6a3a91e1c0c126981de409b00b5fba178503447}
@@ -1817,7 +1811,6 @@ snapshots:
 
   diff@5.2.0: {}
 
-  ds-test@https://codeload.github.com/dapphub/ds-test/tar.gz/e282159d5170298eb2455a6c05280ab5a73a4ef0: {}
 
   eigenlayer-contracts@https://codeload.github.com/Layr-Labs/eigenlayer-contracts/tar.gz/b6a3a91e1c0c126981de409b00b5fba178503447(hardhat@2.22.10):
     dependencies:

--- a/contracts/core/foundry.toml
+++ b/contracts/core/foundry.toml
@@ -5,7 +5,6 @@ libs = ["node_modules"]
 
 remappings = [
   "forge-std/=node_modules/forge-std/src",
-  "ds-test/=node_modules/ds-test/src",
   "src/=src",
   "test/=test",
   "avs/=../avs/src",

--- a/contracts/core/package.json
+++ b/contracts/core/package.json
@@ -13,7 +13,6 @@
     "test": "forge test"
   },
   "devDependencies": {
-    "ds-test": "github:dapphub/ds-test",
     "forge-std": "github:foundry-rs/forge-std",
     "multiproof": "github:sigp/multiproof"
   },

--- a/contracts/core/pnpm-lock.yaml
+++ b/contracts/core/pnpm-lock.yaml
@@ -51,9 +51,6 @@ importers:
         specifier: ^6.8.0
         version: 6.8.0
     devDependencies:
-      ds-test:
-        specifier: github:dapphub/ds-test
-        version: https://codeload.github.com/dapphub/ds-test/tar.gz/e282159d5170298eb2455a6c05280ab5a73a4ef0
       forge-std:
         specifier: github:foundry-rs/forge-std
         version: https://codeload.github.com/foundry-rs/forge-std/tar.gz/8ba9031ffcbe25aa0d1224d3ca263a995026e477
@@ -1214,9 +1211,6 @@ packages:
     resolution: {integrity: sha512-IrPdXQsk2BbzvCBGBOTmmSH5SodmqZNt4ERAZDmW4CT+tL8VtvinqywuANaFu4bOMWki16nqf0e4oC0QIaDr/g==}
     engines: {node: '>=10'}
 
-  ds-test@https://codeload.github.com/dapphub/ds-test/tar.gz/e282159d5170298eb2455a6c05280ab5a73a4ef0:
-    resolution: {tarball: https://codeload.github.com/dapphub/ds-test/tar.gz/e282159d5170298eb2455a6c05280ab5a73a4ef0}
-    version: 1.0.0
 
   dunder-proto@1.0.1:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
@@ -4484,7 +4478,6 @@ snapshots:
 
   dotenv@8.6.0: {}
 
-  ds-test@https://codeload.github.com/dapphub/ds-test/tar.gz/e282159d5170298eb2455a6c05280ab5a73a4ef0: {}
 
   dunder-proto@1.0.1:
     dependencies:

--- a/contracts/solve/foundry.toml
+++ b/contracts/solve/foundry.toml
@@ -5,7 +5,6 @@ libs = ["node_modules"]
 
 remappings = [
   "forge-std/=node_modules/forge-std/src",
-  "ds-test/=node_modules/ds-test/src",
   "src/=src",
   "test/=test",
   "core/=../core"

--- a/contracts/solve/package.json
+++ b/contracts/solve/package.json
@@ -6,7 +6,6 @@
     "test": "forge test"
   },
   "devDependencies": {
-    "ds-test": "github:dapphub/ds-test",
     "forge-std": "github:foundry-rs/forge-std"
   },
   "dependencies": {

--- a/contracts/solve/pnpm-lock.yaml
+++ b/contracts/solve/pnpm-lock.yaml
@@ -27,9 +27,6 @@ importers:
         specifier: ^6.8.0
         version: 6.8.0
     devDependencies:
-      ds-test:
-        specifier: github:dapphub/ds-test
-        version: https://codeload.github.com/dapphub/ds-test/tar.gz/e282159d5170298eb2455a6c05280ab5a73a4ef0
       forge-std:
         specifier: github:foundry-rs/forge-std
         version: https://codeload.github.com/foundry-rs/forge-std/tar.gz/da591f56d8884c5824c0c1b3103fbcfd81123c4c
@@ -1054,9 +1051,6 @@ packages:
     resolution: {integrity: sha512-IrPdXQsk2BbzvCBGBOTmmSH5SodmqZNt4ERAZDmW4CT+tL8VtvinqywuANaFu4bOMWki16nqf0e4oC0QIaDr/g==}
     engines: {node: '>=10'}
 
-  ds-test@https://codeload.github.com/dapphub/ds-test/tar.gz/e282159d5170298eb2455a6c05280ab5a73a4ef0:
-    resolution: {tarball: https://codeload.github.com/dapphub/ds-test/tar.gz/e282159d5170298eb2455a6c05280ab5a73a4ef0}
-    version: 1.0.0
 
   dunder-proto@1.0.1:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
@@ -3874,7 +3868,6 @@ snapshots:
 
   dotenv@8.6.0: {}
 
-  ds-test@https://codeload.github.com/dapphub/ds-test/tar.gz/e282159d5170298eb2455a6c05280ab5a73a4ef0: {}
 
   dunder-proto@1.0.1:
     dependencies:

--- a/contracts/xapps/foundry.toml
+++ b/contracts/xapps/foundry.toml
@@ -5,7 +5,6 @@ libs = ["node_modules"]
 
 remappings = [
   "forge-std/=node_modules/forge-std/src",
-  "ds-test/=node_modules/ds-test/src",
   "src/=src",
   "test/=test",
   "core/=../core",

--- a/contracts/xapps/package.json
+++ b/contracts/xapps/package.json
@@ -6,7 +6,6 @@
     "test": "forge test"
   },
   "devDependencies": {
-    "ds-test": "github:dapphub/ds-test",
     "forge-std": "github:foundry-rs/forge-std"
   },
   "dependencies": {

--- a/contracts/xapps/pnpm-lock.yaml
+++ b/contracts/xapps/pnpm-lock.yaml
@@ -24,9 +24,6 @@ importers:
         specifier: ^0.1.7
         version: 0.1.8
     devDependencies:
-      ds-test:
-        specifier: github:dapphub/ds-test
-        version: https://codeload.github.com/dapphub/ds-test/tar.gz/e282159d5170298eb2455a6c05280ab5a73a4ef0
       forge-std:
         specifier: github:foundry-rs/forge-std
         version: https://codeload.github.com/foundry-rs/forge-std/tar.gz/2b59872eee0b8088ddcade39fe8c041e17bb79c0
@@ -49,9 +46,6 @@ packages:
     resolution: {tarball: https://codeload.github.com/pcaversaccio/createx/tar.gz/ff43c668db7381216ce4e0059ff44ac0d119bfd6}
     version: 1.0.0
 
-  ds-test@https://codeload.github.com/dapphub/ds-test/tar.gz/e282159d5170298eb2455a6c05280ab5a73a4ef0:
-    resolution: {tarball: https://codeload.github.com/dapphub/ds-test/tar.gz/e282159d5170298eb2455a6c05280ab5a73a4ef0}
-    version: 1.0.0
 
   forge-std@https://codeload.github.com/foundry-rs/forge-std/tar.gz/2b59872eee0b8088ddcade39fe8c041e17bb79c0:
     resolution: {tarball: https://codeload.github.com/foundry-rs/forge-std/tar.gz/2b59872eee0b8088ddcade39fe8c041e17bb79c0}
@@ -72,7 +66,6 @@ snapshots:
 
   createx@https://codeload.github.com/pcaversaccio/createx/tar.gz/ff43c668db7381216ce4e0059ff44ac0d119bfd6: {}
 
-  ds-test@https://codeload.github.com/dapphub/ds-test/tar.gz/e282159d5170298eb2455a6c05280ab5a73a4ef0: {}
 
   forge-std@https://codeload.github.com/foundry-rs/forge-std/tar.gz/2b59872eee0b8088ddcade39fe8c041e17bb79c0: {}
 


### PR DESCRIPTION
## Summary
- drop `ds-test` from Foundry remappings
- remove `ds-test` dev dependency from packages
- clean `ds-test` from lockfiles

## Testing
- `bash scripts/install_foundry.sh` *(fails: CONNECT tunnel failed)*

------
https://chatgpt.com/codex/tasks/task_e_684af4aba2f8832b83ccca614b371bec