### PR TITLE
chore(e2e/manifest): fix staging

### DIFF
--- a/e2e/manifests/staging.toml
+++ b/e2e/manifests/staging.toml
@@ -3,6 +3,7 @@ public_chains = ["holesky","op_sepolia","base_sepolia","arb_sepolia"]
 multi_omni_evms = true
 prometheus = true
 
+ephemeral_genesis = "3_drake" # vm_compose evm proxy only supported in 3_drake.
 feature_flags = []
 
 [node.validator01]


### PR DESCRIPTION
EVM proxy introduced in #4251 breaks previous network upgrades since vmcompose ports incorrect. So skip upgrades for now.

issue: none