### PR TITLE
fix(halo): prevent array out of bounds

### DIFF
--- a/halo/app/sdklog.go
+++ b/halo/app/sdklog.go
@@ -69,7 +69,7 @@ func (c sdkLogger) Impl() any {
 func splitOutError(keyvals []any) ([]any, error) {
 	var remaining []any
 	var err error
-	for i := 0; i < len(keyvals); i += 2 {
+	for i := 0; i < len(keyvals)-1; i += 2 {
 		if keyErr, ok := keyvals[i+1].(error); ok {
 			err = keyErr
 		} else {

--- a/halo/comet/cmtlog.go
+++ b/halo/comet/cmtlog.go
@@ -99,7 +99,7 @@ func (c logger) With(keyvals ...any) cmtlog.Logger { //nolint:ireturn // This si
 func splitOutError(keyvals []any) ([]any, error) {
 	var remaining []any
 	var err error
-	for i := 0; i < len(keyvals); i += 2 {
+	for i := 0; i < len(keyvals)-1; i += 2 {
 		if keyErr, ok := keyvals[i+1].(error); ok {
 			err = keyErr
 		} else {


### PR DESCRIPTION
Prevent array-out-of-bounds in `splitOutError`.

issue: none