### PR TITLE
chore(e2e): bump solver pins to 6cedc51

### DIFF
--- a/e2e/manifests/mainnet.toml
+++ b/e2e/manifests/mainnet.toml
@@ -7,7 +7,7 @@ prometheus   = true
 pinned_halo_tag = "f90341d" # EVM Proxy
 pinned_relayer_tag = "07c4ac7"
 pinned_monitor_tag = "e7c1bd8"
-pinned_solver_tag = "855e393"
+pinned_solver_tag = "6cedc51"
 
 [node.validator01]
 [node.validator02]

--- a/e2e/manifests/omega.toml
+++ b/e2e/manifests/omega.toml
@@ -7,7 +7,7 @@ prometheus = true
 pinned_halo_tag = "f90341d" # EVM Proxy
 pinned_relayer_tag = "07c4ac7"
 pinned_monitor_tag = "e7c1bd8"
-pinned_solver_tag = "855e393"
+pinned_solver_tag = "6cedc51"
 
 [node.validator01]
 [node.validator02]


### PR DESCRIPTION
Bump solver pins to 6cedc51.

Includes hyper evm cursor bootstrap.

issue: none