### PR TITLE
refactor(octane): prep for redenom module

### DIFF
--- a/halo/evmredenom/convert.go
+++ b/halo/evmredenom/convert.go
@@ -1,0 +1,28 @@
+package evmredenom
+
+import (
+	"math/big"
+
+	"github.com/omni-network/omni/lib/bi"
+	"github.com/omni-network/omni/lib/errors"
+
+	"cosmossdk.io/math"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+)
+
+const evmToBondMultiplier = 1 // 1 Native EVM == 1 Bond Denom
+
+// ToBondCoin converts the $NATIVE_EVM amount into a $STAKE coin.
+func ToBondCoin(amount *big.Int) sdk.Coin {
+	n := bi.DivRaw(amount, evmToBondMultiplier)
+	return sdk.NewCoin(sdk.DefaultBondDenom, math.NewIntFromBigInt(n))
+}
+
+// ToEVMAmount converts a $STAKE coin into a $NATIVE_EVM amount.
+func ToEVMAmount(coin sdk.Coin) (*big.Int, error) {
+	if coin.Denom != sdk.DefaultBondDenom {
+		return nil, errors.New("not bond denom [BUG]", "denom", coin.Denom)
+	}
+
+	return bi.MulRaw(coin.Amount.BigInt(), evmToBondMultiplier), nil
+}

--- a/halo/evmredenom/convert_test.go
+++ b/halo/evmredenom/convert_test.go
@@ -1,0 +1,156 @@
+package evmredenom_test
+
+import (
+	"fmt"
+	"math"
+	"math/big"
+	"testing"
+
+	"github.com/omni-network/omni/halo/evmredenom"
+	"github.com/omni-network/omni/lib/bi"
+
+	cosmosmath "cosmossdk.io/math"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestToBondCoin(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		amount   *big.Int
+		expected sdk.Coin
+	}{
+		{
+			name:     "zero amount",
+			amount:   bi.N(0),
+			expected: sdk.NewCoin(sdk.DefaultBondDenom, toSDKMath(bi.Ether(0))),
+		},
+		{
+			name:     "one wei",
+			amount:   bi.N(1),
+			expected: sdk.NewCoin(sdk.DefaultBondDenom, toSDKMath(bi.N(1))),
+		},
+		{
+			name:     "one ether in wei",
+			amount:   bi.Ether(1),
+			expected: sdk.NewCoin(sdk.DefaultBondDenom, toSDKMath(bi.Ether(1))),
+		},
+		{
+			name:     "large amount",
+			amount:   bi.N(math.MaxInt64),
+			expected: sdk.NewCoin(sdk.DefaultBondDenom, toSDKMath(bi.N(math.MaxInt64))),
+		},
+		{
+			name:     "random amount",
+			amount:   bi.N(123456789),
+			expected: sdk.NewCoin(sdk.DefaultBondDenom, toSDKMath(bi.N(123456789))),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			result := evmredenom.ToBondCoin(tt.amount)
+			require.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestToEVMAmount(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		coin        sdk.Coin
+		expected    *big.Int
+		expectError bool
+	}{
+		{
+			name:        "zero bond coin",
+			coin:        sdk.NewCoin(sdk.DefaultBondDenom, toSDKMath(bi.Ether(0))),
+			expected:    bi.N(0),
+			expectError: false,
+		},
+		{
+			name:        "one bond coin",
+			coin:        sdk.NewCoin(sdk.DefaultBondDenom, toSDKMath(bi.Ether(1))),
+			expected:    bi.Ether(1),
+			expectError: false,
+		},
+		{
+			name:        "large bond coin amount",
+			coin:        sdk.NewCoin(sdk.DefaultBondDenom, toSDKMath(bi.Ether(1))),
+			expected:    bi.Ether(1),
+			expectError: false,
+		},
+		{
+			name:        "random bond coin amount",
+			coin:        sdk.NewCoin(sdk.DefaultBondDenom, toSDKMath(bi.Ether(987654321))),
+			expected:    bi.Ether(987654321),
+			expectError: false,
+		},
+		{
+			name:        "wrong denomination",
+			coin:        sdk.NewCoin("wrongdenom", toSDKMath(bi.Ether(100))),
+			expected:    nil,
+			expectError: true,
+		},
+		{
+			name:        "custom denomination",
+			coin:        sdk.NewCoin("custom", toSDKMath(bi.Ether(100))),
+			expected:    nil,
+			expectError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			result, err := evmredenom.ToEVMAmount(tt.coin)
+
+			if tt.expectError {
+				require.Error(t, err)
+				require.Nil(t, result)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, tt.expected, result)
+			}
+		})
+	}
+}
+
+func TestRoundTripConversion(t *testing.T) {
+	t.Parallel()
+
+	testAmounts := []*big.Int{
+		bi.N(0),
+		bi.N(1),
+		bi.N(1000),
+		bi.Ether(1), // 1 ETH in wei
+		bi.N(123456789),
+		bi.N(1311768467463790320),
+	}
+
+	for i, amount := range testAmounts {
+		t.Run(fmt.Sprintf("round_trip_%d", i), func(t *testing.T) {
+			t.Parallel()
+
+			// Convert to bond coin
+			bondCoin := evmredenom.ToBondCoin(amount)
+
+			// Convert back to EVM amount
+			evmAmount, err := evmredenom.ToEVMAmount(bondCoin)
+			require.NoError(t, err)
+
+			// Should be equal to original
+			require.Equal(t, amount, evmAmount)
+		})
+	}
+}
+
+// toSDKMath converts a *big.Int to cosmossdk.io/math.Int.
+func toSDKMath(amount *big.Int) cosmosmath.Int {
+	return cosmosmath.NewIntFromBigInt(amount)
+}

--- a/halo/evmstaking/keeper/keeper.go
+++ b/halo/evmstaking/keeper/keeper.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/omni-network/omni/contracts/bindings"
+	"github.com/omni-network/omni/halo/evmredenom"
 	"github.com/omni-network/omni/halo/evmstaking/types"
 	"github.com/omni-network/omni/halo/genutil/evm/predeploys"
 	"github.com/omni-network/omni/lib/errors"
@@ -390,7 +391,7 @@ func (k Keeper) deliverCreateValidator(ctx context.Context, createValidator *bin
 	accAddr := sdk.AccAddress(createValidator.Validator.Bytes())
 	valAddr := sdk.ValAddress(createValidator.Validator.Bytes())
 
-	amountCoin, amountCoins := omniToBondCoin(createValidator.Deposit)
+	amountCoin := evmredenom.ToBondCoin(createValidator.Deposit)
 
 	if _, err := k.sKeeper.GetValidator(ctx, valAddr); err == nil {
 		return errors.New("validator already exists")
@@ -398,11 +399,11 @@ func (k Keeper) deliverCreateValidator(ctx context.Context, createValidator *bin
 
 	k.createAccIfNone(ctx, accAddr)
 
-	if err := k.bKeeper.MintCoins(ctx, k.Name(), amountCoins); err != nil {
+	if err := k.bKeeper.MintCoins(ctx, k.Name(), sdk.NewCoins(amountCoin)); err != nil {
 		return errors.Wrap(err, "mint coins")
 	}
 
-	if err := k.bKeeper.SendCoinsFromModuleToAccountNoWithdrawal(ctx, k.Name(), accAddr, amountCoins); err != nil {
+	if err := k.bKeeper.SendCoinsFromModuleToAccountNoWithdrawal(ctx, k.Name(), accAddr, sdk.NewCoins(amountCoin)); err != nil {
 		return errors.Wrap(err, "send coins")
 	}
 

--- a/halo/withdraw/metrics.go
+++ b/halo/withdraw/metrics.go
@@ -1,14 +1,1 @@
 package withdraw
-
-import (
-	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/client_golang/prometheus/promauto"
-)
-
-var dustCounter = promauto.NewCounter(prometheus.CounterOpts{
-	Namespace:   "halo",
-	Subsystem:   "withdraw",
-	Name:        "dust_total",
-	Help:        "Total withdrawal creation dust in wei (dust is amounts less than 1 gwei)",
-	ConstLabels: nil,
-})

--- a/halo/withdraw/types.go
+++ b/halo/withdraw/types.go
@@ -2,6 +2,7 @@ package withdraw
 
 import (
 	"context"
+	"math/big"
 
 	"github.com/ethereum/go-ethereum/common"
 
@@ -10,7 +11,9 @@ import (
 
 type EVMEngineKeeper interface {
 	// InsertWithdrawal creates a new withdrawal request.
-	InsertWithdrawal(ctx context.Context, withdrawalAddr common.Address, amountGwei uint64) error
+	// Note the amount is the native EVM token amount in wei.
+	// Withdrawals are rounded to gwei, so small amounts result in noop.
+	InsertWithdrawal(ctx context.Context, withdrawalAddr common.Address, weiAmount *big.Int) error
 }
 
 type AccountKeeper interface {

--- a/halo/withdraw/wrapper.go
+++ b/halo/withdraw/wrapper.go
@@ -4,14 +4,14 @@ package withdraw
 
 import (
 	"context"
+	"math/big"
 
+	"github.com/omni-network/omni/halo/evmredenom"
+	"github.com/omni-network/omni/lib/bi"
 	"github.com/omni-network/omni/lib/cast"
 	"github.com/omni-network/omni/lib/errors"
 	"github.com/omni-network/omni/lib/log"
 
-	"github.com/ethereum/go-ethereum/params"
-
-	"cosmossdk.io/math"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 	bankkeeper "github.com/cosmos/cosmos-sdk/x/bank/keeper"
@@ -96,15 +96,12 @@ func (w *BankWrapper) SendCoinsFromModuleToAccount(ctx context.Context, senderMo
 		return errors.Wrap(err, "convert to eth address [BUG]")
 	}
 
-	gwei, dust, err := toGwei(coins[0].Amount)
+	weiAmount, err := evmredenom.ToEVMAmount(coins[0])
 	if err != nil {
-		return errors.Wrap(err, "to gwei conversion")
+		return err
 	}
-	dustCounter.Add(float64(dust))
 
-	if gwei == 0 {
-		log.Debug(ctx, "Not creating all-dust withdrawal", "addr", addr, "amount_wei", coins[0].Amount)
-	} else if err := w.EVMEngineKeeper.InsertWithdrawal(ctx, addr, gwei); err != nil {
+	if err := w.EVMEngineKeeper.InsertWithdrawal(ctx, addr, weiAmount); err != nil {
 		return err
 	}
 
@@ -115,17 +112,18 @@ func (w *BankWrapper) SendCoinsFromModuleToAccount(ctx context.Context, senderMo
 	return nil
 }
 
-// toGwei converts a math.Int to Gwei and the wei remainder.
-func toGwei(amount math.Int) (gwei uint64, wei uint64, err error) { //nolint:nonamedreturns // Disambiguate identical return types.
-	gweiInt := amount.QuoRaw(params.GWei)
-	weiInt := amount.Sub(gweiInt.MulRaw(params.GWei))
+// toGwei converts a wei amount to a gwei amount and the wei remainder.
+func toGwei(weiAmount *big.Int) (gweiU64 uint64, weiRemU64 uint64, err error) { //nolint:nonamedreturns // Disambiguate identical return types.
+	const giga uint64 = 1e9
+	gweiAmount := bi.DivRaw(weiAmount, giga)
+	weiRem := bi.Sub(weiAmount, bi.MulRaw(gweiAmount, giga))
 
 	// This should work up to 18G ETH
-	if !gweiInt.IsUint64() {
+	if !gweiAmount.IsUint64() {
 		return 0, 0, errors.New("invalid amount [BUG]")
 	}
 
-	return gweiInt.Uint64(), weiInt.Uint64(), nil
+	return gweiAmount.Uint64(), weiRem.Uint64(), nil
 }
 
 // anyAmountNil returns true if any coin has a nil amount.

--- a/octane/evmengine/keeper/db_internal_test.go
+++ b/octane/evmengine/keeper/db_internal_test.go
@@ -3,6 +3,7 @@ package keeper
 import (
 	"testing"
 
+	"github.com/omni-network/omni/lib/bi"
 	"github.com/omni-network/omni/lib/errors"
 	"github.com/omni-network/omni/lib/k1util"
 	"github.com/omni-network/omni/lib/tutil"
@@ -11,6 +12,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	etypes "github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/params"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	authtx "github.com/cosmos/cosmos-sdk/x/auth/tx"
@@ -49,7 +51,7 @@ func TestKeeper_withdrawalsPersistence(t *testing.T) {
 	type testCase struct {
 		addr   common.Address
 		height uint64
-		amount uint64
+		amount uint64 // gwei
 		expID  uint64
 	}
 
@@ -62,7 +64,7 @@ func TestKeeper_withdrawalsPersistence(t *testing.T) {
 
 	for _, in := range inputs {
 		ctx = ctx.WithBlockHeight(int64(in.height))
-		err := keeper.InsertWithdrawal(ctx, in.addr, in.amount)
+		err := keeper.InsertWithdrawal(ctx, in.addr, bi.N(in.amount*params.GWei))
 		require.NoError(t, err)
 	}
 
@@ -166,7 +168,7 @@ func TestKeeper_withdrawalsDeletion(t *testing.T) {
 	type testCase struct {
 		addr   common.Address
 		height uint64
-		amount uint64
+		amount uint64 // gwei
 		expID  uint64
 	}
 
@@ -179,7 +181,7 @@ func TestKeeper_withdrawalsDeletion(t *testing.T) {
 
 	for _, in := range inputs {
 		ctx = ctx.WithBlockHeight(int64(in.height))
-		err := keeper.InsertWithdrawal(ctx, in.addr, in.amount)
+		err := keeper.InsertWithdrawal(ctx, in.addr, bi.N(in.amount*params.GWei))
 		require.NoError(t, err)
 	}
 

--- a/octane/evmengine/keeper/metrics.go
+++ b/octane/evmengine/keeper/metrics.go
@@ -12,4 +12,12 @@ var (
 		Name:      "withdrawals_inserted_total",
 		Help:      "Total number of inserted withdrawals",
 	})
+
+	dustCounter = promauto.NewCounter(prometheus.CounterOpts{
+		Namespace:   "octane",
+		Subsystem:   "evmengine",
+		Name:        "withdrawals_dust_total",
+		Help:        "Total withdrawal creation dust in wei (dust is amounts less than 1 gwei)",
+		ConstLabels: nil,
+	})
 )

--- a/octane/evmengine/keeper/msg_server_internal_test.go
+++ b/octane/evmengine/keeper/msg_server_internal_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/omni-network/omni/lib/bi"
 	"github.com/omni-network/omni/lib/errors"
 	"github.com/omni-network/omni/lib/ethclient"
 	"github.com/omni-network/omni/lib/expbackoff"
@@ -19,6 +20,7 @@ import (
 	"github.com/ethereum/go-ethereum/beacon/engine"
 	"github.com/ethereum/go-ethereum/common"
 	etypes "github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/params"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	authtx "github.com/cosmos/cosmos-sdk/x/auth/tx"
@@ -70,7 +72,7 @@ func Test_msgServer_ExecutionPayload(t *testing.T) {
 		keeper.SetCometAPI(cmtAPI)
 		populateGenesisHead(ctx, t, keeper)
 
-		err = keeper.InsertWithdrawal(ctx.WithBlockHeight(0), withdrawalAddr, amountGwei)
+		err = keeper.InsertWithdrawal(ctx.WithBlockHeight(0), withdrawalAddr, bi.N(amountGwei*params.GWei))
 		require.NoError(t, err)
 
 		msgSrv := NewMsgServerImpl(keeper)

--- a/octane/evmengine/keeper/proposal_server_internal_test.go
+++ b/octane/evmengine/keeper/proposal_server_internal_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/omni-network/omni/lib/bi"
 	"github.com/omni-network/omni/lib/ethclient"
 	"github.com/omni-network/omni/lib/tutil"
 	"github.com/omni-network/omni/octane/evmengine/types"
@@ -11,6 +12,7 @@ import (
 	"github.com/ethereum/go-ethereum/beacon/engine"
 	"github.com/ethereum/go-ethereum/common"
 	etypes "github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/params"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	authtx "github.com/cosmos/cosmos-sdk/x/auth/tx"
@@ -37,7 +39,10 @@ func Test_proposalServer_ExecutionPayload(t *testing.T) {
 
 	withdrawalAddr := tutil.RandomAddress()
 	amountGwei := uint64(100)
-	err = keeper.InsertWithdrawal(sdkCtx.WithBlockHeight(0), withdrawalAddr, amountGwei)
+	err = keeper.InsertWithdrawal(sdkCtx.WithBlockHeight(0), withdrawalAddr, bi.N(amountGwei*params.GWei+1_000)) // +1k wei should be rounded out
+	require.NoError(t, err)
+
+	err = keeper.InsertWithdrawal(sdkCtx.WithBlockHeight(0), withdrawalAddr, bi.N(1_000)) // Tiny 1k wei withdrawal ignored
 	require.NoError(t, err)
 
 	propSrv := NewProposalServer(keeper)


### PR DESCRIPTION
Refactors in preparation for evmredenom module:
 - Change evmengine.InsertWithdrawal to handle conversion from wei to gei
 - Centralise conversion from $NativeEVM<>$STAKE in evmredenom package.

issue: none