### PR TITLE
feat(monitor): add NOM pricing

### DIFF
--- a/lib/tokens/asset.go
+++ b/lib/tokens/asset.go
@@ -111,6 +111,13 @@ var (
 		CoingeckoID: "berachain-bera",
 	}
 
+	NOM = Asset{
+		Symbol:      "NOM",
+		Name:        "Nomina",
+		Decimals:    18,
+		CoingeckoID: "", // Derived from OMNI price (OMNI / 75) until listed on CoinGecko
+	}
+
 	PLUME = Asset{
 		Symbol:      "PLUME",
 		Name:        "Plume",

--- a/monitor/xfeemngr/oracle.go
+++ b/monitor/xfeemngr/oracle.go
@@ -217,14 +217,24 @@ func (o feeOracle) syncToNativeRate(ctx context.Context, dest evmchain.Metadata)
 	bufferedRate := destPrice / srcPrice
 
 	log.Info(ctx, "Syncing native token rate", "source_price", srcPrice, "destination_price", destPrice, "buffered_rate", bufferedRate)
-	if o.chain.NativeToken == tokens.OMNI && dest.NativeToken == tokens.ETH && bufferedRate > maxSaneOmniPerEth {
-		log.Warn(ctx, "Buffered omni-per-eth exceeds sane max", errors.New("unexpected conversion rate"), "buffered", bufferedRate, "max_sane", maxSaneOmniPerEth)
-		bufferedRate = maxSaneOmniPerEth
+	if o.chain.NativeToken == tokens.OMNI && dest.NativeToken == tokens.ETH && bufferedRate > maxSaneNativePerEth {
+		log.Warn(ctx, "Buffered omni-per-eth exceeds sane max", errors.New("unexpected conversion rate"), "buffered", bufferedRate, "max_sane", maxSaneNativePerEth)
+		bufferedRate = maxSaneNativePerEth
 	}
 
-	if o.chain.NativeToken == tokens.ETH && dest.NativeToken == tokens.OMNI && bufferedRate > maxSaneEthPerOmni {
-		log.Warn(ctx, "Buffered eth-per-omni exceeds sane max", errors.New("unexpected conversion rate"), "buffered", bufferedRate, "max_sane", maxSaneEthPerOmni)
-		bufferedRate = maxSaneEthPerOmni
+	if o.chain.NativeToken == tokens.ETH && dest.NativeToken == tokens.OMNI && bufferedRate > maxSaneEthPerNative {
+		log.Warn(ctx, "Buffered eth-per-omni exceeds sane max", errors.New("unexpected conversion rate"), "buffered", bufferedRate, "max_sane", maxSaneEthPerNative)
+		bufferedRate = maxSaneEthPerNative
+	}
+
+	if o.chain.NativeToken == tokens.NOM && dest.NativeToken == tokens.ETH && bufferedRate > maxSaneNativePerEth {
+		log.Warn(ctx, "Buffered nom-per-eth exceeds sane max", errors.New("unexpected conversion rate"), "buffered", bufferedRate, "max_sane", maxSaneNativePerEth)
+		bufferedRate = maxSaneNativePerEth
+	}
+
+	if o.chain.NativeToken == tokens.ETH && dest.NativeToken == tokens.NOM && bufferedRate > maxSaneEthPerNative {
+		log.Warn(ctx, "Buffered eth-per-nom exceeds sane max", errors.New("unexpected conversion rate"), "buffered", bufferedRate, "max_sane", maxSaneEthPerNative)
+		bufferedRate = maxSaneEthPerNative
 	}
 
 	bufferedNumer := rateToNumerator(bufferedRate)

--- a/monitor/xfeemngr/xfeemngr.go
+++ b/monitor/xfeemngr/xfeemngr.go
@@ -45,9 +45,9 @@ const (
 	// Check live gas prices every 30 seconds.
 	gasPriceBufferSyncInterval = 30 * time.Second
 
-	maxSaneGasPrice   = uint64(500_000_000_000)
-	maxSaneOmniPerEth = float64(1_000_000)
-	maxSaneEthPerOmni = float64(1)
+	maxSaneGasPrice     = uint64(500_000_000_000)
+	maxSaneNativePerEth = float64(1_000_000)
+	maxSaneEthPerNative = float64(1)
 )
 
 var chainSyncOverrides = map[uint64]time.Duration{
@@ -90,7 +90,7 @@ func Start(
 	}
 
 	tprice := tokenprice.NewBuffer(cgCl,
-		[]tokens.Asset{tokens.OMNI, tokens.ETH},
+		[]tokens.Asset{tokens.OMNI, tokens.NOM, tokens.ETH},
 		tokenPriceBufferThreshold,
 		ticker.New(tokenPriceBufferSyncInterval))
 

--- a/monitor/xfeemngr/xfeemngr_internal_test.go
+++ b/monitor/xfeemngr/xfeemngr_internal_test.go
@@ -29,6 +29,7 @@ func TestStart(t *testing.T) {
 	// mock token prices / pricer
 	initialTokenPrices := map[tokens.Asset]float64{
 		tokens.OMNI: randTokenPrice(tokens.OMNI),
+		tokens.NOM:  randTokenPrice(tokens.NOM),
 		tokens.ETH:  randTokenPrice(tokens.ETH),
 	}
 
@@ -73,11 +74,14 @@ func TestStart(t *testing.T) {
 				rate := tprices[dest.NativeToken] / tprices[src.NativeToken]
 
 				// handle maximum rate case
-				if src.NativeToken == tokens.OMNI && src.NativeToken != dest.NativeToken && rate > maxSaneOmniPerEth {
-					rate = maxSaneOmniPerEth
+				if src.NativeToken == tokens.OMNI && src.NativeToken != dest.NativeToken && rate > maxSaneNativePerEth {
+					rate = maxSaneNativePerEth
 				}
-				if src.NativeToken == tokens.ETH && src.NativeToken != dest.NativeToken && rate > maxSaneEthPerOmni {
-					rate = maxSaneEthPerOmni
+				if src.NativeToken == tokens.NOM && src.NativeToken != dest.NativeToken && rate > maxSaneNativePerEth {
+					rate = maxSaneNativePerEth
+				}
+				if src.NativeToken == tokens.ETH && src.NativeToken != dest.NativeToken && rate > maxSaneEthPerNative {
+					rate = maxSaneEthPerNative
 				}
 
 				numer := rateToNumerator(rate)
@@ -218,13 +222,14 @@ func randGasPrice() *big.Int {
 
 // randTokenPrice generates a random, reasonable token price.
 func randTokenPrice(token tokens.Asset) float64 {
-	// discriminate between ETH and other tokens (OMNI)
-	// so that test omni-per-eth conversion rates do not exceed maxOmniPerEth
+	// discriminate between ETH and other tokens (OMNI/NOM)
+	// so that test conversion rates do not exceed sane maxes
 
 	if token == tokens.ETH {
 		return float64(rand.Intn(500)) + rand.Float64() + 3000
 	}
 
+	// For OMNI and NOM, use reasonable ranges
 	return float64(rand.Intn(50)) + rand.Float64()
 }
 


### PR DESCRIPTION
Modified the CoinGecko Pricer to derive NOM pricing when necessary, and then added NOM to the xfeemngr and oracles. This is intended to be an additive change, where NOM is handled in addition to OMNI, as not all components have been modified to use the NOM yet (relayer, solver, chain metadata, etc), and I wanted to avoid them being served stale or undefined pricing data.

issue: none
