### PR TITLE
feat(halo/app): disable staking buffer in prod

### DIFF
--- a/halo/app/app_config.go
+++ b/halo/app/app_config.go
@@ -68,9 +68,8 @@ const (
 	genesisTrimLag        uint64 = 1      // Allow deleting attestations in block after approval.
 	genesisCTrimLag       uint64 = 72_000 // Delete consensus attestations state after +-1 day (given a period of 1.2s).
 
-	deliverIntervalProtected = 20_000 // Roughly ~12h assuming 0.5bps
-	deliverIntervalEphemeral = 2      // Fast updates while testing
-	deliverIntervalStaging   = 2_400  // ~1h interval on staging for testing DoS
+	deliverIntervalProtected = 1 // Disable batching in protected networks.
+	deliverIntervalEphemeral = 2 // Fast updates while testing
 
 	maxWithdrawalsPerBlock uint64 = 32 // The maximum number of withdrawals included in one block.
 )
@@ -274,8 +273,6 @@ var (
 func deliverInterval(network netconf.ID) int64 {
 	if network.IsProtected() {
 		return deliverIntervalProtected
-	} else if network == netconf.Staging {
-		return deliverIntervalStaging // TODO(corver): Remove this.
 	}
 
 	return deliverIntervalEphemeral


### PR DESCRIPTION
Disable 12h staking event buffer in protected networks. This means that staking events will be processed immediately, resulting in more validator set update messages being emitted from consensus chain, but improves UX.

This will be included in `4_earhart` upgrade.

issue: none