### PR TITLE
CI: migrate workflows to checkout v5

### DIFF
--- a/.github/workflows/changeset-snapshot.yml
+++ b/.github/workflows/changeset-snapshot.yml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
       - name: Clone repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4

--- a/.github/workflows/check-contracts-version.yaml
+++ b/.github/workflows/check-contracts-version.yaml
@@ -11,7 +11,7 @@ jobs:
 
     steps:
     - name: Checkout the repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v5
 
     - name: Check version
       run: |

--- a/.github/workflows/check-sol-artifacts.yaml
+++ b/.github/workflows/check-sol-artifacts.yaml
@@ -11,7 +11,7 @@ jobs:
         working-directory: contracts
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Install Go
         uses: actions/setup-go@v5
         with:

--- a/.github/workflows/ci-docs.yaml
+++ b/.github/workflows/ci-docs.yaml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Install PNPM
         uses: pnpm/action-setup@v4
         with:

--- a/.github/workflows/ci-pr-docs.yaml
+++ b/.github/workflows/ci-pr-docs.yaml
@@ -13,7 +13,7 @@ jobs:
       url: ${{ steps.deploy.outputs.deployment_url }}
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Install PNPM
         uses: pnpm/action-setup@v4
         with:

--- a/.github/workflows/ci-verifypr.yaml
+++ b/.github/workflows/ci-verifypr.yaml
@@ -9,7 +9,7 @@ jobs:
     env:
       GITHUB_PR: ${{ toJSON(github.event.pull_request) }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: actions/setup-go@v5
         with:
           go-version: 'v1.24'

--- a/.github/workflows/clicommand.yaml
+++ b/.github/workflows/clicommand.yaml
@@ -17,7 +17,7 @@ jobs:
             arch: arm64
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
 
     - name: Verify Docker Installation
       run: docker --version
@@ -76,7 +76,7 @@ jobs:
             arch: arm64
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Install Foundry
         uses: ./.github/actions/setup-foundry

--- a/.github/workflows/cliinstall.yaml
+++ b/.github/workflows/cliinstall.yaml
@@ -21,7 +21,7 @@ jobs:
             arch: arm64
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
 
     - name: Run Install Command
       run: bash scripts/install_omni_cli.sh
@@ -41,7 +41,7 @@ jobs:
     runs-on: windows-latest
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
 
     - name: Run Install Command
       run: bash scripts/install_omni_cli.sh || true

--- a/.github/workflows/e2etest.yaml
+++ b/.github/workflows/e2etest.yaml
@@ -8,7 +8,7 @@ jobs:
     runs-on: namespace-profile-default
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Install Go
         uses: actions/setup-go@v5
         with:

--- a/.github/workflows/e2etestadmin.yaml
+++ b/.github/workflows/e2etestadmin.yaml
@@ -8,7 +8,7 @@ jobs:
     runs-on: namespace-profile-default
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Install Go
         uses: actions/setup-go@v5

--- a/.github/workflows/golangci-lint.yaml
+++ b/.github/workflows/golangci-lint.yaml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Install Go
         uses: actions/setup-go@v5
         with:

--- a/.github/workflows/gotest.yaml
+++ b/.github/workflows/gotest.yaml
@@ -9,7 +9,7 @@ jobs:
     runs-on: namespace-profile-default
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Install Go
         uses: actions/setup-go@v5
         with:

--- a/.github/workflows/pr-e2etest.yaml
+++ b/.github/workflows/pr-e2etest.yaml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Install Go
         uses: actions/setup-go@v5
         with:

--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -11,7 +11,7 @@ jobs:
       SKIP: golangci-lint,run-go-tests,no-commit-to-branch,run-forge-tests,run-forge-fmt,run-rust-checks
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Install Python
         uses: actions/setup-python@v5
       - name: Install Go

--- a/.github/workflows/rebalance-test.yaml
+++ b/.github/workflows/rebalance-test.yaml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Install Go
         uses: actions/setup-go@v5

--- a/.github/workflows/release-contracts-npm.yaml
+++ b/.github/workflows/release-contracts-npm.yaml
@@ -15,7 +15,7 @@ jobs:
       id-token: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: actions/setup-node@v3
         with:
           node-version: '20.x'

--- a/.github/workflows/release-official.yaml
+++ b/.github/workflows/release-official.yaml
@@ -8,7 +8,7 @@ jobs:
   release-official:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: actions/setup-go@v5
         with:

--- a/.github/workflows/release-snapshot.yaml
+++ b/.github/workflows/release-snapshot.yaml
@@ -8,7 +8,7 @@ jobs:
   release-snapshot:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: actions/setup-go@v5
         with:
           go-version: 'v1.24'

--- a/.github/workflows/sdk-unit-test.yaml
+++ b/.github/workflows/sdk-unit-test.yaml
@@ -7,7 +7,7 @@ jobs:
   sdk-unit-tests:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Install foundry
         uses: ./.github/actions/setup-foundry
       - name: Install node

--- a/.github/workflows/soltest.yaml
+++ b/.github/workflows/soltest.yaml
@@ -11,7 +11,7 @@ jobs:
       run:
         working-directory: contracts/core
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: ./.github/actions/setup-foundry
       - name: Install pnpm
         run: make install-pnpm
@@ -33,7 +33,7 @@ jobs:
       run:
         working-directory: contracts/avs
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: ./.github/actions/setup-foundry
       - name: Install pnpm
         run: make install-pnpm
@@ -55,7 +55,7 @@ jobs:
       run:
         working-directory: contracts/solve
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: ./.github/actions/setup-foundry
       - name: Install pnpm
         run: make install-pnpm
@@ -77,7 +77,7 @@ jobs:
       run:
         working-directory: contracts/nomina
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: ./.github/actions/setup-foundry
       - name: Install pnpm
         run: make install-pnpm


### PR DESCRIPTION
Node 24 compatibility: switch all jobs to actions/checkout@v5. Requires runner v2.327.1+. Pure maintenance, behavior unchanged.

Ref: https://github.com/actions/checkout/releases/tag/v5.0.0