### PR TITLE
feat(solver): disable chains

### DIFF
--- a/e2e/app/setup.go
+++ b/e2e/app/setup.go
@@ -595,6 +595,11 @@ func writeSolverConfig(ctx context.Context, def Definition, logCfg log.Config) e
 		return errors.Wrap(err, "write private key")
 	}
 
+	omniChain, ok := def.Testnet.OmniEVMChain()
+	if !ok {
+		return errors.New("omni chain not found")
+	}
+
 	solverCfg := solverapp.DefaultConfig()
 	solverCfg.SolverPrivKey = privKeyFile
 	solverCfg.Network = def.Testnet.Network
@@ -602,6 +607,8 @@ func writeSolverConfig(ctx context.Context, def Definition, logCfg log.Config) e
 	solverCfg.Tracer.Endpoint = def.Cfg.TracingEndpoint
 	solverCfg.Tracer.Headers = def.Cfg.TracingHeaders
 	solverCfg.CoinGeckoAPIKey = def.Cfg.CoinGeckoAPIKey
+	// TODO(zodomo): Remove Omni chain from disabled chains once network upgrade is complete
+	solverCfg.DisabledChains = append(solverCfg.DisabledChains, omniChain.ChainID)
 
 	if err := solverapp.WriteConfigTOML(solverCfg, logCfg, filepath.Join(confRoot, configFile)); err != nil {
 		return errors.Wrap(err, "write solver config")

--- a/solver/app/check_integration_internal_test.go
+++ b/solver/app/check_integration_internal_test.go
@@ -58,7 +58,7 @@ func TestCheckSameChainIntegration(t *testing.T) {
 
 	// Create check handler
 	handler := newCheckHandler(
-		newChecker(unibackend.EVMBackends(backends), func(_ uint64, _ common.Address, _ []byte) bool { return true }, unaryPrice, solver, outbox),
+		newChecker(unibackend.EVMBackends(backends), func(_ uint64, _ common.Address, _ []byte) bool { return true }, unaryPrice, solver, outbox, nil),
 		newTracer(backends, solver, outbox),
 	)
 

--- a/solver/app/check_internal_test.go
+++ b/solver/app/check_internal_test.go
@@ -43,7 +43,7 @@ func TestCheck(t *testing.T) {
 
 			callAllower := func(_ uint64, _ common.Address, _ []byte) bool { return !tt.disallowCall }
 			handler := handlerAdapter(newCheckHandler(
-				newChecker(backends, callAllower, priceFunc, solver, outbox),
+				newChecker(backends, callAllower, priceFunc, solver, outbox, nil),
 				func(ctx context.Context, req types.CheckRequest) (types.CallTrace, error) {
 					require.True(t, tt.req.Debug)
 					require.True(t, tt.trace == nil || tt.traceErr == nil)

--- a/solver/app/config.go
+++ b/solver/app/config.go
@@ -25,6 +25,7 @@ type Config struct {
 	DBDir           string
 	Tracer          tracer.Config
 	CoinGeckoAPIKey string
+	DisabledChains  []uint64
 }
 
 func DefaultConfig() Config {

--- a/solver/app/config.toml.tmpl
+++ b/solver/app/config.toml.tmpl
@@ -25,6 +25,9 @@ monitoring-addr = "{{ .MonitoringAddr }}"
 # The CoinGecko API key to use for fetching token prices.
 coingecko-apikey = "{{ .CoinGeckoAPIKey }}"
 
+# Orders to or from these chains will be rejected.
+disabled-chains = [{{ range $i, $v := .DisabledChains }}{{ if $i }}, {{ end }}{{ $v }}{{ end }}]
+
 #######################################################################
 ###                             X-Chain                             ###
 #######################################################################

--- a/solver/app/testdata/default_solver.toml
+++ b/solver/app/testdata/default_solver.toml
@@ -25,6 +25,9 @@ monitoring-addr = ":26660"
 # The CoinGecko API key to use for fetching token prices.
 coingecko-apikey = "secret"
 
+# Orders to or from these chains will be rejected.
+disabled-chains = []
+
 #######################################################################
 ###                             X-Chain                             ###
 #######################################################################

--- a/solver/types/reject.go
+++ b/solver/types/reject.go
@@ -17,7 +17,8 @@ const (
 	RejectExpenseOverMax        RejectReason = 11
 	RejectExpenseUnderMin       RejectReason = 12
 	RejectCallNotAllowed        RejectReason = 13
-	rejectSentinel              RejectReason = 14
+	RejectChainDisabled         RejectReason = 14
+	rejectSentinel              RejectReason = 15
 
 	// RejectSameChain          RejectReason = 10 // Same chain orders supported.
 )

--- a/solver/types/rejectreason_string.go
+++ b/solver/types/rejectreason_string.go
@@ -21,24 +21,25 @@ func _() {
 	_ = x[RejectExpenseOverMax-11]
 	_ = x[RejectExpenseUnderMin-12]
 	_ = x[RejectCallNotAllowed-13]
-	_ = x[rejectSentinel-14]
+	_ = x[RejectChainDisabled-14]
+	_ = x[rejectSentinel-15]
 }
 
 const (
 	_RejectReason_name_0 = "NoneDestCallRevertsInvalidDepositInvalidExpenseInsufficientDepositInsufficientInventoryUnsupportedDepositUnsupportedExpenseUnsupportedDestChainUnsupportedSrcChain"
-	_RejectReason_name_1 = "ExpenseOverMaxExpenseUnderMinCallNotAllowedrejectSentinel"
+	_RejectReason_name_1 = "ExpenseOverMaxExpenseUnderMinCallNotAllowedChainDisabledrejectSentinel"
 )
 
 var (
 	_RejectReason_index_0 = [...]uint8{0, 4, 19, 33, 47, 66, 87, 105, 123, 143, 162}
-	_RejectReason_index_1 = [...]uint8{0, 14, 29, 43, 57}
+	_RejectReason_index_1 = [...]uint8{0, 14, 29, 43, 56, 70}
 )
 
 func (i RejectReason) String() string {
 	switch {
 	case i <= 9:
 		return _RejectReason_name_0[_RejectReason_index_0[i]:_RejectReason_index_0[i+1]]
-	case 11 <= i && i <= 14:
+	case 11 <= i && i <= 15:
 		i -= 11
 		return _RejectReason_name_1[_RejectReason_index_1[i]:_RejectReason_index_1[i+1]]
 	default:


### PR DESCRIPTION
Added the ability to arbitrarily disable filling orders to/from specific chains, and funneling such orders into the rejection pipeline if disabled. I tried to implement this as a feature rather than a temporary stop gap for our migration. For our purposes, the Omni chain in each network definition is temporarily disabled in `setup.go`.

issue: none