### PR TITLE
feat(solver): temp reject omni orders

### DIFF
--- a/solver/app/check_internal_test.go
+++ b/solver/app/check_internal_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/omni-network/omni/e2e/app/eoa"
 	"github.com/omni-network/omni/lib/contracts"
 	"github.com/omni-network/omni/lib/errors"
+	"github.com/omni-network/omni/lib/evmchain"
 	"github.com/omni-network/omni/lib/netconf"
 	"github.com/omni-network/omni/lib/tutil"
 	"github.com/omni-network/omni/solver/client"
@@ -38,6 +39,20 @@ func TestCheck(t *testing.T) {
 	outbox := addrs.SolverNetOutbox
 
 	for _, tt := range checkTestCases(t, solver, outbox) {
+		// TODO(zodomo): Remove this once network upgrade is complete
+		if tt.req.SourceChainID == evmchain.IDOmniMainnet || tt.req.SourceChainID == evmchain.IDOmniOmega || tt.req.SourceChainID == evmchain.IDOmniStaging {
+			tt.res.Accepted = false
+			tt.res.Rejected = true
+			tt.res.RejectReason = types.RejectUnsupportedSrcChain.String()
+		}
+
+		// TODO(zodomo): Remove this once network upgrade is complete
+		if tt.req.DestinationChainID == evmchain.IDOmniMainnet || tt.req.DestinationChainID == evmchain.IDOmniOmega || tt.req.DestinationChainID == evmchain.IDOmniStaging {
+			tt.res.Accepted = false
+			tt.res.Rejected = true
+			tt.res.RejectReason = types.RejectUnsupportedDestChain.String()
+		}
+
 		t.Run(tt.name, func(t *testing.T) {
 			backends, clients := testBackends(t)
 

--- a/solver/app/reject.go
+++ b/solver/app/reject.go
@@ -71,6 +71,18 @@ func newShouldRejector(
 			return types.RejectNone, false, err
 		}
 
+		// TODO(zodomo): Remove this once network upgrade is complete
+		if order.SourceChainID == evmchain.IDOmniMainnet || order.SourceChainID == evmchain.IDOmniOmega || order.SourceChainID == evmchain.IDOmniStaging {
+			return types.RejectUnsupportedSrcChain, true, newRejection(types.RejectUnsupportedSrcChain,
+				errors.New("unsupported source chain", "chain_id", order.SourceChainID))
+		}
+
+		// TODO(zodomo): Remove this once network upgrade is complete
+		if pendingData.DestinationChainID == evmchain.IDOmniMainnet || pendingData.DestinationChainID == evmchain.IDOmniOmega || pendingData.DestinationChainID == evmchain.IDOmniStaging {
+			return types.RejectUnsupportedDestChain, true, newRejection(types.RejectUnsupportedDestChain,
+				errors.New("unsupported destination chain", "chain_id", pendingData.DestinationChainID))
+		}
+
 		// Internal logic just return errors (convert them to rejections below)
 		err = func(ctx context.Context, order Order) error {
 			_, ok := solvernet.Provider(order.SourceChainID, pendingData.DestinationChainID)

--- a/solver/app/reject_internal_test.go
+++ b/solver/app/reject_internal_test.go
@@ -6,7 +6,9 @@ import (
 
 	"github.com/omni-network/omni/e2e/app/eoa"
 	"github.com/omni-network/omni/lib/contracts"
+	"github.com/omni-network/omni/lib/evmchain"
 	"github.com/omni-network/omni/lib/netconf"
+	"github.com/omni-network/omni/solver/types"
 
 	"github.com/ethereum/go-ethereum/common"
 
@@ -50,6 +52,18 @@ func TestShouldReject(t *testing.T) {
 	priceFunc := unaryPrice
 
 	for _, tt := range rejectTestCases(t, solver, outbox) {
+		// TODO(zodomo): Remove this once network upgrade is complete
+		if tt.order.SourceChainID == evmchain.IDOmniMainnet || tt.order.SourceChainID == evmchain.IDOmniOmega || tt.order.SourceChainID == evmchain.IDOmniStaging {
+			tt.reject = true
+			tt.reason = types.RejectUnsupportedSrcChain
+		}
+
+		// TODO(zodomo): Remove this once network upgrade is complete
+		if tt.order.pendingData.DestinationChainID == evmchain.IDOmniMainnet || tt.order.pendingData.DestinationChainID == evmchain.IDOmniOmega || tt.order.pendingData.DestinationChainID == evmchain.IDOmniStaging {
+			tt.reject = true
+			tt.reason = types.RejectUnsupportedDestChain
+		}
+
 		t.Run(tt.name, func(t *testing.T) {
 			backends, clients := testBackends(t)
 

--- a/solver/app/testdata/TestCheck/sufficient_ERC20_balance/resp_body.json
+++ b/solver/app/testdata/TestCheck/sufficient_ERC20_balance/resp_body.json
@@ -1,8 +1,8 @@
 {
-  "accepted": true,
-  "rejected": false,
-  "rejectCode": 0,
-  "rejectReason": "",
-  "rejectDescription": "",
+  "accepted": false,
+  "rejected": true,
+  "rejectCode": 9,
+  "rejectReason": "UnsupportedSrcChain",
+  "rejectDescription": "unsupported source chain [chain_id=164]",
   "trace": null
 }

--- a/solver/app/testdata/TestCheck/sufficient_native_balance/resp_body.json
+++ b/solver/app/testdata/TestCheck/sufficient_native_balance/resp_body.json
@@ -1,8 +1,8 @@
 {
-  "accepted": true,
-  "rejected": false,
-  "rejectCode": 0,
-  "rejectReason": "",
-  "rejectDescription": "",
+  "accepted": false,
+  "rejected": true,
+  "rejectCode": 8,
+  "rejectReason": "UnsupportedDestChain",
+  "rejectDescription": "unsupported destination chain [chain_id=164]",
   "trace": null
 }


### PR DESCRIPTION
Implemented simple rejections for all orders to and from Omni EVM. These changes should be removed after the EVM upgrade is successful.

issue: none
