### PR TITLE
chore(e2e/manifests): bump protected network halos to v17

### DIFF
--- a/e2e/manifests/mainnet.toml
+++ b/e2e/manifests/mainnet.toml
@@ -4,7 +4,7 @@ public_chains = ["ethereum","arbitrum_one","base","optimism"]
 multi_omni_evms = true
 prometheus   = true
 
-pinned_halo_tag = "f90341d" # EVM Proxy
+pinned_halo_tag = "v0.17.0"
 pinned_relayer_tag = "07c4ac7"
 pinned_monitor_tag = "78e9bab"
 pinned_solver_tag = "a917e50"

--- a/e2e/manifests/omega.toml
+++ b/e2e/manifests/omega.toml
@@ -4,7 +4,7 @@ public_chains = ["holesky","op_sepolia", "base_sepolia","arb_sepolia"]
 multi_omni_evms = true
 prometheus = true
 
-pinned_halo_tag = "f90341d" # EVM Proxy
+pinned_halo_tag = "v0.17.0"
 pinned_relayer_tag = "07c4ac7"
 pinned_monitor_tag = "78e9bab"
 pinned_solver_tag = "a917e50"


### PR DESCRIPTION
Bumps omega and mainnet halos to v0.17.0 in preparation for `4_earhart` network upgrade.

issue: none