### PR TITLE
chore(e2e): bump omega solver pin

### DIFF
--- a/e2e/manifests/omega.toml
+++ b/e2e/manifests/omega.toml
@@ -7,7 +7,7 @@ prometheus = true
 pinned_halo_tag = "0609013" # redenom concurrency fix
 pinned_relayer_tag = "07c4ac7"
 pinned_monitor_tag = "ee06e15"
-pinned_solver_tag = "ee06e15"
+pinned_solver_tag = "a837775"
 
 [node.validator01]
 [node.validator02]


### PR DESCRIPTION
Solver pin bump reenables solver on Omega.

issue: none
