### PR TITLE
feat(e2e): update manifest and solver script

### DIFF
--- a/contracts/solve/script/fixtures/SolverNetStagingFixtures.sol
+++ b/contracts/solve/script/fixtures/SolverNetStagingFixtures.sol
@@ -10,6 +10,7 @@ import { ISolverNetInbox } from "src/interfaces/ISolverNetInbox.sol";
 
 contract SolverNetStagingFixtures is Script {
     IERC20 internal omni;
+    IERC20 internal nom;
     IOmniPortal internal portal;
     ISolverNetInbox internal inbox;
 
@@ -36,6 +37,7 @@ contract SolverNetStagingFixtures is Script {
         JSONParserLib.Item memory object = JSONParserLib.parse(stagingAddrsJson);
         /* solhint-disable quotes */
         JSONParserLib.Item memory omniItem = JSONParserLib.at(object, '"token"');
+        JSONParserLib.Item memory nomItem = JSONParserLib.at(object, '"nom"');
         JSONParserLib.Item memory portalItem = JSONParserLib.at(object, '"portal"');
         JSONParserLib.Item memory inboxItem = JSONParserLib.at(object, '"solvernetinbox"');
         /* solhint-enable quotes */
@@ -43,6 +45,10 @@ contract SolverNetStagingFixtures is Script {
         string memory omniAddr = JSONParserLib.value(omniItem);
         omniAddr = LibString.slice(omniAddr, 1, bytes(omniAddr).length - 1);
         omni = IERC20(vm.parseAddress(omniAddr));
+
+        string memory nomAddr = JSONParserLib.value(nomItem);
+        nomAddr = LibString.slice(nomAddr, 1, bytes(nomAddr).length - 1);
+        nom = IERC20(vm.parseAddress(nomAddr));
 
         string memory portalAddr = JSONParserLib.value(portalItem);
         portalAddr = LibString.slice(portalAddr, 1, bytes(portalAddr).length - 1);

--- a/contracts/solve/script/staging/Nomina_transfer.s.sol
+++ b/contracts/solve/script/staging/Nomina_transfer.s.sol
@@ -5,8 +5,8 @@ import { SolverNetStagingFixtures } from "../fixtures/SolverNetStagingFixtures.s
 import { SolverNet } from "src/lib/SolverNet.sol";
 import { IERC7683 } from "src/erc7683/IERC7683.sol";
 
-contract Omni_transfer is SolverNetStagingFixtures {
-    uint96 internal constant defaultAmount = 100 ether;
+contract Staging_Nomina_transfer is SolverNetStagingFixtures {
+    uint96 internal constant defaultAmount = 10_000 ether;
 
     function run() public {
         IERC7683.OnchainCrossChainOrder memory order = _getOrder(defaultAmount, address(0));
@@ -57,7 +57,7 @@ contract Omni_transfer is SolverNetStagingFixtures {
         view
         returns (IERC7683.OnchainCrossChainOrder memory)
     {
-        SolverNet.Deposit memory deposit = SolverNet.Deposit({ token: address(omni), amount: amount });
+        SolverNet.Deposit memory deposit = SolverNet.Deposit({ token: address(nom), amount: amount });
 
         SolverNet.Call[] memory call = new SolverNet.Call[](1);
         call[0] = SolverNet.Call({
@@ -83,10 +83,10 @@ contract Omni_transfer is SolverNetStagingFixtures {
     }
 
     function _checkApprovals(uint96 amount) internal view returns (bool) {
-        return omni.allowance(msg.sender, address(inbox)) >= amount;
+        return nom.allowance(msg.sender, address(inbox)) >= amount;
     }
 
     function _setApprovals() internal {
-        omni.approve(address(inbox), type(uint256).max);
+        nom.approve(address(inbox), type(uint256).max);
     }
 }

--- a/e2e/manifests/omega.toml
+++ b/e2e/manifests/omega.toml
@@ -5,9 +5,9 @@ multi_omni_evms = true
 prometheus = true
 
 pinned_halo_tag = "0609013" # redenom concurrency fix
-pinned_relayer_tag = "07c4ac7"
-pinned_monitor_tag = "ee06e15"
-pinned_solver_tag = "a837775"
+pinned_relayer_tag = "d1dd6c1"
+pinned_monitor_tag = "d1dd6c1"
+pinned_solver_tag = "d1dd6c1"
 
 [node.validator01]
 [node.validator02]


### PR DESCRIPTION
Adjusted solver script to test ERC20 NOM to Native NOM orders on staging. As they were successful, I've bumped the relayer, solver, and monitor versions in the omega manifest.

issue: none