### PR TITLE
chore: fix some function names in comment

### DIFF
--- a/e2e/app/admin/common.go
+++ b/e2e/app/admin/common.go
@@ -312,7 +312,7 @@ func (s shared) runForge(ctx context.Context, rpc string, script string, dir str
 	}
 }
 
-// runForge runs an Admin forge script against an rpc, returning the ouptut.
+// runForgeOnce runs an Admin forge script against an rpc, returning the ouptut.
 // if the senders are known anvil accounts, it will sign with private keys directly.
 // otherwise, it will use the unlocked flag.
 func runForgeOnce(ctx context.Context, rpc string, script string, dir string, input []byte, broadcast, resume bool, senders ...common.Address,

--- a/monitor/xmonitor/monitor.go
+++ b/monitor/xmonitor/monitor.go
@@ -53,7 +53,7 @@ func Start(
 	return nil
 }
 
-// monitorConsOffsetsForever blocks and periodically monitors the emitted
+// monitorConsOffsetForever blocks and periodically monitors the emitted
 // offsets for a given consensus chain.
 // Note that submitted offsets are not monitored as the consensus chain doesn't support submissions.
 func monitorConsOffsetForever(ctx context.Context, network netconf.Network, xprovider xchain.Provider) {


### PR DESCRIPTION
fix some function names in comment

issue: none

<!--
  PR title and body follows conventional commit; https://www.conventionalcommits.org/en/v1.0.0
  Title template: `type(app/pkg): concise description`
  See allowed types: https://github.com/conventional-changelog/commitlint/tree/master/%40commitlint/config-conventional#type-enum
  Description must be concise: lower case, no punctuation, no more than 50 characters.
  Scope must be concise: only a one or two folders; e.g. 'halo/cmd' or 'github' or '*'
-->
