### PR TITLE
feat(e2e): update mainnet solver pin

### DIFF
--- a/e2e/manifests/mainnet.toml
+++ b/e2e/manifests/mainnet.toml
@@ -7,7 +7,7 @@ prometheus   = true
 pinned_halo_tag = "0609013" # redenom concurrency fix
 pinned_relayer_tag = "07c4ac7"
 pinned_monitor_tag = "ee06e15"
-pinned_solver_tag = "ee06e15"
+pinned_solver_tag = "902fc10"
 
 [node.validator01]
 [node.validator02]


### PR DESCRIPTION
Updating mainnet solver pin. Solver still has mainnet disabled at this commit.

issue: none
