### PR TITLE
chore(e2e): unpause bridge

### DIFF
--- a/e2e/app/admin/bridgespec.go
+++ b/e2e/app/admin/bridgespec.go
@@ -22,18 +22,7 @@ var bridgeSpec = map[netconf.ID]NetworkBridgeSpec{
 	netconf.Devnet:  DefaultBridgeSpec(),
 	netconf.Staging: DefaultBridgeSpec(),
 	netconf.Omega:   DefaultBridgeSpec(),
-	netconf.Mainnet: {
-		Native: BridgeSpec{
-			PauseAll:      false,
-			PauseWithdraw: false,
-			PauseBridge:   true,
-		},
-		L1: BridgeSpec{
-			PauseAll:      false,
-			PauseWithdraw: false,
-			PauseBridge:   true,
-		},
-	},
+	netconf.Mainnet: DefaultBridgeSpec(),
 }
 
 // BridgeSpec is the specification for a bridge contract (native or L1).

--- a/e2e/app/admin/solvernetspec.go
+++ b/e2e/app/admin/solvernetspec.go
@@ -19,22 +19,10 @@ import (
 // To update SolverNet spec, update this map.
 // Then run `ensure-solvernet-spec` to apply the changes.
 var solverNetSpec = map[netconf.ID]NetworkSolverNetSpec{
-	netconf.Devnet: {Global: DefaultSolverNetSpec()},
-	netconf.Staging: {Global: SolverNetSpec{
-		PauseAll:   false,
-		PauseOpen:  true,
-		PauseClose: false,
-	}},
-	netconf.Omega: {Global: SolverNetSpec{
-		PauseAll:   false,
-		PauseOpen:  true,
-		PauseClose: false,
-	}},
-	netconf.Mainnet: {Global: SolverNetSpec{
-		PauseAll:   false,
-		PauseOpen:  true,
-		PauseClose: false,
-	}},
+	netconf.Devnet:  {Global: DefaultSolverNetSpec()},
+	netconf.Staging: {Global: DefaultSolverNetSpec()},
+	netconf.Omega:   {Global: DefaultSolverNetSpec()},
+	netconf.Mainnet: {Global: DefaultSolverNetSpec()},
 }
 
 // SolverNetSpec is the specification for the SolverNetInbox contract.

--- a/e2e/app/admin/testdata/TestNetworkBridgeSpec.golden
+++ b/e2e/app/admin/testdata/TestNetworkBridgeSpec.golden
@@ -15,12 +15,12 @@
   "Native": {
    "PauseAll": false,
    "PauseWithdraw": false,
-   "PauseBridge": true
+   "PauseBridge": false
   },
   "L1": {
    "PauseAll": false,
    "PauseWithdraw": false,
-   "PauseBridge": true
+   "PauseBridge": false
   }
  },
  "omega": {

--- a/e2e/app/admin/testdata/TestNetworkSolverNetSpec.golden
+++ b/e2e/app/admin/testdata/TestNetworkSolverNetSpec.golden
@@ -10,7 +10,7 @@
  "mainnet": {
   "Global": {
    "PauseAll": false,
-   "PauseOpen": true,
+   "PauseOpen": false,
    "PauseClose": false
   },
   "ChainOverrides": null
@@ -18,7 +18,7 @@
  "omega": {
   "Global": {
    "PauseAll": false,
-   "PauseOpen": true,
+   "PauseOpen": false,
    "PauseClose": false
   },
   "ChainOverrides": null
@@ -26,7 +26,7 @@
  "staging": {
   "Global": {
    "PauseAll": false,
-   "PauseOpen": true,
+   "PauseOpen": false,
    "PauseClose": false
   },
   "ChainOverrides": null


### PR DESCRIPTION
Unpausing bridge, set all specs back to default even though we didn't pause solvernet.

issue: none