### PR TITLE
chore(e2e): update mainnet pins

### DIFF
--- a/e2e/manifests/mainnet.toml
+++ b/e2e/manifests/mainnet.toml
@@ -5,9 +5,9 @@ multi_omni_evms = true
 prometheus   = true
 
 pinned_halo_tag = "0609013" # redenom concurrency fix
-pinned_relayer_tag = "07c4ac7"
-pinned_monitor_tag = "ee06e15"
-pinned_solver_tag = "902fc10"
+pinned_relayer_tag = "813a5e6"
+pinned_monitor_tag = "813a5e6"
+pinned_solver_tag = "813a5e6"
 
 [node.validator01]
 [node.validator02]


### PR DESCRIPTION
Updating mainnet pins for relayer, solver, and monitor to handle NOM now having replaced OMNI.

issue: none