### PR TITLE
chore(e2e): update mainnet solver pin

### DIFF
--- a/e2e/manifests/mainnet.toml
+++ b/e2e/manifests/mainnet.toml
@@ -7,7 +7,7 @@ prometheus   = true
 pinned_halo_tag = "0609013" # redenom concurrency fix
 pinned_relayer_tag = "813a5e6"
 pinned_monitor_tag = "813a5e6"
-pinned_solver_tag = "813a5e6"
+pinned_solver_tag = "ab95a0b"
 
 [node.validator01]
 [node.validator02]


### PR DESCRIPTION
Updating mainnet solver pin to fully reenable solver.

issue: none