### PR TITLE
refactor: replace sort.Slice with slices.Sort for natural ordering

### DIFF
--- a/e2e/app/admin/test.go
+++ b/e2e/app/admin/test.go
@@ -4,7 +4,7 @@ package admin
 import (
 	"context"
 	"math/rand"
-	"sort"
+	"slices"
 
 	"github.com/omni-network/omni/contracts/bindings"
 	"github.com/omni-network/omni/e2e/app"
@@ -398,7 +398,7 @@ func randBridgeSpec() BridgeSpec {
 }
 
 func sortUint64(ns []uint64) {
-	sort.Slice(ns, func(i, j int) bool { return ns[i] < ns[j] })
+	slices.Sort(ns)
 }
 
 func randChain(chains []types.EVMChain) types.EVMChain {

--- a/halo/registry/keeper/cache.go
+++ b/halo/registry/keeper/cache.go
@@ -2,7 +2,7 @@ package keeper
 
 import (
 	"context"
-	"sort"
+	"slices"
 	"sync"
 
 	"github.com/omni-network/omni/halo/registry/types"
@@ -72,9 +72,7 @@ func (k Keeper) ConfLevels(ctx context.Context) (map[uint64][]xchain.ConfLevel, 
 			confLevels = append(confLevels, confLevel)
 		}
 
-		sort.Slice(confLevels, func(i, j int) bool {
-			return confLevels[i] < confLevels[j]
-		})
+		slices.Sort(confLevels)
 
 		resp[portal.GetChainId()] = confLevels
 	}

--- a/lib/netconf/netconf.go
+++ b/lib/netconf/netconf.go
@@ -4,7 +4,7 @@ package netconf
 
 import (
 	"fmt"
-	"sort"
+	"slices"
 	"time"
 
 	"github.com/omni-network/omni/lib/errors"
@@ -385,9 +385,7 @@ func (c Chain) ConfLevels() []xchain.ConfLevel {
 	}
 
 	// Sort for deterministic ordering.
-	sort.Slice(confs, func(i, j int) bool {
-		return confs[i] < confs[j]
-	})
+	slices.Sort(confs)
 
 	return confs
 }

--- a/lib/netconf/network.go
+++ b/lib/netconf/network.go
@@ -1,7 +1,7 @@
 package netconf
 
 import (
-	"sort"
+	"slices"
 
 	"github.com/omni-network/omni/lib/errors"
 )
@@ -90,9 +90,7 @@ func All() []ID {
 		}
 	}
 
-	sort.Slice(resp, func(i, j int) bool {
-		return resp[i] < resp[j]
-	})
+	slices.Sort(resp)
 
 	return resp
 }


### PR DESCRIPTION
There is a [new function](https://pkg.go.dev/slices#Sort) added in the go1.21 standard library, which can make the code more concise and easy to read.



issue: none

<!--
  PR title and body follows conventional commit; https://www.conventionalcommits.org/en/v1.0.0
  Title template: `type(app/pkg): concise description`
  See allowed types: https://github.com/conventional-changelog/commitlint/tree/master/%40commitlint/config-conventional#type-enum
  Description must be concise: lower case, no punctuation, no more than 50 characters.
  Scope must be concise: only a one or two folders; e.g. 'halo/cmd' or 'github' or '*'
-->
